### PR TITLE
Add local profile source loading

### DIFF
--- a/.deepreview
+++ b/.deepreview
@@ -157,6 +157,29 @@ test_file_quality:
       - FAIL: Issues found. List each with the test name, line number, and a
         concise description.
 
+doc_consistency:
+  description: "Verify architecture and file structure documentation stay consistent."
+  match:
+    include:
+      - "doc/architecture.md"
+      - "doc/file_structure.md"
+  review:
+    strategy: matches_together
+    additional_context:
+      unchanged_matching_files: true
+    instructions: |
+      Review doc/architecture.md and doc/file_structure.md together for consistency.
+
+      Check that:
+      1. doc/file_structure.md stays limited to repository file structure, not runtime instance file conventions.
+      2. Runtime file conventions such as settings directories, profile folders, and tack paths live in doc/architecture.md.
+      3. Cross-document links and filenames are accurate.
+      4. Terminology such as profile, tack, settings, adapter, and pi is used consistently.
+
+      Output Format:
+      - PASS: The documents are consistent and links are accurate.
+      - FAIL: Issues found. List each conflicting statement, missing update, or broken reference with a line reference.
+
 controllable_elements_matrix:
   description: "Verify BRIDL-REQ-007 controllable element documentation has a complete support matrix."
   match:

--- a/.deepreview
+++ b/.deepreview
@@ -70,6 +70,7 @@ requirements_traceability:
     include:
       - "requirements/BRIDL-REQ-*.md"
       - "src/**/*.ts"
+      - "src/schemas/**/*.json"
       - "bin/**/*.ts"
       - "tests/**/*.ts"
       - "tests/**/*.tsx"
@@ -189,6 +190,7 @@ update_readme:
       - "package.json"
       - "tsconfig.json"
       - "src/**/*.ts"
+      - "src/schemas/**/*.json"
       - "bin/**/*.ts"
   review:
     strategy: matches_together

--- a/README.md
+++ b/README.md
@@ -43,26 +43,15 @@ Under the hood, `bridl` will translate a selected profile into the appropriate `
 A profile will use YAML. An initial profile shape is:
 
 ```yaml
-name: engineering-default
-display_name: Engineering Default
+id: engineering-default
+label: Engineering Default
 inherits:
   - base-typescript
 
 controls:
-  env:
+  model: anthropic/claude-sonnet-4
+  environment:
     ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
