### PR TITLE
Implement setup and sync commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ bridl run --profile engineering-default
 bridl run -p support -- --cwd ~/work/customer-issue
 bridl sync
 bridl setup
-bridl create_profile --scope user --name regulated
+bridl create_profile regulated --scope user
 ```
 
 Under the hood, `bridl` will translate a selected profile into the appropriate `pi` launch environment, such as `PI_CODING_AGENT_DIR`, CLI flags, injected extensions, prompts, model settings, session directories, and environment variables.
@@ -70,15 +70,15 @@ See [`recommendation.md`](./recommendation.md) for current notes on pi startup b
 
 ## Status
 
-This repository is currently a skeleton. The README exists primarily to preserve project intent for future development and future agent sessions.
+This repository is under phased implementation.
 
-A minimal executable CLI shell exists, with initial settings/profile schemas plus local profile loading and resolution internals. Functional end-user commands and a stable profile schema do not exist yet. The initial dependency and architecture decisions are documented in `package.json`, `doc/architecture.md`, and `requirements/`.
+A minimal executable CLI shell exists, with initial settings/profile schemas, local profile loading and resolution internals, and first-pass `setup`, `sync`, and `create_profile` / `create-profile` commands. The `run` command and stable end-to-end pi launch behavior are still in progress. The initial dependency and architecture decisions are documented in `package.json`, `doc/architecture.md`, and `requirements/`.
 
 ## Future work
 
 - Define a stable profile schema.
 - Decide where organization-managed profiles are discovered from.
-- Implement `bridl run <profile>`.
+- Implement stable `bridl run --profile <profile>` behavior.
 - Add validation and inspection commands.
 - Wire resolved profile inheritance and composition into user-facing commands.
 - Add locking / policy controls for business-managed environments.

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -173,7 +173,7 @@ profile_sources:
 ~/.bridl/cache/profiles/<encoded-uri>/
 ```
 
-The encoding should preserve meaningful segments such as site, organization, repository, ref/tag, and path when available, while allowing non-GitHub URIs.
+The encoded path must be filesystem-safe and deterministic for arbitrary URI strings, including non-GitHub URIs.
 
 ## Profile Layout
 
@@ -369,9 +369,9 @@ Creates a placeholder profile folder at a requested scope.
 Example shape:
 
 ```bash
-bridl create_profile --scope user --name engineering
-bridl create_profile --scope project --name support
-bridl create_profile --scope project-local --name sandbox
+bridl create_profile engineering --scope user
+bridl create_profile support --scope project
+bridl create_profile sandbox --scope project-local
 ```
 
 Responsibilities:

--- a/doc/file_structure.md
+++ b/doc/file_structure.md
@@ -31,6 +31,7 @@ Bridl is organized around clear TypeScript source boundaries, requirement docume
 │   │   └── SettingsMerger.ts
 │   ├── profiles/                      # profile loading, validation, resolution, and merging
 │   │   ├── Profile.ts
+│   │   ├── ProfileCache.ts
 │   │   ├── ProfileLoader.ts
 │   │   ├── ProfileMerger.ts
 │   │   └── ProfileSource.ts

