### PR TITLE
Implement settings YAML validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && shx chmod +x dist/cli.js",
+    "build": "tsc -p tsconfig.build.json && shx rm -rf dist/schemas && shx mkdir -p dist/schemas && shx cp src/schemas/*.json dist/schemas/ && shx chmod +x dist/cli.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/src/profiles/ProfileLoader.ts
+++ b/src/profiles/ProfileLoader.ts
@@ -2,27 +2,19 @@
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
-import type { AnySchema } from 'ajv';
-import { Ajv2020 } from 'ajv/dist/2020.js';
-import { parse } from 'yaml';
-
+import type { ValidationIssue } from '../validation/SchemaValidator.js';
+import { validateSchema } from '../validation/SchemaValidator.js';
+import { parseYamlDocument } from '../validation/YamlDocument.js';
 import type { Profile, ProfileControls } from './Profile.js';
 import type { ProfileSourceReference } from './ProfileSource.js';
 
 const profileIdPattern = /^[a-z0-9][a-z0-9._-]*[a-z0-9]$|^[a-z0-9]$/u;
-const profileSchema = JSON.parse(
-  readFileSync(new URL('../schemas/profile.schema.json', import.meta.url), 'utf8'),
-) as AnySchema;
-const profileValidator = new Ajv2020().compile(profileSchema);
 
 export interface ProfileLoadPlan {
   readonly sources: readonly ProfileSourceReference[];
 }
 