-  args:
-    - --model
-    - anthropic/claude-sonnet-4
-  extensions:
-    - ./extensions/company-bootstrap
-  skills:
-    - ./skills/company-debugging
-  system_prompt: ./prompts/system.md
-  append_system_prompts:
-    - ./prompts/company-policy.md
-  session_dir: ~/.bridl/sessions/engineering-default
-  project_overrides: allow
 ```
 
 The exact stable schema is governed by the requirements in `requirements/` and the JSON Schema files in `src/schemas/`, which are still expected to evolve with implementation.

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -64,63 +64,11 @@ Development dependencies:
 
 The project includes `tsconfig.json` for strict typechecking across source, tests, and config, plus `tsconfig.build.json` for production emission from `src/` to `dist/`.
 
-## Repository Layout
+## Repository File Structure
 
-Proposed initial layout:
+The repository layout and source/test directory boundaries live in `doc/file_structure.md`.
 
-```text
-.
-├── doc/
-│   ├── architecture.md
-│   ├── controllable-elements.md
-│   └── specs/
-├── requirements/
-│   ├── BRIDL-REQ-001-project-foundation.md
-│   └── ...
-├── plan.md
-├── src/
-│   ├── cli/
-│   │   ├── BridlCli.ts
-│   │   └── commands/
-│   │       ├── RunCommand.ts
-│   │       ├── SetupCommand.ts
-│   │       ├── SyncCommand.ts
-│   │       └── CreateProfileCommand.ts
-│   ├── settings/
-│   │   ├── Settings.ts
-│   │   ├── SettingsLoader.ts
-│   │   └── SettingsMerger.ts
-│   ├── profiles/
-│   │   ├── Profile.ts
-│   │   ├── ProfileLoader.ts
-│   │   ├── ProfileMerger.ts
-│   │   └── ProfileSource.ts
-│   ├── tack/
-│   │   ├── Tack.ts
-│   │   ├── TackAssembler.ts
-│   │   ├── TackFile.ts
-│   │   └── TackWatcher.ts
-│   ├── agents/
-│   │   ├── AgentAdapter.ts
-│   │   └── pi/
-│   │       ├── PiAdapter.ts
-│   │       └── PiTackWriter.ts
-│   ├── schemas/
-│   │   ├── settings.schema.json
-│   │   ├── profile.schema.json
-│   │   └── profile-source.schema.json
-│   └── validation/
-│       └── SchemaValidator.ts
-├── tests/
-│   ├── fixtures/
-│   │   └── scenarios/
-│   └── unit/
-└── package.json
-```
-
-The exact layout may evolve, but the boundaries above should stay recognizable.
-
-## Configuration Directories
+## Settings Resolution
 
 Bridl uses a `.bridl` folder convention at multiple scopes:
 
@@ -486,20 +434,7 @@ Requirements:
 - deterministic tests for unsupported controls and `--hard-tack`;
 - scenario fixtures for common combinations instead of one-off bespoke setup.
 
-Scenario fixtures should live under `tests/fixtures/scenarios/`, for example:
-
-```text
-tests/fixtures/scenarios/
-  user-default-only/
-  project-overrides-user/
-  project-local-overrides-project/
-  uri-source-with-filter/
-  profile-inheritance-chain/
-  cli-specific-pi-overrides/
-  unsupported-control-warning/
-```
-
-Each scenario should include realistic `.bridl` folders and expected resolution output.
+Scenario fixture directory conventions are documented in `doc/file_structure.md`. Each scenario should include realistic `.bridl` folders and expected resolution output.
 
 ## Settled Initial Decisions
 

--- a/doc/file_structure.md
+++ b/doc/file_structure.md
@@ -1,0 +1,77 @@
+# Bridl File Structure
+
+This document records the key repository file and directory structure used by Bridl. See `doc/architecture.md` for runtime file conventions such as `.bridl` settings folders, profile folders, and generated tack directories.
+
+## Repository Layout
+
+Bridl is organized around clear TypeScript source boundaries, requirement documents, and scenario-based tests.
+
+```text
+.                                      # repository root
+├── doc/                               # architecture, design, and specification docs
+│   ├── architecture.md                # architectural rationale and runtime file conventions
+│   ├── controllable-elements.md       # controllable element terminology and support matrix
+│   ├── file_structure.md              # repository file structure overview
+│   └── specs/                         # detailed supporting specs
+├── requirements/                      # formal BRIDL requirement documents
+│   ├── BRIDL-REQ-001-project-foundation.md
+│   └── ...
+├── plan.md                            # implementation plan
+├── src/                               # production TypeScript source
+│   ├── cli/                           # CLI parser construction and command registration
+│   │   ├── BridlCli.ts
+│   │   └── commands/                  # command objects for non-trivial CLI behavior
+│   │       ├── RunCommand.ts
+│   │       ├── SetupCommand.ts
+│   │       ├── SyncCommand.ts
+│   │       └── CreateProfileCommand.ts
+│   ├── settings/                      # settings loading and merging
+│   │   ├── Settings.ts
+│   │   ├── SettingsLoader.ts
+│   │   └── SettingsMerger.ts
+│   ├── profiles/                      # profile loading, validation, resolution, and merging
+│   │   ├── Profile.ts
+│   │   ├── ProfileLoader.ts
+│   │   ├── ProfileMerger.ts
+│   │   └── ProfileSource.ts
+│   ├── tack/                          # generated runtime tack assembly and watching
+│   │   ├── Tack.ts
+│   │   ├── TackAssembler.ts
+│   │   ├── TackFile.ts
+│   │   └── TackWatcher.ts
+│   ├── agents/                        # agent adapter boundary and CLI-specific adapters
+│   │   ├── AgentAdapter.ts
+│   │   └── pi/                        # pi-specific adapter implementation
+│   │       ├── PiAdapter.ts
+│   │       └── PiTackWriter.ts
+│   ├── schemas/                       # JSON Schema artifacts for persisted formats
+│   │   ├── settings.schema.json
+│   │   ├── profile.schema.json
+│   │   └── profile-source.schema.json
+│   └── validation/                    # shared validation helpers
+│       └── SchemaValidator.ts
+├── tests/                             # automated tests
+│   ├── fixtures/                      # reusable test fixtures
+│   │   └── scenarios/                 # realistic .bridl scenarios and expected outputs
+│   └── unit/                          # unit tests
+└── package.json                       # npm package metadata and scripts
+```
+
+The exact layout may evolve, but these boundaries should stay recognizable.
+
+## Test Scenario Fixtures
+
+Scenario fixtures should live under `tests/fixtures/scenarios/`, for example:
+
+```text
+tests/fixtures/scenarios/
+  user-default-only/
+  project-overrides-user/
+  project-local-overrides-project/
+  uri-source-with-filter/
+  profile-inheritance-chain/
+  cli-specific-pi-overrides/
+  unsupported-control-warning/
+```
+
+Each scenario should include realistic `.bridl` folders and expected resolution output.

--- a/plan.md
+++ b/plan.md
@@ -2,27 +2,27 @@
 
 This plan describes the order of work. Formal obligations live in `requirements/`.
 
-## Phase 1: Project foundation
+## Phase 1: Project foundation — Done
 
-- Use npm with the committed `package.json` and `package-lock.json` as the dependency baseline.
-- Use Commander for CLI parsing, Vitest with V8 coverage for tests, ESLint with `typescript-eslint` for linting, and TypeScript strict mode.
-- Add the initial source layout for CLI command objects, settings, profiles, tack, adapters, schemas, and validation.
-- Wire CI-equivalent local commands: typecheck, lint, test, coverage.
+- [x] Use npm with the committed `package.json` and `package-lock.json` as the dependency baseline.
+- [x] Use Commander for CLI parsing, Vitest with V8 coverage for tests, ESLint with `typescript-eslint` for linting, and TypeScript strict mode.
+- [x] Add the initial source layout for CLI command objects, settings, profiles, tack, adapters, schemas, and validation.
+- [x] Wire CI-equivalent local commands: typecheck, lint, test, coverage.
 
-## Phase 2: Schemas and configuration loading
+## Phase 2: Schemas and configuration loading — In progress
 
-- Define `settings.yml` and `profile.yml` JSON Schemas.
-- Implement YAML parsing and schema validation with useful diagnostics.
-- Implement `.bridl/settings.yml` discovery across user, project, and project-local scopes.
-- Implement deterministic settings merging into the internal `Settings` object.
+- [x] Define initial `settings.yml` and `profile.yml` JSON Schemas.
+- [ ] Implement YAML parsing and schema validation with useful diagnostics.
+- [x] Implement `.bridl/settings.yml` discovery scaffolding across user, project, and project-local scopes.
+- [x] Implement deterministic settings merging into the internal `Settings` object.
 
-## Phase 3: Profile sources and profile resolution
+## Phase 3: Profile sources and profile resolution — In progress
 
-- Implement local profile source loading and `only` / `except` filters.
-- Implement profile folder validation and `profile.yml` parsing.
-- Implement profile scope precedence and merge behavior.
-- Implement inheritance resolution, default-profile inclusion, and cycle detection.
-- Add scenario fixtures for common source, inheritance, and precedence combinations.
+- [x] Implement local profile source loading and `only` / `except` filters.
+- [x] Implement profile folder validation and `profile.yml` parsing.
+- [ ] Implement profile scope precedence and merge behavior.
+- [ ] Implement inheritance resolution, default-profile inclusion, and cycle detection.
+- [ ] Add scenario fixtures for common source, inheritance, and precedence combinations.
 
 ## Phase 4: Setup and sync commands
 

--- a/src/profiles/ProfileLoader.ts
+++ b/src/profiles/ProfileLoader.ts
@@ -1,10 +1,190 @@
-// Defines profile loading plan scaffolding before profile.yml parsing exists.
+// Loads local profile folders and parses profile.yml documents.
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { AnySchema } from 'ajv';
+import { Ajv2020 } from 'ajv/dist/2020.js';
+import { parse } from 'yaml';
+
+import type { Profile, ProfileControls } from './Profile.js';
 import type { ProfileSourceReference } from './ProfileSource.js';
+
+const profileIdPattern = /^[a-z0-9][a-z0-9._-]*[a-z0-9]$|^[a-z0-9]$/u;
+const profileSchema = JSON.parse(
+  readFileSync(new URL('../schemas/profile.schema.json', import.meta.url), 'utf8'),
+) as AnySchema;
+const profileValidator = new Ajv2020().compile(profileSchema);
 
 export interface ProfileLoadPlan {
   readonly sources: readonly ProfileSourceReference[];
 }
 
+export interface ProfileLoadIssue {
+  readonly path: string;
+  readonly message: string;
+}
+
+export interface LoadedProfile {
+  readonly source: ProfileSourceReference;
+  readonly folderPath: string;
+  readonly profilePath: string;
+  readonly profile: Profile;
+}
+
+export interface ProfileLoadResult {
+  readonly profiles: readonly LoadedProfile[];
+  readonly issues: readonly ProfileLoadIssue[];
+}
+
 export const createProfileLoadPlan = (sources: readonly ProfileSourceReference[]): ProfileLoadPlan => ({
   sources,
 });
+
+export const isValidProfileId = (profileId: string): boolean => profileIdPattern.test(profileId);
+
+export const isProfileIncludedBySource = (profileId: string, source: ProfileSourceReference): boolean =>
+  (source.only === undefined || source.only.includes(profileId)) &&
+  (source.except === undefined || !source.except.includes(profileId));
+
+export const parseProfileDocument = (document: unknown, fallbackId: string): Profile | ProfileLoadIssue => {
+  const record = readObject(document);
+
+  if (record === undefined) {
+    return { path: '/', message: 'Profile document must be a mapping.' };
+  }
+
+  const id = readString(record.id, fallbackId);
+  const validationIssue = validateProfileRecord({ ...record, id });
+
+  if (validationIssue !== undefined) {
+    return validationIssue;
+  }
+
+  return {
+    id,
+    label: readOptionalString(record.label),
+    inherits: readStringArray(record.inherits),
+    controls: readControls(record.controls),
+  };
+};
+
+export const parseProfileYaml = (content: string, fallbackId: string): Profile | ProfileLoadIssue => {
+  try {
+    return parseProfileDocument(parse(content), fallbackId);
+  } catch (error) {
+    return { path: '/profile.yml', message: readErrorMessage(error) };
+  }
+};
+
+export const loadLocalProfileSource = (source: ProfileSourceReference): ProfileLoadResult => {
+  if (source.path === undefined) {
+    return { profiles: [], issues: [{ path: '<uri-source>', message: 'Only local profile sources can be loaded directly.' }] };
+  }
+
+  if (!existsSync(source.path) || !statSync(source.path).isDirectory()) {
+    return { profiles: [], issues: [{ path: source.path, message: 'Profile source must be an existing directory.' }] };
+  }
+
+  const profiles: LoadedProfile[] = [];
+  const issues: ProfileLoadIssue[] = [];
+
+  for (const entryName of readdirSync(source.path).sort()) {
+    const folderPath = join(source.path, entryName);
+    const profilePath = join(folderPath, 'profile.yml');
+
+    if (statSync(folderPath).isDirectory() && existsSync(profilePath)) {
+      addProfileFromFolder(source, entryName, folderPath, profilePath, profiles, issues);
+    }
+  }
+
+  return { profiles, issues };
+};
+
+const addProfileFromFolder = (
+  source: ProfileSourceReference,
+  fallbackId: string,
+  folderPath: string,
+  profilePath: string,
+  profiles: LoadedProfile[],
+  issues: ProfileLoadIssue[],
+): void => {
+  const profile = parseProfileYaml(readFileSync(profilePath, 'utf8'), fallbackId);
+
+  if ('message' in profile) {
+    issues.push({ path: profilePath, message: profile.message });
+  } else if (isProfileIncludedBySource(profile.id, source)) {
+    profiles.push({ source, folderPath, profilePath, profile });
+  }
+};
+
+const validateProfileRecord = (record: Readonly<Record<string, unknown>>): ProfileLoadIssue | undefined => {
+  if (profileValidator(record)) {
+    return undefined;
+  }
+
+  const error = profileValidator.errors![0] as { readonly instancePath: string; readonly message: string };
+
+  return {
+    path: error.instancePath,
+    message: error.message,
+  };
+};
+
+const readObject = (value: unknown): Readonly<Record<string, unknown>> | undefined => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value as Readonly<Record<string, unknown>>;
+};
+
+const readString = (value: unknown, fallback: string): string => {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  return fallback;
+};
+
+const readOptionalString = (value: unknown): string | undefined => {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  return undefined;
+};
+
+const readStringArray = (value: unknown): readonly string[] => {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string');
+  }
+
+  return [];
+};
+
+const readControls = (value: unknown): ProfileControls => {
+  const controls = readObject(value);
+
+  if (controls === undefined) {
+    return {};
+  }
+
+  return {
+    model: readOptionalString(controls.model),
+    environment: readEnvironment(controls.environment),
+  };
+};
+
+const readEnvironment = (value: unknown): Readonly<Record<string, string>> | undefined => {
+  const environment = readObject(value);
+
+  if (environment === undefined) {
+    return undefined;
+  }
+
+  return Object.fromEntries(
+    Object.entries(environment).filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
+  );
+};
+
+const readErrorMessage = (error: unknown): string => String(error);

--- a/src/profiles/ProfileLoader.ts
+++ b/src/profiles/ProfileLoader.ts
@@ -111,7 +111,7 @@ const addProfileFromFolder = (
   const profile = parseProfileYaml(readFileSync(profilePath, 'utf8'), fallbackId);
 
   if ('message' in profile) {
-    issues.push({ path: profilePath, message: profile.message });
+    issues.push({ path: `${profilePath}#${profile.path}`, message: profile.message });
   } else if (isProfileIncludedBySource(profile.id, source)) {
     profiles.push({ source, folderPath, profilePath, profile });
   }
