### PR TITLE
Fix snapper runner and markdown headings

### DIFF
--- a/.snapperrc.toml
+++ b/.snapperrc.toml
@@ -1,0 +1,5 @@
+# snapper project configuration
+# Keep numbered Markdown headings such as "## 1. Title" on one heading line.
+extra_abbreviations = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]
+format = "markdown"
+max_width = 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,9 +18,9 @@
 ## Project checks
 
 - Run `npm run check` for local verification.
-  It runs ESLint with auto-fixing enabled, then runs the coverage test suite.
+  It runs Snapper on Markdown files, writes Prettier formatting, runs ESLint with auto-fixing enabled, then runs the coverage test suite.
 - Run `npm run check-ci` for CI-equivalent verification.
-  It runs the same lint and coverage checks without modifying files.
+  It checks Prettier formatting, then runs the same lint and coverage checks without modifying files.
 - `npm run coverage` enforces the configured Vitest coverage thresholds.
 - Coverage includes all `src/**/*.ts` files, so new source files need tests even if they are only scaffolding.
 

--- a/doc/file_structure.md
+++ b/doc/file_structure.md
@@ -19,6 +19,7 @@ Bridl is organized around clear TypeScript source boundaries, requirement docume
 │   └── ...
 ├── .prettierignore                    # Prettier ignore rules
 ├── .prettierrc.json                   # Prettier formatting configuration
+├── .snapperrc.toml                    # Snapper Markdown formatting configuration
 ├── plan.md                            # implementation plan
 ├── src/                               # production TypeScript source
 │   ├── cli/                           # CLI parser construction and command registration
@@ -54,6 +55,8 @@ Bridl is organized around clear TypeScript source boundaries, requirement docume
 │   │   └── profile-source.schema.json
 │   └── validation/                    # shared validation helpers
 │       └── SchemaValidator.ts
