### PR TITLE
Run setup automatically before first run

### DIFF
--- a/requirements/BRIDL-REQ-005-run-and-tack.md
+++ b/requirements/BRIDL-REQ-005-run-and-tack.md
@@ -14,6 +14,7 @@ The `run` command assembles a temporary agent-specific configuration directory c
 4. The `run` command MUST accept `-p` and `--profile` options for selecting the profile.
 5. The `run` command MUST use the resolved default profile when no profile option is provided.
 6. The `run` command MUST pass unrecognized arguments through to the selected agent CLI unaltered.
+7. When invoked before user setup has created `~/.bridl/settings.yml`, the default `run` command MUST print `` `bridl setup` has not been run yet - running now `` and execute setup before resolving the profile.
 
 ### BRIDL-REQ-005.2: Tack Definition
 

--- a/src/cli/commands/RunCommand.ts
+++ b/src/cli/commands/RunCommand.ts
@@ -1,5 +1,7 @@
 // Provides the command object for launching selected profiles.
+import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
+import { join } from 'node:path';
 
 import type { ChildProcess } from 'node:child_process';
 import type { Command } from 'commander';
@@ -17,6 +19,8 @@ import { discoverSettingsLoadPlan, loadSettings } from '../../settings/SettingsL
 import { createTackRootDirectory, writeTack } from '../../tack/TackAssembler.js';
 import { watchTackInputs } from '../../tack/TackWatcher.js';
 import type { CommandObject } from './CommandObject.js';
+import { executeSetupCommand } from './SetupCommand.js';
+import type { SetupCommandDependencies } from './SetupCommand.js';
 
 export interface RunCommandInput {
   readonly homeDirectory: string;
@@ -39,11 +43,9 @@ export interface AgentProcessLauncher {
   launch(plan: AgentLaunchPlan): Promise<number>;
 }
 
-export interface RunCommandDependencies {
+export interface RunCommandDependencies extends SetupCommandDependencies {
   readonly adapter?: AgentAdapter;
   readonly launcher?: AgentProcessLauncher;
-  readonly homeDirectory?: string;
-  readonly projectDirectory?: string;
   readonly writeError?: (message: string) => void;
 }
 
@@ -51,6 +53,7 @@ export const executeRunCommand = async (
   input: RunCommandInput,
   dependencies: RunCommandDependencies = {},
 ): Promise<RunCommandResult> => {
+  runSetupIfNeeded(input, dependencies);
   const resolvedProfile = loadResolvedProfile(input);
   const adapter = dependencies.adapter ?? createPiAdapter();
   const tackRootDirectory = createTackRootDirectory(resolvedProfile.profile.id, adapter.id);
@@ -151,6 +154,18 @@ const createAdapterTackPlan = (adapter: AgentAdapter, resolvedProfile: ResolvedR
     rootDirectory,
     profilePaths: resolvedProfile.profilePaths,
   });
+
+const runSetupIfNeeded = (input: RunCommandInput, dependencies: RunCommandDependencies): void => {
+  const settingsPath = join(input.homeDirectory, '.bridl', 'settings.yml');
+
+  if (existsSync(settingsPath)) {
+    return;
+  }
+
+  /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
+  (dependencies.writeLine ?? console.log)('`bridl setup` has not been run yet - running now');
+  executeSetupCommand(input, dependencies);
+};
 
 const loadResolvedProfile = (input: RunCommandInput): ResolvedRunProfile => {
   const loadedSettings = loadSettings(discoverSettingsLoadPlan(input));

--- a/tests/unit/phase5-6-run.test.ts
+++ b/tests/unit/phase5-6-run.test.ts
@@ -393,6 +393,32 @@ describe('phase 5 tack assembly and phase 6 pi run support', () => {
     );
   });
 
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('runs setup automatically before the default run when user setup has not run', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const messages: string[] = [];
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        writeLine: (message) => messages.push(message),
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(messages).toEqual(['`bridl setup` has not been run yet - running now']);
+    expect(result.profileId).toBe('default');
+    expect(existsSync(join(homeDirectory, '.bridl', 'settings.yml'))).toBe(true);
+    expect(existsSync(join(homeDirectory, '.bridl', 'profiles', 'default', 'profile.yml'))).toBe(true);
+  });
+
   // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.1, BRIDL-REQ-006.1).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('reports invalid settings, invalid profile sources, missing profiles, URI caches, and child exit codes', async () => {


### PR DESCRIPTION
## Summary
- automatically run setup when the default run command is invoked before user settings exist
- add requirement text for the first-run behavior
- add unit coverage for auto-setup before run

## Tests
- npm run check-ci