@@ -187,4 +187,10 @@ const readEnvironment = (value: unknown): Readonly<Record<string, string>> | und
   );
 };
 
-const readErrorMessage = (error: unknown): string => String(error);
+export const readErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+};

--- a/src/schemas/profile.schema.json
+++ b/src/schemas/profile.schema.json
@@ -3,5 +3,30 @@
   "$id": "https://bridl.dev/schemas/profile.schema.json",
   "title": "Bridl profile",
   "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]*[a-z0-9]$|^[a-z0-9]$"
+    },
+    "label": { "type": "string" },
+    "inherits": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9][a-z0-9._-]*[a-z0-9]$|^[a-z0-9]$"
+      }
+    },
+    "controls": {
+      "type": "object",
+      "properties": {
+        "model": { "type": "string" },
+        "environment": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      },
+      "additionalProperties": true
+    }
+  },
   "additionalProperties": true
 }

--- a/tests/unit/profile-loader.test.ts
+++ b/tests/unit/profile-loader.test.ts
@@ -11,6 +11,7 @@ import {
   loadLocalProfileSource,
   parseProfileDocument,
   parseProfileYaml,
+  readErrorMessage,
 } from '../../src/profiles/ProfileLoader.js';
 import { createLocalProfileSource, createUriProfileSource } from '../../src/profiles/ProfileSource.js';
 
