### PR TITLE
Configure markdown snapper and prettier

### DIFF
--- a/.deepwork/review/typescript_conventions.md
+++ b/.deepwork/review/typescript_conventions.md
@@ -1,6 +1,7 @@
 # TypeScript Conventions
 
-This project is planned as a TypeScript CLI/wrapper. Until implementation code exists, use these placeholder conventions as reviewable defaults.
+This project is planned as a TypeScript CLI/wrapper.
+Until implementation code exists, use these placeholder conventions as reviewable defaults.
 
 ## General style
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+.deepwork
+dist
+coverage
+node_modules

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,12 @@
+{
+  "printWidth": 120,
+  "singleQuote": true,
+  "overrides": [
+    {
+      "files": "*.md",
+      "options": {
+        "proseWrap": "preserve"
+      }
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,12 +12,15 @@
 - Warn to stderr when an adapter cannot support a requested control; `--hard-tack` must make unsupported controls or tack assembly warnings fatal.
 - Implement non-trivial CLI behavior as command objects with explicit dependencies and typed inputs/outputs, not parser callback logic.
 - A tack is the temporary runtime configuration directory assembled for one profile and agent CLI run; Bridl owns the tack lifecycle while the child agent runs.
-- Pi is the only day-one adapter. Claude is roadmap-only unless requirements change.
+- Pi is the only day-one adapter.
+  Claude is roadmap-only unless requirements change.
 
 ## Project checks
 
-- Run `npm run check` for local verification. It runs ESLint with auto-fixing enabled, then runs the coverage test suite.
-- Run `npm run check-ci` for CI-equivalent verification. It runs the same lint and coverage checks without modifying files.
+- Run `npm run check` for local verification.
+  It runs ESLint with auto-fixing enabled, then runs the coverage test suite.
+- Run `npm run check-ci` for CI-equivalent verification.
+  It runs the same lint and coverage checks without modifying files.
 - `npm run coverage` enforces the configured Vitest coverage thresholds.
 - Coverage includes all `src/**/*.ts` files, so new source files need tests even if they are only scaffolding.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ The goal is "manageable pi": organizations should be able to define standard pi 
 
 ## Why this exists
 
-Pi is highly configurable through settings directories, extensions, skills, prompts, themes, model settings, environment variables, and CLI flags. That flexibility is powerful, but businesses often need a higher-level control plane for repeatable deployments.
+Pi is highly configurable through settings directories, extensions, skills, prompts, themes, model settings, environment variables, and CLI flags.
+That flexibility is powerful, but businesses often need a higher-level control plane for repeatable deployments.
 
 `bridl` should make it easy to answer questions like:
 
@@ -40,7 +41,8 @@ Under the hood, `bridl` will translate a selected profile into the appropriate `
 
 ## Profile model sketch
 
-A profile will use YAML. An initial profile shape is:
+A profile will use YAML.
+An initial profile shape is:
 
 ```yaml
 id: engineering-default
@@ -72,7 +74,9 @@ See [`recommendation.md`](./recommendation.md) for current notes on pi startup b
 
 This repository is under phased implementation.
 
-A minimal executable CLI shell exists, with initial settings/profile schemas, local profile loading and resolution internals, and first-pass `setup`, `sync`, and `create_profile` / `create-profile` commands. The `run` command and stable end-to-end pi launch behavior are still in progress. The initial dependency and architecture decisions are documented in `package.json`, `doc/architecture.md`, and `requirements/`.
+A minimal executable CLI shell exists, with initial settings/profile schemas, local profile loading and resolution internals, and first-pass `setup`, `sync`, and `create_profile` / `create-profile` commands.
+The `run` command and stable end-to-end pi launch behavior are still in progress.
+The initial dependency and architecture decisions are documented in `package.json`, `doc/architecture.md`, and `requirements/`.
 
 ## Future work
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -2,7 +2,8 @@
 
 ## Purpose
 
-Bridl is a TypeScript CLI that assembles and launches reproducible agent-CLI profiles. It is generic enough for organizations to define profiles once and run them across multiple agent CLIs, while supporting `pi` first, most deeply, and most natively.
+Bridl is a TypeScript CLI that assembles and launches reproducible agent-CLI profiles.
+It is generic enough for organizations to define profiles once and run them across multiple agent CLIs, while supporting `pi` first, most deeply, and most natively.
 
 Formal implementation requirements live in `requirements/`; this document explains the architectural shape behind those requirements.
 
@@ -25,9 +26,12 @@ Formal implementation requirements live in `requirements/`; this document explai
 
 - Runtime: Node.js `>=22.19.0`.
 - Language: TypeScript.
-- Package manager: npm. This matches the current pi-coding-agent package distribution model and gives Bridl a conventional `package-lock.json`-based install path.
-- CLI framework: Commander `^14`. Commander is the initial choice because it supports default commands, command aliases, `allowUnknownOption`, pass-through argument collection, and testable parser construction without spawning child processes.
-- Test framework: Vitest `^4` with `@vitest/coverage-v8`. Pi currently uses Vitest, and Vitest is well suited to TypeScript unit tests around command objects and generated launch plans.
+- Package manager: npm.
+  This matches the current pi-coding-agent package distribution model and gives Bridl a conventional `package-lock.json`-based install path.
+- CLI framework: Commander `^14`.
+  Commander is the initial choice because it supports default commands, command aliases, `allowUnknownOption`, pass-through argument collection, and testable parser construction without spawning child processes.
+- Test framework: Vitest `^4` with `@vitest/coverage-v8`.
+  Pi currently uses Vitest, and Vitest is well suited to TypeScript unit tests around command objects and generated launch plans.
 - Coverage: 100% global threshold for statements, branches, functions, and lines from the first implementation.
 - Linting: ESLint `^10`, `@eslint/js`, and `typescript-eslint`, with `complexity: ["error", 10]`.
 - Schema and validation: TypeBox for schema authoring where TypeScript-schema coupling is useful, JSON Schema artifacts for persisted format contracts, and AJV for runtime validation.
@@ -88,7 +92,8 @@ Bridl uses a `.bridl` folder convention at multiple scopes:
   profiles/
 ```
 
-All discovered `settings.yml` files are collectively referred to as Bridl settings. The internal `Settings` object is the single conceptual result of reading all settings sources and applying precedence.
+All discovered `settings.yml` files are collectively referred to as Bridl settings.
+The internal `Settings` object is the single conceptual result of reading all settings sources and applying precedence.
 
 Note they are all the same in conceptual structure, with the exceptions that the <project>/.bridl/ contains the local one inside it, and the ~/.bridl includes the cache folder.
 
@@ -105,7 +110,8 @@ Future sources can be added behind the same `SettingsLoader` abstraction.
 
 ### Required User Default Profile
 
-`~/.bridl/settings.yml` MUST declare a default profile after setup completes. This guarantees `bridl run` can resolve a profile even when no `--profile` is provided.
+`~/.bridl/settings.yml` MUST declare a default profile after setup completes.
+This guarantees `bridl run` can resolve a profile even when no `--profile` is provided.
 
 Example:
 
@@ -258,7 +264,8 @@ Tacks are generated under the system temp directory so they can be reclaimed tri
 $TMPDIR/bridl/tacks/<run-id>/
 ```
 
-During `bridl run`, the Bridl process remains alive while the child agent CLI runs. It owns the tack lifecycle.
+During `bridl run`, the Bridl process remains alive while the child agent CLI runs.
+It owns the tack lifecycle.
 
 ### Tack Assembly
 
@@ -306,7 +313,8 @@ The adapter owns CLI-specific details such as env vars, flags, copied files, war
 
 ### Initial Adapter: Pi
 
-Pi is the only day-one supported adapter. Bridl should prefer native pi mechanisms:
+Pi is the only day-one supported adapter.
+Bridl should prefer native pi mechanisms:
 
 - `PI_CODING_AGENT_DIR` for profile-scoped global state;
 - `PI_CODING_AGENT_SESSION_DIR` or `--session-dir` for sessions;
@@ -434,7 +442,8 @@ Requirements:
 - deterministic tests for unsupported controls and `--hard-tack`;
 - scenario fixtures for common combinations instead of one-off bespoke setup.
 
-Scenario fixture directory conventions are documented in `doc/file_structure.md`. Each scenario should include realistic `.bridl` folders and expected resolution output.
+Scenario fixture directory conventions are documented in `doc/file_structure.md`.
+Each scenario should include realistic `.bridl` folders and expected resolution output.
 
 ## Settled Initial Decisions
 

--- a/doc/controllable-elements.md
+++ b/doc/controllable-elements.md
@@ -1,6 +1,8 @@
 # Controllable Elements
 
-This document defines cross-agent-CLI concepts that Bridl profiles may control. Pi is the planned first supported CLI, but this project skeleton does not yet implement runtime adapter support. Other CLIs are listed to keep the model generic and to clarify future adapter work.
+This document defines cross-agent-CLI concepts that Bridl profiles may control.
+Pi is the planned first supported CLI, but this project skeleton does not yet implement runtime adapter support.
+Other CLIs are listed to keep the model generic and to clarify future adapter work.
 
 Status values:
 
@@ -124,25 +126,27 @@ An early-startup customization used to register providers, tools, hooks, or addi
 
 ## Support Matrix
 
-| Controllable Element | Pi | Claude |
-| --- | --- | --- |
-| Agent Config Directory | Roadmap | Roadmap |
-| Session Directory | Roadmap | Roadmap |
-| Extensions | Roadmap | Roadmap |
-| Skills | Roadmap | Roadmap |
-| Prompt Templates | Roadmap | Roadmap |
-| System Prompt | Roadmap | Roadmap |
-| Appended System Prompt | Roadmap | Roadmap |
-| Model Selection | Roadmap | Roadmap |
+| Controllable Element        | Pi      | Claude  |
+| --------------------------- | ------- | ------- |
+| Agent Config Directory      | Roadmap | Roadmap |
+| Session Directory           | Roadmap | Roadmap |
+| Extensions                  | Roadmap | Roadmap |
+| Skills                      | Roadmap | Roadmap |
+| Prompt Templates            | Roadmap | Roadmap |
+| System Prompt               | Roadmap | Roadmap |
+| Appended System Prompt      | Roadmap | Roadmap |
+| Model Selection             | Roadmap | Roadmap |
 | Credentials and Environment | Roadmap | Roadmap |
-| Tool Availability | Roadmap | Roadmap |
-| Context Files | Roadmap | Roadmap |
-| Theme / UI Presentation | Roadmap | Roadmap |
-| Project Override Policy | Roadmap | Roadmap |
-| Working Directory | Roadmap | Roadmap |
-| Pass-through Arguments | Roadmap | Roadmap |
-| Bootstrap Hook | Roadmap | Roadmap |
+| Tool Availability           | Roadmap | Roadmap |
+| Context Files               | Roadmap | Roadmap |
+| Theme / UI Presentation     | Roadmap | Roadmap |
+| Project Override Policy     | Roadmap | Roadmap |
+| Working Directory           | Roadmap | Roadmap |
+| Pass-through Arguments      | Roadmap | Roadmap |
+| Bootstrap Hook              | Roadmap | Roadmap |
 
 ## Day-One Interpretation
 
-For v1, a Bridl profile may describe all defined terms generically. The Pi adapter is the first implementation target, and its matrix entries should move from Roadmap to Supported only as tested adapter behavior lands. Any non-Pi adapter should be considered experimental until its matrix entries are upgraded from Roadmap to Supported.
+For v1, a Bridl profile may describe all defined terms generically.
+The Pi adapter is the first implementation target, and its matrix entries should move from Roadmap to Supported only as tested adapter behavior lands.
+Any non-Pi adapter should be considered experimental until its matrix entries are upgraded from Roadmap to Supported.

--- a/doc/file_structure.md
+++ b/doc/file_structure.md
@@ -1,6 +1,7 @@
 # Bridl File Structure
 
-This document records the key repository file and directory structure used by Bridl. See `doc/architecture.md` for runtime file conventions such as `.bridl` settings folders, profile folders, and generated tack directories.
+This document records the key repository file and directory structure used by Bridl.
+See `doc/architecture.md` for runtime file conventions such as `.bridl` settings folders, profile folders, and generated tack directories.
 
 ## Repository Layout
 
@@ -16,6 +17,8 @@ Bridl is organized around clear TypeScript source boundaries, requirement docume
 ├── requirements/                      # formal BRIDL requirement documents
 │   ├── BRIDL-REQ-001-project-foundation.md
 │   └── ...
+├── .prettierignore                    # Prettier ignore rules
+├── .prettierrc.json                   # Prettier formatting configuration
 ├── plan.md                            # implementation plan
 ├── src/                               # production TypeScript source
 │   ├── cli/                           # CLI parser construction and command registration
@@ -55,6 +58,7 @@ Bridl is organized around clear TypeScript source boundaries, requirement docume
 │   ├── fixtures/                      # reusable test fixtures
 │   │   └── scenarios/                 # realistic .bridl scenarios and expected outputs
 │   └── unit/                          # unit tests
+├── package-lock.json                  # locked npm dependency graph
 └── package.json                       # npm package metadata and scripts
 ```
 

--- a/doc/specs/validating_requirements_with_rules.md
+++ b/doc/specs/validating_requirements_with_rules.md
@@ -1,6 +1,7 @@
 ## Validating Requirements with Tests, DeepSchemas, and Review Rules
 
-Formal requirements use RFC 2119 keywords such as MUST, SHOULD, and MAY. Each requirement needs an appropriate validation mechanism.
+Formal requirements use RFC 2119 keywords such as MUST, SHOULD, and MAY.
+Each requirement needs an appropriate validation mechanism.
 
 ### Use automated TypeScript tests for deterministic requirements
 
@@ -33,7 +34,8 @@ Examples:
 
 ### Anti-patterns
 
-Do not use fragile keyword tests for judgment requirements. A test such as `expect(text).toContain("safe")` does not prove that a prompt or policy meaningfully enforces safety.
+Do not use fragile keyword tests for judgment requirements.
+A test such as `expect(text).toContain("safe")` does not prove that a prompt or policy meaningfully enforces safety.
 
 Do not spend reviewer judgment on facts that TypeScript tests or JSON Schema can verify exactly.
 
@@ -44,9 +46,10 @@ Tests that validate a formal requirement should use a durable comment immediatel
 ```ts
 // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-008.3).
 // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-it("rejects stale requirement traceability comments", () => {
+it('rejects stale requirement traceability comments', () => {
   // ...
 });
 ```
 
-Comments should explain durable policy intent. They should not reference source line numbers, pull request numbers, or one-time migration context.
+Comments should explain durable policy intent.
+They should not reference source line numbers, pull request numbers, or one-time migration context.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@types/node": "^22.19.19",
         "@vitest/coverage-v8": "^4.1.7",
         "eslint": "^10.4.0",
+        "prettier": "^3.8.3",
         "shx": "^0.4.0",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.60.0",
@@ -2748,6 +2749,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pump": {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
     "lint:fix": "eslint . --fix",
     "test": "vitest --run",
     "coverage": "vitest --run --coverage",
-    "check": "npm run lint:fix && npm run coverage",
-    "check-ci": "npm run lint && npm run coverage"
+    "snapper:format": "git ls-files -z '*.md' | xargs -0 snapper -i",
+    "check": "npm run snapper:format && prettier --write . && npm run lint:fix && npm run coverage",
+    "check-ci": "prettier --check . && npm run lint && npm run coverage"
   },
   "dependencies": {
     "ajv": "^8.20.0",
@@ -40,6 +41,7 @@
     "@types/node": "^22.19.19",
     "@vitest/coverage-v8": "^4.1.7",
     "eslint": "^10.4.0",
+    "prettier": "^3.8.3",
     "shx": "^0.4.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.60.0",

--- a/plan.md
+++ b/plan.md
@@ -1,6 +1,7 @@
 # Bridl Phased Implementation Plan
 
-This plan describes the order of work. Formal obligations live in `requirements/`.
+This plan describes the order of work.
+Formal obligations live in `requirements/`.
 
 ## Phase 1: Project foundation — Done
 

--- a/recommendation.md
+++ b/recommendation.md
@@ -2,9 +2,13 @@
 
 ## Summary
 
-`pi` already has a strong native foundation for launching in different configurations. A wrapper should primarily use separate `PI_CODING_AGENT_DIR` profile directories, then layer CLI flags and environment variables on top. For early in-process behavior changes, use a bootstrap extension passed with `--extension` / `-e`; it loads early enough to register providers, tools, flags, and prompt behavior, but not early enough to alter the config directory or initial settings discovery.
+`pi` already has a strong native foundation for launching in different configurations.
+A wrapper should primarily use separate `PI_CODING_AGENT_DIR` profile directories, then layer CLI flags and environment variables on top.
+For early in-process behavior changes, use a bootstrap extension passed with `--extension` / `-e`; it loads early enough to register providers, tools, flags, and prompt behavior, but not early enough to alter the config directory or initial settings discovery.
 
-## 1. Native pi mechanisms for different configurations
+## 1.
+
+Native pi mechanisms for different configurations
 
 ### Best native profile mechanism: separate agent directories
 
@@ -90,13 +94,16 @@ Pi also reads project-local configuration from:
 .pi/APPEND_SYSTEM.md
 ```
 
-Project settings override global settings. Bridl profiles control project-level behavior with one of these policies:
+Project settings override global settings.
+Bridl profiles control project-level behavior with one of these policies:
 
 1. Global profile only via `PI_CODING_AGENT_DIR`.
 2. Global profile plus current project's `.pi` overrides.
 3. Isolated profile launched from a controlled cwd / temp workspace when project overrides should not apply.
 
-## 2. Load order and injection opportunities
+## 2.
+
+Load order and injection opportunities
 
 ### High-level startup order
 
@@ -125,7 +132,8 @@ Pi roughly starts in this order:
 
 ### Useful injection point: `--extension`
 
-Explicit CLI extensions are merged before configured/discovered extensions. A wrapper can inject a bootstrap extension with:
+Explicit CLI extensions are merged before configured/discovered extensions.
+A wrapper can inject a bootstrap extension with:
 
 ```bash
 pi -e /path/to/bootstrap-extension ...
@@ -145,7 +153,8 @@ This is the best hook for code that needs to run early inside pi.
 
 ### Limits of extension injection
 
-A bootstrap extension does not run before everything. It cannot cleanly affect:
+A bootstrap extension does not run before everything.
+It cannot cleanly affect:
 
 - which `agentDir` is used
 - initial settings file paths
@@ -166,7 +175,7 @@ Each wrapper profile can map to something like:
 agent_dir: ~/.bridl/work
 env:
   ANTHROPIC_API_KEY: ...optional...
-  PI_OFFLINE: "1"
+  PI_OFFLINE: '1'
 args:
   - --model
   - anthropic/claude-sonnet-4
@@ -216,4 +225,6 @@ Use this priority model:
 
 Pi already has a native profile mechanism through `PI_CODING_AGENT_DIR`; this should be the core of `bridl`'s wrapper design.
 
-For early in-process injection, use `-e bootstrap-extension`. It loads early enough to register providers/tools/flags and affect model availability and per-turn prompts, but not early enough to change config directory selection or initial settings discovery. Those must be controlled by the wrapper before launching pi.
+For early in-process injection, use `-e bootstrap-extension`.
+It loads early enough to register providers/tools/flags and affect model availability and per-turn prompts, but not early enough to change config directory selection or initial settings discovery.
+Those must be controlled by the wrapper before launching pi.

--- a/requirements/BRIDL-REQ-001-project-foundation.md
+++ b/requirements/BRIDL-REQ-001-project-foundation.md
@@ -2,7 +2,8 @@
 
 ## Overview
 
-Bridl is a TypeScript CLI project. This document specifies the baseline runtime, language, test, lint, and documentation conventions that must exist before feature work grows.
+Bridl is a TypeScript CLI project.
+This document specifies the baseline runtime, language, test, lint, and documentation conventions that must exist before feature work grows.
 
 ## Requirements
 
@@ -15,7 +16,6 @@ Bridl is a TypeScript CLI project. This document specifies the baseline runtime,
 5. The project MUST use npm as its package manager for the first version.
 6. The project MUST commit `package-lock.json` after dependency installation or updates.
 7. When an implementation library choice remains unclear, the project SHOULD prefer the same library or convention used by pi.dev.
-
 
 ### BRIDL-REQ-001.2: Test Framework and Coverage
 

--- a/requirements/BRIDL-REQ-002-settings.md
+++ b/requirements/BRIDL-REQ-002-settings.md
@@ -2,7 +2,8 @@
 
 ## Overview
 
-Bridl settings are the merged result of user, project, and project-local `.bridl/settings.yml` files. The internal Settings object is the single source of resolved configuration for commands.
+Bridl settings are the merged result of user, project, and project-local `.bridl/settings.yml` files.
+The internal Settings object is the single source of resolved configuration for commands.
 
 ## Requirements
 

--- a/requirements/BRIDL-REQ-003-profiles.md
+++ b/requirements/BRIDL-REQ-003-profiles.md
@@ -2,7 +2,8 @@
 
 ## Overview
 
-Profiles describe reusable agent-CLI loadouts. Bridl resolves profile definitions across settings scopes, explicit sources, inherited profiles, and the implicit user default profile.
+Profiles describe reusable agent-CLI loadouts.
+Bridl resolves profile definitions across settings scopes, explicit sources, inherited profiles, and the implicit user default profile.
 
 ## Requirements
 

--- a/requirements/BRIDL-REQ-006-agent-adapters.md
+++ b/requirements/BRIDL-REQ-006-agent-adapters.md
@@ -2,7 +2,8 @@
 
 ## Overview
 
-Agent adapters translate generic Bridl profile controls into native configuration files, environment variables, and command-line arguments for specific agent CLIs. Pi is the only day-one supported adapter.
+Agent adapters translate generic Bridl profile controls into native configuration files, environment variables, and command-line arguments for specific agent CLIs.
+Pi is the only day-one supported adapter.
 
 ## Requirements
 

--- a/requirements/BRIDL-REQ-007-controllable-elements.md
+++ b/requirements/BRIDL-REQ-007-controllable-elements.md
@@ -2,7 +2,8 @@
 
 ## Overview
 
-Bridl maintains a generic cross-agent-CLI vocabulary for profile-controlled concepts. This vocabulary is documented separately from implementation details so companies can reason about profiles across multiple agent CLIs.
+Bridl maintains a generic cross-agent-CLI vocabulary for profile-controlled concepts.
+This vocabulary is documented separately from implementation details so companies can reason about profiles across multiple agent CLIs.
 
 ## Requirements
 

--- a/requirements/BRIDL-REQ-008-requirements-governance.md
+++ b/requirements/BRIDL-REQ-008-requirements-governance.md
@@ -2,7 +2,8 @@
 
 ## Overview
 
-Bridl requirements define reviewable project obligations. Each requirement should be traceable to TypeScript implementation, tests, DeepSchemas, or DeepReview rules depending on the appropriate validation mechanism.
+Bridl requirements define reviewable project obligations.
+Each requirement should be traceable to TypeScript implementation, tests, DeepSchemas, or DeepReview rules depending on the appropriate validation mechanism.
 
 ## Requirements
 

--- a/src/cli/commands/CreateProfileCommand.ts
+++ b/src/cli/commands/CreateProfileCommand.ts
@@ -118,7 +118,10 @@ const assertValidCreateProfileInput = (input: CreateProfileInput): void => {
     throw new Error(`Profile name '${input.name}' is not a filesystem-safe Bridl profile id.`);
   }
 
-  if ((input.scope === undefined && input.path === undefined) || (input.scope !== undefined && input.path !== undefined)) {
+  if (
+    (input.scope === undefined && input.path === undefined) ||
+    (input.scope !== undefined && input.path !== undefined)
+  ) {
     throw new Error('Create profile requires exactly one destination: --scope or --path.');
   }
 };
@@ -141,7 +144,8 @@ const resolveProfileRoot = (input: CreateProfileInput): string => {
   }
 };
 
-const createPlaceholderProfileYaml = (profileId: string): string => `id: ${profileId}\nlabel: ${profileId}\ncontrols: {}\n`;
+const createPlaceholderProfileYaml = (profileId: string): string =>
+  `id: ${profileId}\nlabel: ${profileId}\ncontrols: {}\n`;
 
 const readCreateProfileScope = (scope: string | undefined): CreateProfileScope | undefined => {
   if (scope === undefined) {

--- a/src/cli/commands/SetupCommand.ts
+++ b/src/cli/commands/SetupCommand.ts
@@ -54,7 +54,9 @@ export const executeSetupCommand = (
     createdDefaultProfile,
     syncResult,
     messages: [
-      createdSettings ? `Created user settings at ${settingsPath}.` : `User settings already exists at ${settingsPath}; left unchanged.`,
+      createdSettings
+        ? `Created user settings at ${settingsPath}.`
+        : `User settings already exists at ${settingsPath}; left unchanged.`,
       createdDefaultProfile
         ? `Created default user profile '${defaultProfileId}' at ${defaultProfilePath}.`
         : `Default user profile '${defaultProfileId}' already exists at ${defaultProfilePath}; left unchanged.`,
@@ -68,22 +70,25 @@ export const createSetupCommand = (dependencies: SetupCommandDependencies = {}):
     name: 'setup',
     description: 'Create initial Bridl settings and a default profile.',
     register(program: Command): void {
-      program.command(command.name).description(command.description).action(() => {
-        const result = executeSetupCommand(
-          {
-            /* v8 ignore next -- default process home is exercised by the direct CLI entrypoint, not unit tests. */
-            homeDirectory: dependencies.homeDirectory ?? homedir(),
-            /* v8 ignore next -- default process cwd is exercised by the direct CLI entrypoint, not unit tests. */
-            projectDirectory: dependencies.projectDirectory ?? process.cwd(),
-          },
-          dependencies,
-        );
+      program
+        .command(command.name)
+        .description(command.description)
+        .action(() => {
+          const result = executeSetupCommand(
+            {
+              /* v8 ignore next -- default process home is exercised by the direct CLI entrypoint, not unit tests. */
+              homeDirectory: dependencies.homeDirectory ?? homedir(),
+              /* v8 ignore next -- default process cwd is exercised by the direct CLI entrypoint, not unit tests. */
+              projectDirectory: dependencies.projectDirectory ?? process.cwd(),
+            },
+            dependencies,
+          );
 
-        for (const message of result.messages) {
-          /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
-          (dependencies.writeLine ?? console.log)(message);
-        }
-      });
+          for (const message of result.messages) {
+            /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
+            (dependencies.writeLine ?? console.log)(message);
+          }
+        });
     },
   };
 
@@ -91,7 +96,10 @@ export const createSetupCommand = (dependencies: SetupCommandDependencies = {}):
 };
 
 const readUserDefaultProfileId = (
-  files: readonly { readonly location: { readonly scope: string }; readonly settings: { readonly defaultProfile?: string } }[],
+  files: readonly {
+    readonly location: { readonly scope: string };
+    readonly settings: { readonly defaultProfile?: string };
+  }[],
 ): string => files.find((file) => file.location.scope === 'user')?.settings.defaultProfile ?? 'default';
 
 const assertValidDefaultProfileId = (profileId: string): void => {
@@ -120,5 +128,8 @@ const createDefaultProfileIfMissing = (profilePath: string, profileId: string): 
   return true;
 };
 
-const formatSettingsIssue = (issue: { readonly filePath: string; readonly path: string; readonly message: string }): string =>
-  `${issue.filePath}#${issue.path} ${issue.message}`;
+const formatSettingsIssue = (issue: {
+  readonly filePath: string;
+  readonly path: string;
+  readonly message: string;
+}): string => `${issue.filePath}#${issue.path} ${issue.message}`;

--- a/src/cli/commands/SyncCommand.ts
+++ b/src/cli/commands/SyncCommand.ts
@@ -6,7 +6,11 @@ import { dirname } from 'node:path';
 import type { Command } from 'commander';
 import spawn from 'cross-spawn';
 
-import { createProfileSourceCachePath, normalizeGitUri, redactProfileSourceUriCredentials } from '../../profiles/ProfileCache.js';
+import {
+  createProfileSourceCachePath,
+  normalizeGitUri,
+  redactProfileSourceUriCredentials,
+} from '../../profiles/ProfileCache.js';
 import { loadLocalProfileSource } from '../../profiles/ProfileLoader.js';
 import type { ProfileSourceReference } from '../../profiles/ProfileSource.js';
 import { discoverSettingsLoadPlan, loadSettings } from '../../settings/SettingsLoader.js';
@@ -58,9 +62,10 @@ export const executeSyncCommand = (
 
   return {
     sources: sourceResults,
-    messages: sourceResults.length === 0
-      ? ['No URI profile sources configured; nothing to sync.']
-      : sourceResults.map((result) => `${result.status}: ${result.uri} -> ${result.cachePath} (${result.message})`),
+    messages:
+      sourceResults.length === 0
+        ? ['No URI profile sources configured; nothing to sync.']
+        : sourceResults.map((result) => `${result.status}: ${result.uri} -> ${result.cachePath} (${result.message})`),
   };
 };
 
@@ -69,22 +74,25 @@ export const createSyncCommand = (dependencies: SyncCommandDependencies = {}): C
     name: 'sync',
     description: 'Synchronize URI-backed Bridl profile sources into the local cache.',
     register(program: Command): void {
-      program.command(command.name).description(command.description).action(() => {
-        const result = executeSyncCommand(
-          {
-            /* v8 ignore next -- default process home is exercised by the direct CLI entrypoint, not unit tests. */
-            homeDirectory: dependencies.homeDirectory ?? homedir(),
-            /* v8 ignore next -- default process cwd is exercised by the direct CLI entrypoint, not unit tests. */
-            projectDirectory: dependencies.projectDirectory ?? process.cwd(),
-          },
-          dependencies,
-        );
+      program
+        .command(command.name)
+        .description(command.description)
+        .action(() => {
+          const result = executeSyncCommand(
+            {
+              /* v8 ignore next -- default process home is exercised by the direct CLI entrypoint, not unit tests. */
+              homeDirectory: dependencies.homeDirectory ?? homedir(),
+              /* v8 ignore next -- default process cwd is exercised by the direct CLI entrypoint, not unit tests. */
+              projectDirectory: dependencies.projectDirectory ?? process.cwd(),
+            },
+            dependencies,
+          );
 
-        for (const message of result.messages) {
-          /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
-          (dependencies.writeLine ?? console.log)(message);
-        }
-      });
+          for (const message of result.messages) {
+            /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
+            (dependencies.writeLine ?? console.log)(message);
+          }
+        });
     },
   };
 
@@ -116,9 +124,8 @@ const syncUriSource = (
       uri: displayUri,
       cachePath,
       status,
-      message: validation.profiles.length === 1
-        ? '1 profile validated.'
-        : `${validation.profiles.length} profiles validated.`,
+      message:
+        validation.profiles.length === 1 ? '1 profile validated.' : `${validation.profiles.length} profiles validated.`,
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -165,8 +172,11 @@ const redactSensitiveText = (message: string, uri: string): string =>
     .split(normalizeGitUri(uri))
     .join(redactProfileSourceUriCredentials(normalizeGitUri(uri)));
 
-const formatSettingsIssue = (issue: { readonly filePath: string; readonly path: string; readonly message: string }): string =>
-  `${issue.filePath}#${issue.path} ${issue.message}`;
+const formatSettingsIssue = (issue: {
+  readonly filePath: string;
+  readonly path: string;
+  readonly message: string;
+}): string => `${issue.filePath}#${issue.path} ${issue.message}`;
 
 const formatProfileIssue = (issue: { readonly path: string; readonly message: string }): string =>
   `${issue.path} ${issue.message}`;

--- a/src/profiles/ProfileCache.ts
+++ b/src/profiles/ProfileCache.ts
@@ -26,4 +26,4 @@ export const redactProfileSourceUriCredentials = (uri: string): string => {
   }
 };
 
-export const normalizeGitUri = (uri: string): string => uri.startsWith('git+') ? uri.slice('git+'.length) : uri;
+export const normalizeGitUri = (uri: string): string => (uri.startsWith('git+') ? uri.slice('git+'.length) : uri);

--- a/src/profiles/ProfileLoader.ts
+++ b/src/profiles/ProfileLoader.ts
@@ -72,7 +72,10 @@ export const parseProfileYaml = (content: string, fallbackId: string): Profile |
 
 export const loadLocalProfileSource = (source: ProfileSourceReference): ProfileLoadResult => {
   if (source.path === undefined) {
-    return { profiles: [], issues: [{ path: '<uri-source>', message: 'Only local profile sources can be loaded directly.' }] };
+    return {
+      profiles: [],
+      issues: [{ path: '<uri-source>', message: 'Only local profile sources can be loaded directly.' }],
+    };
   }
 
   if (!existsSync(source.path) || !statSync(source.path).isDirectory()) {

--- a/src/profiles/ProfileMerger.ts
+++ b/src/profiles/ProfileMerger.ts
@@ -37,16 +37,20 @@ export const resolveProfile = (input: ProfileResolutionInput): ProfileResolution
   const definitions = createProfileDefinitions(input.profiles);
   const issues: ProfileResolutionIssue[] = [];
   const explicitStack = resolveProfileStack(input.profileId, definitions, [], issues);
-  const defaultStack = input.defaultProfileId === undefined || input.defaultProfileId === input.profileId
-    ? []
-    : resolveProfileStack(input.defaultProfileId, definitions, [], issues);
+  const defaultStack =
+    input.defaultProfileId === undefined || input.defaultProfileId === input.profileId
+      ? []
+      : resolveProfileStack(input.defaultProfileId, definitions, [], issues);
   const profileStack = uniqueProfileStack([
     ...defaultStack.filter((profile) => profile.id !== input.profileId),
     ...explicitStack,
   ]);
 
   return {
-    profile: issues.length === 0 && profileStack.length > 0 ? mergeProfileStack(profileStack as NonEmptyProfileStack) : undefined,
+    profile:
+      issues.length === 0 && profileStack.length > 0
+        ? mergeProfileStack(profileStack as NonEmptyProfileStack)
+        : undefined,
     profileStack,
     issues,
   };

--- a/src/settings/SettingsLoader.ts
+++ b/src/settings/SettingsLoader.ts
@@ -105,7 +105,10 @@ const addSettingsFile = (
     return;
   }
 
-  files.push({ location, settings: convertSettingsDocument(parsed.document as SettingsDocument, dirname(location.path)) });
+  files.push({
+    location,
+    settings: convertSettingsDocument(parsed.document as SettingsDocument, dirname(location.path)),
+  });
 };
 
 const convertSettingsDocument = (document: SettingsDocument, settingsDirectory: string): Settings => ({
@@ -113,10 +116,7 @@ const convertSettingsDocument = (document: SettingsDocument, settingsDirectory: 
   profileSources: (document.profile_sources ?? []).map((source) => convertProfileSource(source, settingsDirectory)),
 });
 
-const convertProfileSource = (
-  source: ProfileSourceDocument,
-  settingsDirectory: string,
-): ProfileSourceReference => {
+const convertProfileSource = (source: ProfileSourceDocument, settingsDirectory: string): ProfileSourceReference => {
   const filters = {
     only: source.only,
     except: source.except,

--- a/tests/fixtures/scenarios/profile-inheritance-chain/profiles/base/profile.yml
+++ b/tests/fixtures/scenarios/profile-inheritance-chain/profiles/base/profile.yml
@@ -2,5 +2,5 @@ id: base
 controls:
   model: base-model
   environment:
-    BASE: "enabled"
+    BASE: 'enabled'
     SHARED: base

--- a/tests/fixtures/scenarios/profile-inheritance-chain/profiles/default/profile.yml
+++ b/tests/fixtures/scenarios/profile-inheritance-chain/profiles/default/profile.yml
@@ -2,5 +2,5 @@ id: default
 inherits: [base]
 controls:
   environment:
-    DEFAULT: "enabled"
+    DEFAULT: 'enabled'
     SHARED: default

--- a/tests/fixtures/scenarios/profile-inheritance-chain/profiles/engineering/profile.yml
+++ b/tests/fixtures/scenarios/profile-inheritance-chain/profiles/engineering/profile.yml
@@ -3,5 +3,5 @@ inherits: [base]
 controls:
   model: engineering-model
   environment:
-    ENGINEERING: "enabled"
+    ENGINEERING: 'enabled'
     SHARED: engineering

--- a/tests/fixtures/scenarios/profile-multiple-inheritance/profiles/composite/profile.yml
+++ b/tests/fixtures/scenarios/profile-multiple-inheritance/profiles/composite/profile.yml
@@ -3,5 +3,5 @@ inherits: [first, second]
 controls:
   model: composite-model
   environment:
-    COMPOSITE: "enabled"
+    COMPOSITE: 'enabled'
     SHARED: composite

--- a/tests/fixtures/scenarios/profile-multiple-inheritance/profiles/first/profile.yml
+++ b/tests/fixtures/scenarios/profile-multiple-inheritance/profiles/first/profile.yml
@@ -1,5 +1,5 @@
 id: first
 controls:
   environment:
-    FIRST: "enabled"
+    FIRST: 'enabled'
     SHARED: first

--- a/tests/fixtures/scenarios/profile-multiple-inheritance/profiles/second/profile.yml
+++ b/tests/fixtures/scenarios/profile-multiple-inheritance/profiles/second/profile.yml
@@ -1,5 +1,5 @@
 id: second
 controls:
   environment:
-    SECOND: "enabled"
+    SECOND: 'enabled'
     SHARED: second

--- a/tests/fixtures/scenarios/profile-precedence/project-local-profiles/engineering/profile.yml
+++ b/tests/fixtures/scenarios/profile-precedence/project-local-profiles/engineering/profile.yml
@@ -3,4 +3,4 @@ controls:
   model: local-model
   environment:
     SHARED: local
-    LOCAL_ONLY: "yes"
+    LOCAL_ONLY: 'yes'

--- a/tests/fixtures/scenarios/profile-precedence/project-profiles/engineering/profile.yml
+++ b/tests/fixtures/scenarios/profile-precedence/project-profiles/engineering/profile.yml
@@ -3,4 +3,4 @@ label: Project Engineering
 controls:
   environment:
     SHARED: project
-    PROJECT_ONLY: "yes"
+    PROJECT_ONLY: 'yes'

--- a/tests/fixtures/scenarios/profile-precedence/user-profiles/base/profile.yml
+++ b/tests/fixtures/scenarios/profile-precedence/user-profiles/base/profile.yml
@@ -1,4 +1,4 @@
 id: base
 controls:
   environment:
-    BASE_ONLY: "yes"
+    BASE_ONLY: 'yes'

--- a/tests/fixtures/scenarios/profile-precedence/user-profiles/engineering/profile.yml
+++ b/tests/fixtures/scenarios/profile-precedence/user-profiles/engineering/profile.yml
@@ -5,4 +5,4 @@ controls:
   model: user-model
   environment:
     SHARED: user
-    USER_ONLY: "yes"
+    USER_ONLY: 'yes'

--- a/tests/unit/phase4-commands.test.ts
+++ b/tests/unit/phase4-commands.test.ts
@@ -13,7 +13,11 @@ import {
 } from '../../src/cli/commands/CreateProfileCommand.js';
 import { createSetupCommand, executeSetupCommand } from '../../src/cli/commands/SetupCommand.js';
 import { createSyncCommand, executeSyncCommand } from '../../src/cli/commands/SyncCommand.js';
-import { createProfileSourceCachePath, encodeProfileSourceUri, normalizeGitUri } from '../../src/profiles/ProfileCache.js';
+import {
+  createProfileSourceCachePath,
+  encodeProfileSourceUri,
+  normalizeGitUri,
+} from '../../src/profiles/ProfileCache.js';
 
 const temporaryRoots: string[] = [];
 
@@ -40,10 +44,14 @@ const createGitProfileRepository = (root: string): string => {
   writeCachedProfile(repositoryPath, 'remote');
   execFileSync('git', ['init'], { cwd: repositoryPath, stdio: 'pipe' });
   execFileSync('git', ['add', '.'], { cwd: repositoryPath, stdio: 'pipe' });
-  execFileSync('git', ['-c', 'user.name=Bridl Test', '-c', 'user.email=bridl@example.test', 'commit', '-m', 'profiles'], {
-    cwd: repositoryPath,
-    stdio: 'pipe',
-  });
+  execFileSync(
+    'git',
+    ['-c', 'user.name=Bridl Test', '-c', 'user.email=bridl@example.test', 'commit', '-m', 'profiles'],
+    {
+      cwd: repositoryPath,
+      stdio: 'pipe',
+    },
+  );
   return repositoryPath;
 };
 
@@ -69,7 +77,9 @@ describe('phase 4 setup and sync commands', () => {
 
     expect(firstResult.createdSettings).toBe(true);
     expect(firstResult.createdDefaultProfile).toBe(true);
-    expect(readFileSync(settingsPath, 'utf8')).toBe('default_profile: default\nprofile_sources:\n  - path: ./profiles\n');
+    expect(readFileSync(settingsPath, 'utf8')).toBe(
+      'default_profile: default\nprofile_sources:\n  - path: ./profiles\n',
+    );
     expect(readFileSync(defaultProfilePath, 'utf8')).toBe('id: default\nlabel: Default\ncontrols: {}\n');
     expect(firstResult.messages).toContain('No URI profile sources configured; nothing to sync.');
 
@@ -117,30 +127,42 @@ describe('phase 4 setup and sync commands', () => {
     const fallbackHomeDirectory = join(root, 'fallback-home');
     writeSettings(fallbackHomeDirectory, 'profile_sources: []\n');
     const fallbackDefaultResult = executeSetupCommand({ homeDirectory: fallbackHomeDirectory, projectDirectory });
-    expect(fallbackDefaultResult.defaultProfilePath).toBe(join(fallbackHomeDirectory, '.bridl', 'profiles', 'default', 'profile.yml'));
+    expect(fallbackDefaultResult.defaultProfilePath).toBe(
+      join(fallbackHomeDirectory, '.bridl', 'profiles', 'default', 'profile.yml'),
+    );
 
     const projectDefaultHomeDirectory = join(root, 'project-default-home');
     const projectDefaultDirectory = join(root, 'project-default');
     mkdirSync(join(projectDefaultDirectory, '.bridl'), { recursive: true });
     writeFileSync(join(projectDefaultDirectory, '.bridl', 'settings.yml'), 'default_profile: remote\n');
-    const projectDefaultResult = executeSetupCommand({ homeDirectory: projectDefaultHomeDirectory, projectDirectory: projectDefaultDirectory });
+    const projectDefaultResult = executeSetupCommand({
+      homeDirectory: projectDefaultHomeDirectory,
+      projectDirectory: projectDefaultDirectory,
+    });
     expect(readFileSync(projectDefaultResult.settingsPath, 'utf8')).toContain('default_profile: default');
-    expect(projectDefaultResult.defaultProfilePath).toBe(join(projectDefaultHomeDirectory, '.bridl', 'profiles', 'default', 'profile.yml'));
+    expect(projectDefaultResult.defaultProfilePath).toBe(
+      join(projectDefaultHomeDirectory, '.bridl', 'profiles', 'default', 'profile.yml'),
+    );
 
     const unsafeDefaultHomeDirectory = join(root, 'unsafe-default-home');
     writeSettings(unsafeDefaultHomeDirectory, 'default_profile: ../../outside\n');
-    expect(() => executeSetupCommand({ homeDirectory: unsafeDefaultHomeDirectory, projectDirectory })).toThrow('filesystem-safe');
+    expect(() => executeSetupCommand({ homeDirectory: unsafeDefaultHomeDirectory, projectDirectory })).toThrow(
+      'filesystem-safe',
+    );
     expect(existsSync(join(root, 'outside', 'profile.yml'))).toBe(false);
 
     writeSettings(homeDirectory, 'profile_sources:\n  - only: [remote]\n');
-    expect(() => executeSetupCommand({ homeDirectory, projectDirectory })).toThrow('Cannot setup with invalid settings');
+    expect(() => executeSetupCommand({ homeDirectory, projectDirectory })).toThrow(
+      'Cannot setup with invalid settings',
+    );
 
     const invalidProjectHomeDirectory = join(root, 'invalid-project-home');
     const invalidProjectDirectory = join(root, 'invalid-project');
     mkdirSync(join(invalidProjectDirectory, '.bridl'), { recursive: true });
     writeFileSync(join(invalidProjectDirectory, '.bridl', 'settings.yml'), 'profile_sources:\n  - only: [remote]\n');
-    expect(() => executeSetupCommand({ homeDirectory: invalidProjectHomeDirectory, projectDirectory: invalidProjectDirectory }))
-      .toThrow('Cannot setup with invalid settings');
+    expect(() =>
+      executeSetupCommand({ homeDirectory: invalidProjectHomeDirectory, projectDirectory: invalidProjectDirectory }),
+    ).toThrow('Cannot setup with invalid settings');
     expect(existsSync(join(invalidProjectHomeDirectory, '.bridl', 'settings.yml'))).toBe(false);
   });
 
@@ -187,7 +209,10 @@ describe('phase 4 setup and sync commands', () => {
     const uri = 'git+https://user:secret@example.test/team/profiles.git';
     const failedUri = 'https://token@example.test/private/profiles.git';
     const unparsableUri = '//deploy-key@example.test/private/profiles.git';
-    writeSettings(homeDirectory, `profile_sources:\n  - uri: ${uri}\n  - uri: ${failedUri}\n  - uri: '${unparsableUri}'\n`);
+    writeSettings(
+      homeDirectory,
+      `profile_sources:\n  - uri: ${uri}\n  - uri: ${failedUri}\n  - uri: '${unparsableUri}'\n`,
+    );
 
     const result = executeSyncCommand(
       { homeDirectory, projectDirectory },
@@ -216,7 +241,9 @@ describe('phase 4 setup and sync commands', () => {
     expect(result.messages.join('\n')).not.toContain('deploy-key');
     expect(result.sources[0]?.cachePath).toBe(createProfileSourceCachePath(homeDirectory, uri));
     expect(Buffer.from(encodeProfileSourceUri(uri), 'base64url').toString('utf8')).not.toContain('secret');
-    expect(Buffer.from(encodeProfileSourceUri(normalizeGitUri(uri)), 'base64url').toString('utf8')).not.toContain('secret');
+    expect(Buffer.from(encodeProfileSourceUri(normalizeGitUri(uri)), 'base64url').toString('utf8')).not.toContain(
+      'secret',
+    );
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-004.2).
@@ -312,8 +339,18 @@ describe('phase 4 setup and sync commands', () => {
     const root = createTemporaryRoot();
     const homeDirectory = join(root, 'home');
     const projectDirectory = join(root, 'project');
-    const byScope = executeCreateProfileCommand({ name: 'engineering', scope: 'user', homeDirectory, projectDirectory });
-    const byProject = executeCreateProfileCommand({ name: 'project-profile', scope: 'project', homeDirectory, projectDirectory });
+    const byScope = executeCreateProfileCommand({
+      name: 'engineering',
+      scope: 'user',
+      homeDirectory,
+      projectDirectory,
+    });
+    const byProject = executeCreateProfileCommand({
+      name: 'project-profile',
+      scope: 'project',
+      homeDirectory,
+      projectDirectory,
+    });
     const byProjectLocal = executeCreateProfileCommand({
       name: 'local-profile',
       scope: 'project-local',
@@ -329,12 +366,16 @@ describe('phase 4 setup and sync commands', () => {
     expect(existsSync(join(byScope.profileDirectory, 'extensions'))).toBe(true);
     expect(existsSync(join(byScope.profileDirectory, 'cli_specific', 'pi'))).toBe(true);
     expect(byProject.profileDirectory).toBe(join(projectDirectory, '.bridl', 'profiles', 'project-profile'));
-    expect(byProjectLocal.profileDirectory).toBe(join(projectDirectory, '.bridl', 'local', 'profiles', 'local-profile'));
+    expect(byProjectLocal.profileDirectory).toBe(
+      join(projectDirectory, '.bridl', 'local', 'profiles', 'local-profile'),
+    );
     expect(byPath.profileDirectory).toBe(join(customRoot, 'research'));
 
     writeFileSync(byPath.profilePath, 'id: research\nlabel: Existing\n');
-    expect(executeCreateProfileCommand({ name: 'research', path: customRoot, homeDirectory, projectDirectory }).createdProfile)
-      .toBe(false);
+    expect(
+      executeCreateProfileCommand({ name: 'research', path: customRoot, homeDirectory, projectDirectory })
+        .createdProfile,
+    ).toBe(false);
 
     const program = new Command();
     createCreateProfileCommand().register(program);
@@ -348,27 +389,30 @@ describe('phase 4 setup and sync commands', () => {
     const homeDirectory = join(root, 'home');
     const projectDirectory = join(root, 'project');
 
-    expect(() => executeCreateProfileCommand({ name: 'Bad Name', scope: 'user', homeDirectory, projectDirectory })).toThrow(
-      'filesystem-safe',
-    );
+    expect(() =>
+      executeCreateProfileCommand({ name: 'Bad Name', scope: 'user', homeDirectory, projectDirectory }),
+    ).toThrow('filesystem-safe');
     expect(() => executeCreateProfileCommand({ name: 'valid', homeDirectory, projectDirectory })).toThrow(
       'requires exactly one destination',
     );
-    expect(() => executeCreateProfileCommand({ name: 'valid', scope: 'user', path: root, homeDirectory, projectDirectory })).toThrow(
-      'requires exactly one destination',
-    );
+    expect(() =>
+      executeCreateProfileCommand({ name: 'valid', scope: 'user', path: root, homeDirectory, projectDirectory }),
+    ).toThrow('requires exactly one destination');
 
     const messages: string[] = [];
     const createProgram = new Command();
-    createCreateProfileCommand({ homeDirectory, projectDirectory, writeLine: (message) => messages.push(message) })
-      .register(createProgram);
+    createCreateProfileCommand({
+      homeDirectory,
+      projectDirectory,
+      writeLine: (message) => messages.push(message),
+    }).register(createProgram);
     await createProgram.parseAsync(['node', 'bridl', 'create-profile', 'valid', '--path', join(root, 'cli-profiles')]);
     expect(messages).toContainEqual(expect.stringContaining("Created profile 'valid'"));
     await createProgram.parseAsync(['node', 'bridl', 'create_profile', 'scoped', '--scope', 'user']);
     expect(existsSync(join(homeDirectory, '.bridl', 'profiles', 'scoped', 'profile.yml'))).toBe(true);
-    await expect(createProgram.parseAsync(['node', 'bridl', 'create_profile', 'valid', '--scope', 'invalid'])).rejects.toThrow(
-      "Unknown profile scope 'invalid'",
-    );
+    await expect(
+      createProgram.parseAsync(['node', 'bridl', 'create_profile', 'valid', '--scope', 'invalid']),
+    ).rejects.toThrow("Unknown profile scope 'invalid'");
 
     const missingNameProgram = new Command();
     missingNameProgram.exitOverride();
@@ -380,14 +424,19 @@ describe('phase 4 setup and sync commands', () => {
     const syncMessages: string[] = [];
     const syncProgram = new Command();
     writeSettings(homeDirectory, 'default_profile: default\n');
-    createSyncCommand({ homeDirectory, projectDirectory, writeLine: (message) => syncMessages.push(message) }).register(syncProgram);
+    createSyncCommand({ homeDirectory, projectDirectory, writeLine: (message) => syncMessages.push(message) }).register(
+      syncProgram,
+    );
     await syncProgram.parseAsync(['node', 'bridl', 'sync']);
     expect(syncMessages).toEqual(['No URI profile sources configured; nothing to sync.']);
 
     const setupMessages: string[] = [];
     const setupProgram = new Command();
-    createSetupCommand({ homeDirectory: join(root, 'setup-home'), projectDirectory, writeLine: (message) => setupMessages.push(message) })
-      .register(setupProgram);
+    createSetupCommand({
+      homeDirectory: join(root, 'setup-home'),
+      projectDirectory,
+      writeLine: (message) => setupMessages.push(message),
+    }).register(setupProgram);
     await setupProgram.parseAsync(['node', 'bridl', 'setup']);
     expect(setupMessages[0]).toContain('Created user settings');
   });

--- a/tests/unit/profile-loader.test.ts
+++ b/tests/unit/profile-loader.test.ts
@@ -56,7 +56,11 @@ describe('profile loading', () => {
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('parses profile.yml files from profile folders with fallback folder identity', () => {
     const root = createProfileSourceRoot();
-    writeProfile(root, 'base', 'label: Base Profile\ninherits:\n  - shared\ncontrols:\n  environment:\n    MODE: test\n');
+    writeProfile(
+      root,
+      'base',
+      'label: Base Profile\ninherits:\n  - shared\ncontrols:\n  environment:\n    MODE: test\n',
+    );
     writeFileSync(join(root, 'README.md'), 'not a profile folder');
 
     const result = loadLocalProfileSource(createLocalProfileSource(root));

--- a/tests/unit/profile-resolution.test.ts
+++ b/tests/unit/profile-resolution.test.ts
@@ -21,9 +21,15 @@ describe('profile resolution', () => {
   // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-003.3, BRIDL-REQ-003.6).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('merges same-id profile definitions with project-local precedence over project and user definitions', () => {
-    const userProfiles = loadLocalProfileSource(createLocalProfileSource(scenarioPath('profile-precedence', 'user-profiles')));
-    const projectProfiles = loadLocalProfileSource(createLocalProfileSource(scenarioPath('profile-precedence', 'project-profiles')));
-    const projectLocalProfiles = loadLocalProfileSource(createLocalProfileSource(scenarioPath('profile-precedence', 'project-local-profiles')));
+    const userProfiles = loadLocalProfileSource(
+      createLocalProfileSource(scenarioPath('profile-precedence', 'user-profiles')),
+    );
+    const projectProfiles = loadLocalProfileSource(
+      createLocalProfileSource(scenarioPath('profile-precedence', 'project-profiles')),
+    );
+    const projectLocalProfiles = loadLocalProfileSource(
+      createLocalProfileSource(scenarioPath('profile-precedence', 'project-local-profiles')),
+    );
 
     expect([...userProfiles.issues, ...projectProfiles.issues, ...projectLocalProfiles.issues]).toEqual([]);
 
@@ -65,16 +71,22 @@ describe('profile resolution', () => {
       profile: { id: 'uri-backed', inherits: [], controls: { model: 'user' } },
     });
 
-    expect(resolveProfile({ profileId: 'uri-backed', profiles: [firstUriProfile, secondUriProfile] }).profile?.controls.model)
-      .toBe('second-uri');
-    expect(resolveProfile({ profileId: 'uri-backed', profiles: [firstUriProfile, secondUriProfile, userProfile] }).profile?.controls.model)
-      .toBe('user');
+    expect(
+      resolveProfile({ profileId: 'uri-backed', profiles: [firstUriProfile, secondUriProfile] }).profile?.controls
+        .model,
+    ).toBe('second-uri');
+    expect(
+      resolveProfile({ profileId: 'uri-backed', profiles: [firstUriProfile, secondUriProfile, userProfile] }).profile
+        ?.controls.model,
+    ).toBe('user');
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-003.4, BRIDL-REQ-003.5).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('resolves inherited profiles below explicit profiles and includes the implicit user default without duplicates', () => {
-    const loaded = loadLocalProfileSource(createLocalProfileSource(scenarioPath('profile-inheritance-chain', 'profiles')));
+    const loaded = loadLocalProfileSource(
+      createLocalProfileSource(scenarioPath('profile-inheritance-chain', 'profiles')),
+    );
     const multipleInheritanceProfiles = loadLocalProfileSource(
       createLocalProfileSource(scenarioPath('profile-multiple-inheritance', 'profiles')),
     );
@@ -103,7 +115,11 @@ describe('profile resolution', () => {
       },
     });
     expect(multipleInheritanceResult.issues).toEqual([]);
-    expect(multipleInheritanceResult.profileStack.map((profile) => profile.id)).toEqual(['first', 'second', 'composite']);
+    expect(multipleInheritanceResult.profileStack.map((profile) => profile.id)).toEqual([
+      'first',
+      'second',
+      'composite',
+    ]);
     expect(multipleInheritanceResult.profile?.controls.environment?.SHARED).toBe('composite');
   });
 

--- a/tests/unit/settings-loader.test.ts
+++ b/tests/unit/settings-loader.test.ts
@@ -67,9 +67,7 @@ describe('settings loading', () => {
     expect(loaded.issues).toEqual([]);
     expect(loaded.files.map((file) => file.location.scope)).toEqual(['user', 'project', 'project-local']);
     expect(loaded.settings.defaultProfile).toBe('local-default');
-    expect(loaded.settings.profileSources).toEqual([
-      { path: join(homeDirectory, '.bridl', 'profiles') },
-    ]);
+    expect(loaded.settings.profileSources).toEqual([{ path: join(homeDirectory, '.bridl', 'profiles') }]);
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.3).
@@ -81,10 +79,12 @@ describe('settings loading', () => {
     writeSettings(malformedPath, ': invalid: yaml:');
     writeSettings(invalidPath, 'profile_sources:\n  - only:\n      - engineering\n');
 
-    const result = loadSettingsFiles(createSettingsLoadPlan([
-      { scope: 'user', path: malformedPath },
-      { scope: 'project', path: invalidPath },
-    ]));
+    const result = loadSettingsFiles(
+      createSettingsLoadPlan([
+        { scope: 'user', path: malformedPath },
+        { scope: 'project', path: invalidPath },
+      ]),
+    );
 
     expect(result.files).toEqual([]);
     expect(result.issues[0]?.filePath).toBe(malformedPath);
@@ -92,7 +92,7 @@ describe('settings loading', () => {
     expect(result.issues).toContainEqual({
       filePath: invalidPath,
       path: '/profile_sources/0',
-      message: 'must have required property \'path\'',
+      message: "must have required property 'path'",
     });
   });
 

--- a/tests/unit/source-layout.test.ts
+++ b/tests/unit/source-layout.test.ts
@@ -18,7 +18,11 @@ import { createEmptyProfile } from '../../src/profiles/Profile.js';
 import { createProfileLoadPlan } from '../../src/profiles/ProfileLoader.js';
 import { mergeProfileStack } from '../../src/profiles/ProfileMerger.js';
 import { createLocalProfileSource, createUriProfileSource } from '../../src/profiles/ProfileSource.js';
-import { profileSchemaDocument, profileSourceSchemaDocument, settingsSchemaDocument } from '../../src/schemas/SchemaDocument.js';
+import {
+  profileSchemaDocument,
+  profileSourceSchemaDocument,
+  settingsSchemaDocument,
+} from '../../src/schemas/SchemaDocument.js';
 import { emptySettings } from '../../src/settings/Settings.js';
 import { createSettingsLoadPlan } from '../../src/settings/SettingsLoader.js';
 import { mergeSettingsStack } from '../../src/settings/SettingsMerger.js';
@@ -51,11 +55,7 @@ describe('source layout scaffolding', () => {
     createSyncCommand().register(standaloneProgram);
     createCreateProfileCommand().register(standaloneProgram);
 
-    expect(standaloneProgram.commands.map((command) => command.name())).toEqual([
-      'setup',
-      'sync',
-      'create_profile',
-    ]);
+    expect(standaloneProgram.commands.map((command) => command.name())).toEqual(['setup', 'sync', 'create_profile']);
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.5).
@@ -88,11 +88,7 @@ describe('source layout scaffolding', () => {
 
     expect(mergedSettings.defaultProfile).toBe('engineering');
     expect(mergedSettings.profileSources).toEqual([localSource]);
-    expect(settingsLoadPlan.locations.map((location) => location.scope)).toEqual([
-      'user',
-      'project',
-      'project-local',
-    ]);
+    expect(settingsLoadPlan.locations.map((location) => location.scope)).toEqual(['user', 'project', 'project-local']);
     expect(profileLoadPlan.sources).toEqual([localSource, uriSource]);
   });
 


### PR DESCRIPTION
## Summary
- Add Prettier config with preserved Markdown prose wrapping and project quote style
- Add snapper formatting before Prettier in npm check and Prettier checking in check-ci
- Run snapper/Prettier formatting across tracked files

## Verification
- npm run check