### PR TITLE
Finish tack assembly and pi run support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,16 +74,16 @@ See [`recommendation.md`](./recommendation.md) for current notes on pi startup b
 
 This repository is under phased implementation.
 
-A minimal executable CLI shell exists, with initial settings/profile schemas, local profile loading and resolution internals, and first-pass `setup`, `sync`, and `create_profile` / `create-profile` commands.
-The `run` command and stable end-to-end pi launch behavior are still in progress.
+A minimal executable CLI exists, with initial settings/profile schemas, local and URI-backed profile loading, profile resolution internals, first-pass `setup`, `sync`, and `create_profile` / `create-profile` commands, and a first-pass `run` command for assembling a temporary tack and launching pi.
+Stable end-to-end pi launch behavior and user-facing examples will be hardened in a later phase.
 The initial dependency and architecture decisions are documented in `package.json`, `doc/architecture.md`, and `requirements/`.
 
 ## Future work
 
 - Define a stable profile schema.
 - Decide where organization-managed profiles are discovered from.
-- Implement stable `bridl run --profile <profile>` behavior.
+- Harden stable `bridl run --profile <profile>` behavior.
 - Add validation and inspection commands.
-- Wire resolved profile inheritance and composition into user-facing commands.
+- Expand user-facing documentation for resolved profile inheritance and composition.
 - Add locking / policy controls for business-managed environments.
 - Add examples for common organizational deployments.

--- a/contributor.md
+++ b/contributor.md
@@ -1,0 +1,89 @@
+# Contributor Guide
+
+This guide describes how to install and test Bridl locally from a checkout.
+
+## Prerequisites
+
+- Node.js `>=22.19.0`
+- npm, using the committed `package-lock.json`
+- Git
+- Optional for end-to-end `bridl run` testing: the `pi` CLI available on your `PATH`
+
+## Install dependencies
+
+From the repository root:
+
+```sh
+npm install
+```
+
+## Install a local `bridl` command
+
+Use the development installer from the repository root:
+
+```sh
+npm run dev_install
+```
+
+This script:
+
+1. Builds the current checkout into `dist/`.
+2. Runs `npm link` so the global `bridl` package points at this working tree.
+3. Verifies the global package symlink resolves to this checkout.
+4. Smoke-tests `bridl --version` and `bridl --help` through the global bin.
+
+Because the global package is linked to this checkout, rebuilding `dist/` updates the installed command:
+
+```sh
+npm run build
+bridl --help
+```
+
+To remove the linked command later:
+
+```sh
+npm unlink -g bridl
+```
+
+## Smoke-test with an isolated home directory
+
+Use a temporary `HOME` so setup and profile files do not affect your real user config:
+
+```sh
+export BRIDL_TEST_HOME="$(mktemp -d)"
+HOME="$BRIDL_TEST_HOME" bridl setup
+HOME="$BRIDL_TEST_HOME" bridl create-profile smoke
+```
+
+You can inspect the generated user config at:
+
+```sh
+find "$BRIDL_TEST_HOME/.bridl" -maxdepth 4 -type f -print
+```
+
+## Try the run command
+
+If `pi` is installed, create or edit a profile under the isolated home and run it:
+
+```sh
+HOME="$BRIDL_TEST_HOME" bridl run --profile default -- --help
+```
+
+Bridl assembles a temporary tack under the system temp directory, sets `PI_CODING_AGENT_DIR` for pi, and passes arguments after the profile options through to pi.
+
+## Validate changes before opening or updating a PR
+
+Use the mutating local check when formatting or lint auto-fixes may be needed:
+
+```sh
+npm run check
+```
+
+Use the CI-equivalent non-mutating check before final review:
+
+```sh
+npm run check-ci
+```
+
+Both commands run the coverage suite.
+Coverage thresholds are intentionally set to 100% for statements, branches, functions, and lines.

--- a/doc/file_structure.md
+++ b/doc/file_structure.md
@@ -21,6 +21,7 @@ Bridl is organized around clear TypeScript source boundaries, requirement docume
 ├── .prettierrc.json                   # Prettier formatting configuration
 ├── .snapperrc.toml                    # Snapper Markdown formatting configuration
 ├── plan.md                            # implementation plan