+├── scripts/                           # local development and formatting helper scripts
+│   └── run-snapper.mjs                # pinned Snapper binary downloader/runner
 ├── tests/                             # automated tests
 │   ├── fixtures/                      # reusable test fixtures
 │   │   └── scenarios/                 # realistic .bridl scenarios and expected outputs

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ export default tseslint.config(
   js.configs.recommended,
   ...tseslint.configs.recommendedTypeChecked,
   {
-    ignores: ['dist/**', 'coverage/**', 'node_modules/**', 'eslint.config.js'],
+    ignores: ['dist/**', 'coverage/**', 'node_modules/**', 'eslint.config.js', 'scripts/**/*.mjs'],
   },
   {
     languageOptions: {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint:fix": "eslint . --fix",
     "test": "vitest --run",
     "coverage": "vitest --run --coverage",
-    "snapper:format": "git ls-files -z '*.md' | xargs -0 snapper -i",
+    "snapper:format": "node scripts/run-snapper.mjs --git-md -i",
     "check": "npm run snapper:format && prettier --write . && npm run lint:fix && npm run coverage",
     "check-ci": "prettier --check . && npm run lint && npm run coverage"
   },

--- a/recommendation.md
+++ b/recommendation.md
@@ -6,9 +6,7 @@
 A wrapper should primarily use separate `PI_CODING_AGENT_DIR` profile directories, then layer CLI flags and environment variables on top.
 For early in-process behavior changes, use a bootstrap extension passed with `--extension` / `-e`; it loads early enough to register providers, tools, flags, and prompt behavior, but not early enough to alter the config directory or initial settings discovery.
 
-## 1.
-
-Native pi mechanisms for different configurations
+## 1. Native pi mechanisms for different configurations
 
 ### Best native profile mechanism: separate agent directories
 
@@ -101,9 +99,7 @@ Bridl profiles control project-level behavior with one of these policies:
 2. Global profile plus current project's `.pi` overrides.
 3. Isolated profile launched from a controlled cwd / temp workspace when project overrides should not apply.
 
-## 2.
-
-Load order and injection opportunities
+## 2. Load order and injection opportunities
 
 ### High-level startup order
 

--- a/scripts/run-snapper.mjs
+++ b/scripts/run-snapper.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto';
+import { createWriteStream, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { chmod, readFile, rm } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { pipeline } from 'node:stream/promises';
+import https from 'node:https';
+
+const VERSION = '0.7.7';
+const REPO = 'TurtleTech-ehf/snapper';
+
+const targets = {
+  'darwin-arm64': 'aarch64-apple-darwin',
+  'darwin-x64': 'x86_64-apple-darwin',
+  'linux-arm64': 'aarch64-unknown-linux-gnu',
+  'linux-x64': 'x86_64-unknown-linux-gnu',
+};
+
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const target = targets[`${process.platform}-${process.arch}`];
+
+if (!target) {
+  console.error(`Unsupported snapper-fmt platform: ${process.platform}-${process.arch}`);
+  process.exit(1);
+}
+
+const cacheDir = join(projectRoot, 'node_modules', '.cache', 'snapper-fmt', VERSION, target);
+const snapperPath = join(cacheDir, `snapper-fmt-${target}`, 'snapper');
+
+const rawArgs = process.argv.slice(2);
+const useGitMarkdownFiles = rawArgs.includes('--git-md');
+const snapperArgs = rawArgs.filter((arg) => arg !== '--git-md');
+
+if (useGitMarkdownFiles) {
+  const result = spawnSync('git', ['ls-files', '-z', '*.md'], { cwd: projectRoot, encoding: 'utf8' });
+  if (result.status !== 0) {
+    process.stderr.write(result.stderr);
+    process.exit(result.status ?? 1);
+  }
+  const files = result.stdout.split('\0').filter(Boolean);
+  snapperArgs.push(...files);
+}
+
+await ensureSnapper();
+
+const result = spawnSync(snapperPath, snapperArgs, { cwd: projectRoot, stdio: 'inherit' });
+process.exit(result.status ?? 1);
+
+async function ensureSnapper() {
+  if (existsSync(snapperPath)) {
+    return;
+  }
+
+  mkdirSync(cacheDir, { recursive: true });
+
+  const archiveName = `snapper-fmt-${target}.tar.xz`;
+  const baseUrl = `https://github.com/${REPO}/releases/download/v${VERSION}`;
+  const archivePath = join(cacheDir, archiveName);
+  const checksumPath = `${archivePath}.sha256`;
+
+  await download(`${baseUrl}/${archiveName}`, archivePath);
+  await download(`${baseUrl}/${archiveName}.sha256`, checksumPath);
+  await verifyChecksum(archivePath, checksumPath);
+
+  const tar = spawnSync('tar', ['-xJf', archivePath, '-C', cacheDir], { cwd: cacheDir, stdio: 'inherit' });
+  if (tar.status !== 0) {
+    process.exit(tar.status ?? 1);
+  }
+
+  await chmod(snapperPath, 0o755);
+  await rm(archivePath, { force: true });
+  await rm(checksumPath, { force: true });
+}
+
+async function download(url, destination) {
+  await pipeline(await request(url), createWriteStream(destination));
+}
+
+function request(url, redirects = 0) {
+  return new Promise((resolveStream, reject) => {
+    https
+      .get(url, { headers: { 'User-Agent': 'bridl-snapper-runner' } }, (response) => {
+        if ([301, 302, 303, 307, 308].includes(response.statusCode ?? 0)) {
+          if (redirects > 5 || !response.headers.location) {
+            reject(new Error(`Too many redirects while downloading ${url}`));
+            return;
+          }
+          resolveStream(request(new URL(response.headers.location, url).toString(), redirects + 1));
+          return;
+        }
+
+        if (response.statusCode !== 200) {
+          reject(new Error(`Failed to download ${url}: HTTP ${response.statusCode}`));
+          return;
+        }
+
+        resolveStream(response);
+      })
+      .on('error', reject);
+  });
+}
+
+async function verifyChecksum(archivePath, checksumPath) {
+  const expected = (await readFile(checksumPath, 'utf8')).trim().split(/\s+/)[0];
+  const actual = createHash('sha256').update(readFileSync(archivePath)).digest('hex');
+
+  if (actual !== expected) {
+    throw new Error(`Checksum mismatch for ${archivePath}: expected ${expected}, got ${actual}`);
+  }
+}


### PR DESCRIPTION
## Summary
- Replace the global snapper dependency with a pinned snapper-fmt 0.7.7 runner that downloads and verifies release checksums
- Add Snapper config to keep numbered Markdown headings intact
- Fix recommendation headings and update contributor check descriptions

## Verification
- npm run check