--- a/plan.md
+++ b/plan.md
@@ -18,19 +18,23 @@ This plan describes the order of work. Formal obligations live in `requirements/
 
 ## Phase 3: Profile sources and profile resolution — Done
 
+Merged in PR #6 (`phase-3-profile-resolution`).
+
 - [x] Implement local profile source loading and `only` / `except` filters.
 - [x] Implement profile folder validation and `profile.yml` parsing.
 - [x] Implement profile scope precedence and merge behavior.
 - [x] Implement inheritance resolution, default-profile inclusion, and cycle detection.
 - [x] Add scenario fixtures for common source, inheritance, and precedence combinations.
 
-## Phase 4: Setup and sync commands
+## Phase 4: Setup and sync commands — Done
 
-- Implement `setup` as a command object that creates initial user settings and a default profile.
-- Implement URI source cache path encoding.
-- Implement `sync` for URI-based profile sources.
-- Validate synced profiles and produce clear command output.
-- Implement `create_profile` and the `create-profile` alias against the same command object.
+Implemented in `phase-4-setup-sync`.
+
+- [x] Implement `setup` as a command object that creates initial user settings and a default profile.
+- [x] Implement URI source cache path encoding.
+- [x] Implement `sync` for URI-based profile sources.
+- [x] Validate synced profiles and produce clear command output.
+- [x] Implement `create_profile` and the `create-profile` alias against the same command object.
 
 ## Phase 5: Tack assembly core
 

--- a/src/cli/commands/CreateProfileCommand.ts
+++ b/src/cli/commands/CreateProfileCommand.ts
@@ -1,16 +1,156 @@
-// Provides the placeholder command object for creating a Bridl profile folder.
+// Provides the command object for creating a Bridl profile folder.
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
 import type { Command } from 'commander';
 
+import { isValidProfileId } from '../../profiles/ProfileLoader.js';
 import type { CommandObject } from './CommandObject.js';
 
-export const createCreateProfileCommand = (): CommandObject => {
+export type CreateProfileScope = 'user' | 'project' | 'project-local';
+
+export interface CreateProfileInput {
+  readonly name: string;
+  readonly scope?: CreateProfileScope;
+  readonly path?: string;
+  readonly homeDirectory: string;
+  readonly projectDirectory: string;
+}
+
+export interface CreateProfileResult {
+  readonly profileDirectory: string;
+  readonly profilePath: string;
+  readonly createdDirectories: readonly string[];
+  readonly createdProfile: boolean;
+  readonly messages: readonly string[];
+}
+
+interface CreateProfileOptions {
+  readonly scope?: string;
+  readonly path?: string;
+}
+
+export interface CreateProfileCommandDependencies {
+  readonly homeDirectory?: string;
+  readonly projectDirectory?: string;
+  readonly writeLine?: (message: string) => void;
+}
+
+export const executeCreateProfileCommand = (input: CreateProfileInput): CreateProfileResult => {
+  assertValidCreateProfileInput(input);
+
+  const profileRoot = resolveProfileRoot(input);
+  const profileDirectory = join(profileRoot, input.name);
+  const profilePath = join(profileDirectory, 'profile.yml');
+  const resourceDirectories = ['prompts', 'skills', 'extensions', join('cli_specific', 'pi')].map((resourcePath) =>
+    join(profileDirectory, resourcePath),
+  );
+  const createdDirectories: string[] = [];
+
+  if (!existsSync(profileDirectory)) {
+    mkdirSync(profileDirectory, { recursive: true });
+    createdDirectories.push(profileDirectory);
+  }
+
+  for (const resourceDirectory of resourceDirectories) {
+    if (!existsSync(resourceDirectory)) {
+      mkdirSync(resourceDirectory, { recursive: true });
+      createdDirectories.push(resourceDirectory);
+    }
+  }
+
+  const createdProfile = !existsSync(profilePath);
+
+  if (createdProfile) {
+    writeFileSync(profilePath, createPlaceholderProfileYaml(input.name));
+  }
+
+  return {
+    profileDirectory,
+    profilePath,
+    createdDirectories,
+    createdProfile,
+    messages: [
+      createdProfile
+        ? `Created profile '${input.name}' at ${profileDirectory}.`
+        : `Profile '${input.name}' already exists at ${profileDirectory}; left profile.yml unchanged.`,
+    ],
+  };
+};
+
+export const createCreateProfileCommand = (dependencies: CreateProfileCommandDependencies = {}): CommandObject => {
   const command: CommandObject = {
     name: 'create_profile',
     description: 'Create a new Bridl profile skeleton.',
     register(program: Command): void {
-      program.command(command.name).alias('create-profile').description(command.description);
+      program
+        .command(command.name)
+        .alias('create-profile')
+        .description(command.description)
+        .argument('<name>', 'filesystem-safe profile name')
+        .option('--scope <scope>', 'destination scope: user, project, or project-local')
+        .option('--path <path>', 'destination profile source directory')
+        .action((name: string, options: CreateProfileOptions) => {
+          const result = executeCreateProfileCommand({
+            name,
+            scope: readCreateProfileScope(options.scope),
+            path: options.path,
+            /* v8 ignore next -- default process home is exercised by the direct CLI entrypoint, not unit tests. */
+            homeDirectory: dependencies.homeDirectory ?? homedir(),
+            /* v8 ignore next -- default process cwd is exercised by the direct CLI entrypoint, not unit tests. */
+            projectDirectory: dependencies.projectDirectory ?? process.cwd(),
+          });
+
+          for (const message of result.messages) {
+            /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
+            (dependencies.writeLine ?? console.log)(message);
+          }
+        });
     },
   };
 
   return command;
+};
+
+const assertValidCreateProfileInput = (input: CreateProfileInput): void => {
+  if (!isValidProfileId(input.name)) {
+    throw new Error(`Profile name '${input.name}' is not a filesystem-safe Bridl profile id.`);
+  }
+
+  if ((input.scope === undefined && input.path === undefined) || (input.scope !== undefined && input.path !== undefined)) {
+    throw new Error('Create profile requires exactly one destination: --scope or --path.');
+  }
+};
+
+const resolveProfileRoot = (input: CreateProfileInput): string => {
+  if (input.path !== undefined) {
+    return input.path;
+  }
+
+  switch (input.scope) {
+    case 'user':
+      return join(input.homeDirectory, '.bridl', 'profiles');
+    case 'project':
+      return join(input.projectDirectory, '.bridl', 'profiles');
+    case 'project-local':
+      return join(input.projectDirectory, '.bridl', 'local', 'profiles');
+    /* v8 ignore next 2 -- assertValidCreateProfileInput rejects missing scopes before this exhaustive guard. */
+    default:
+      throw new Error('Create profile requires exactly one destination: --scope or --path.');
+  }
+};
+
+const createPlaceholderProfileYaml = (profileId: string): string => `id: ${profileId}\nlabel: ${profileId}\ncontrols: {}\n`;
+
+const readCreateProfileScope = (scope: string | undefined): CreateProfileScope | undefined => {
+  if (scope === undefined) {
+    return undefined;
+  }
+
+  if (scope === 'user' || scope === 'project' || scope === 'project-local') {
+    return scope;
+  }
+
+  throw new Error(`Unknown profile scope '${scope}'. Expected user, project, or project-local.`);
 };

--- a/src/cli/commands/SetupCommand.ts
+++ b/src/cli/commands/SetupCommand.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path';
 
 import type { Command } from 'commander';
 
+import { isValidProfileId } from '../../profiles/ProfileLoader.js';
 import { discoverSettingsLoadPlan, loadSettings } from '../../settings/SettingsLoader.js';
 import type { CommandObject } from './CommandObject.js';
 import type { SyncCommandDependencies, SyncCommandResult } from './SyncCommand.js';
@@ -31,14 +32,17 @@ export const executeSetupCommand = (
   dependencies: SetupCommandDependencies = {},
 ): SetupCommandResult => {
   const settingsPath = join(input.homeDirectory, '.bridl', 'settings.yml');
-  const createdSettings = createInitialSettingsIfMissing(settingsPath);
+  const initialSettingsMissing = !existsSync(settingsPath);
   const loadedSettings = loadSettings(discoverSettingsLoadPlan(input));
 
   if (loadedSettings.issues.length > 0) {
     throw new Error(`Cannot setup with invalid settings: ${loadedSettings.issues.map(formatSettingsIssue).join('; ')}`);
   }
 
-  const defaultProfileId = loadedSettings.settings.defaultProfile ?? 'default';
+  const defaultProfileId = initialSettingsMissing ? 'default' : readUserDefaultProfileId(loadedSettings.files);
+  assertValidDefaultProfileId(defaultProfileId);
+
+  const createdSettings = createInitialSettingsIfMissing(settingsPath);
   const defaultProfilePath = join(input.homeDirectory, '.bridl', 'profiles', defaultProfileId, 'profile.yml');
   const createdDefaultProfile = createDefaultProfileIfMissing(defaultProfilePath, defaultProfileId);
   const syncResult = executeSyncCommand(input, dependencies);
@@ -84,6 +88,16 @@ export const createSetupCommand = (dependencies: SetupCommandDependencies = {}):
   };
 
   return command;
+};
+
+const readUserDefaultProfileId = (
+  files: readonly { readonly location: { readonly scope: string }; readonly settings: { readonly defaultProfile?: string } }[],
+): string => files.find((file) => file.location.scope === 'user')?.settings.defaultProfile ?? 'default';
+
+const assertValidDefaultProfileId = (profileId: string): void => {
+  if (!isValidProfileId(profileId)) {
+    throw new Error(`Default profile '${profileId}' is not a filesystem-safe Bridl profile id.`);
+  }
 };
 
 const createInitialSettingsIfMissing = (settingsPath: string): boolean => {

--- a/src/cli/commands/SetupCommand.ts
+++ b/src/cli/commands/SetupCommand.ts
@@ -1,16 +1,110 @@
-// Provides the placeholder command object for first-run Bridl setup.
+// Provides the command object for first-run Bridl setup.
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
 import type { Command } from 'commander';
 
+import { discoverSettingsLoadPlan, loadSettings } from '../../settings/SettingsLoader.js';
 import type { CommandObject } from './CommandObject.js';
+import type { SyncCommandDependencies, SyncCommandResult } from './SyncCommand.js';
+import { executeSyncCommand } from './SyncCommand.js';
 
-export const createSetupCommand = (): CommandObject => {
+export interface SetupCommandInput {
+  readonly homeDirectory: string;
+  readonly projectDirectory: string;
+}
+
+export interface SetupCommandResult {
+  readonly settingsPath: string;
+  readonly defaultProfilePath: string;
+  readonly createdSettings: boolean;
+  readonly createdDefaultProfile: boolean;
+  readonly syncResult: SyncCommandResult;
+  readonly messages: readonly string[];
+}
+
+export type SetupCommandDependencies = SyncCommandDependencies;
+
+export const executeSetupCommand = (
+  input: SetupCommandInput,
+  dependencies: SetupCommandDependencies = {},
+): SetupCommandResult => {
+  const settingsPath = join(input.homeDirectory, '.bridl', 'settings.yml');
+  const createdSettings = createInitialSettingsIfMissing(settingsPath);
+  const loadedSettings = loadSettings(discoverSettingsLoadPlan(input));
+
+  if (loadedSettings.issues.length > 0) {
+    throw new Error(`Cannot setup with invalid settings: ${loadedSettings.issues.map(formatSettingsIssue).join('; ')}`);
+  }
+
+  const defaultProfileId = loadedSettings.settings.defaultProfile ?? 'default';
+  const defaultProfilePath = join(input.homeDirectory, '.bridl', 'profiles', defaultProfileId, 'profile.yml');
+  const createdDefaultProfile = createDefaultProfileIfMissing(defaultProfilePath, defaultProfileId);
+  const syncResult = executeSyncCommand(input, dependencies);
+
+  return {
+    settingsPath,
+    defaultProfilePath,
+    createdSettings,
+    createdDefaultProfile,
+    syncResult,
+    messages: [
+      createdSettings ? `Created user settings at ${settingsPath}.` : `User settings already exists at ${settingsPath}; left unchanged.`,
+      createdDefaultProfile
+        ? `Created default user profile '${defaultProfileId}' at ${defaultProfilePath}.`
+        : `Default user profile '${defaultProfileId}' already exists at ${defaultProfilePath}; left unchanged.`,
+      ...syncResult.messages,
+    ],
+  };
+};
+
+export const createSetupCommand = (dependencies: SetupCommandDependencies = {}): CommandObject => {
   const command: CommandObject = {
     name: 'setup',
     description: 'Create initial Bridl settings and a default profile.',
     register(program: Command): void {
-      program.command(command.name).description(command.description);
+      program.command(command.name).description(command.description).action(() => {
+        const result = executeSetupCommand(
+          {
+            /* v8 ignore next -- default process home is exercised by the direct CLI entrypoint, not unit tests. */
+            homeDirectory: dependencies.homeDirectory ?? homedir(),
+            /* v8 ignore next -- default process cwd is exercised by the direct CLI entrypoint, not unit tests. */
+            projectDirectory: dependencies.projectDirectory ?? process.cwd(),
+          },
+          dependencies,
+        );
+
+        for (const message of result.messages) {
+          /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
+          (dependencies.writeLine ?? console.log)(message);
+        }
+      });
     },
   };
 
   return command;
 };
+
+const createInitialSettingsIfMissing = (settingsPath: string): boolean => {
+  if (existsSync(settingsPath)) {
+    return false;
+  }
+
+  mkdirSync(dirname(settingsPath), { recursive: true });
+  writeFileSync(settingsPath, 'default_profile: default\nprofile_sources:\n  - path: ./profiles\n');
+  return true;
+};
+
+const createDefaultProfileIfMissing = (profilePath: string, profileId: string): boolean => {
+  if (existsSync(profilePath)) {
+    return false;
+  }
+
+  mkdirSync(dirname(profilePath), { recursive: true });
+  writeFileSync(profilePath, `id: ${profileId}\nlabel: Default\ncontrols: {}\n`);
+  return true;
+};
+
+const formatSettingsIssue = (issue: { readonly filePath: string; readonly path: string; readonly message: string }): string =>
+  `${issue.filePath}#${issue.path} ${issue.message}`;