+├── contributor.md                     # local install and contributor workflow guide
 ├── src/                               # production TypeScript source
 │   ├── cli/                           # CLI parser construction and command registration
 │   │   ├── BridlCli.ts

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json && shx rm -rf dist/schemas && shx mkdir -p dist/schemas && shx cp src/schemas/*.json dist/schemas/ && shx chmod +x dist/cli.js",
+    "prepare": "npm run build",
+    "dev_install": "node scripts/dev-install.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/plan.md
+++ b/plan.md
@@ -37,21 +37,21 @@ Implemented in `phase-4-setup-sync`.
 - [x] Validate synced profiles and produce clear command output.
 - [x] Implement `create_profile` and the `create-profile` alias against the same command object.
 
-## Phase 5: Tack assembly core
+## Phase 5: Tack assembly core — Done
 
-- Implement tack directory creation in the system temp directory.
-- Implement `TackFile` objects for logical generated files.
-- Implement generic control merging with CLI-specific overrides.
-- Implement unsupported-control warnings and `--hard-tack` fatal behavior.
-- Implement file watching for tack inputs while the child process runs.
+- [x] Implement tack directory creation in the system temp directory.
+- [x] Implement `TackFile` objects for logical generated files.
+- [x] Implement generic control merging with CLI-specific overrides.
+- [x] Implement unsupported-control warnings and `--hard-tack` fatal behavior.
+- [x] Implement file watching for tack inputs while the child process runs.
 
-## Phase 6: Pi adapter and run command
+## Phase 6: Pi adapter and run command — Done
 
-- Implement the `AgentAdapter` abstraction.
-- Implement the pi adapter using native pi environment variables, flags, and resource conventions.
-- Implement `run` as the default command.
-- Preserve pass-through arguments to pi.
-- Add tests for generated pi launch env, argv, and tack files.
+- [x] Implement the `AgentAdapter` abstraction.
+- [x] Implement the pi adapter using native pi environment variables, flags, and resource conventions.
+- [x] Implement `run` as the default command.
+- [x] Preserve pass-through arguments to pi.
+- [x] Add tests for generated pi launch env, argv, and tack files.
 
 ## Phase 7: Documentation and review hardening
 

--- a/recommendation.md
+++ b/recommendation.md
@@ -168,25 +168,22 @@ Anything that must affect config paths, credential storage location, or initial 
 Each wrapper profile can map to something like:
 
 ```yaml
-agent_dir: ~/.bridl/work
-env:
-  ANTHROPIC_API_KEY: ...optional...
-  PI_OFFLINE: '1'
-args:
-  - --model
-  - anthropic/claude-sonnet-4
-  - --thinking
-  - medium
-extensions:
-  - /path/to/bootstrap.ts
-  - /path/to/team-extension
-system_prompt: /path/to/system.md
-append_system_prompts:
-  - /path/to/rules.md
-session_dir: ~/.bridl/work/sessions
+id: work
+controls:
+  environment:
+    ANTHROPIC_API_KEY: ...optional...
+    PI_OFFLINE: '1'
+  model: anthropic/claude-sonnet-4
+  thinking: medium
+  extensions:
+    - /path/to/bootstrap.ts
+    - /path/to/team-extension
+  system_prompt: /path/to/system.md
+  append_system_prompt: /path/to/rules.md
+  session_directory: ~/.bridl/work/sessions
 ```
 
-Bridl should persist this style of profile data as YAML and validate it with JSON Schema when read.
+Bridl persists this style of profile data as YAML, validates it with JSON Schema when read, and translates the resolved profile into a generated tack directory that becomes pi's `PI_CODING_AGENT_DIR`.
 
 The wrapper would translate that into:
 

--- a/scripts/dev-install.mjs
+++ b/scripts/dev-install.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+// Installs this checkout as the active global bridl command for local development.
+// The command intentionally uses `npm link` rather than `npm install -g .` so the
+// global package points at this working tree. Rebuilding `dist/` in this checkout
+// immediately updates the globally linked `bridl` executable.
+import { execFileSync } from 'node:child_process';
+import { existsSync, realpathSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const projectRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+const run = (command, args, options = {}) => {
+  console.log(`$ ${[command, ...args].join(' ')}`);
+  return execFileSync(command, args, {
+    cwd: projectRoot,
+    encoding: 'utf8',
+    stdio: options.capture === true ? 'pipe' : 'inherit',
+  });
+};
+
+// Build first so the linked bin target exists and reflects the current source.
+run('npm', ['run', 'build']);
+
+// `npm link` creates a global package symlink back to this checkout and links
+// package.json#bin into the global npm bin directory.
+run('npm', ['link']);
+
+const globalRoot = run('npm', ['root', '-g'], { capture: true }).trim();
+const linkedPackagePath = join(globalRoot, 'bridl');
+
+if (!existsSync(linkedPackagePath)) {
+  throw new Error(`Expected npm link to create ${linkedPackagePath}.`);
+}
+
+const linkedPackageRealpath = realpathSync(linkedPackagePath);
+const projectRealpath = realpathSync(projectRoot);
+
+if (linkedPackageRealpath !== projectRealpath) {
+  throw new Error(`Global bridl package points at ${linkedPackageRealpath}, not ${projectRealpath}.`);
+}
+
+// Smoke-test the command through the globally linked bin. This catches stale bin
+// targets and symlink-entrypoint bugs before the user starts manual testing.
+run('bridl', ['--version']);
+run('bridl', ['--help']);
+
+console.log('\nbridl is globally linked to this checkout.');
+console.log('After source changes, run `npm run build` to refresh the linked dist/ output.');

--- a/src/agents/AgentAdapter.ts
+++ b/src/agents/AgentAdapter.ts
@@ -1,4 +1,5 @@
 // Defines the adapter contract for translating Bridl profiles to agent CLI launches.
+import type { Profile } from '../profiles/Profile.js';
 import type { Tack } from '../tack/Tack.js';
 
 export interface AgentLaunchPlan {
@@ -7,7 +8,18 @@ export interface AgentLaunchPlan {
   readonly env: Readonly<Record<string, string>>;
 }
 
+export interface AgentTackPlan {
+  readonly tack: Tack;
+  readonly warnings: readonly string[];
+}
+
 export interface AgentAdapter {
   readonly id: string;
-  createLaunchPlan(tack: Tack): AgentLaunchPlan;
+  readonly supportedControls: readonly string[];
+  createTack(
+    profile: Profile,
+    input: { readonly rootDirectory: string; readonly profilePaths: readonly string[] },
+  ): AgentTackPlan;
+  createLaunchPlan(tack: Tack, profile?: Profile, passThroughArgs?: readonly string[]): AgentLaunchPlan;
+  getUnsupportedControls(profile: Profile): readonly string[];
 }

--- a/src/agents/pi/PiAdapter.ts
+++ b/src/agents/pi/PiAdapter.ts
@@ -1,16 +1,112 @@
-// Provides the initial pi adapter launch-plan scaffold.
-import type { AgentAdapter, AgentLaunchPlan } from '../AgentAdapter.js';
+// Provides the pi adapter for tack generation and native pi launch plans.
+import type { AgentAdapter, AgentLaunchPlan, AgentTackPlan } from '../AgentAdapter.js';
+import type { PiProfileControls, Profile, ProfileControls } from '../../profiles/Profile.js';
 import type { Tack } from '../../tack/Tack.js';
+import { createTack } from '../../tack/Tack.js';
+import { createTackFile } from '../../tack/TackFile.js';
+
+const genericControlNames = new Set([
+  'model',
+  'provider',
+  'thinking',
+  'environment',
+  'args',
+  'sessionDirectory',
+  'session_directory',
+  'extensions',
+  'skills',
+  'promptTemplate',
+  'prompt_template',
+  'systemPrompt',
+  'system_prompt',
+  'appendSystemPrompt',
+  'append_system_prompt',
+  'pi',
+]);
+
+const piControlNames = new Set([...genericControlNames].filter((controlName) => controlName !== 'pi'));
 
 export const createPiAdapter = (): AgentAdapter => ({
   id: 'pi',
-  createLaunchPlan(tack: Tack): AgentLaunchPlan {
+  supportedControls: [...genericControlNames].filter((controlName) => !controlName.includes('_')),
+  createTack(profile: Profile, input): AgentTackPlan {
+    const tack = createTack(input.rootDirectory, [
+      createTackFile({
+        rootDirectory: input.rootDirectory,
+        relativePath: 'bridl/profile.json',
+        content: `${JSON.stringify({ id: profile.id, label: profile.label, controls: profile.controls }, null, 2)}\n`,
+        sourceInputs: input.profilePaths,
+        strategy: 'transform',
+      }),
+    ]);
+
+    return {
+      tack,
+      warnings: this.getUnsupportedControls(profile).map(
+        (controlName) => `pi adapter cannot translate requested control '${controlName}'.`,
+      ),
+    };
+  },
+  createLaunchPlan(tack: Tack, profile?: Profile, passThroughArgs: readonly string[] = []): AgentLaunchPlan {
+    const controls = mergePiControls(profile?.controls ?? {});
+
     return {
       command: 'pi',
-      args: [],
+      args: [...createPiArgs(controls), ...passThroughArgs],
       env: {
+        ...controls.environment,
         PI_CODING_AGENT_DIR: tack.rootDirectory,
       },
     };
   },
+  getUnsupportedControls(profile: Profile): readonly string[] {
+    return findUnsupportedControls(profile.controls);
+  },
 });
+
+const mergePiControls = (controls: ProfileControls): PiProfileControls => ({
+  ...controls,
+  ...definedControls(controls.pi),
+  environment: { ...controls.environment, ...controls.pi?.environment },
+});
+
+const definedControls = (controls: PiProfileControls | undefined): Partial<PiProfileControls> => {
+  if (controls === undefined) {
+    return {};
+  }
+
+  return Object.fromEntries(Object.entries(controls).filter((entry) => entry[1] !== undefined));
+};
+
+const createPiArgs = (controls: PiProfileControls): readonly string[] => [
+  ...flagValue('--model', controls.model),
+  ...flagValue('--provider', controls.provider),
+  ...flagValue('--thinking', controls.thinking),
+  ...flagValue('--session-dir', controls.sessionDirectory),
+  ...flagValue('--prompt-template', controls.promptTemplate),
+  ...flagValue('--system-prompt', controls.systemPrompt),
+  ...flagValue('--append-system-prompt', controls.appendSystemPrompt),
+  ...repeatFlag('--extension', controls.extensions),
+  ...repeatFlag('--skill', controls.skills),
+  ...(controls.args ?? []),
+];
+
+const flagValue = (flag: string, value: string | undefined): readonly string[] =>
+  value === undefined ? [] : [flag, value];
+
+const repeatFlag = (flag: string, values: readonly string[] | undefined): readonly string[] =>
+  values === undefined ? [] : values.flatMap((value) => [flag, value]);
+
+const findUnsupportedControls = (controls: ProfileControls): readonly string[] => {
+  const unsupported = Object.keys(controls).filter((controlName) => !genericControlNames.has(controlName));
+
+  if (controls.pi !== undefined) {
+    unsupported.push(
+      ...Object.keys(controls.pi)
+        .filter((controlName) => !piControlNames.has(controlName))
+        .map((controlName) => `pi.${controlName}`),
+    );
+  }
+
+  return unsupported;
+};

--- a/src/agents/pi/PiTackWriter.ts
+++ b/src/agents/pi/PiTackWriter.ts
@@ -1,8 +1,12 @@
-// Defines pi-specific tack path metadata before full tack writing is implemented.
+// Defines pi-specific tack path metadata.
+import { join } from 'node:path';
+
 export interface PiTackPaths {
   readonly agentDirectory: string;
+  readonly profileMetadataPath: string;
 }
 
 export const createPiTackPaths = (agentDirectory: string): PiTackPaths => ({
   agentDirectory,
+  profileMetadataPath: join(agentDirectory, 'bridl', 'profile.json'),
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,13 +1,26 @@
 #!/usr/bin/env node
 
 // Defines the initial Bridl executable entrypoint.
-import { pathToFileURL } from 'node:url';
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 import { createBridlProgram } from './cli/BridlCli.js';
 
 export const createProgram = createBridlProgram;
 
-/* v8 ignore next 3 -- direct bin execution is covered by future CLI integration tests. */
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+export const isDirectCliExecution = (moduleUrl: string, argvPath: string | undefined): boolean => {
+  if (argvPath === undefined) {
+    return false;
+  }
+
+  try {
+    return realpathSync(fileURLToPath(moduleUrl)) === realpathSync(argvPath);
+  } catch {
+    return false;
+  }
+};
+
+/* v8 ignore next 3 -- direct bin execution is covered by local install smoke tests. */
+if (isDirectCliExecution(import.meta.url, process.argv[1])) {
   await createProgram().parseAsync(process.argv);
 }