@@ -82,14 +83,28 @@ describe('profile loading', () => {
       message: 'Profile document must be a mapping.',
     });
     const invalidIdResult = parseProfileYaml('id: Engineering Default\n', 'fallback');
-    const invalidEnvironmentResult = parseProfileYaml('controls:\n  environment:\n    COUNT: 1\n', 'fallback');
 
     expect('message' in invalidIdResult && invalidIdResult.path).toBe('/id');
     expect('message' in invalidIdResult && invalidIdResult.message).toContain('must match pattern');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-003.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('reports profile.yml schema validation diagnostics with field pointers', () => {
+    const root = createProfileSourceRoot();
+    writeProfile(root, 'invalid-field', 'controls:\n  environment:\n    COUNT: 1\n');
+    const invalidEnvironmentResult = parseProfileYaml('controls:\n  environment:\n    COUNT: 1\n', 'fallback');
+
     expect(invalidEnvironmentResult).toEqual({
       path: '/controls/environment/COUNT',
       message: 'must be string',
     });
+    expect(loadLocalProfileSource(createLocalProfileSource(root)).issues).toEqual([
+      {
+        path: `${join(root, 'invalid-field', 'profile.yml')}#/controls/environment/COUNT`,
+        message: 'must be string',
+      },
+    ]);
   });
 
   it('reports non-local, missing, and malformed profile sources as load issues', () => {
@@ -103,6 +118,13 @@ describe('profile loading', () => {
     expect(loadLocalProfileSource(createLocalProfileSource(missingRoot)).issues).toEqual([
       { path: missingRoot, message: 'Profile source must be an existing directory.' },
     ]);
-    expect(loadLocalProfileSource(createLocalProfileSource(root)).issues).toHaveLength(1);
+    expect(loadLocalProfileSource(createLocalProfileSource(root)).issues).toEqual([
+      {
+        path: `${join(root, 'broken', 'profile.yml')}#/profile.yml`,
+        message: expect.any(String) as string,
+      },
+    ]);
+    expect(readErrorMessage(new Error('clean parser message'))).toBe('clean parser message');
+    expect(readErrorMessage('fallback parser message')).toBe('fallback parser message');
   });
 });