--- a/src/cli/commands/SyncCommand.ts
+++ b/src/cli/commands/SyncCommand.ts
@@ -1,16 +1,172 @@
-// Provides the placeholder command object for synchronizing profile sources.
-import type { Command } from 'commander';
+// Provides the command object for synchronizing URI-backed profile sources.
+import { existsSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname } from 'node:path';
 
+import type { Command } from 'commander';
+import spawn from 'cross-spawn';
+
+import { createProfileSourceCachePath, normalizeGitUri, redactProfileSourceUriCredentials } from '../../profiles/ProfileCache.js';
+import { loadLocalProfileSource } from '../../profiles/ProfileLoader.js';
+import type { ProfileSourceReference } from '../../profiles/ProfileSource.js';
+import { discoverSettingsLoadPlan, loadSettings } from '../../settings/SettingsLoader.js';
 import type { CommandObject } from './CommandObject.js';
 
-export const createSyncCommand = (): CommandObject => {
+export type SyncSourceStatus = 'updated' | 'unchanged' | 'skipped' | 'failed';
+
+export interface SyncCommandInput {
+  readonly homeDirectory: string;
+  readonly projectDirectory: string;
+}
+
+export interface SyncSourceResult {
+  readonly uri: string;
+  readonly cachePath: string;
+  readonly status: SyncSourceStatus;
+  readonly message: string;
+}
+
+export interface SyncCommandResult {
+  readonly sources: readonly SyncSourceResult[];
+  readonly messages: readonly string[];
+}
+
+export interface UriProfileSourceSynchronizer {
+  sync(source: ProfileSourceReference & { readonly uri: string }, cachePath: string): SyncSourceStatus;
+}
+
+export interface SyncCommandDependencies {
+  readonly synchronizer?: UriProfileSourceSynchronizer;
+  readonly homeDirectory?: string;
+  readonly projectDirectory?: string;
+  readonly writeLine?: (message: string) => void;
+}
+
+export const executeSyncCommand = (
+  input: SyncCommandInput,
+  dependencies: SyncCommandDependencies = {},
+): SyncCommandResult => {
+  const loadedSettings = loadSettings(discoverSettingsLoadPlan(input));
+
+  if (loadedSettings.issues.length > 0) {
+    throw new Error(`Cannot sync with invalid settings: ${loadedSettings.issues.map(formatSettingsIssue).join('; ')}`);
+  }
+
+  const uriSources = loadedSettings.settings.profileSources.filter(hasUri);
+  const synchronizer = dependencies.synchronizer ?? createGitSynchronizer();
+  const sourceResults = uriSources.map((source) => syncUriSource(input.homeDirectory, source, synchronizer));
+
+  return {
+    sources: sourceResults,
+    messages: sourceResults.length === 0
+      ? ['No URI profile sources configured; nothing to sync.']
+      : sourceResults.map((result) => `${result.status}: ${result.uri} -> ${result.cachePath} (${result.message})`),
+  };
+};
+
+export const createSyncCommand = (dependencies: SyncCommandDependencies = {}): CommandObject => {
   const command: CommandObject = {
     name: 'sync',
     description: 'Synchronize URI-backed Bridl profile sources into the local cache.',
     register(program: Command): void {
-      program.command(command.name).description(command.description);
+      program.command(command.name).description(command.description).action(() => {
+        const result = executeSyncCommand(
+          {
+            /* v8 ignore next -- default process home is exercised by the direct CLI entrypoint, not unit tests. */
+            homeDirectory: dependencies.homeDirectory ?? homedir(),
+            /* v8 ignore next -- default process cwd is exercised by the direct CLI entrypoint, not unit tests. */
+            projectDirectory: dependencies.projectDirectory ?? process.cwd(),
+          },
+          dependencies,
+        );
+
+        for (const message of result.messages) {
+          /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
+          (dependencies.writeLine ?? console.log)(message);
+        }
+      });
     },
   };
 
   return command;
 };
+
+const syncUriSource = (
+  homeDirectory: string,
+  source: ProfileSourceReference & { readonly uri: string },
+  synchronizer: UriProfileSourceSynchronizer,
+): SyncSourceResult => {
+  const cachePath = createProfileSourceCachePath(homeDirectory, source.uri);
+  const displayUri = redactProfileSourceUriCredentials(source.uri);
+
+  try {
+    const status = synchronizer.sync(source, cachePath);
+    const validation = loadLocalProfileSource({ path: cachePath, only: source.only, except: source.except });
+
+    if (validation.issues.length > 0) {
+      return {
+        uri: displayUri,
+        cachePath,
+        status: 'failed',
+        message: `Synced source failed profile validation: ${validation.issues.map(formatProfileIssue).join('; ')}`,
+      };
+    }
+
+    return {
+      uri: displayUri,
+      cachePath,
+      status,
+      message: validation.profiles.length === 1
+        ? '1 profile validated.'
+        : `${validation.profiles.length} profiles validated.`,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    return {
+      uri: displayUri,
+      cachePath,
+      status: 'failed',
+      message: redactSensitiveText(message, source.uri),
+    };
+  }
+};
+
+const createGitSynchronizer = (): UriProfileSourceSynchronizer => ({
+  sync(source, cachePath) {
+    mkdirSync(dirname(cachePath), { recursive: true });
+
+    if (existsSync(cachePath)) {
+      runGit(['-C', cachePath, 'pull', '--ff-only']);
+      return 'updated';
+    }
+
+    runGit(['clone', normalizeGitUri(source.uri), cachePath]);
+    return 'updated';
+  },
+});
+
+const runGit = (args: readonly string[]): void => {
+  const result = spawn.sync('git', args, { stdio: 'pipe', encoding: 'utf8' });
+
+  if (result.status !== 0) {
+    /* v8 ignore next -- the final fallback only applies if git emits no stdout or stderr. */
+    throw new Error((result.stderr || result.stdout || `git ${args.join(' ')} failed`).trim());
+  }
+};
+
+const hasUri = (source: ProfileSourceReference): source is ProfileSourceReference & { readonly uri: string } =>
+  source.uri !== undefined;
+
+const redactSensitiveText = (message: string, uri: string): string =>
+  message
+    .split(uri)
+    .join(redactProfileSourceUriCredentials(uri))
+    .split(normalizeGitUri(uri))
+    .join(redactProfileSourceUriCredentials(normalizeGitUri(uri)));
+
+const formatSettingsIssue = (issue: { readonly filePath: string; readonly path: string; readonly message: string }): string =>
+  `${issue.filePath}#${issue.path} ${issue.message}`;
+
+const formatProfileIssue = (issue: { readonly path: string; readonly message: string }): string =>
+  `${issue.path} ${issue.message}`;

--- a/src/profiles/ProfileCache.ts
+++ b/src/profiles/ProfileCache.ts
@@ -1,0 +1,29 @@
+// Encodes URI-backed profile source cache paths.
+import { join } from 'node:path';
+
+export const encodeProfileSourceUri = (uri: string): string =>
+  Buffer.from(redactProfileSourceUriCredentials(uri), 'utf8').toString('base64url');
+
+export const createProfileSourceCachePath = (homeDirectory: string, uri: string): string =>
+  join(homeDirectory, '.bridl', 'cache', 'profiles', encodeProfileSourceUri(uri));
+
+export const redactProfileSourceUriCredentials = (uri: string): string => {
+  const prefix = uri.startsWith('git+') ? 'git+' : '';
+  const normalizedUri = normalizeGitUri(uri);
+
+  try {
+    const parsedUri = new URL(normalizedUri);
+
+    if (parsedUri.username === '' && parsedUri.password === '') {
+      return uri;
+    }
+
+    parsedUri.username = 'REDACTED';
+    parsedUri.password = '';
+    return `${prefix}${parsedUri.toString()}`;
+  } catch {
+    return uri.replace(/\/\/[^/@\s]+@/u, '//REDACTED@');
+  }
+};
+
+export const normalizeGitUri = (uri: string): string => uri.startsWith('git+') ? uri.slice('git+'.length) : uri;

--- a/tests/unit/phase4-commands.test.ts
+++ b/tests/unit/phase4-commands.test.ts
@@ -119,8 +119,29 @@ describe('phase 4 setup and sync commands', () => {
     const fallbackDefaultResult = executeSetupCommand({ homeDirectory: fallbackHomeDirectory, projectDirectory });
     expect(fallbackDefaultResult.defaultProfilePath).toBe(join(fallbackHomeDirectory, '.bridl', 'profiles', 'default', 'profile.yml'));
 
+    const projectDefaultHomeDirectory = join(root, 'project-default-home');
+    const projectDefaultDirectory = join(root, 'project-default');
+    mkdirSync(join(projectDefaultDirectory, '.bridl'), { recursive: true });
+    writeFileSync(join(projectDefaultDirectory, '.bridl', 'settings.yml'), 'default_profile: remote\n');
+    const projectDefaultResult = executeSetupCommand({ homeDirectory: projectDefaultHomeDirectory, projectDirectory: projectDefaultDirectory });
+    expect(readFileSync(projectDefaultResult.settingsPath, 'utf8')).toContain('default_profile: default');
+    expect(projectDefaultResult.defaultProfilePath).toBe(join(projectDefaultHomeDirectory, '.bridl', 'profiles', 'default', 'profile.yml'));
+
+    const unsafeDefaultHomeDirectory = join(root, 'unsafe-default-home');
+    writeSettings(unsafeDefaultHomeDirectory, 'default_profile: ../../outside\n');
+    expect(() => executeSetupCommand({ homeDirectory: unsafeDefaultHomeDirectory, projectDirectory })).toThrow('filesystem-safe');
+    expect(existsSync(join(root, 'outside', 'profile.yml'))).toBe(false);
+
     writeSettings(homeDirectory, 'profile_sources:\n  - only: [remote]\n');
     expect(() => executeSetupCommand({ homeDirectory, projectDirectory })).toThrow('Cannot setup with invalid settings');
+
+    const invalidProjectHomeDirectory = join(root, 'invalid-project-home');
+    const invalidProjectDirectory = join(root, 'invalid-project');
+    mkdirSync(join(invalidProjectDirectory, '.bridl'), { recursive: true });
+    writeFileSync(join(invalidProjectDirectory, '.bridl', 'settings.yml'), 'profile_sources:\n  - only: [remote]\n');
+    expect(() => executeSetupCommand({ homeDirectory: invalidProjectHomeDirectory, projectDirectory: invalidProjectDirectory }))
+      .toThrow('Cannot setup with invalid settings');
+    expect(existsSync(join(invalidProjectHomeDirectory, '.bridl', 'settings.yml'))).toBe(false);
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-004.2).

--- a/tests/unit/phase4-commands.test.ts
+++ b/tests/unit/phase4-commands.test.ts
@@ -1,0 +1,373 @@
+// Tests setup, sync, URI cache encoding, and profile creation command behavior.
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { Command } from 'commander';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  executeCreateProfileCommand,
+  createCreateProfileCommand,
+} from '../../src/cli/commands/CreateProfileCommand.js';
+import { createSetupCommand, executeSetupCommand } from '../../src/cli/commands/SetupCommand.js';
+import { createSyncCommand, executeSyncCommand } from '../../src/cli/commands/SyncCommand.js';
+import { createProfileSourceCachePath, encodeProfileSourceUri, normalizeGitUri } from '../../src/profiles/ProfileCache.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'bridl-phase4-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const writeSettings = (homeDirectory: string, content: string): void => {
+  const settingsDirectory = join(homeDirectory, '.bridl');
+  mkdirSync(settingsDirectory, { recursive: true });
+  writeFileSync(join(settingsDirectory, 'settings.yml'), content);
+};
+
+const writeCachedProfile = (cachePath: string, profileId = 'remote'): void => {
+  const profileDirectory = join(cachePath, profileId);
+  mkdirSync(profileDirectory, { recursive: true });
+  writeFileSync(join(profileDirectory, 'profile.yml'), `id: ${profileId}\ncontrols: {}\n`);
+};
+
+const createGitProfileRepository = (root: string): string => {
+  const repositoryPath = join(root, 'remote-profiles');
+  writeCachedProfile(repositoryPath, 'remote');
+  execFileSync('git', ['init'], { cwd: repositoryPath, stdio: 'pipe' });
+  execFileSync('git', ['add', '.'], { cwd: repositoryPath, stdio: 'pipe' });
+  execFileSync('git', ['-c', 'user.name=Bridl Test', '-c', 'user.email=bridl@example.test', 'commit', '-m', 'profiles'], {
+    cwd: repositoryPath,
+    stdio: 'pipe',
+  });
+  return repositoryPath;
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('phase 4 setup and sync commands', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.4, BRIDL-REQ-004.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('creates initial user settings and a default user profile without overwriting existing files', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+
+    const firstResult = executeSetupCommand({ homeDirectory, projectDirectory });
+    const settingsPath = join(homeDirectory, '.bridl', 'settings.yml');
+    const defaultProfilePath = join(homeDirectory, '.bridl', 'profiles', 'default', 'profile.yml');
+
+    expect(firstResult.createdSettings).toBe(true);
+    expect(firstResult.createdDefaultProfile).toBe(true);
+    expect(readFileSync(settingsPath, 'utf8')).toBe('default_profile: default\nprofile_sources:\n  - path: ./profiles\n');
+    expect(readFileSync(defaultProfilePath, 'utf8')).toBe('id: default\nlabel: Default\ncontrols: {}\n');
+    expect(firstResult.messages).toContain('No URI profile sources configured; nothing to sync.');
+
+    writeFileSync(defaultProfilePath, 'id: default\nlabel: Custom\n');
+    const secondResult = executeSetupCommand({ homeDirectory, projectDirectory });
+
+    expect(secondResult.createdSettings).toBe(false);
+    expect(secondResult.createdDefaultProfile).toBe(false);
+    expect(readFileSync(defaultProfilePath, 'utf8')).toBe('id: default\nlabel: Custom\n');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-004.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('validates discovered settings before setup and runs URI sync behavior', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const uri = 'ssh://git.example.test/team/profiles';
+    writeSettings(homeDirectory, `default_profile: remote\nprofile_sources:\n  - uri: ${uri}\n`);
+
+    const result = executeSetupCommand(
+      { homeDirectory, projectDirectory },
+      {
+        synchronizer: {
+          sync(source, cachePath) {
+            expect(source.uri).toBe(uri);
+            writeCachedProfile(cachePath);
+            return 'unchanged';
+          },
+        },
+      },
+    );
+
+    expect(result.createdSettings).toBe(false);
+    expect(result.createdDefaultProfile).toBe(true);
+    expect(result.syncResult.sources).toEqual([
+      {
+        uri,
+        cachePath: createProfileSourceCachePath(homeDirectory, uri),
+        status: 'unchanged',
+        message: '1 profile validated.',
+      },
+    ]);
+
+    const fallbackHomeDirectory = join(root, 'fallback-home');
+    writeSettings(fallbackHomeDirectory, 'profile_sources: []\n');
+    const fallbackDefaultResult = executeSetupCommand({ homeDirectory: fallbackHomeDirectory, projectDirectory });
+    expect(fallbackDefaultResult.defaultProfilePath).toBe(join(fallbackHomeDirectory, '.bridl', 'profiles', 'default', 'profile.yml'));
+
+    writeSettings(homeDirectory, 'profile_sources:\n  - only: [remote]\n');
+    expect(() => executeSetupCommand({ homeDirectory, projectDirectory })).toThrow('Cannot setup with invalid settings');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-004.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('encodes URI cache paths for arbitrary URIs and validates synced profiles', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const firstUri = 'git+https://example.test/team/profiles.git?ref=v1';
+    const secondUri = 'file:///tmp/non-github profiles';
+    writeSettings(
+      homeDirectory,
+      `profile_sources:\n  - uri: ${firstUri}\n  - uri: ${secondUri}\n    only: [remote]\n  - path: ./profiles\n`,
+    );
+
+    const syncedUris: string[] = [];
+    const result = executeSyncCommand(
+      { homeDirectory, projectDirectory },
+      {
+        synchronizer: {
+          sync(source, cachePath) {
+            syncedUris.push(source.uri);
+            writeCachedProfile(cachePath);
+            return source.uri === firstUri ? 'updated' : 'skipped';
+          },
+        },
+      },
+    );
+
+    expect(encodeProfileSourceUri(firstUri)).toMatch(/^[A-Za-z0-9_-]+$/u);
+    expect(createProfileSourceCachePath(homeDirectory, firstUri)).toBe(
+      join(homeDirectory, '.bridl', 'cache', 'profiles', encodeProfileSourceUri(firstUri)),
+    );
+    expect(syncedUris).toEqual([firstUri, secondUri]);
+    expect(result.sources.map((source) => source.status)).toEqual(['updated', 'skipped']);
+    expect(result.messages[0]).toContain(`${firstUri} -> ${createProfileSourceCachePath(homeDirectory, firstUri)}`);
+  });
+
+  it('redacts URI credentials from sync results and messages', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const uri = 'git+https://user:secret@example.test/team/profiles.git';
+    const failedUri = 'https://token@example.test/private/profiles.git';
+    const unparsableUri = '//deploy-key@example.test/private/profiles.git';
+    writeSettings(homeDirectory, `profile_sources:\n  - uri: ${uri}\n  - uri: ${failedUri}\n  - uri: '${unparsableUri}'\n`);
+
+    const result = executeSyncCommand(
+      { homeDirectory, projectDirectory },
+      {
+        synchronizer: {
+          sync(source, cachePath) {
+            if (source.uri === failedUri || source.uri === unparsableUri) {
+              throw new Error(`Could not fetch ${source.uri}`);
+            }
+
+            writeCachedProfile(cachePath);
+            return 'updated';
+          },
+        },
+      },
+    );
+
+    expect(result.sources[0]?.uri).toBe('git+https://REDACTED@example.test/team/profiles.git');
+    expect(result.sources[1]?.uri).toBe('https://REDACTED@example.test/private/profiles.git');
+    expect(result.sources[2]?.uri).toBe('//REDACTED@example.test/private/profiles.git');
+    expect(result.messages[0]).toContain('git+https://REDACTED@example.test/team/profiles.git');
+    expect(result.messages[1]).toContain('Could not fetch https://REDACTED@example.test/private/profiles.git');
+    expect(result.messages[2]).toContain('Could not fetch //REDACTED@example.test/private/profiles.git');
+    expect(result.messages.join('\n')).not.toContain('secret');
+    expect(result.messages.join('\n')).not.toContain('token');
+    expect(result.messages.join('\n')).not.toContain('deploy-key');
+    expect(result.sources[0]?.cachePath).toBe(createProfileSourceCachePath(homeDirectory, uri));
+    expect(Buffer.from(encodeProfileSourceUri(uri), 'base64url').toString('utf8')).not.toContain('secret');
+    expect(Buffer.from(encodeProfileSourceUri(normalizeGitUri(uri)), 'base64url').toString('utf8')).not.toContain('secret');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-004.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('fetches URI profile sources with the default git synchronizer and updates existing caches', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const repositoryPath = createGitProfileRepository(root);
+    const uri = `git+file://${repositoryPath}`;
+    writeSettings(homeDirectory, `profile_sources:\n  - uri: ${uri}\n`);
+
+    const firstResult = executeSyncCommand({ homeDirectory, projectDirectory });
+    const secondResult = executeSyncCommand({ homeDirectory, projectDirectory });
+    const failedUri = `file://${join(root, 'missing-repository')}`;
+    writeSettings(homeDirectory, `profile_sources:\n  - uri: ${failedUri}\n`);
+    const failedResult = executeSyncCommand({ homeDirectory, projectDirectory });
+
+    expect(firstResult.sources).toEqual([
+      {
+        uri,
+        cachePath: createProfileSourceCachePath(homeDirectory, uri),
+        status: 'updated',
+        message: '1 profile validated.',
+      },
+    ]);
+    expect(secondResult.sources[0]?.status).toBe('updated');
+    expect(failedResult.sources[0]?.status).toBe('failed');
+    expect(failedResult.sources[0]?.message).toContain('does not appear to be a git repository');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-004.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('reports sync validation failures, synchronizer failures, invalid settings, and no-op syncs clearly', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const invalidProfileUri = 'https://example.test/invalid.git';
+    const failedUri = 'https://example.test/fail.git';
+    const stringFailureUri = 'https://example.test/string-fail.git';
+    const emptyUri = 'https://example.test/empty.git';
+    writeSettings(
+      homeDirectory,
+      `profile_sources:\n  - uri: ${invalidProfileUri}\n  - uri: ${failedUri}\n  - uri: ${stringFailureUri}\n  - uri: ${emptyUri}\n`,
+    );
+
+    const result = executeSyncCommand(
+      { homeDirectory, projectDirectory },
+      {
+        synchronizer: {
+          sync(source, cachePath) {
+            if (source.uri === failedUri) {
+              throw new Error('network unavailable');
+            }
+
+            if (source.uri === stringFailureUri) {
+              // eslint-disable-next-line @typescript-eslint/only-throw-error -- covers defensive formatting for non-Error throw values from injected dependencies.
+              throw 'string failure';
+            }
+
+            if (source.uri === emptyUri) {
+              mkdirSync(cachePath, { recursive: true });
+              return 'unchanged';
+            }
+
+            const profileDirectory = join(cachePath, 'broken');
+            mkdirSync(profileDirectory, { recursive: true });
+            writeFileSync(join(profileDirectory, 'profile.yml'), 'controls:\n  environment:\n    COUNT: 1\n');
+            return 'updated';
+          },
+        },
+      },
+    );
+
+    expect(result.sources.map((source) => source.status)).toEqual(['failed', 'failed', 'failed', 'unchanged']);
+    expect(result.sources[0]?.message).toContain('failed profile validation');
+    expect(result.sources[1]?.message).toBe('network unavailable');
+    expect(result.sources[2]?.message).toBe('string failure');
+    expect(result.sources[3]?.message).toBe('0 profiles validated.');
+
+    writeSettings(homeDirectory, 'profile_sources:\n  - only: [missing-source]\n');
+    expect(() => executeSyncCommand({ homeDirectory, projectDirectory })).toThrow('Cannot sync with invalid settings');
+
+    writeSettings(homeDirectory, 'default_profile: default\n');
+    expect(executeSyncCommand({ homeDirectory, projectDirectory }).messages).toEqual([
+      'No URI profile sources configured; nothing to sync.',
+    ]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-004.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('creates placeholder profiles by scope or path and exposes create-profile as the same command alias', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const byScope = executeCreateProfileCommand({ name: 'engineering', scope: 'user', homeDirectory, projectDirectory });
+    const byProject = executeCreateProfileCommand({ name: 'project-profile', scope: 'project', homeDirectory, projectDirectory });
+    const byProjectLocal = executeCreateProfileCommand({
+      name: 'local-profile',
+      scope: 'project-local',
+      homeDirectory,
+      projectDirectory,
+    });
+    const customRoot = join(root, 'custom-profiles');
+    const byPath = executeCreateProfileCommand({ name: 'research', path: customRoot, homeDirectory, projectDirectory });
+
+    expect(readFileSync(byScope.profilePath, 'utf8')).toBe('id: engineering\nlabel: engineering\ncontrols: {}\n');
+    expect(existsSync(join(byScope.profileDirectory, 'prompts'))).toBe(true);
+    expect(existsSync(join(byScope.profileDirectory, 'skills'))).toBe(true);
+    expect(existsSync(join(byScope.profileDirectory, 'extensions'))).toBe(true);
+    expect(existsSync(join(byScope.profileDirectory, 'cli_specific', 'pi'))).toBe(true);
+    expect(byProject.profileDirectory).toBe(join(projectDirectory, '.bridl', 'profiles', 'project-profile'));
+    expect(byProjectLocal.profileDirectory).toBe(join(projectDirectory, '.bridl', 'local', 'profiles', 'local-profile'));
+    expect(byPath.profileDirectory).toBe(join(customRoot, 'research'));
+
+    writeFileSync(byPath.profilePath, 'id: research\nlabel: Existing\n');
+    expect(executeCreateProfileCommand({ name: 'research', path: customRoot, homeDirectory, projectDirectory }).createdProfile)
+      .toBe(false);
+
+    const program = new Command();
+    createCreateProfileCommand().register(program);
+    expect(program.commands[0]?.aliases()).toEqual(['create-profile']);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-004.3, BRIDL-REQ-004.4).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('rejects invalid create_profile inputs and wires command actions to the command object executors', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+
+    expect(() => executeCreateProfileCommand({ name: 'Bad Name', scope: 'user', homeDirectory, projectDirectory })).toThrow(
+      'filesystem-safe',
+    );
+    expect(() => executeCreateProfileCommand({ name: 'valid', homeDirectory, projectDirectory })).toThrow(
+      'requires exactly one destination',
+    );
+    expect(() => executeCreateProfileCommand({ name: 'valid', scope: 'user', path: root, homeDirectory, projectDirectory })).toThrow(
+      'requires exactly one destination',
+    );
+
+    const messages: string[] = [];
+    const createProgram = new Command();
+    createCreateProfileCommand({ homeDirectory, projectDirectory, writeLine: (message) => messages.push(message) })
+      .register(createProgram);
+    await createProgram.parseAsync(['node', 'bridl', 'create-profile', 'valid', '--path', join(root, 'cli-profiles')]);
+    expect(messages).toContainEqual(expect.stringContaining("Created profile 'valid'"));
+    await createProgram.parseAsync(['node', 'bridl', 'create_profile', 'scoped', '--scope', 'user']);
+    expect(existsSync(join(homeDirectory, '.bridl', 'profiles', 'scoped', 'profile.yml'))).toBe(true);
+    await expect(createProgram.parseAsync(['node', 'bridl', 'create_profile', 'valid', '--scope', 'invalid'])).rejects.toThrow(
+      "Unknown profile scope 'invalid'",
+    );
+
+    const missingNameProgram = new Command();
+    missingNameProgram.exitOverride();
+    createCreateProfileCommand({ homeDirectory, projectDirectory }).register(missingNameProgram);
+    await expect(missingNameProgram.parseAsync(['node', 'bridl', 'create_profile', '--scope', 'user'])).rejects.toThrow(
+      "missing required argument 'name'",
+    );
+
+    const syncMessages: string[] = [];
+    const syncProgram = new Command();
+    writeSettings(homeDirectory, 'default_profile: default\n');
+    createSyncCommand({ homeDirectory, projectDirectory, writeLine: (message) => syncMessages.push(message) }).register(syncProgram);
+    await syncProgram.parseAsync(['node', 'bridl', 'sync']);
+    expect(syncMessages).toEqual(['No URI profile sources configured; nothing to sync.']);
+
+    const setupMessages: string[] = [];
+    const setupProgram = new Command();
+    createSetupCommand({ homeDirectory: join(root, 'setup-home'), projectDirectory, writeLine: (message) => setupMessages.push(message) })
+      .register(setupProgram);
+    await setupProgram.parseAsync(['node', 'bridl', 'setup']);
+    expect(setupMessages[0]).toContain('Created user settings');
+  });
+});


### PR DESCRIPTION
## Summary
- implement Phase 4 setup, sync, and create_profile/create-profile command objects
- add URI profile source cache encoding with credential redaction for displayed/cacheable values
- update Phase 4 plan status and docs/README command examples

## Validation
- npm run check-ci
- npm run build
- git diff --check
- DeepWork reviews passed and marked