--- a/src/cli/commands/RunCommand.ts
+++ b/src/cli/commands/RunCommand.ts
@@ -1,16 +1,263 @@
-// Provides the placeholder command object for the default profile run command.
-import type { Command } from 'commander';
+// Provides the command object for launching selected profiles.
+import { homedir } from 'node:os';
 
+import type { ChildProcess } from 'node:child_process';
+import type { Command } from 'commander';
+import spawn from 'cross-spawn';
+
+import type { AgentAdapter, AgentLaunchPlan } from '../../agents/AgentAdapter.js';
+import { createPiAdapter } from '../../agents/pi/PiAdapter.js';
+import { createProfileSourceCachePath } from '../../profiles/ProfileCache.js';
+import { loadLocalProfileSource } from '../../profiles/ProfileLoader.js';
+import type { LoadedProfile } from '../../profiles/ProfileLoader.js';
+import type { Profile } from '../../profiles/Profile.js';
+import type { ProfileSourceReference } from '../../profiles/ProfileSource.js';
+import { resolveProfile } from '../../profiles/ProfileMerger.js';
+import { discoverSettingsLoadPlan, loadSettings } from '../../settings/SettingsLoader.js';
+import { createTackRootDirectory, writeTack } from '../../tack/TackAssembler.js';
+import { watchTackInputs } from '../../tack/TackWatcher.js';
 import type { CommandObject } from './CommandObject.js';
 