--- a/tests/unit/profile-loader.test.ts
+++ b/tests/unit/profile-loader.test.ts
@@ -1,0 +1,108 @@
+// Tests profile source loading and profile.yml parsing behavior.
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  isProfileIncludedBySource,
+  isValidProfileId,
+  loadLocalProfileSource,
+  parseProfileDocument,
+  parseProfileYaml,
+} from '../../src/profiles/ProfileLoader.js';
+import { createLocalProfileSource, createUriProfileSource } from '../../src/profiles/ProfileSource.js';
+
+const temporaryRoots: string[] = [];
+
+const createProfileSourceRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'bridl-profile-source-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const writeProfile = (root: string, id: string, content: string): void => {
+  const folderPath = join(root, id);
+  mkdirSync(folderPath);
+  writeFileSync(join(folderPath, 'profile.yml'), content);
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('profile loading', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('applies profile source only and except filters to local profile loading', () => {
+    const root = createProfileSourceRoot();
+    writeProfile(root, 'base', 'label: Base\n');
+    writeProfile(root, 'engineering', 'id: engineering\ncontrols:\n  model: pi/default\n');
+    writeProfile(root, 'research', 'id: research\n');
+
+    const result = loadLocalProfileSource({ path: root, only: ['base', 'engineering'], except: ['base'] });
+
+    expect(result.issues).toEqual([]);
+    expect(result.profiles.map((loadedProfile) => loadedProfile.profile.id)).toEqual(['engineering']);
+    expect(result.profiles.at(0)?.profile.controls.model).toBe('pi/default');
+    expect(isProfileIncludedBySource('research', createLocalProfileSource(root))).toBe(true);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-003.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('parses profile.yml files from profile folders with fallback folder identity', () => {
+    const root = createProfileSourceRoot();
+    writeProfile(root, 'base', 'label: Base Profile\ninherits:\n  - shared\ncontrols:\n  environment:\n    MODE: test\n');
+    writeFileSync(join(root, 'README.md'), 'not a profile folder');
+
+    const result = loadLocalProfileSource(createLocalProfileSource(root));
+
+    expect(result.issues).toEqual([]);
+    expect(result.profiles).toHaveLength(1);
+    expect(result.profiles[0]?.folderPath).toBe(join(root, 'base'));
+    expect(result.profiles[0]?.profilePath).toBe(join(root, 'base', 'profile.yml'));
+    expect(result.profiles[0]?.profile).toEqual({
+      id: 'base',
+      label: 'Base Profile',
+      inherits: ['shared'],
+      controls: { environment: { MODE: 'test' } },
+    });
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-003.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('rejects profile IDs that are not safe for CLI references', () => {
+    expect(isValidProfileId('engineering.default')).toBe(true);
+    expect(isValidProfileId('Engineering Default')).toBe(false);
+    expect(parseProfileDocument(['not', 'a', 'mapping'], 'fallback')).toEqual({
+      path: '/',
+      message: 'Profile document must be a mapping.',
+    });
+    const invalidIdResult = parseProfileYaml('id: Engineering Default\n', 'fallback');
+    const invalidEnvironmentResult = parseProfileYaml('controls:\n  environment:\n    COUNT: 1\n', 'fallback');
+
+    expect('message' in invalidIdResult && invalidIdResult.path).toBe('/id');
+    expect('message' in invalidIdResult && invalidIdResult.message).toContain('must match pattern');
+    expect(invalidEnvironmentResult).toEqual({
+      path: '/controls/environment/COUNT',
+      message: 'must be string',
+    });
+  });
+
+  it('reports non-local, missing, and malformed profile sources as load issues', () => {
+    const missingRoot = join(tmpdir(), 'bridl-missing-profile-source');
+    const root = createProfileSourceRoot();
+    writeProfile(root, 'broken', ': invalid: yaml:');
+
+    expect(loadLocalProfileSource(createUriProfileSource('git+https://example.test/profiles.git')).issues).toEqual([
+      { path: '<uri-source>', message: 'Only local profile sources can be loaded directly.' },
+    ]);
+    expect(loadLocalProfileSource(createLocalProfileSource(missingRoot)).issues).toEqual([
+      { path: missingRoot, message: 'Profile source must be an existing directory.' },
+    ]);
+    expect(loadLocalProfileSource(createLocalProfileSource(root)).issues).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Mark Phase 1 completion and make plan progress explicit without overstating remaining Phase 2 work.
- Add local profile source loading with only/except filters.
- Parse and validate profile.yml files against the profile schema.
- Update the README profile sketch to match the implemented schema fields.

## Validation
- `npm run typecheck`
- `npm run check-ci`
- DeepWork reviews: no remaining tasks