-export interface ProfileLoadIssue {
-  readonly path: string;
-  readonly message: string;
-}
+export type ProfileLoadIssue = ValidationIssue;
 
 export interface LoadedProfile {
   readonly source: ProfileSourceReference;
@@ -69,11 +61,13 @@ export const parseProfileDocument = (document: unknown, fallbackId: string): Pro
 };
 
 export const parseProfileYaml = (content: string, fallbackId: string): Profile | ProfileLoadIssue => {
-  try {
-    return parseProfileDocument(parse(content), fallbackId);
-  } catch (error) {
-    return { path: '/profile.yml', message: readErrorMessage(error) };
+  const parsed = parseYamlDocument(content, '/profile.yml');
+
+  if (!parsed.ok) {
+    return parsed.issue;
   }
+
+  return parseProfileDocument(parsed.document, fallbackId);
 };
 
 export const loadLocalProfileSource = (source: ProfileSourceReference): ProfileLoadResult => {
@@ -118,16 +112,13 @@ const addProfileFromFolder = (
 };
 
 const validateProfileRecord = (record: Readonly<Record<string, unknown>>): ProfileLoadIssue | undefined => {
-  if (profileValidator(record)) {
+  const validation = validateSchema('profile', record);
+
+  if (validation.valid) {
     return undefined;
   }
 
-  const error = profileValidator.errors![0] as { readonly instancePath: string; readonly message: string };
-
-  return {
-    path: error.instancePath,
-    message: error.message,
-  };
+  return validation.issues[0];
 };
 
 const readObject = (value: unknown): Readonly<Record<string, unknown>> | undefined => {
@@ -186,5 +177,3 @@ const readEnvironment = (value: unknown): Readonly<Record<string, string>> | und
     Object.entries(environment).filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
   );
 };
-
-const readErrorMessage = (error: unknown): string => String(error);

--- a/src/settings/SettingsLoader.ts
+++ b/src/settings/SettingsLoader.ts
@@ -1,4 +1,14 @@
-// Defines settings discovery inputs before YAML parsing is implemented.
+// Discovers, parses, validates, and converts Bridl settings.yml files.
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+
+import type { ProfileSourceReference } from '../profiles/ProfileSource.js';
+import type { ValidationIssue } from '../validation/SchemaValidator.js';
+import { validateSchema } from '../validation/SchemaValidator.js';
+import { parseYamlDocument } from '../validation/YamlDocument.js';
+import type { Settings } from './Settings.js';
+import { mergeSettingsStack } from './SettingsMerger.js';
+
 export interface SettingsLocation {
   readonly scope: 'user' | 'project' | 'project-local';
   readonly path: string;
@@ -8,6 +18,121 @@ export interface SettingsLoadPlan {
   readonly locations: readonly SettingsLocation[];
 }
 
+export interface LoadedSettingsFile {
+  readonly location: SettingsLocation;
+  readonly settings: Settings;
+}
+
+export interface SettingsLoadResult {
+  readonly files: readonly LoadedSettingsFile[];
+  readonly issues: readonly SettingsLoadIssue[];
+}
+
+export interface LoadedSettings extends SettingsLoadResult {
+  readonly settings: Settings;
+}
+
+export interface SettingsLoadIssue extends ValidationIssue {
+  readonly filePath: string;
+}
+
+interface SettingsDocument {
+  readonly default_profile?: string;
+  readonly profile_sources?: readonly ProfileSourceDocument[];
+}
+
+interface ProfileSourceDocument {
+  readonly path?: string;
+  readonly uri?: string;
+  readonly only?: readonly string[];
+  readonly except?: readonly string[];
+}
+
+export interface SettingsDiscoveryInput {
+  readonly homeDirectory: string;
+  readonly projectDirectory: string;
+}
+
 export const createSettingsLoadPlan = (locations: readonly SettingsLocation[]): SettingsLoadPlan => ({
   locations,
 });
+
+export const discoverSettingsLoadPlan = (input: SettingsDiscoveryInput): SettingsLoadPlan =>
+  createSettingsLoadPlan([
+    { scope: 'user', path: join(input.homeDirectory, '.bridl', 'settings.yml') },
+    { scope: 'project', path: join(input.projectDirectory, '.bridl', 'settings.yml') },
+    { scope: 'project-local', path: join(input.projectDirectory, '.bridl', 'local', 'settings.yml') },
+  ]);
+
+export const loadSettingsFiles = (plan: SettingsLoadPlan): SettingsLoadResult => {
+  const files: LoadedSettingsFile[] = [];
+  const issues: SettingsLoadIssue[] = [];
+
+  for (const location of plan.locations) {
+    if (existsSync(location.path)) {
+      addSettingsFile(location, files, issues);
+    }
+  }
+
+  return { files, issues };
+};
+
+export const loadSettings = (plan: SettingsLoadPlan): LoadedSettings => {
+  const result = loadSettingsFiles(plan);
+
+  return {
+    ...result,
+    settings: mergeSettingsStack(result.files.map((file) => file.settings)),
+  };
+};
+
+const addSettingsFile = (
+  location: SettingsLocation,
+  files: LoadedSettingsFile[],
+  issues: SettingsLoadIssue[],
+): void => {
+  const parsed = parseYamlDocument(readFileSync(location.path, 'utf8'), location.path);
+
+  if (!parsed.ok) {
+    issues.push({ filePath: location.path, path: parsed.issue.path, message: parsed.issue.message });
+    return;
+  }
+
+  const validation = validateSchema('settings', parsed.document);
+
+  if (!validation.valid) {
+    issues.push(...validation.issues.map((issue) => ({ filePath: location.path, ...issue })));
+    return;
+  }
+
+  files.push({ location, settings: convertSettingsDocument(parsed.document as SettingsDocument, dirname(location.path)) });
+};
+
+const convertSettingsDocument = (document: SettingsDocument, settingsDirectory: string): Settings => ({
+  defaultProfile: document.default_profile,
+  profileSources: (document.profile_sources ?? []).map((source) => convertProfileSource(source, settingsDirectory)),
+});
+
+const convertProfileSource = (
+  source: ProfileSourceDocument,
+  settingsDirectory: string,
+): ProfileSourceReference => {
+  const filters = {
+    only: source.only,
+    except: source.except,
+  };
+
+  if (source.path !== undefined) {
+    return { ...filters, path: resolveProfileSourcePath(source.path, settingsDirectory) };
+  }
+
+  return { ...filters, uri: source.uri! };
+};
+
+const resolveProfileSourcePath = (sourcePath: string, settingsDirectory: string): string => {
+  if (isAbsolute(sourcePath)) {
+    return sourcePath;
+  }
+
+  return resolve(settingsDirectory, sourcePath);
+};

--- a/src/validation/SchemaValidator.ts
+++ b/src/validation/SchemaValidator.ts
@@ -1,4 +1,11 @@
-// Defines validation result types before AJV-backed schema validation is implemented.
+// Validates parsed Bridl YAML documents against bundled JSON Schemas.
+import { readFileSync } from 'node:fs';
+
+import type { AnySchema, ErrorObject, ValidateFunction } from 'ajv';
+import { Ajv2020 } from 'ajv/dist/2020.js';
+
+export type SchemaName = 'settings' | 'profile' | 'profile-source';
+
 export interface ValidationIssue {
   readonly path: string;
   readonly message: string;
@@ -9,7 +16,45 @@ export interface ValidationResult {
   readonly issues: readonly ValidationIssue[];
 }
 
+const readSchema = (schemaFileName: string): unknown =>
+  JSON.parse(readFileSync(new URL(`../schemas/${schemaFileName}`, import.meta.url), 'utf8'));
+
+const settingsSchema = readSchema('settings.schema.json');
+const profileSchema = readSchema('profile.schema.json');
+const profileSourceSchema = readSchema('profile-source.schema.json');
+
+const createAjv = (): Ajv2020 => {
+  const ajv = new Ajv2020({ allErrors: true });
+  ajv.addSchema(profileSourceSchema as AnySchema, 'profile-source.schema.json');
+  ajv.addSchema(profileSchema as AnySchema, 'profile.schema.json');
+  ajv.addSchema(settingsSchema as AnySchema, 'settings.schema.json');
+  return ajv;
+};
+
+const ajv = createAjv();
+
+const validators: Record<SchemaName, ValidateFunction> = {
+  settings: ajv.compile(settingsSchema as AnySchema),
+  profile: ajv.compile(profileSchema as AnySchema),
+  'profile-source': ajv.compile(profileSourceSchema as AnySchema),
+};
+
 export const createValidationResult = (issues: readonly ValidationIssue[]): ValidationResult => ({
   valid: issues.length === 0,
   issues,
+});
+
+export const validateSchema = (schemaName: SchemaName, document: unknown): ValidationResult => {
+  const validate = validators[schemaName];
+
+  if (validate(document)) {
+    return createValidationResult([]);
+  }
+
+  return createValidationResult((validate.errors as readonly ErrorObject[]).map(formatAjvError));
+};
+
+const formatAjvError = (error: ErrorObject): ValidationIssue => ({
+  path: error.instancePath === '' ? '/' : error.instancePath,
+  message: String(error.message),
 });

--- a/src/validation/YamlDocument.ts
+++ b/src/validation/YamlDocument.ts
@@ -1,0 +1,25 @@
+// Parses YAML text into Bridl validation-friendly document results.
+import { parse } from 'yaml';
+
+export interface ParsedYamlDocument {
+  readonly ok: true;
+  readonly document: unknown;
+}
+
+export interface YamlParseFailure {
+  readonly ok: false;
+  readonly issue: {
+    readonly path: string;
+    readonly message: string;
+  };
+}
+
+export type YamlParseResult = ParsedYamlDocument | YamlParseFailure;
+
+export const parseYamlDocument = (content: string, issuePath: string): YamlParseResult => {
+  try {
+    return { ok: true, document: parse(content) };
+  } catch (error) {
+    return { ok: false, issue: { path: issuePath, message: String(error) } };
+  }
+};

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -43,6 +43,7 @@ describe('project foundation', () => {
     expect(buildTsconfig.compilerOptions.rootDir).toBe('src');
     expect(buildTsconfig.compilerOptions.outDir).toBe('dist');
     expect(buildTsconfig.compilerOptions.types).toEqual(['node']);
+    expect(packageJson.scripts.build).toContain('shx cp src/schemas/*.json dist/schemas/');
     expect(buildTsconfig.include).toEqual(['src/**/*.ts']);
   });
 

--- a/tests/unit/settings-loader.test.ts
+++ b/tests/unit/settings-loader.test.ts
@@ -1,0 +1,131 @@
+// Tests settings.yml discovery, YAML parsing, schema validation, and merging.
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  createSettingsLoadPlan,
+  discoverSettingsLoadPlan,
+  loadSettings,
+  loadSettingsFiles,
+} from '../../src/settings/SettingsLoader.js';
+import { validateSchema } from '../../src/validation/SchemaValidator.js';
+import { parseYamlDocument } from '../../src/validation/YamlDocument.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'bridl-settings-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const writeSettings = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('settings loading', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('discovers user, project, and project-local settings.yml locations', () => {
+    const homeDirectory = '/home/example';
+    const projectDirectory = '/work/project';
+
+    const plan = discoverSettingsLoadPlan({ homeDirectory, projectDirectory });
+
+    expect(plan.locations).toEqual([
+      { scope: 'user', path: '/home/example/.bridl/settings.yml' },
+      { scope: 'project', path: '/work/project/.bridl/settings.yml' },
+      { scope: 'project-local', path: '/work/project/.bridl/local/settings.yml' },
+    ]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('loads discovered settings and merges them with project-local precedence', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    writeSettings(
+      join(homeDirectory, '.bridl', 'settings.yml'),
+      'default_profile: user-default\nprofile_sources:\n  - path: ./profiles\n',
+    );
+    writeSettings(join(projectDirectory, '.bridl', 'settings.yml'), 'default_profile: project-default\n');
+    writeSettings(join(projectDirectory, '.bridl', 'local', 'settings.yml'), 'default_profile: local-default\n');
+
+    const loaded = loadSettings(discoverSettingsLoadPlan({ homeDirectory, projectDirectory }));
+
+    expect(loaded.issues).toEqual([]);
+    expect(loaded.files.map((file) => file.location.scope)).toEqual(['user', 'project', 'project-local']);
+    expect(loaded.settings.defaultProfile).toBe('local-default');
+    expect(loaded.settings.profileSources).toEqual([
+      { path: join(homeDirectory, '.bridl', 'profiles') },
+    ]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('reports YAML parse and schema validation diagnostics with file paths', () => {
+    const root = createTemporaryRoot();
+    const malformedPath = join(root, 'malformed.yml');
+    const invalidPath = join(root, 'invalid.yml');
+    writeSettings(malformedPath, ': invalid: yaml:');
+    writeSettings(invalidPath, 'profile_sources:\n  - only:\n      - engineering\n');
+
+    const result = loadSettingsFiles(createSettingsLoadPlan([
+      { scope: 'user', path: malformedPath },
+      { scope: 'project', path: invalidPath },
+    ]));
+
+    expect(result.files).toEqual([]);
+    expect(result.issues[0]?.filePath).toBe(malformedPath);
+    expect(result.issues[0]?.path).toBe(malformedPath);
+    expect(result.issues).toContainEqual({
+      filePath: invalidPath,
+      path: '/profile_sources/0',
+      message: 'must have required property \'path\'',
+    });
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('validates profile source entries and resolves relative paths from the settings file', () => {
+    const root = createTemporaryRoot();
+    const settingsPath = join(root, '.bridl', 'settings.yml');
+    writeSettings(
+      settingsPath,
+      `profile_sources:\n  - path: ./profiles\n    only: [engineering]\n  - path: ${join(root, 'absolute-profiles')}\n  - uri: git+https://example.test/profiles.git\n    except: [sandbox]\n`,
+    );
+
+    const result = loadSettingsFiles(createSettingsLoadPlan([{ scope: 'user', path: settingsPath }]));
+
+    expect(result.issues).toEqual([]);
+    expect(result.files[0]?.settings.profileSources).toEqual([
+      { path: join(root, '.bridl', 'profiles'), only: ['engineering'] },
+      { path: join(root, 'absolute-profiles') },
+      { uri: 'git+https://example.test/profiles.git', except: ['sandbox'] },
+    ]);
+  });
+
+  it('skips missing settings files and exposes generic YAML and schema helpers', () => {
+    const root = createTemporaryRoot();
+    const missingPath = join(root, 'missing.yml');
+
+    expect(loadSettingsFiles(createSettingsLoadPlan([{ scope: 'user', path: missingPath }]))).toEqual({
+      files: [],
+      issues: [],
+    });
+    expect(parseYamlDocument('answer: 42\n', '/inline')).toEqual({ ok: true, document: { answer: 42 } });
+    expect(validateSchema('profile-source', { path: './profiles' })).toEqual({ valid: true, issues: [] });
+    expect(validateSchema('settings', null).issues[0]?.path).toBe('/');
+  });
+});


### PR DESCRIPTION
## Summary

- Add reusable YAML parsing and AJV-backed schema validation helpers.
- Implement `settings.yml` discovery/loading across user, project, and project-local scopes.
- Validate settings before conversion and resolve relative profile source paths.
- Add requirement-traced tests for phase 2 settings parsing and validation.
- Copy schema JSON files into `dist/schemas` during build so runtime validation works after compilation.

## Verification

- `npm run check-ci`
- `npm run build`