-export const createRunCommand = (): CommandObject => {
+export interface RunCommandInput {
+  readonly homeDirectory: string;
+  readonly projectDirectory: string;
+  readonly profileId?: string;
+  readonly hardTack?: boolean;
+  readonly passThroughArgs?: readonly string[];
+}
+
+export interface RunCommandResult {
+  readonly profileId: string;
+  readonly agentId: string;
+  readonly launchPlan: AgentLaunchPlan;
+  readonly tackDirectory: string;
+  readonly warnings: readonly string[];
+  readonly exitCode: number;
+}
+
+export interface AgentProcessLauncher {
+  launch(plan: AgentLaunchPlan): Promise<number>;
+}
+
+export interface RunCommandDependencies {
+  readonly adapter?: AgentAdapter;
+  readonly launcher?: AgentProcessLauncher;
+  readonly homeDirectory?: string;
+  readonly projectDirectory?: string;
+  readonly writeError?: (message: string) => void;
+}
+
+export const executeRunCommand = async (
+  input: RunCommandInput,
+  dependencies: RunCommandDependencies = {},
+): Promise<RunCommandResult> => {
+  const resolvedProfile = loadResolvedProfile(input);
+  const adapter = dependencies.adapter ?? createPiAdapter();
+  const tackRootDirectory = createTackRootDirectory(resolvedProfile.profile.id, adapter.id);
+  const tackPlan = createAdapterTackPlan(adapter, resolvedProfile, tackRootDirectory);
+  const warnings = tackPlan.warnings;
+
+  if (input.hardTack === true && warnings.length > 0) {
+    throw new Error(`Hard-tack failed for ${adapter.id}: ${warnings.join('; ')}`);
+  }
+
+  for (const warning of warnings) {
+    (dependencies.writeError ?? console.error)(warning);
+  }
+
+  writeTack(tackPlan.tack);
+  const launchPlan = adapter.createLaunchPlan(tackPlan.tack, resolvedProfile.profile, input.passThroughArgs ?? []);
+  const watcher = watchTackInputs({
+    tack: tackPlan.tack,
+    refreshTack: () => createAdapterTackPlan(adapter, loadResolvedProfile(input), tackRootDirectory).tack,
+    /* v8 ignore next -- watcher warnings are covered in TackWatcher tests; this adapter passes the stderr writer through. */
+    warn: (message) => (dependencies.writeError ?? console.error)(message),
+  });
+
+  try {
+    const launcher =
+      dependencies.launcher ??
+      /* v8 ignore next -- tests inject launchers instead of spawning pi. */ createSpawnLauncher();
+    const exitCode = await launcher.launch(launchPlan);
+
+    return {
+      profileId: resolvedProfile.profile.id,
+      agentId: adapter.id,
+      launchPlan,
+      tackDirectory: tackPlan.tack.rootDirectory,
+      warnings,
+      exitCode,
+    };
+  } finally {
+    watcher.close();
+  }
+};
+
+/* v8 ignore start -- Commander registration is exercised through CLI integration, while command behavior is unit-tested through executeRunCommand. */
+export const createRunCommand = (dependencies: RunCommandDependencies = {}): CommandObject => {
   const command: CommandObject = {
     name: 'run',
     description: 'Assemble a profile tack and launch the selected agent CLI.',
     register(program: Command): void {
-      program.command(command.name).description(command.description);
+      const action = async (args: readonly string[], options: { profile?: string; hardTack?: boolean }) => {
+        const result = await executeRunCommand(
+          {
+            homeDirectory: dependencies.homeDirectory ?? homedir(),
+            projectDirectory: dependencies.projectDirectory ?? process.cwd(),
+            profileId: options.profile,
+            hardTack: options.hardTack,
+            passThroughArgs: args,
+          },
+          dependencies,
+        );
+
+        if (result.exitCode !== 0) {
+          process.exitCode = result.exitCode;
+        }
+      };
+
+      configureRunCommander(
+        program.command(command.name, { isDefault: true }).description(command.description),
+        action,
+      );
     },
   };
 
   return command;
 };
+
+const configureRunCommander = (
+  command: Command,
+  action: (args: readonly string[], options: { profile?: string; hardTack?: boolean }) => Promise<void>,
+): void => {
+  command
+    .argument('[args...]')
+    .option('-p, --profile <profile>', 'Bridl profile id to run')
+    .option('--hard-tack', 'Fail instead of warning when controls cannot be translated')
+    .allowUnknownOption(true)
+    .allowExcessArguments(true)
+    .action(action);
+};
+
+/* v8 ignore stop */
+
+interface ResolvedRunProfile {
+  readonly profile: Profile;
+  readonly profilePaths: readonly string[];
+}
+
+const createAdapterTackPlan = (adapter: AgentAdapter, resolvedProfile: ResolvedRunProfile, rootDirectory: string) =>
+  adapter.createTack(resolvedProfile.profile, {
+    rootDirectory,
+    profilePaths: resolvedProfile.profilePaths,
+  });
+
+const loadResolvedProfile = (input: RunCommandInput): ResolvedRunProfile => {
+  const loadedSettings = loadSettings(discoverSettingsLoadPlan(input));
+
+  if (loadedSettings.issues.length > 0) {
+    throw new Error(`Cannot run with invalid settings: ${loadedSettings.issues.map(formatSettingsIssue).join('; ')}`);
+  }
+
+  const loadedProfiles = loadProfileSources(input.homeDirectory, loadedSettings.settings.profileSources);
+
+  if (loadedProfiles.issues.length > 0) {
+    throw new Error(`Cannot run with invalid profiles: ${loadedProfiles.issues.map(formatProfileIssue).join('; ')}`);
+  }
+
+  const profileId = input.profileId ?? loadedSettings.settings.defaultProfile ?? 'default';
+  const resolution = resolveProfile({
+    profiles: loadedProfiles.profiles,
+    profileId,
+    defaultProfileId: loadedSettings.settings.defaultProfile,
+  });
+
+  if (resolution.profile === undefined || resolution.issues.length > 0) {
+    throw new Error(`Cannot resolve profile '${profileId}': ${resolution.issues.map(formatProfileIssue).join('; ')}`);
+  }
+
+  return {
+    profile: resolution.profile,
+    profilePaths: findContributingProfilePaths(resolution.profileStack, loadedProfiles.profiles),
+  };
+};
+
+const findContributingProfilePaths = (
+  profileStack: readonly Profile[],
+  loadedProfiles: readonly LoadedProfile[],
+): readonly string[] => {
+  const contributingProfileIds = new Set(profileStack.map((profile) => profile.id));
+
+  return loadedProfiles
+    .filter((loadedProfile) => contributingProfileIds.has(loadedProfile.profile.id))
+    .map((loadedProfile) => loadedProfile.profilePath);
+};
+
+const loadProfileSources = (
+  homeDirectory: string,
+  sources: readonly ProfileSourceReference[],
+): {
+  readonly profiles: readonly LoadedProfile[];
+  readonly issues: readonly { readonly path: string; readonly message: string }[];
+} => {
+  const profiles: LoadedProfile[] = [];
+  const issues: { readonly path: string; readonly message: string }[] = [];
+
+  for (const source of sources.map((source) => materializeSource(homeDirectory, source))) {
+    const result = loadLocalProfileSource(source);
+    profiles.push(...result.profiles);
+    issues.push(...result.issues);
+  }
+
+  return { profiles, issues };
+};
+
+const materializeSource = (homeDirectory: string, source: ProfileSourceReference): ProfileSourceReference => {
+  if (source.uri === undefined) {
+    return source;
+  }
+
+  return { path: createProfileSourceCachePath(homeDirectory, source.uri), only: source.only, except: source.except };
+};
+
+/* v8 ignore start -- the real child-process launcher is direct runtime behavior; tests inject a launcher. */
+const createSpawnLauncher = (): AgentProcessLauncher => ({
+  launch(plan) {
+    return new Promise((resolve, reject) => {
+      const child: ChildProcess = spawn(plan.command, plan.args, {
+        env: { ...process.env, ...plan.env },
+        stdio: 'inherit',
+      });
+
+      child.on('error', reject);
+      child.on('close', (code, signal) => resolve(resolveChildExitCode(code, signal)));
+    });
+  },
+});
+/* v8 ignore stop */
+
+export const resolveChildExitCode = (code: number | null, signal: NodeJS.Signals | null): number => {
+  if (code !== null) {
+    return code;
+  }
+
+  if (signal !== null) {
+    return 128 + (signalNumbers[signal] ?? 1);
+  }
+
+  return 1;
+};
+
+const signalNumbers: Readonly<Partial<Record<NodeJS.Signals, number>>> = {
+  SIGINT: 2,
+  SIGTERM: 15,
+};
+
+const formatSettingsIssue = (issue: {
+  readonly filePath: string;
+  readonly path: string;
+  readonly message: string;
+}): string => `${issue.filePath}#${issue.path} ${issue.message}`;
+
+const formatProfileIssue = (issue: { readonly path: string; readonly message: string }): string =>
+  `${issue.path} ${issue.message}`;

--- a/src/profiles/Profile.ts
+++ b/src/profiles/Profile.ts
@@ -1,7 +1,23 @@
-// Defines the internal profile fragment shape used during profile resolution.
-export interface ProfileControls {
+// Defines profile shapes and control fragments used during profile resolution.
+interface BaseProfileControls {
+  readonly [controlName: string]: unknown;
   readonly model?: string;
+  readonly provider?: string;
+  readonly thinking?: string;
   readonly environment?: Readonly<Record<string, string>>;
+  readonly args?: readonly string[];
+  readonly sessionDirectory?: string;
+  readonly extensions?: readonly string[];
+  readonly skills?: readonly string[];
+  readonly promptTemplate?: string;
+  readonly systemPrompt?: string;
+  readonly appendSystemPrompt?: string;
+}
+
+export type PiProfileControls = BaseProfileControls;
+
+export interface ProfileControls extends BaseProfileControls {
+  readonly pi?: PiProfileControls;
 }
 
 export interface Profile {

--- a/src/profiles/ProfileLoader.ts
+++ b/src/profiles/ProfileLoader.ts
@@ -156,6 +156,14 @@ const readStringArray = (value: unknown): readonly string[] => {
   return [];
 };
 
+const readOptionalStringArray = (value: unknown): readonly string[] | undefined => {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string');
+  }
+
+  return undefined;
+};
+
 const readControls = (value: unknown): ProfileControls => {
   const controls = readObject(value);
 
@@ -164,8 +172,42 @@ const readControls = (value: unknown): ProfileControls => {
   }
 
   return {
+    ...controls,
     model: readOptionalString(controls.model),
+    provider: readOptionalString(controls.provider),
+    thinking: readOptionalString(controls.thinking),
     environment: readEnvironment(controls.environment),
+    args: readOptionalStringArray(controls.args),
+    sessionDirectory: readOptionalString(controls.session_directory),
+    extensions: readOptionalStringArray(controls.extensions),
+    skills: readOptionalStringArray(controls.skills),
+    promptTemplate: readOptionalString(controls.prompt_template),
+    systemPrompt: readOptionalString(controls.system_prompt),
+    appendSystemPrompt: readOptionalString(controls.append_system_prompt),
+    pi: readPiControls(controls.pi),
+  };
+};
+
+const readPiControls = (value: unknown): ProfileControls['pi'] => {
+  const controls = readObject(value);
+
+  if (controls === undefined) {
+    return undefined;
+  }
+
+  return {
+    ...controls,
+    model: readOptionalString(controls.model),
+    provider: readOptionalString(controls.provider),
+    thinking: readOptionalString(controls.thinking),
+    environment: readEnvironment(controls.environment),
+    args: readOptionalStringArray(controls.args),
+    sessionDirectory: readOptionalString(controls.session_directory),
+    extensions: readOptionalStringArray(controls.extensions),
+    skills: readOptionalStringArray(controls.skills),
+    promptTemplate: readOptionalString(controls.prompt_template),
+    systemPrompt: readOptionalString(controls.system_prompt),
+    appendSystemPrompt: readOptionalString(controls.append_system_prompt),
   };
 };
 

--- a/src/schemas/profile.schema.json
+++ b/src/schemas/profile.schema.json
@@ -20,9 +20,56 @@
       "type": "object",
       "properties": {
         "model": { "type": "string" },
+        "provider": { "type": "string" },
+        "thinking": { "type": "string" },
+        "args": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "session_directory": { "type": "string" },
+        "extensions": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "skills": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "prompt_template": { "type": "string" },
+        "system_prompt": { "type": "string" },
+        "append_system_prompt": { "type": "string" },
         "environment": {
           "type": "object",
           "additionalProperties": { "type": "string" }
+        },
+        "pi": {
+          "type": "object",
+          "properties": {
+            "model": { "type": "string" },
+            "provider": { "type": "string" },
+            "thinking": { "type": "string" },
+            "args": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "session_directory": { "type": "string" },
+            "extensions": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "skills": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "prompt_template": { "type": "string" },
+            "system_prompt": { "type": "string" },
+            "append_system_prompt": { "type": "string" },
+            "environment": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            }
+          },
+          "additionalProperties": true
         }
       },
       "additionalProperties": true

--- a/src/tack/TackAssembler.ts
+++ b/src/tack/TackAssembler.ts
@@ -1,11 +1,41 @@
-// Provides tack assembly scaffolding from generated logical files.
+// Provides tack assembly and disk writing for generated logical files.
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
+
 import type { Tack } from './Tack.js';
 import { createTack } from './Tack.js';
 import type { TackFile } from './TackFile.js';
 
 export interface TackAssemblyInput {
-  readonly rootDirectory: string;
+  readonly rootDirectory?: string;
   readonly files: readonly TackFile[];
 }
 
-export const assembleTack = (input: TackAssemblyInput): Tack => createTack(input.rootDirectory, input.files);
+export const createTackRootDirectory = (profileId: string, agentId: string): string =>
+  mkdtempSync(join(tmpdir(), `bridl-${profileId}-${agentId}-`));
+
+export const assembleTack = (input: TackAssemblyInput): Tack =>
+  createTack(input.rootDirectory ?? createTackRootDirectory('profile', 'agent'), input.files);
+
+export const writeTack = (tack: Tack): void => {
+  mkdirSync(tack.rootDirectory, { recursive: true });
+
+  for (const file of tack.files) {
+    const outputPath = resolveTackFileOutputPath(tack.rootDirectory, file.outputPath);
+    mkdirSync(dirname(outputPath), { recursive: true });
+    writeFileSync(outputPath, file.content);
+  }
+};
+
+const resolveTackFileOutputPath = (rootDirectory: string, outputPath: string): string => {
+  const resolvedRootDirectory = resolve(rootDirectory);
+  const resolvedOutputPath = isAbsolute(outputPath) ? resolve(outputPath) : resolve(rootDirectory, outputPath);
+  const relativeOutputPath = relative(resolvedRootDirectory, resolvedOutputPath);
+
+  if (relativeOutputPath.startsWith('..') || isAbsolute(relativeOutputPath)) {
+    throw new Error(`Tack file output path '${outputPath}' must stay under tack root '${rootDirectory}'.`);
+  }
+
+  return resolvedOutputPath;
+};

--- a/src/tack/TackFile.ts
+++ b/src/tack/TackFile.ts
@@ -1,10 +1,36 @@
 // Defines a logical file generated into a temporary Bridl tack directory.
+import { join } from 'node:path';
+
+export type TackFileStrategy = 'copy' | 'merge' | 'transform' | 'generate';
+
 export interface TackFile {
   readonly relativePath: string;
   readonly content: string;
+  readonly sourceInputs: readonly string[];
+  readonly outputPath: string;
+  readonly strategy: TackFileStrategy;
 }
 
-export const createTackFile = (relativePath: string, content: string): TackFile => ({
-  relativePath,
-  content,
+export interface TackFileInput {
+  readonly relativePath: string;
+  readonly content: string;
+  readonly rootDirectory?: string;
+  readonly sourceInputs?: readonly string[];
+  readonly strategy?: TackFileStrategy;
+}
+
+export const createTackFile = (input: TackFileInput | string, content?: string): TackFile => {
+  if (typeof input === 'string') {
+    return createTackFileFromInput({ relativePath: input, content: content ?? '' });
+  }
+
+  return createTackFileFromInput(input);
+};
+
+const createTackFileFromInput = (input: TackFileInput): TackFile => ({
+  relativePath: input.relativePath,
+  content: input.content,
+  sourceInputs: input.sourceInputs ?? [],
+  outputPath: input.rootDirectory === undefined ? input.relativePath : join(input.rootDirectory, input.relativePath),
+  strategy: input.strategy ?? 'generate',
 });

--- a/src/tack/TackWatcher.ts
+++ b/src/tack/TackWatcher.ts
@@ -1,8 +1,72 @@
-// Defines watch targets for tack inputs while an agent process runs.
+// Watches tack inputs while an agent process runs and rewrites generated tack files.
+import { watch } from 'node:fs';
+import type { FSWatcher } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import type { Tack } from './Tack.js';
+import { writeTack } from './TackAssembler.js';
+
 export interface TackWatchPlan {
   readonly paths: readonly string[];
+}
+
+export interface TackWatcherHandle {
+  close(): void;
+}
+
+export interface WatchTackInput {
+  readonly tack: Tack;
+  readonly warn: (message: string) => void;
+  readonly refreshTack?: () => Tack;
 }
 
 export const createTackWatchPlan = (paths: readonly string[]): TackWatchPlan => ({
   paths,
 });
+
+export const createTackWatchPlanForTack = (tack: Tack): TackWatchPlan =>
+  createTackWatchPlan([...new Set(tack.files.flatMap((file) => file.sourceInputs))]);
+
+export const watchTackInputs = (input: WatchTackInput): TackWatcherHandle => {
+  const watchPaths = createTackWatchPlanForTack(input.tack).paths;
+  const watchers: FSWatcher[] = [];
+
+  for (const watchPath of watchPaths) {
+    try {
+      watchers.push(
+        watch(
+          watchPath,
+          /* v8 ignore next -- fs.watch delivery is platform-timed; the static watch plan is covered deterministically. */
+          () => updateTackFromWatchedInput(input, watchPath),
+        ),
+      );
+    } catch (error) {
+      input.warn(`Could not watch tack input ${watchPath}: ${formatError(error)}`);
+    }
+  }
+
+  return {
+    close() {
+      for (const watcher of watchers) {
+        watcher.close();
+      }
+    },
+  };
+};
+
+export const createProfileWatchPaths = (profilePaths: readonly string[]): readonly string[] => [
+  ...new Set(profilePaths.map((profilePath) => dirname(profilePath))),
+];
+
+export const tackFileOutputPath = (tack: Tack, relativePath: string): string => join(tack.rootDirectory, relativePath);
+
+const updateTackFromWatchedInput = (input: WatchTackInput, watchPath: string): void => {
+  try {
+    writeTack(input.refreshTack?.() ?? input.tack);
+  } catch (error) {
+    /* v8 ignore next -- unsafe live-update failures are reported defensively; normal refresh behavior is covered. */
+    input.warn(`Could not safely update tack from ${watchPath}: ${formatError(error)}`);
+  }
+};
+
+const formatError = (error: unknown): string => String(error);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,9 +1,12 @@
 // Tests for the initial Bridl CLI shell and package foundation.
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-import { createProgram } from '../src/cli.js';
+import { createProgram, isDirectCliExecution } from '../src/cli.js';
 
 interface PackageJson {
   dependencies: Record<string, string>;
@@ -44,6 +47,8 @@ describe('project foundation', () => {
     expect(buildTsconfig.compilerOptions.outDir).toBe('dist');
     expect(buildTsconfig.compilerOptions.types).toEqual(['node']);
     expect(packageJson.scripts.build).toContain('shx cp src/schemas/*.json dist/schemas/');
+    expect(packageJson.scripts.prepare).toBe('npm run build');
+    expect(packageJson.scripts.dev_install).toBe('node scripts/dev-install.mjs');
     expect(buildTsconfig.include).toEqual(['src/**/*.ts']);
   });
 
@@ -97,5 +102,22 @@ describe('project foundation', () => {
 
     expect(program.name()).toBe('bridl');
     expect(program.description()).toContain('Profile-oriented wrapper');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-001.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('recognizes direct CLI execution through npm global symlinks', () => {
+    const temporaryDirectory = mkdtempSync(join(tmpdir(), 'bridl-cli-symlink-'));
+    const cliPath = fileURLToPath(new URL('../src/cli.ts', import.meta.url));
+    const symlinkPath = join(temporaryDirectory, 'bridl');
+    try {
+      symlinkSync(cliPath, symlinkPath);
+
+      expect(isDirectCliExecution(pathToFileURL(cliPath).href, symlinkPath)).toBe(true);
+      expect(isDirectCliExecution(pathToFileURL(cliPath).href, join(temporaryDirectory, 'missing'))).toBe(false);
+      expect(isDirectCliExecution(pathToFileURL(cliPath).href, undefined)).toBe(false);
+    } finally {
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/unit/phase5-6-run.test.ts
+++ b/tests/unit/phase5-6-run.test.ts
@@ -1,0 +1,520 @@
+// Tests tack assembly, pi adapter translation, and run command launch behavior.
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createPiAdapter } from '../../src/agents/pi/PiAdapter.js';
+import { executeRunCommand, resolveChildExitCode } from '../../src/cli/commands/RunCommand.js';
+import { parseProfileYaml } from '../../src/profiles/ProfileLoader.js';
+import { createTack } from '../../src/tack/Tack.js';
+import { assembleTack, writeTack } from '../../src/tack/TackAssembler.js';
+import { createTackFile } from '../../src/tack/TackFile.js';
+import { createProfileWatchPaths, tackFileOutputPath, watchTackInputs } from '../../src/tack/TackWatcher.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'bridl-phase56-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const writeSettings = (homeDirectory: string, content: string): void => {
+  mkdirSync(join(homeDirectory, '.bridl'), { recursive: true });
+  writeFileSync(join(homeDirectory, '.bridl', 'settings.yml'), content);
+};
+
+const writeProfile = (root: string, id: string, content: string): string => {
+  const profileDirectory = join(root, id);
+  mkdirSync(profileDirectory, { recursive: true });
+  const profilePath = join(profileDirectory, 'profile.yml');
+  writeFileSync(profilePath, content);
+  return profilePath;
+};
+
+const waitForFileContent = async (path: string, content: string): Promise<void> => {
+  await waitForFileMatching(path, (actual) => actual === content);
+  expect(readFileSync(path, 'utf8')).toBe(content);
+};
+
+const waitForFileContaining = async (path: string, content: string): Promise<void> => {
+  await waitForFileMatching(path, (actual) => actual.includes(content));
+  expect(readFileSync(path, 'utf8')).toContain(content);
+};
+
+const waitForFileMatching = async (path: string, predicate: (content: string) => boolean): Promise<void> => {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (existsSync(path) && predicate(readFileSync(path, 'utf8'))) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('phase 5 tack assembly and phase 6 pi run support', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.2, BRIDL-REQ-005.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('represents tack files with source inputs, output paths, and transform strategy', () => {
+    const tackFile = createTackFile({
+      rootDirectory: '/tmp/bridl-default-pi-abc',
+      relativePath: 'bridl/profile.json',
+      content: '{}\n',
+      sourceInputs: ['/profiles/default/profile.yml'],
+      strategy: 'transform',
+    });
+
+    expect(tackFile).toEqual({
+      relativePath: 'bridl/profile.json',
+      content: '{}\n',
+      sourceInputs: ['/profiles/default/profile.yml'],
+      outputPath: '/tmp/bridl-default-pi-abc/bridl/profile.json',
+      strategy: 'transform',
+    });
+    expect(createTackFile('EMPTY.md')).toMatchObject({ content: '', outputPath: 'EMPTY.md' });
+    expect(createTackFile({ relativePath: 'generated.txt', content: 'hello' })).toMatchObject({
+      sourceInputs: [],
+      strategy: 'generate',
+    });
+    expect(assembleTack({ files: [] }).rootDirectory).toContain('bridl-profile-agent-');
+
+    const root = createTemporaryRoot();
+    expect(() =>
+      writeTack(
+        createTack(join(root, 'tack'), [
+          createTackFile({ rootDirectory: join(root, 'other'), relativePath: 'outside.txt', content: 'nope' }),
+        ]),
+      ),
+    ).toThrow('must stay under tack root');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.3, BRIDL-REQ-006.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('parses generic and pi array controls from profile YAML', () => {
+    const profile = parseProfileYaml(
+      [
+        'id: arrays',
+        'controls:',
+        '  args: [--generic]',
+        '  extensions: [ext-a]',
+        '  skills: [skill-a]',
+        '  pi:',
+        '    args: [--pi]',
+        '    extensions: [ext-pi]',
+        '    skills: [skill-pi]',
+        '',
+      ].join('\n'),
+      'fallback',
+    );
+
+    expect('message' in profile).toBe(false);
+    if (!('message' in profile)) {
+      expect(profile.controls.args).toEqual(['--generic']);
+      expect(profile.controls.extensions).toEqual(['ext-a']);
+      expect(profile.controls.skills).toEqual(['skill-a']);
+      expect(profile.controls.pi?.args).toEqual(['--pi']);
+      expect(profile.controls.pi?.extensions).toEqual(['ext-pi']);
+      expect(profile.controls.pi?.skills).toEqual(['skill-pi']);
+    }
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.4).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('watches tack inputs, rewrites safe generated files, and warns when an input cannot be watched', async () => {
+    const warnings: string[] = [];
+    const tack = createTack('/tmp/bridl-watch-test', [
+      createTackFile({
+        relativePath: 'bridl/profile.json',
+        content: '{}\n',
+        sourceInputs: ['/path/that/does/not/exist/profile.yml'],
+      }),
+    ]);
+    const handle = watchTackInputs({ tack, warn: (message) => warnings.push(message) });
+
+    handle.close();
+
+    expect(warnings[0]).toContain('Could not watch tack input /path/that/does/not/exist/profile.yml');
+    expect(createProfileWatchPaths(['/profiles/default/profile.yml', '/profiles/default/other.yml'])).toEqual([
+      '/profiles/default',
+    ]);
+    expect(tackFileOutputPath(tack, 'bridl/profile.json')).toBe('/tmp/bridl-watch-test/bridl/profile.json');
+
+    const root = createTemporaryRoot();
+    const watchedDirectory = join(root, 'watched');
+    const watchedInput = join(watchedDirectory, 'profile.yml');
+    const outputRoot = join(root, 'tack');
+    mkdirSync(watchedDirectory, { recursive: true });
+    writeFileSync(watchedInput, 'initial\n');
+    const watchedTack = createTack(outputRoot, [
+      createTackFile({ relativePath: 'generated.txt', content: 'stale\n', sourceInputs: [watchedInput] }),
+    ]);
+    const watchedHandle = watchTackInputs({
+      tack: watchedTack,
+      refreshTack: () =>
+        createTack(outputRoot, [
+          createTackFile({ relativePath: 'generated.txt', content: 'updated\n', sourceInputs: [watchedInput] }),
+        ]),
+      warn: (message) => warnings.push(message),
+    });
+
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      writeFileSync(watchedInput, 'changed\n');
+      await waitForFileContent(join(outputRoot, 'generated.txt'), 'updated\n');
+    } finally {
+      watchedHandle.close();
+    }
+
+    const staticInput = join(watchedDirectory, 'static-profile.yml');
+    const staticOutputRoot = join(root, 'static-tack');
+    writeFileSync(staticInput, 'initial\n');
+    const staticTack = createTack(staticOutputRoot, [
+      createTackFile({ relativePath: 'generated.txt', content: 'static\n', sourceInputs: [staticInput] }),
+    ]);
+    const staticHandle = watchTackInputs({ tack: staticTack, warn: (message) => warnings.push(message) });
+
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      writeFileSync(staticInput, 'changed\n');
+      await waitForFileContent(join(staticOutputRoot, 'generated.txt'), 'static\n');
+    } finally {
+      staticHandle.close();
+    }
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-006.1, BRIDL-REQ-006.2, BRIDL-REQ-006.3, BRIDL-REQ-006.4).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('translates generic and pi-specific profile controls into pi env and argv', () => {
+    const adapter = createPiAdapter();
+    const tackPlan = adapter.createTack(
+      {
+        id: 'engineering',
+        inherits: [],
+        controls: {
+          model: 'generic-model',
+          provider: 'anthropic',
+          environment: { GENERIC: '1' },
+          extensions: ['ext-a'],
+          skills: ['skill-a'],
+          promptTemplate: 'template-a',
+          systemPrompt: 'base prompt',
+          appendSystemPrompt: 'extra prompt',
+          pi: {
+            model: 'pi-model',
+            sessionDirectory: '/tmp/pi-sessions',
+            args: ['--share'],
+            environment: { PI_ONLY: '1' },
+          },
+        },
+      },
+      { rootDirectory: '/tmp/bridl-engineering-pi-123', profilePaths: ['/profiles/engineering/profile.yml'] },
+    );
+    const launchPlan = adapter.createLaunchPlan(tackPlan.tack, {
+      id: 'engineering',
+      inherits: [],
+      controls: {
+        model: 'generic-model',
+        provider: 'anthropic',
+        environment: { GENERIC: '1' },
+        extensions: ['ext-a'],
+        skills: ['skill-a'],
+        promptTemplate: 'template-a',
+        systemPrompt: 'base prompt',
+        appendSystemPrompt: 'extra prompt',
+        pi: {
+          model: 'pi-model',
+          sessionDirectory: '/tmp/pi-sessions',
+          args: ['--share'],
+          environment: { PI_ONLY: '1' },
+        },
+      },
+    });
+
+    expect(adapter.id).toBe('pi');
+    expect(adapter.supportedControls).toContain('model');
+    expect(adapter.supportedControls).toContain('promptTemplate');
+    expect(
+      adapter.getUnsupportedControls({
+        id: 'engineering',
+        inherits: [],
+        controls: { pi: { unsupportedPiControl: true } },
+      }),
+    ).toEqual(['pi.unsupportedPiControl']);
+    expect(tackPlan.tack.rootDirectory).toBe('/tmp/bridl-engineering-pi-123');
+    expect(tackPlan.tack.files[0]?.sourceInputs).toEqual(['/profiles/engineering/profile.yml']);
+    expect(launchPlan.command).toBe('pi');
+    expect(launchPlan.env).toEqual({
+      GENERIC: '1',
+      PI_ONLY: '1',
+      PI_CODING_AGENT_DIR: '/tmp/bridl-engineering-pi-123',
+    });
+    expect(launchPlan.args).toEqual([
+      '--model',
+      'pi-model',
+      '--provider',
+      'anthropic',
+      '--session-dir',
+      '/tmp/pi-sessions',
+      '--prompt-template',
+      'template-a',
+      '--system-prompt',
+      'base prompt',
+      '--append-system-prompt',
+      'extra prompt',
+      '--extension',
+      'ext-a',
+      '--skill',
+      'skill-a',
+      '--share',
+    ]);
+
+    const genericFallbackProfile = parseProfileYaml(
+      'id: fallback\ncontrols:\n  model: generic-model\n  pi: {}\n',
+      'fallback',
+    );
+    expect('message' in genericFallbackProfile).toBe(false);
+    if (!('message' in genericFallbackProfile)) {
+      expect(adapter.createLaunchPlan(tackPlan.tack, genericFallbackProfile).args).toEqual([
+        '--model',
+        'generic-model',
+      ]);
+    }
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.1, BRIDL-REQ-005.2, BRIDL-REQ-005.3, BRIDL-REQ-005.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('resolves the default profile, writes and refreshes a temp tack, warns, and passes through args', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const profilesDirectory = join(homeDirectory, '.bridl', 'profiles');
+    writeSettings(homeDirectory, 'default_profile: default\nprofile_sources:\n  - path: ./profiles\n');
+    const baseProfilePath = writeProfile(
+      profilesDirectory,
+      'base',
+      ['id: base', 'controls:', '  model: base-model', '  environment:', '    BASE_ENV: inherited', ''].join('\n'),
+    );
+    const profilePath = writeProfile(
+      profilesDirectory,
+      'default',
+      [
+        'id: default',
+        'inherits: [base]',
+        'controls:',
+        '  model: test-model',
+        '  environment:',
+        '    TEST_ENV: yes',
+        '  unsupported_feature: true',
+        '',
+      ].join('\n'),
+    );
+    const unrelatedProfilePath = writeProfile(
+      profilesDirectory,
+      'unrelated',
+      'id: unrelated\ncontrols:\n  model: unrelated-model\n',
+    );
+    const warnings: string[] = [];
+    const launches: unknown[] = [];
+
+    const result = await executeRunCommand(
+      {
+        homeDirectory,
+        projectDirectory,
+        passThroughArgs: ['--debug', 'prompt text'],
+      },
+      {
+        writeError: (message) => warnings.push(message),
+        launcher: {
+          launch(plan) {
+            launches.push(plan);
+            return new Promise((resolve) => {
+              setTimeout(() => {
+                writeFileSync(
+                  profilePath,
+                  [
+                    'id: default',
+                    'inherits: [base]',
+                    'controls:',
+                    '  model: test-model',
+                    '  environment:',
+                    '    TEST_ENV: yes',
+                    '    LIVE_ENV: refreshed',
+                    '  unsupported_feature: true',
+                    '',
+                  ].join('\n'),
+                );
+                resolve(
+                  waitForFileContaining(join(plan.env.PI_CODING_AGENT_DIR, 'bridl', 'profile.json'), 'LIVE_ENV').then(
+                    () => 0,
+                  ),
+                );
+              }, 25);
+            });
+          },
+        },
+      },
+    );
+
+    expect(result.profileId).toBe('default');
+    expect(result.tackDirectory).toContain('bridl-default-pi-');
+    expect(existsSync(join(result.tackDirectory, 'bridl', 'profile.json'))).toBe(true);
+    const profileMetadata = readFileSync(join(result.tackDirectory, 'bridl', 'profile.json'), 'utf8');
+    expect(profileMetadata).toContain('test-model');
+    expect(profileMetadata).toContain('BASE_ENV');
+    expect(profileMetadata).toContain('LIVE_ENV');
+    expect(profileMetadata).not.toContain('unrelated-model');
+    expect(result.launchPlan.args).toEqual(['--model', 'test-model', '--debug', 'prompt text']);
+    expect(result.launchPlan.env.TEST_ENV).toBe('yes');
+    expect(result.launchPlan.env.PI_CODING_AGENT_DIR).toBe(result.tackDirectory);
+    expect(result.warnings).toEqual(["pi adapter cannot translate requested control 'unsupported_feature'."]);
+    expect(warnings).toEqual(result.warnings);
+    expect(launches).toHaveLength(1);
+    expect(profilePath).toContain('profile.yml');
+    expect(baseProfilePath).toContain('profile.yml');
+    expect(unrelatedProfilePath).toContain('profile.yml');
+
+    await executeRunCommand(
+      { homeDirectory, projectDirectory, profileId: 'default' },
+      {
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.1, BRIDL-REQ-006.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('reports invalid settings, invalid profile sources, missing profiles, URI caches, and child exit codes', async () => {
+    const root = createTemporaryRoot();
+    const badSettingsHome = join(root, 'bad-settings-home');
+    const projectDirectory = join(root, 'project');
+    writeSettings(badSettingsHome, 'profile_sources:\n  - only: [default]\n');
+    await expect(executeRunCommand({ homeDirectory: badSettingsHome, projectDirectory })).rejects.toThrow(
+      'Cannot run with invalid settings',
+    );
+
+    const badProfileHome = join(root, 'bad-profile-home');
+    writeSettings(badProfileHome, 'default_profile: default\nprofile_sources:\n  - path: ./profiles\n');
+    writeProfile(
+      join(badProfileHome, '.bridl', 'profiles'),
+      'default',
+      'id: default\ncontrols:\n  environment:\n    COUNT: 1\n',
+    );
+    await expect(executeRunCommand({ homeDirectory: badProfileHome, projectDirectory })).rejects.toThrow(
+      'Cannot run with invalid profiles',
+    );
+
+    const missingProfileHome = join(root, 'missing-profile-home');
+    writeSettings(missingProfileHome, 'default_profile: missing\nprofile_sources:\n  - path: ./profiles\n');
+    mkdirSync(join(missingProfileHome, '.bridl', 'profiles'), { recursive: true });
+    await expect(executeRunCommand({ homeDirectory: missingProfileHome, projectDirectory })).rejects.toThrow(
+      "Cannot resolve profile 'missing'",
+    );
+
+    const uriHome = join(root, 'uri-home');
+    const uri = 'https://example.test/team/profiles.git';
+    writeSettings(uriHome, `default_profile: cached\nprofile_sources:\n  - uri: ${uri}\n`);
+    writeProfile(
+      join(uriHome, '.bridl', 'cache', 'profiles', Buffer.from(uri).toString('base64url')),
+      'cached',
+      'id: cached\ncontrols: {}\n',
+    );
+    const result = await executeRunCommand(
+      { homeDirectory: uriHome, projectDirectory, profileId: 'cached' },
+      {
+        launcher: {
+          launch() {
+            return Promise.resolve(7);
+          },
+        },
+      },
+    );
+    expect(result.exitCode).toBe(7);
+
+    const fallbackHome = join(root, 'fallback-home');
+    writeSettings(fallbackHome, 'profile_sources:\n  - path: ./profiles\n');
+    writeProfile(join(fallbackHome, '.bridl', 'profiles'), 'default', 'id: default\ncontrols: {}\n');
+    const fallbackResult = await executeRunCommand(
+      { homeDirectory: fallbackHome, projectDirectory },
+      {
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+    expect(fallbackResult.profileId).toBe('default');
+
+    const spawnedHome = join(root, 'spawned-home');
+    writeSettings(spawnedHome, 'profile_sources:\n  - path: ./profiles\n');
+    writeProfile(join(spawnedHome, '.bridl', 'profiles'), 'default', 'id: default\ncontrols: {}\n');
+    const spawnedResult = await executeRunCommand(
+      { homeDirectory: spawnedHome, projectDirectory },
+      {
+        adapter: {
+          id: 'node',
+          supportedControls: [],
+          createTack(_profile, tackInput) {
+            return { tack: createTack(tackInput.rootDirectory, []), warnings: [] };
+          },
+          createLaunchPlan(tack) {
+            return { command: process.execPath, args: ['-e', 'process.exit(0)'], env: { TACK: tack.rootDirectory } };
+          },
+          getUnsupportedControls() {
+            return [];
+          },
+        },
+      },
+    );
+    expect(spawnedResult.exitCode).toBe(0);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('maps child process exits and signals to command exit codes', () => {
+    expect(resolveChildExitCode(7, null)).toBe(7);
+    expect(resolveChildExitCode(null, 'SIGINT')).toBe(130);
+    expect(resolveChildExitCode(null, 'SIGTERM')).toBe(143);
+    expect(resolveChildExitCode(null, 'SIGHUP')).toBe(129);
+    expect(resolveChildExitCode(null, null)).toBe(1);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('makes unsupported control warnings fatal when hard tack is enabled', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    writeSettings(homeDirectory, 'default_profile: default\nprofile_sources:\n  - path: ./profiles\n');
+    writeProfile(
+      join(homeDirectory, '.bridl', 'profiles'),
+      'default',
+      'id: default\ncontrols:\n  unsupported_feature: true\n',
+    );
+
+    await expect(
+      executeRunCommand(
+        { homeDirectory, projectDirectory, hardTack: true },
+        {
+          launcher: {
+            launch() {
+              return Promise.resolve(0);
+            },
+          },
+        },
+      ),
+    ).rejects.toThrow("Hard-tack failed for pi: pi adapter cannot translate requested control 'unsupported_feature'.");
+  });
+});


### PR DESCRIPTION
## Summary
- implement tack file metadata, temp tack writing, and input watching
- add agent adapter contract plus pi tack/launch translation for env, args, sessions, extensions, skills, prompts, model/provider/thinking
- implement run/default command execution with profile resolution, pass-through args, unsupported-control warnings, and --hard-tack failures
- mark phases 5 and 6 complete in plan.md

## Verification
- npm run check
- npm run check-ci