### PR TITLE
Implement tack state persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,12 @@ The exact stable schema is governed by the requirements in `requirements/` and t
 
 The current recommendation is to build `bridl` around pi's existing native configuration mechanisms:
 
-1. Use profile-specific `PI_CODING_AGENT_DIR` values as the main isolation boundary.
-2. Layer profile-controlled environment variables and pi CLI flags on top.
-3. Use explicit `--extension` / `-e` injection for bootstrap behavior that needs to run inside pi.
-4. Decide per profile whether project-local `.pi` overrides are allowed.
-5. Keep the wrapper responsible for anything that must happen before pi starts, such as selecting config directories, setting credentials, or choosing session locations.
+1. Use a temporary tack directory as `PI_CODING_AGENT_DIR` for each run.
+2. Persist intentional pi state through adapter-declared symlinks to profile or native pi files.
+3. Layer profile-controlled environment variables and pi CLI flags on top.
+4. Use explicit `--extension` / `-e` injection for bootstrap behavior that needs to run inside pi.
+5. Decide per profile whether project-local `.pi` overrides are allowed.
+6. Keep the wrapper responsible for anything that must happen before pi starts, such as selecting config directories, setting credentials, or choosing session locations.
 
 See [`recommendation.md`](./recommendation.md) for current notes on pi startup behavior and wrapper strategy.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ inherits:
 controls:
   model: anthropic/claude-sonnet-4
   environment:
-    ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+    TEAM_MODE: engineering
 ```
 
 The exact stable schema is governed by the requirements in `requirements/` and the JSON Schema files in `src/schemas/`, which are still expected to evolve with implementation.

--- a/doc/file_structure.md
+++ b/doc/file_structure.md
@@ -13,6 +13,7 @@ Bridl is organized around clear TypeScript source boundaries, requirement docume
 │   ├── architecture.md                # architectural rationale and runtime file conventions
 │   ├── controllable-elements.md       # controllable element terminology and support matrix
 │   ├── file_structure.md              # repository file structure overview
+│   ├── state_writeback_strategy.md    # tack state persistence and writeback design
 │   └── specs/                         # detailed supporting specs
 ├── requirements/                      # formal BRIDL requirement documents
 │   ├── BRIDL-REQ-001-project-foundation.md

--- a/doc/state_writeback_strategy.md
+++ b/doc/state_writeback_strategy.md
@@ -1,0 +1,178 @@
+# State Writeback Strategy
+
+This document describes Bridl's current model for handling writes that agent CLIs make inside a tack.
+
+A tack is temporary, but agent CLIs sometimes perform intentionally durable writes, such as logging in, installing plugins, changing settings, or updating MCP configuration. Bridl makes those paths explicit: adapter-declared writable paths are materialized with a resolved `state_persistence` strategy before the child CLI starts, and non-persistent or unknown writes are diagnosed after the child exits.
+
+## Current behavior
+
+- Tacks remain temporary and reproducible by default.
+- Bridl does not do generic post-run copy-back or JSON/YAML merge-back.
+- Persistent state is represented by symlinking a tack path to a profile file/directory or to the native CLI fallback path.
+- Every adapter-declared state path has a resolved strategy before launch: profile overrides win, otherwise the adapter `default_strategy` is used.
+- Invalid or disallowed strategies fail before launch.
+- Non-persistent `warn` and `error` strategies are checked after the child CLI exits.
+- Unknown writes outside adapter-declared paths are checked with the adapter's `unknown` pseudo-path strategy.
+- `prompt` is reserved for a future interactive/control-plane workflow. When accepted by a declaration today, it is treated as a non-persistent diagnostic like `warn`.
+
+## Non-goals
+
+- Bridl does not implement generic copy-back from the tack to profiles.
+- Bridl does not implement generic structured merge-back.
+- Bridl does not silently persist unknown writes.
+
+## Profile stack
+
+State persistence is a normal profile setting. It resolves through the same profile stack as other profile data, with one adapter-provided native fallback layer for symlink sources:
+
+```text
+project-local profile
+project profile
+user profile
+URI/cache profiles
+explicit inheritance
+implicit user default profile
+Bridl default profile
+native-cli-settings-profile
+```
+
+The `native-cli-settings-profile` is synthesized by the adapter as a fallback source for native CLI files, such as `~/.pi/...`. It is not a user-editable Bridl profile.
+
+## Path-keyed adapter declarations
+
+Adapters declare writable state paths directly, using relative file paths as keys. Directory paths use a trailing slash. The same key is used for adapter coverage, `state_persistence` overrides, profile resource lookup, native fallback lookup, and tack materialization.
+
+The Pi adapter currently declares:
+
+```yaml
+state_paths:
+  auth.json:
+    default_strategy: symlink
+    allowed_strategies: [symlink, error, prompt]
+
+  settings.json:
+    default_strategy: symlink
+    allowed_strategies: [symlink, warn, error, prompt]
+
+  mcp.json:
+    default_strategy: symlink
+    allowed_strategies: [symlink, warn, error, prompt]
+
+  plugins/:
+    default_strategy: symlink
+    allowed_strategies: [symlink, discard, warn, error, prompt]
+
+  cache/:
+    default_strategy: symlink
+    allowed_strategies: [symlink, discard, warn, error]
+
+  sessions/:
+    default_strategy: symlink
+    allowed_strategies: [symlink, discard, warn, error]
+
+  unknown:
+    default_strategy: warn
+    allowed_strategies: [discard, warn, error, prompt]
+```
+
+## Profile layout for state files
+
+State files live under the relevant CLI-specific profile folder:
+
+```text
+profiles/
+  default/
+    profile.yml
+    cli_specific/
+      pi/
+        auth.json
+        settings.json
+        plugins/
+```
+
+When a selected strategy is `symlink`, Bridl searches the resolved profile folders from highest to lowest precedence for `cli_specific/<adapter>/<state-path>`. If a profile contains the file or directory, Bridl symlinks the tack path to that source.
+
+If no profile source exists for a Pi path, Bridl falls back to the corresponding native Pi agent path under `~/.pi/agent`. Missing native fallback files/directories are created so the tack symlink has a durable destination.
+
+## `state_persistence`
+
+Profiles may override persistence by mapping adapter-declared paths to strategy names:
+
+```yaml
+state_persistence:
+  auth.json: symlink
+  settings.json: symlink
+  plugins/: symlink
+  cache/: discard
+  sessions/: discard
+  unknown: warn
+```
+
+The values are concrete strategy names. `state_persistence` only needs overrides; omitted paths use the adapter declaration's `default_strategy`.
+
+`state_persistence` is validated by the profile JSON Schema at read boundaries. Bridl also validates the resolved strategy against the adapter declaration before launch.
+
+## Tack materialization
+
+Before launch, Bridl processes each adapter-declared state path:
+
+1. Resolve the path's strategy from profile `state_persistence` overrides, then the adapter `default_strategy`.
+2. Validate that the strategy is allowed for that path.
+3. Resolve a source path through the profile hierarchy when the strategy is `symlink`.
+4. Materialize the tack path.
+5. Record a baseline fingerprint for non-persistent and unknown write detection.
+
+For `symlink`, Bridl creates a symlink from the tack path to the resolved profile or native CLI source.
+
+For `discard`, `warn`, `error`, and `prompt`, Bridl creates normal temporary tack paths where needed and observes whether they changed.
+
+## Unknown writes
+
+The `unknown` pseudo-path controls writes outside adapter-declared paths:
+
+```yaml
+state_persistence:
+  unknown: warn
+```
+
+Supported `unknown` strategies are non-persistent only:
+
+- `discard`
+- `warn`
+- `error`
+- `prompt`
+
+`unknown` does not support `symlink`, because there is no declared durable destination.
+
+## Strategies
+
+### `symlink`
+
+Bridl resolves the state path through the profile hierarchy, then the native CLI fallback, and symlinks that source into the tack. Persistence happens because the CLI writes through the symlink to an intentional file or directory.
+
+### `discard`
+
+Writes are allowed in the tack and are thrown away when the tack is deleted. Bridl does not emit diagnostics for changed `discard` paths.
+
+### `warn`
+
+Writes are allowed, discarded, and reported after the child exits. `--hard-tack` makes these warnings fatal.
+
+### `error`
+
+Writes are allowed during the child process but cause Bridl to fail after the child exits if the path changed. This is useful for CI and strict reproducibility.
+
+### `prompt`
+
+`prompt` is reserved for a future interactive/control-plane workflow. Current implementations that allow it treat writes as non-persistent diagnostics, equivalent to `warn`, with the strategy name preserved in the message.
+
+## Rationale
+
+Path-keyed state declarations keep the model simple:
+
+- the adapter declares the paths it knows the CLI may write and their default strategies;
+- profiles may provide files at those same paths;
+- the native fallback exposes native CLI files at those same paths;
+- `state_persistence` says what to do with each path.
+
+This avoids ambiguous writeback behavior and gives users a clear rule: if a CLI write should persist, configure that tack path as `symlink` and provide or accept the profile/native file that should receive the mutation.

--- a/recommendation.md
+++ b/recommendation.md
@@ -16,16 +16,16 @@ Pi supports changing the global agent/config directory with:
 PI_CODING_AGENT_DIR=/path/to/profile-dir pi ...
 ```
 
-That directory controls the profile-scoped global state:
+In native pi, that directory can contain profile-scoped global state such as settings, auth, models, extensions, skills, prompts, themes, and sessions.
 
-- `settings.json`
+Bridl currently declares and materializes a narrower day-one state set for pi:
+
 - `auth.json`
-- `models.json`
-- global `extensions/`
-- global `skills/`
-- global `prompts/`
-- global `themes/`
-- sessions, unless separately overridden
+- `settings.json`
+- `mcp.json`
+- `plugins/`
+- `cache/`
+- `sessions/`
 
 Native pi can be isolated by pointing `PI_CODING_AGENT_DIR` at a different directory. Bridl's implemented model uses that same boundary with a temporary tack directory for each run, then symlinks adapter-declared durable state paths back to profile files or native pi files such as `~/.pi/agent/auth.json`.
 
@@ -43,7 +43,7 @@ Launch shape:
 PI_CODING_AGENT_DIR=/tmp/bridl-default-pi-... pi
 ```
 
-This keeps the runtime tack disposable while preserving intentional credentials, plugins, default models, themes, prompts, and other user-level settings through declared state paths.
+This keeps the runtime tack disposable while preserving intentional credentials, settings, MCP configuration, plugins, caches, and sessions through declared state paths.
 
 ### Other native launch controls
 

--- a/recommendation.md
+++ b/recommendation.md
@@ -27,21 +27,23 @@ That directory controls the profile-scoped global state:
 - global `themes/`
 - sessions, unless separately overridden
 
-Recommended wrapper model:
+Native pi can be isolated by pointing `PI_CODING_AGENT_DIR` at a different directory. Bridl's implemented model uses that same boundary with a temporary tack directory for each run, then symlinks adapter-declared durable state paths back to profile files or native pi files such as `~/.pi/agent/auth.json`.
+
+Conceptually:
 
 ```text
-~/.bridl/work/
-~/.bridl/personal/
-~/.bridl/sandbox/
+/tmp/bridl-default-pi-.../      # temporary tack used as PI_CODING_AGENT_DIR
+profiles/default/cli_specific/pi/settings.json
+~/.pi/agent/auth.json           # native fallback for login state
 ```
 
-Launch example:
+Launch shape:
 
 ```bash
-PI_CODING_AGENT_DIR=~/.bridl/work pi
+PI_CODING_AGENT_DIR=/tmp/bridl-default-pi-... pi
 ```
 
-This is the cleanest boundary for different credentials, plugins, default models, themes, prompts, and other user-level settings.
+This keeps the runtime tack disposable while preserving intentional credentials, plugins, default models, themes, prompts, and other user-level settings through declared state paths.
 
 ### Other native launch controls
 
@@ -199,15 +201,16 @@ The wrapper would translate that into:
 Use this priority model:
 
 1. Wrapper profile env vars and CLI args.
-2. Profile-specific `PI_CODING_AGENT_DIR`.
-3. Optional injected bootstrap extension.
-4. Pi's normal project `.pi` overrides.
-5. Pi's normal runtime behavior.
+2. Temporary tack `PI_CODING_AGENT_DIR` assembled from the resolved Bridl profile.
+3. Adapter-declared state paths symlinked to profile or native pi sources.
+4. Optional injected bootstrap extension.
+5. Pi's normal project `.pi` overrides.
+6. Pi's normal runtime behavior.
 
 ### Which mechanism to use
 
-- Different credentials: separate `PI_CODING_AGENT_DIR`, env vars, or `--api-key`.
-- Different installed plugins/extensions: separate `PI_CODING_AGENT_DIR`, or explicit `-e`.
+- Different credentials: profile/native state path symlinks, env vars, or `--api-key`.
+- Different installed plugins/extensions: profile/native state path symlinks, or explicit `-e`.
 - Temporary one-off extension: `pi -e ...`.
 - Hard isolation from user config: set `PI_CODING_AGENT_DIR` to an empty/temp profile dir.
 - Hard isolation from project config: launch from controlled cwd or use `--no-extensions`, `--no-skills`, `--no-prompt-templates`, `--no-context-files`.
@@ -216,7 +219,7 @@ Use this priority model:
 
 ## Conclusion
 
-Pi already has a native profile mechanism through `PI_CODING_AGENT_DIR`; this should be the core of `bridl`'s wrapper design.
+Pi already has a native profile mechanism through `PI_CODING_AGENT_DIR`; Bridl uses a temporary tack at that boundary and makes durable writes explicit through declared state paths.
 
 For early in-process injection, use `-e bootstrap-extension`.
 It loads early enough to register providers/tools/flags and affect model availability and per-turn prompts, but not early enough to change config directory selection or initial settings discovery.

--- a/requirements/BRIDL-REQ-005-run-and-tack.md
+++ b/requirements/BRIDL-REQ-005-run-and-tack.md
@@ -50,9 +50,11 @@ The `run` command assembles a temporary agent-specific configuration directory c
 1. Profiles MAY define `state_persistence` entries that map adapter-declared state paths to persistence strategies.
 2. Bridl MUST validate `state_persistence` values at profile read boundaries.
 3. Before launch, Bridl MUST resolve each adapter-declared state path to either a profile override strategy or the adapter default strategy.
-4. Bridl MUST reject strategies that are not allowed for the adapter-declared state path.
-5. For `symlink` strategy paths, Bridl MUST materialize the tack path as a symlink to the resolved profile or native CLI source path.
-6. For non-persistent strategies, Bridl MUST materialize normal temporary tack paths and detect writes after the child agent exits.
-7. Unknown writes MUST be governed by the adapter's `unknown` pseudo-path strategy and MUST NOT be persisted by symlink.
-8. Bridl MUST warn for `warn`, `prompt`, and symlink-replacement state write issues, fail for `error` state write issues, and ignore `discard` state writes.
-9. State path materialization MUST reject paths that escape the tack root.
+4. Bridl MUST reject profile `state_persistence` keys that are not declared by the selected adapter.
+5. Bridl MUST reject strategies that are not allowed for the adapter-declared state path.
+6. For `symlink` strategy paths, Bridl MUST materialize the tack path as a symlink to the resolved profile or native CLI source path.
+7. For non-persistent strategies, Bridl MUST materialize normal temporary tack paths and detect writes after the child agent exits.
+8. Unknown writes MUST be governed by the adapter's `unknown` pseudo-path strategy and MUST NOT be persisted by symlink.
+9. Bridl MUST warn for `warn`, `prompt`, and symlink-replacement state write issues, fail for `error` state write issues, and ignore `discard` state writes.
+10. State path materialization MUST reject paths that escape the tack root.
+11. During live tack updates, Bridl MUST update generated tack files without re-materializing declared state paths so post-launch write detection can still observe agent changes to those paths.

--- a/src/agents/AgentAdapter.ts
+++ b/src/agents/AgentAdapter.ts
@@ -1,5 +1,6 @@
 // Defines the adapter contract for translating Bridl profiles to agent CLI launches.
 import type { Profile } from '../profiles/Profile.js';
+import type { StatePathDeclaration } from '../tack/StatePersistence.js';
 import type { Tack } from '../tack/Tack.js';
 
 export interface AgentLaunchPlan {
@@ -16,9 +17,15 @@ export interface AgentTackPlan {
 export interface AgentAdapter {
   readonly id: string;
   readonly supportedControls: readonly string[];
+  readonly statePaths?: Readonly<Record<string, StatePathDeclaration>>;
   createTack(
     profile: Profile,
-    input: { readonly rootDirectory: string; readonly profilePaths: readonly string[] },
+    input: {
+      readonly rootDirectory: string;
+      readonly profilePaths: readonly string[];
+      readonly profileFolders?: readonly string[];
+      readonly homeDirectory?: string;
+    },
   ): AgentTackPlan;
   createLaunchPlan(tack: Tack, profile?: Profile, passThroughArgs?: readonly string[]): AgentLaunchPlan;
   getUnsupportedControls(profile: Profile): readonly string[];

--- a/src/agents/pi/PiAdapter.ts
+++ b/src/agents/pi/PiAdapter.ts
@@ -1,9 +1,14 @@
 // Provides the pi adapter for tack generation and native pi launch plans.
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
 import type { AgentAdapter, AgentLaunchPlan, AgentTackPlan } from '../AgentAdapter.js';
 import type { PiProfileControls, Profile, ProfileControls } from '../../profiles/Profile.js';
 import type { Tack } from '../../tack/Tack.js';
 import { createTack } from '../../tack/Tack.js';
 import { createTackFile } from '../../tack/TackFile.js';
+import type { StatePathDeclaration, StatePersistenceStrategy, TackStatePath } from '../../tack/StatePersistence.js';
+import { ensureStateSourcePath } from '../../tack/StatePersistence.js';
 
 const genericControlNames = new Set([
   'model',
@@ -26,19 +31,34 @@ const genericControlNames = new Set([
 
 const piControlNames = new Set([...genericControlNames].filter((controlName) => controlName !== 'pi'));
 
+const piStatePathDeclarations = {
+  'auth.json': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'error', 'prompt'] },
+  'settings.json': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'warn', 'error', 'prompt'] },
+  'mcp.json': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'warn', 'error', 'prompt'] },
+  'plugins/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error', 'prompt'] },
+  'cache/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error'] },
+  'sessions/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error'] },
+  unknown: { defaultStrategy: 'warn', allowedStrategies: ['discard', 'warn', 'error', 'prompt'] },
+} as const satisfies Readonly<Record<string, StatePathDeclaration>>;
+
 export const createPiAdapter = (): AgentAdapter => ({
   id: 'pi',
   supportedControls: [...genericControlNames].filter((controlName) => !controlName.includes('_')),
+  statePaths: piStatePathDeclarations,
   createTack(profile: Profile, input): AgentTackPlan {
-    const tack = createTack(input.rootDirectory, [
-      createTackFile({
-        rootDirectory: input.rootDirectory,
-        relativePath: 'bridl/profile.json',
-        content: `${JSON.stringify({ id: profile.id, label: profile.label, controls: profile.controls }, null, 2)}\n`,
-        sourceInputs: input.profilePaths,
-        strategy: 'transform',
-      }),
-    ]);
+    const tack = createTack(
+      input.rootDirectory,
+      [
+        createTackFile({
+          rootDirectory: input.rootDirectory,
+          relativePath: 'bridl/profile.json',
+          content: `${JSON.stringify({ id: profile.id, label: profile.label, controls: profile.controls }, null, 2)}\n`,
+          sourceInputs: input.profilePaths,
+          strategy: 'transform',
+        }),
+      ],
+      createPiStatePaths(profile, input),
+    );
 
     return {
       tack,
@@ -63,6 +83,72 @@ export const createPiAdapter = (): AgentAdapter => ({
     return findUnsupportedControls(profile.controls);
   },
 });
+
+const createPiStatePaths = (
+  profile: Profile,
+  input: { readonly profileFolders?: readonly string[]; readonly homeDirectory?: string },
+): readonly TackStatePath[] =>
+  Object.entries(piStatePathDeclarations).map(([relativePath, declaration]) => {
+    const strategy = resolveStateStrategy(profile, relativePath, declaration);
+    const directory = relativePath.endsWith('/');
+
+    return {
+      relativePath,
+      strategy,
+      directory,
+      sourcePath:
+        strategy === 'symlink' && relativePath !== 'unknown'
+          ? resolvePiStateSourcePath(input.profileFolders ?? [], input.homeDirectory, relativePath, directory)
+          : undefined,
+    };
+  });
+
+const resolveStateStrategy = (
+  profile: Profile,
+  relativePath: string,
+  declaration: StatePathDeclaration,
+): StatePersistenceStrategy => {
+  const strategy = profile.statePersistence?.[relativePath] ?? declaration.defaultStrategy;
+
+  /* v8 ignore next -- Pi declarations all define defaults; this guards future adapter declaration regressions. */
+  if (strategy === undefined) {
+    throw new Error(`missing state_persistence strategy for "${relativePath}"`);
+  }
+
+  if (!declaration.allowedStrategies.includes(strategy)) {
+    throw new Error(`state_persistence strategy '${strategy}' is not allowed for "${relativePath}"`);
+  }
+
+  return strategy;
+};
+
+const resolvePiStateSourcePath = (
+  profileFolders: readonly string[],
+  homeDirectory: string | undefined,
+  relativePath: string,
+  directory: boolean,
+): string => {
+  const normalizedRelativePath = directory ? relativePath.slice(0, -1) : relativePath;
+  const profileSource = [...profileFolders]
+    .reverse()
+    .map((profileFolder) => join(profileFolder, 'cli_specific', 'pi', normalizedRelativePath))
+    .find((candidate) => existsSync(candidate));
+
+  if (profileSource !== undefined) {
+    return profileSource;
+  }
+
+  return ensureStateSourcePath(
+    join(
+      /* v8 ignore next -- run command always passes homeDirectory; environment fallbacks are defensive. */
+      homeDirectory ?? process.env.HOME ?? '.',
+      '.pi',
+      'agent',
+      normalizedRelativePath,
+    ),
+    directory,
+  );
+};
 
 const mergePiControls = (controls: ProfileControls): PiProfileControls => ({
   ...controls,

--- a/src/agents/pi/PiAdapter.ts
+++ b/src/agents/pi/PiAdapter.ts
@@ -108,7 +108,7 @@ const createPiStatePaths = (
 
 const assertDeclaredStatePersistenceKeys = (profile: Profile): void => {
   for (const relativePath of Object.keys(profile.statePersistence ?? {})) {
-    if (!(relativePath in piStatePathDeclarations)) {
+    if (!Object.hasOwn(piStatePathDeclarations, relativePath)) {
       throw new Error(`state_persistence path '${relativePath}' is not declared by the pi adapter`);
     }
   }

--- a/src/agents/pi/PiAdapter.ts
+++ b/src/agents/pi/PiAdapter.ts
@@ -8,7 +8,6 @@ import type { Tack } from '../../tack/Tack.js';
 import { createTack } from '../../tack/Tack.js';
 import { createTackFile } from '../../tack/TackFile.js';
 import type { StatePathDeclaration, StatePersistenceStrategy, TackStatePath } from '../../tack/StatePersistence.js';
-import { ensureStateSourcePath } from '../../tack/StatePersistence.js';
 
 const genericControlNames = new Set([
   'model',
@@ -149,15 +148,12 @@ const resolvePiStateSourcePath = (
     return profileSource;
   }
 
-  return ensureStateSourcePath(
-    join(
-      /* v8 ignore next -- run command always passes homeDirectory; environment fallbacks are defensive. */
-      homeDirectory ?? process.env.HOME ?? '.',
-      '.pi',
-      'agent',
-      normalizedRelativePath,
-    ),
-    directory,
+  return join(
+    /* v8 ignore next -- run command always passes homeDirectory; environment fallbacks are defensive. */
+    homeDirectory ?? process.env.HOME ?? '.',
+    '.pi',
+    'agent',
+    normalizedRelativePath,
   );
 };
 

--- a/src/agents/pi/PiAdapter.ts
+++ b/src/agents/pi/PiAdapter.ts
@@ -87,8 +87,10 @@ export const createPiAdapter = (): AgentAdapter => ({
 const createPiStatePaths = (
   profile: Profile,
   input: { readonly profileFolders?: readonly string[]; readonly homeDirectory?: string },
-): readonly TackStatePath[] =>
-  Object.entries(piStatePathDeclarations).map(([relativePath, declaration]) => {
+): readonly TackStatePath[] => {
+  assertDeclaredStatePersistenceKeys(profile);
+
+  return Object.entries(piStatePathDeclarations).map(([relativePath, declaration]) => {
     const strategy = resolveStateStrategy(profile, relativePath, declaration);
     const directory = relativePath.endsWith('/');
 
@@ -102,6 +104,15 @@ const createPiStatePaths = (
           : undefined,
     };
   });
+};
+
+const assertDeclaredStatePersistenceKeys = (profile: Profile): void => {
+  for (const relativePath of Object.keys(profile.statePersistence ?? {})) {
+    if (!(relativePath in piStatePathDeclarations)) {
+      throw new Error(`state_persistence path '${relativePath}' is not declared by the pi adapter`);
+    }
+  }
+};
 
 const resolveStateStrategy = (
   profile: Profile,

--- a/src/cli/commands/RunCommand.ts
+++ b/src/cli/commands/RunCommand.ts
@@ -273,9 +273,7 @@ const findContributingLoadedProfiles = (
   profileStack: readonly Profile[],
   loadedProfiles: readonly LoadedProfile[],
 ): readonly LoadedProfile[] =>
-  profileStack
-    .map((profile) => loadedProfiles.find((loadedProfile) => loadedProfile.profile.id === profile.id))
-    .filter((loadedProfile): loadedProfile is LoadedProfile => loadedProfile !== undefined);
+  profileStack.flatMap((profile) => loadedProfiles.filter((loadedProfile) => loadedProfile.profile.id === profile.id));
 
 const loadProfileSources = (
   homeDirectory: string,

--- a/src/cli/commands/RunCommand.ts
+++ b/src/cli/commands/RunCommand.ts
@@ -15,6 +15,8 @@ import type { ProfileSourceReference } from '../../profiles/ProfileSource.js';
 import { resolveProfile } from '../../profiles/ProfileMerger.js';
 import { discoverSettingsLoadPlan, loadSettings } from '../../settings/SettingsLoader.js';
 import { createTackRootDirectory, writeTack } from '../../tack/TackAssembler.js';
+import { createTackStateBaseline, detectTackStateWrites } from '../../tack/StatePersistence.js';
+import type { TackStateBaseline, TackStatePath, TackStateWriteIssue } from '../../tack/StatePersistence.js';
 import { watchTackInputs } from '../../tack/TackWatcher.js';
 import type { CommandObject } from './CommandObject.js';
 
@@ -57,15 +59,11 @@ export const executeRunCommand = async (
   const tackPlan = createAdapterTackPlan(adapter, resolvedProfile, tackRootDirectory);
   const warnings = tackPlan.warnings;
 
-  if (input.hardTack === true && warnings.length > 0) {
-    throw new Error(`Hard-tack failed for ${adapter.id}: ${warnings.join('; ')}`);
-  }
-
-  for (const warning of warnings) {
-    (dependencies.writeError ?? console.error)(warning);
-  }
+  failHardTackOnWarnings(adapter.id, warnings, input.hardTack);
+  emitWarnings(warnings, dependencies.writeError);
 
   writeTack(tackPlan.tack);
+  const stateBaseline = createTackStateBaseline(tackPlan.tack.rootDirectory);
   const launchPlan = adapter.createLaunchPlan(tackPlan.tack, resolvedProfile.profile, input.passThroughArgs ?? []);
   const watcher = watchTackInputs({
     tack: tackPlan.tack,
@@ -79,13 +77,21 @@ export const executeRunCommand = async (
       dependencies.launcher ??
       /* v8 ignore next -- tests inject launchers instead of spawning pi. */ createSpawnLauncher();
     const exitCode = await launcher.launch(launchPlan);
+    const stateWriteWarnings = handleTackStateWrites(
+      tackPlan.tack.rootDirectory,
+      tackPlan.tack.statePaths,
+      stateBaseline,
+    );
+
+    failHardTackOnWarnings(adapter.id, stateWriteWarnings, input.hardTack);
+    emitWarnings(stateWriteWarnings, dependencies.writeError);
 
     return {
       profileId: resolvedProfile.profile.id,
       agentId: adapter.id,
       launchPlan,
       tackDirectory: tackPlan.tack.rootDirectory,
-      warnings,
+      warnings: [...warnings, ...stateWriteWarnings],
       exitCode,
     };
   } finally {
@@ -144,13 +150,61 @@ const configureRunCommander = (
 interface ResolvedRunProfile {
   readonly profile: Profile;
   readonly profilePaths: readonly string[];
+  readonly profileFolders: readonly string[];
+  readonly homeDirectory: string;
 }
+
+const failHardTackOnWarnings = (
+  adapterId: string,
+  warnings: readonly string[],
+  hardTack: boolean | undefined,
+): void => {
+  if (hardTack === true && warnings.length > 0) {
+    throw new Error(`Hard-tack failed for ${adapterId}: ${warnings.join('; ')}`);
+  }
+};
+
+const emitWarnings = (warnings: readonly string[], writeError: ((message: string) => void) | undefined): void => {
+  const writer = writeError ?? console.error;
+
+  for (const warning of warnings) {
+    writer(warning);
+  }
+};
 
 const createAdapterTackPlan = (adapter: AgentAdapter, resolvedProfile: ResolvedRunProfile, rootDirectory: string) =>
   adapter.createTack(resolvedProfile.profile, {
     rootDirectory,
     profilePaths: resolvedProfile.profilePaths,
+    profileFolders: resolvedProfile.profileFolders,
+    homeDirectory: resolvedProfile.homeDirectory,
   });
+
+const handleTackStateWrites = (
+  tackRootDirectory: string,
+  statePaths: readonly TackStatePath[],
+  stateBaseline: TackStateBaseline,
+): readonly string[] => {
+  const warnings: string[] = [];
+
+  for (const issue of detectTackStateWrites(tackRootDirectory, statePaths, stateBaseline)) {
+    if (issue.strategy === 'error') {
+      throw new Error(formatTackStateWriteIssue(issue));
+    }
+
+    /* v8 ignore next -- state write issues are only emitted for warn/prompt or thrown for error. */
+    if (issue.strategy === 'warn' || issue.strategy === 'prompt') {
+      warnings.push(formatTackStateWriteIssue(issue));
+    }
+  }
+
+  return warnings;
+};
+
+const formatTackStateWriteIssue = (issue: TackStateWriteIssue): string =>
+  issue.unknown
+    ? `pi wrote undeclared tack state '${issue.relativePath}' and it was not persisted.`
+    : `pi wrote '${issue.relativePath}' with state_persistence '${issue.strategy}' and it was not persisted.`;
 
 const loadResolvedProfile = (input: RunCommandInput): ResolvedRunProfile => {
   const loadedSettings = loadSettings(discoverSettingsLoadPlan(input));
@@ -179,19 +233,30 @@ const loadResolvedProfile = (input: RunCommandInput): ResolvedRunProfile => {
   return {
     profile: resolution.profile,
     profilePaths: findContributingProfilePaths(resolution.profileStack, loadedProfiles.profiles),
+    profileFolders: findContributingProfileFolders(resolution.profileStack, loadedProfiles.profiles),
+    homeDirectory: input.homeDirectory,
   };
 };
 
 const findContributingProfilePaths = (
   profileStack: readonly Profile[],
   loadedProfiles: readonly LoadedProfile[],
-): readonly string[] => {
-  const contributingProfileIds = new Set(profileStack.map((profile) => profile.id));
+): readonly string[] =>
+  findContributingLoadedProfiles(profileStack, loadedProfiles).map((loadedProfile) => loadedProfile.profilePath);
 
-  return loadedProfiles
-    .filter((loadedProfile) => contributingProfileIds.has(loadedProfile.profile.id))
-    .map((loadedProfile) => loadedProfile.profilePath);
-};
+const findContributingProfileFolders = (
+  profileStack: readonly Profile[],
+  loadedProfiles: readonly LoadedProfile[],
+): readonly string[] =>
+  findContributingLoadedProfiles(profileStack, loadedProfiles).map((loadedProfile) => loadedProfile.folderPath);
+
+const findContributingLoadedProfiles = (
+  profileStack: readonly Profile[],
+  loadedProfiles: readonly LoadedProfile[],
+): readonly LoadedProfile[] =>
+  profileStack
+    .map((profile) => loadedProfiles.find((loadedProfile) => loadedProfile.profile.id === profile.id))
+    .filter((loadedProfile): loadedProfile is LoadedProfile => loadedProfile !== undefined);
 
 const loadProfileSources = (
   homeDirectory: string,

--- a/src/cli/commands/RunCommand.ts
+++ b/src/cli/commands/RunCommand.ts
@@ -21,7 +21,11 @@ import type { ProfileSourceReference } from '../../profiles/ProfileSource.js';
 import { resolveProfile } from '../../profiles/ProfileMerger.js';
 import { loadSettingsWithCachedRemoteSettings } from '../../settings/SettingsLoader.js';
 import { createTackRootDirectory, writeTack } from '../../tack/TackAssembler.js';
-import { createTackStateBaseline, detectTackStateWrites } from '../../tack/StatePersistence.js';
+import {
+  createTackStateBaseline,
+  detectTackStateWrites,
+  updateTackStateBaselinePaths,
+} from '../../tack/StatePersistence.js';
 import type { TackStateBaseline, TackStatePath, TackStateWriteIssue } from '../../tack/StatePersistence.js';
 import { watchTackInputs } from '../../tack/TackWatcher.js';
 import type { CommandObject } from './CommandObject.js';
@@ -70,11 +74,18 @@ export const executeRunCommand = async (
   emitWarnings(warnings, dependencies.writeError);
 
   writeTack(tackPlan.tack);
-  const stateBaseline = createTackStateBaseline(tackPlan.tack.rootDirectory);
+  let stateBaseline = createTackStateBaseline(tackPlan.tack.rootDirectory);
   const launchPlan = adapter.createLaunchPlan(tackPlan.tack, resolvedProfile.profile, input.passThroughArgs ?? []);
   const watcher = watchTackInputs({
     tack: tackPlan.tack,
     refreshTack: () => createAdapterTackPlan(adapter, loadResolvedProfile(input), tackRootDirectory).tack,
+    onTackWritten: (tack) => {
+      stateBaseline = updateTackStateBaselinePaths(
+        tack.rootDirectory,
+        stateBaseline,
+        tack.files.map((file) => file.outputPath),
+      );
+    },
     /* v8 ignore next -- watcher warnings are covered in TackWatcher tests; this adapter passes the stderr writer through. */
     warn: (message) => (dependencies.writeError ?? console.error)(message),
   });

--- a/src/cli/commands/RunCommand.ts
+++ b/src/cli/commands/RunCommand.ts
@@ -74,7 +74,7 @@ export const executeRunCommand = async (
   emitWarnings(warnings, dependencies.writeError);
 
   writeTack(tackPlan.tack);
-  let stateBaseline = createTackStateBaseline(tackPlan.tack.rootDirectory);
+  let stateBaseline = createTackStateBaseline(tackPlan.tack.rootDirectory, tackPlan.tack.statePaths);
   const launchPlan = adapter.createLaunchPlan(tackPlan.tack, resolvedProfile.profile, input.passThroughArgs ?? []);
   const watcher = watchTackInputs({
     tack: tackPlan.tack,

--- a/src/cli/commands/RunCommand.ts
+++ b/src/cli/commands/RunCommand.ts
@@ -85,6 +85,7 @@ export const executeRunCommand = async (
       /* v8 ignore next -- tests inject launchers instead of spawning pi. */ createSpawnLauncher();
     const exitCode = await launcher.launch(launchPlan);
     const stateWriteWarnings = handleTackStateWrites(
+      adapter.id,
       tackPlan.tack.rootDirectory,
       tackPlan.tack.statePaths,
       stateBaseline,
@@ -188,6 +189,7 @@ const createAdapterTackPlan = (adapter: AgentAdapter, resolvedProfile: ResolvedR
   });
 
 const handleTackStateWrites = (
+  adapterId: string,
   tackRootDirectory: string,
   statePaths: readonly TackStatePath[],
   stateBaseline: TackStateBaseline,
@@ -196,25 +198,25 @@ const handleTackStateWrites = (
 
   for (const issue of detectTackStateWrites(tackRootDirectory, statePaths, stateBaseline)) {
     if (issue.strategy === 'error') {
-      throw new Error(formatTackStateWriteIssue(issue));
+      throw new Error(formatTackStateWriteIssue(adapterId, issue));
     }
 
-    warnings.push(formatTackStateWriteIssue(issue));
+    warnings.push(formatTackStateWriteIssue(adapterId, issue));
   }
 
   return warnings;
 };
 
-const formatTackStateWriteIssue = (issue: TackStateWriteIssue): string => {
+const formatTackStateWriteIssue = (adapterId: string, issue: TackStateWriteIssue): string => {
   if (issue.unknown) {
-    return `pi wrote undeclared tack state '${issue.relativePath}' and it was not persisted.`;
+    return `${adapterId} wrote undeclared tack state '${issue.relativePath}' and it was not persisted.`;
   }
 
   if (issue.strategy === 'symlink') {
-    return `pi replaced symlinked state path '${issue.relativePath}' and the change was not persisted.`;
+    return `${adapterId} replaced symlinked state path '${issue.relativePath}' and the change was not persisted.`;
   }
 
-  return `pi wrote '${issue.relativePath}' with state_persistence '${issue.strategy}' and it was not persisted.`;
+  return `${adapterId} wrote '${issue.relativePath}' with state_persistence '${issue.strategy}' and it was not persisted.`;
 };
 
 const runSetupIfNeeded = (input: RunCommandInput, dependencies: RunCommandDependencies): void => {

--- a/src/profiles/Profile.ts
+++ b/src/profiles/Profile.ts
@@ -1,4 +1,8 @@
 // Defines profile shapes and control fragments used during profile resolution.
+import type { StatePersistenceStrategy } from '../tack/StatePersistence.js';
+
+export type StatePersistenceOverrides = Readonly<Record<string, StatePersistenceStrategy>>;
+
 interface BaseProfileControls {
   readonly [controlName: string]: unknown;
   readonly model?: string;
@@ -25,10 +29,12 @@ export interface Profile {
   readonly label?: string;
   readonly inherits: readonly string[];
   readonly controls: ProfileControls;
+  readonly statePersistence?: StatePersistenceOverrides;
 }
 
 export const createEmptyProfile = (id: string): Profile => ({
   id,
   inherits: [],
   controls: {},
+  statePersistence: {},
 });

--- a/src/profiles/ProfileLoader.ts
+++ b/src/profiles/ProfileLoader.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import type { ValidationIssue } from '../validation/SchemaValidator.js';
 import { validateSchema } from '../validation/SchemaValidator.js';
 import { parseYamlDocument } from '../validation/YamlDocument.js';
-import type { Profile, ProfileControls } from './Profile.js';
+import type { Profile, ProfileControls, StatePersistenceOverrides } from './Profile.js';
 import type { ProfileSourceReference } from './ProfileSource.js';
 
 const profileIdPattern = /^[a-z0-9][a-z0-9._-]*[a-z0-9]$|^[a-z0-9]$/u;
@@ -52,12 +52,15 @@ export const parseProfileDocument = (document: unknown, fallbackId: string): Pro
     return validationIssue;
   }
 
-  return {
+  const statePersistence = readStatePersistence(record.state_persistence);
+
+  return omitUndefined({
     id,
     label: readOptionalString(record.label),
     inherits: readStringArray(record.inherits),
     controls: readControls(record.controls),
-  };
+    statePersistence: Object.keys(statePersistence).length > 0 ? statePersistence : undefined,
+  });
 };
 
 export const parseProfileYaml = (content: string, fallbackId: string): Profile | ProfileLoadIssue => {
@@ -171,7 +174,7 @@ const readControls = (value: unknown): ProfileControls => {
     return {};
   }
 
-  return {
+  return omitUndefined({
     ...controls,
     model: readOptionalString(controls.model),
     provider: readOptionalString(controls.provider),
@@ -185,7 +188,7 @@ const readControls = (value: unknown): ProfileControls => {
     systemPrompt: readOptionalString(controls.system_prompt),
     appendSystemPrompt: readOptionalString(controls.append_system_prompt),
     pi: readPiControls(controls.pi),
-  };
+  });
 };
 
 const readPiControls = (value: unknown): ProfileControls['pi'] => {
@@ -195,7 +198,7 @@ const readPiControls = (value: unknown): ProfileControls['pi'] => {
     return undefined;
   }
 
-  return {
+  return omitUndefined({
     ...controls,
     model: readOptionalString(controls.model),
     provider: readOptionalString(controls.provider),
@@ -208,7 +211,24 @@ const readPiControls = (value: unknown): ProfileControls['pi'] => {
     promptTemplate: readOptionalString(controls.prompt_template),
     systemPrompt: readOptionalString(controls.system_prompt),
     appendSystemPrompt: readOptionalString(controls.append_system_prompt),
-  };
+  });
+};
+
+const omitUndefined = <T extends Readonly<Record<string, unknown>>>(record: T): T =>
+  Object.fromEntries(Object.entries(record).filter((entry) => entry[1] !== undefined)) as T;
+
+const readStatePersistence = (value: unknown): StatePersistenceOverrides => {
+  const statePersistence = readObject(value);
+
+  if (statePersistence === undefined) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(statePersistence).filter(
+      (entry): entry is [string, StatePersistenceOverrides[string]] => typeof entry[1] === 'string',
+    ),
+  );
 };
 
 const readEnvironment = (value: unknown): Readonly<Record<string, string>> | undefined => {

--- a/src/schemas/profile.schema.json
+++ b/src/schemas/profile.schema.json
@@ -16,6 +16,12 @@
         "pattern": "^[a-z0-9][a-z0-9._-]*[a-z0-9]$|^[a-z0-9]$"
       }
     },
+    "state_persistence": {
+      "type": "object",
+      "additionalProperties": {
+        "enum": ["symlink", "discard", "warn", "error", "prompt"]
+      }
+    },
     "controls": {
       "type": "object",
       "properties": {

--- a/src/tack/StatePersistence.ts
+++ b/src/tack/StatePersistence.ts
@@ -12,6 +12,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { sep as posixSeparator } from 'node:path/posix';
 
 export type StatePersistenceStrategy = 'symlink' | 'discard' | 'warn' | 'error' | 'prompt';
 
@@ -197,7 +198,7 @@ const addFingerprint = (absolutePath: string, relativePath: string, fingerprints
     for (const entryName of readdirSync(absolutePath).sort()) {
       addFingerprint(
         join(absolutePath, entryName),
-        relativePath === '' ? entryName : join(relativePath, entryName),
+        relativePath === '' ? entryName : `${relativePath}${posixSeparator}${entryName}`,
         fingerprints,
       );
     }
@@ -232,13 +233,13 @@ const shouldReportStatePathChange = (changedPath: string, statePath: TackStatePa
 const isWithinStatePath = (changedPath: string, statePath: TackStatePath): boolean => {
   const stateRelativePath = normalizeStateRelativePath(statePath.relativePath);
 
-  return changedPath === stateRelativePath || changedPath.startsWith(`${stateRelativePath}${sep}`);
+  return changedPath === stateRelativePath || changedPath.startsWith(`${stateRelativePath}${posixSeparator}`);
 };
 
 const normalizeStateRelativePath = (relativePath: string): string =>
   relativePath.endsWith('/') ? relativePath.slice(0, -1) : relativePath;
 
 const isUserWritePath = (relativePath: string): boolean =>
-  relativePath !== 'bridl' && !relativePath.startsWith(`bridl${sep}`);
+  relativePath !== 'bridl' && !relativePath.startsWith(`bridl${posixSeparator}`);
 
 const isNodeError = (error: unknown): error is NodeJS.ErrnoException => error instanceof Error && 'code' in error;

--- a/src/tack/StatePersistence.ts
+++ b/src/tack/StatePersistence.ts
@@ -246,7 +246,7 @@ const addFingerprint = (
   }
 };
 
-const createEntryFingerprint = (absolutePath: string, stat: ReturnType<typeof lstatSync>): string => {
+const createEntryFingerprint = (absolutePath: string, stat: NonNullable<ReturnType<typeof lstatSync>>): string => {
   if (stat.isDirectory()) {
     return 'dir';
   }

--- a/src/tack/StatePersistence.ts
+++ b/src/tack/StatePersistence.ts
@@ -6,6 +6,7 @@ import {
   readdirSync,
   readFileSync,
   readlinkSync,
+  statSync,
   symlinkSync,
   unlinkSync,
   writeFileSync,
@@ -96,14 +97,43 @@ export const detectTackStateWrites = (
 };
 
 export const ensureStateSourcePath = (sourcePath: string, directory: boolean): string => {
-  if (directory) {
-    mkdirSync(sourcePath, { recursive: true });
-  } else if (!existsSync(sourcePath)) {
-    mkdirSync(dirname(sourcePath), { recursive: true });
-    writeFileSync(sourcePath, '');
+  const sourceType = getExistingSourceType(sourcePath);
+
+  if (sourceType === undefined) {
+    if (directory) {
+      mkdirSync(sourcePath, { recursive: true });
+    } else {
+      mkdirSync(dirname(sourcePath), { recursive: true });
+      writeFileSync(sourcePath, '');
+    }
+
+    return sourcePath;
+  }
+
+  if (directory && sourceType !== 'directory') {
+    throw new Error(`State source path '${sourcePath}' must be a directory.`);
+  }
+
+  if (!directory && sourceType !== 'file') {
+    throw new Error(`State source path '${sourcePath}' must be a file.`);
   }
 
   return sourcePath;
+};
+
+const getExistingSourceType = (sourcePath: string): 'file' | 'directory' | undefined => {
+  try {
+    const stat = statSync(sourcePath);
+    return stat.isDirectory() ? 'directory' : 'file';
+  } catch (error) {
+    /* v8 ignore next -- non-ENOENT stat failures should surface as actionable filesystem errors. */
+    if (isNodeError(error) && error.code === 'ENOENT') {
+      return undefined;
+    }
+
+    /* v8 ignore next -- non-ENOENT stat failures should surface as actionable filesystem errors. */
+    throw error;
+  }
 };
 
 const materializeSymlink = (

--- a/src/tack/StatePersistence.ts
+++ b/src/tack/StatePersistence.ts
@@ -115,13 +115,27 @@ const materializeSymlink = (
   const outputPath = resolveTackStateOutputPath(rootDirectory, relativePath);
   mkdirSync(dirname(outputPath), { recursive: true });
 
-  /* v8 ignore next -- repeat materialization cleanup is defensive for live tack rewrites. */
-  if (existsSync(outputPath)) {
+  if (pathLexicallyExists(outputPath)) {
     unlinkSync(outputPath);
   }
 
   ensureStateSourcePath(sourcePath, directory);
   symlinkSync(sourcePath, outputPath, directory ? 'dir' : 'file');
+};
+
+const pathLexicallyExists = (path: string): boolean => {
+  try {
+    lstatSync(path);
+    return true;
+  } catch (error) {
+    /* v8 ignore next -- non-ENOENT lstat failures should surface as actionable filesystem errors. */
+    if (isNodeError(error) && error.code === 'ENOENT') {
+      return false;
+    }
+
+    /* v8 ignore next -- non-ENOENT lstat failures should surface as actionable filesystem errors. */
+    throw error;
+  }
 };
 
 const fingerprintTree = (rootDirectory: string): ReadonlyMap<string, string> => {
@@ -196,3 +210,5 @@ const normalizeStateRelativePath = (relativePath: string): string =>
 
 const isUserWritePath = (relativePath: string): boolean =>
   relativePath !== 'bridl' && !relativePath.startsWith(`bridl${sep}`);
+
+const isNodeError = (error: unknown): error is NodeJS.ErrnoException => error instanceof Error && 'code' in error;

--- a/src/tack/StatePersistence.ts
+++ b/src/tack/StatePersistence.ts
@@ -57,8 +57,11 @@ export const materializeTackStatePath = (rootDirectory: string, statePath: TackS
   }
 };
 
-export const createTackStateBaseline = (rootDirectory: string): TackStateBaseline => ({
-  fingerprints: fingerprintTree(rootDirectory),
+export const createTackStateBaseline = (
+  rootDirectory: string,
+  statePaths: readonly TackStatePath[] = [],
+): TackStateBaseline => ({
+  fingerprints: fingerprintTree(rootDirectory, createDiscardStatePathSet(statePaths)),
 });
 
 export const updateTackStateBaselinePaths = (
@@ -66,18 +69,12 @@ export const updateTackStateBaselinePaths = (
   baseline: TackStateBaseline,
   outputPaths: readonly string[],
 ): TackStateBaseline => {
-  const current = fingerprintTree(rootDirectory);
   const fingerprints = new Map(baseline.fingerprints);
 
   for (const outputPath of outputPaths) {
     const relativePath = normalizeTackRelativePath(rootDirectory, outputPath);
-    const fingerprint = current.get(relativePath);
-
-    if (fingerprint === undefined) {
-      fingerprints.delete(relativePath);
-    } else {
-      fingerprints.set(relativePath, fingerprint);
-    }
+    deleteFingerprintSubtree(fingerprints, relativePath);
+    addPathFingerprints(rootDirectory, relativePath, fingerprints, new Set());
   }
 
   return { fingerprints };
@@ -88,7 +85,7 @@ export const detectTackStateWrites = (
   statePaths: readonly TackStatePath[],
   baseline: TackStateBaseline,
 ): readonly TackStateWriteIssue[] => {
-  const current = fingerprintTree(rootDirectory);
+  const current = fingerprintTree(rootDirectory, createDiscardStatePathSet(statePaths));
   const changedPaths = [...new Set([...current.keys(), ...baseline.fingerprints.keys()])].filter(
     (path) => current.get(path) !== baseline.fingerprints.get(path),
   );
@@ -191,17 +188,41 @@ const pathLexicallyExists = (path: string): boolean => {
   }
 };
 
-const fingerprintTree = (rootDirectory: string): ReadonlyMap<string, string> => {
+const fingerprintTree = (
+  rootDirectory: string,
+  skippedRelativePaths: ReadonlySet<string> = new Set(),
+): ReadonlyMap<string, string> => {
   const fingerprints = new Map<string, string>();
 
-  if (existsSync(rootDirectory)) {
-    addFingerprint(rootDirectory, '', fingerprints);
-  }
+  addPathFingerprints(rootDirectory, '', fingerprints, skippedRelativePaths);
 
   return fingerprints;
 };
 
-const addFingerprint = (absolutePath: string, relativePath: string, fingerprints: Map<string, string>): void => {
+const addPathFingerprints = (
+  rootDirectory: string,
+  relativePath: string,
+  fingerprints: Map<string, string>,
+  skippedRelativePaths: ReadonlySet<string>,
+): void => {
+  const absolutePath =
+    relativePath === '' ? rootDirectory : resolveTackRelativePath(rootDirectory, relativePath, 'Tack path');
+
+  if (existsSync(absolutePath)) {
+    addFingerprint(absolutePath, relativePath, fingerprints, skippedRelativePaths);
+  }
+};
+
+const addFingerprint = (
+  absolutePath: string,
+  relativePath: string,
+  fingerprints: Map<string, string>,
+  skippedRelativePaths: ReadonlySet<string>,
+): void => {
+  if (shouldSkipFingerprint(relativePath, skippedRelativePaths)) {
+    return;
+  }
+
   const stat = lstatSync(absolutePath);
 
   if (stat.isSymbolicLink()) {
@@ -210,10 +231,7 @@ const addFingerprint = (absolutePath: string, relativePath: string, fingerprints
   }
 
   if (relativePath !== '') {
-    fingerprints.set(
-      relativePath,
-      stat.isDirectory() ? 'dir' : `file:${readFileSync(absolutePath).toString('base64')}`,
-    );
+    fingerprints.set(relativePath, createEntryFingerprint(absolutePath, stat));
   }
 
   if (stat.isDirectory()) {
@@ -222,7 +240,42 @@ const addFingerprint = (absolutePath: string, relativePath: string, fingerprints
         join(absolutePath, entryName),
         relativePath === '' ? entryName : `${relativePath}${posixSeparator}${entryName}`,
         fingerprints,
+        skippedRelativePaths,
       );
+    }
+  }
+};
+
+const createEntryFingerprint = (absolutePath: string, stat: ReturnType<typeof lstatSync>): string => {
+  if (stat.isDirectory()) {
+    return 'dir';
+  }
+
+  if (stat.isFile()) {
+    return `file:${readFileSync(absolutePath).toString('base64')}`;
+  }
+
+  return `special:${stat.mode}:${stat.rdev}`;
+};
+
+const shouldSkipFingerprint = (relativePath: string, skippedRelativePaths: ReadonlySet<string>): boolean =>
+  relativePath !== '' &&
+  [...skippedRelativePaths].some(
+    (skippedRelativePath) =>
+      relativePath === skippedRelativePath || relativePath.startsWith(`${skippedRelativePath}${posixSeparator}`),
+  );
+
+const createDiscardStatePathSet = (statePaths: readonly TackStatePath[]): ReadonlySet<string> =>
+  new Set(
+    statePaths
+      .filter((statePath) => statePath.strategy === 'discard' && statePath.relativePath !== 'unknown')
+      .map((statePath) => normalizeStateRelativePath(statePath.relativePath)),
+  );
+
+const deleteFingerprintSubtree = (fingerprints: Map<string, string>, relativePath: string): void => {
+  for (const fingerprintPath of [...fingerprints.keys()]) {
+    if (fingerprintPath === relativePath || fingerprintPath.startsWith(`${relativePath}${posixSeparator}`)) {
+      fingerprints.delete(fingerprintPath);
     }
   }
 };

--- a/src/tack/StatePersistence.ts
+++ b/src/tack/StatePersistence.ts
@@ -61,6 +61,28 @@ export const createTackStateBaseline = (rootDirectory: string): TackStateBaselin
   fingerprints: fingerprintTree(rootDirectory),
 });
 
+export const updateTackStateBaselinePaths = (
+  rootDirectory: string,
+  baseline: TackStateBaseline,
+  outputPaths: readonly string[],
+): TackStateBaseline => {
+  const current = fingerprintTree(rootDirectory);
+  const fingerprints = new Map(baseline.fingerprints);
+
+  for (const outputPath of outputPaths) {
+    const relativePath = normalizeTackRelativePath(rootDirectory, outputPath);
+    const fingerprint = current.get(relativePath);
+
+    if (fingerprint === undefined) {
+      fingerprints.delete(relativePath);
+    } else {
+      fingerprints.set(relativePath, fingerprint);
+    }
+  }
+
+  return { fingerprints };
+};
+
 export const detectTackStateWrites = (
   rootDirectory: string,
   statePaths: readonly TackStatePath[],
@@ -207,15 +229,33 @@ const addFingerprint = (absolutePath: string, relativePath: string, fingerprints
 
 const resolveTackStateOutputPath = (rootDirectory: string, relativePath: string): string => {
   const normalizedRelativePath = relativePath.endsWith('/') ? relativePath.slice(0, -1) : relativePath;
+
+  return resolveTackRelativePath(rootDirectory, normalizedRelativePath, `State path '${relativePath}'`);
+};
+
+const normalizeTackRelativePath = (rootDirectory: string, outputPath: string): string => {
+  const resolvedOutputPath = isAbsolute(outputPath) ? resolve(outputPath) : resolve(rootDirectory, outputPath);
+  const relativeOutputPath = relative(resolve(rootDirectory), resolvedOutputPath);
+
+  assertTackRelativePath(rootDirectory, relativeOutputPath, `Tack file output path '${outputPath}'`);
+
+  return relativeOutputPath.split(sep).join(posixSeparator);
+};
+
+const resolveTackRelativePath = (rootDirectory: string, relativePath: string, label: string): string => {
   const resolvedRootDirectory = resolve(rootDirectory);
-  const resolvedOutputPath = resolve(rootDirectory, normalizedRelativePath);
+  const resolvedOutputPath = resolve(rootDirectory, relativePath);
   const relativeOutputPath = relative(resolvedRootDirectory, resolvedOutputPath);
 
-  if (relativeOutputPath === '..' || relativeOutputPath.startsWith(`..${sep}`) || isAbsolute(relativeOutputPath)) {
-    throw new Error(`State path '${relativePath}' must stay under tack root '${rootDirectory}'.`);
-  }
+  assertTackRelativePath(rootDirectory, relativeOutputPath, label);
 
   return resolvedOutputPath;
+};
+
+const assertTackRelativePath = (rootDirectory: string, relativePath: string, label: string): void => {
+  if (relativePath === '..' || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
+    throw new Error(`${label} must stay under tack root '${rootDirectory}'.`);
+  }
 };
 
 const shouldReportStatePathChange = (changedPath: string, statePath: TackStatePath): boolean => {

--- a/src/tack/StatePersistence.ts
+++ b/src/tack/StatePersistence.ts
@@ -210,7 +210,7 @@ const resolveTackStateOutputPath = (rootDirectory: string, relativePath: string)
   const resolvedOutputPath = resolve(rootDirectory, normalizedRelativePath);
   const relativeOutputPath = relative(resolvedRootDirectory, resolvedOutputPath);
 
-  if (relativeOutputPath.startsWith('..') || isAbsolute(relativeOutputPath)) {
+  if (relativeOutputPath === '..' || relativeOutputPath.startsWith(`..${sep}`) || isAbsolute(relativeOutputPath)) {
     throw new Error(`State path '${relativePath}' must stay under tack root '${rootDirectory}'.`);
   }
 

--- a/src/tack/StatePersistence.ts
+++ b/src/tack/StatePersistence.ts
@@ -1,0 +1,180 @@
+// Defines tack state persistence declarations, strategies, and write detection helpers.
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+
+export type StatePersistenceStrategy = 'symlink' | 'discard' | 'warn' | 'error' | 'prompt';
+
+export interface StatePathDeclaration {
+  readonly defaultStrategy?: StatePersistenceStrategy;
+  readonly allowedStrategies: readonly StatePersistenceStrategy[];
+}
+
+export interface TackStatePath {
+  readonly relativePath: string;
+  readonly strategy: StatePersistenceStrategy;
+  readonly sourcePath?: string;
+  readonly directory: boolean;
+}
+
+export interface TackStateBaseline {
+  readonly fingerprints: ReadonlyMap<string, string>;
+}
+
+export interface TackStateWriteIssue {
+  readonly relativePath: string;
+  readonly strategy: StatePersistenceStrategy;
+  readonly unknown: boolean;
+}
+
+export const materializeTackStatePath = (rootDirectory: string, statePath: TackStatePath): void => {
+  if (statePath.strategy === 'symlink') {
+    if (statePath.sourcePath === undefined) {
+      throw new Error(`State path '${statePath.relativePath}' uses symlink without a source path.`);
+    }
+
+    materializeSymlink(rootDirectory, statePath.relativePath, statePath.sourcePath, statePath.directory);
+    return;
+  }
+
+  const outputPath = resolveTackStateOutputPath(rootDirectory, statePath.relativePath);
+
+  if (statePath.directory) {
+    mkdirSync(outputPath, { recursive: true });
+  } else {
+    mkdirSync(dirname(outputPath), { recursive: true });
+  }
+};
+
+export const createTackStateBaseline = (rootDirectory: string): TackStateBaseline => ({
+  fingerprints: fingerprintTree(rootDirectory),
+});
+
+export const detectTackStateWrites = (
+  rootDirectory: string,
+  statePaths: readonly TackStatePath[],
+  baseline: TackStateBaseline,
+): readonly TackStateWriteIssue[] => {
+  const current = fingerprintTree(rootDirectory);
+  const changedPaths = [...new Set([...current.keys(), ...baseline.fingerprints.keys()])].filter(
+    (path) => current.get(path) !== baseline.fingerprints.get(path),
+  );
+  const issues = new Map<string, TackStateWriteIssue>();
+  const declaredPaths = statePaths.filter((statePath) => statePath.relativePath !== 'unknown');
+  const unknownStatePath = statePaths.find((statePath) => statePath.relativePath === 'unknown');
+
+  for (const changedPath of changedPaths) {
+    const statePath = declaredPaths.find((candidate) => isWithinStatePath(changedPath, candidate));
+
+    if (statePath !== undefined) {
+      /* v8 ignore next -- symlink and discard changes are intentionally ignored; warning/error/prompt paths are covered. */
+      if (statePath.strategy !== 'symlink' && statePath.strategy !== 'discard') {
+        issues.set(statePath.relativePath, {
+          relativePath: statePath.relativePath,
+          strategy: statePath.strategy,
+          unknown: false,
+        });
+      }
+    } else if (unknownStatePath !== undefined && isUserWritePath(changedPath)) {
+      issues.set(changedPath, { relativePath: changedPath, strategy: unknownStatePath.strategy, unknown: true });
+    }
+  }
+
+  return [...issues.values()].sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+};
+
+export const ensureStateSourcePath = (sourcePath: string, directory: boolean): string => {
+  if (directory) {
+    mkdirSync(sourcePath, { recursive: true });
+  } else if (!existsSync(sourcePath)) {
+    mkdirSync(dirname(sourcePath), { recursive: true });
+    writeFileSync(sourcePath, '');
+  }
+
+  return sourcePath;
+};
+
+const materializeSymlink = (
+  rootDirectory: string,
+  relativePath: string,
+  sourcePath: string,
+  directory: boolean,
+): void => {
+  const outputPath = resolveTackStateOutputPath(rootDirectory, relativePath);
+  mkdirSync(dirname(outputPath), { recursive: true });
+
+  /* v8 ignore next -- repeat materialization cleanup is defensive for live tack rewrites. */
+  if (existsSync(outputPath)) {
+    unlinkSync(outputPath);
+  }
+
+  ensureStateSourcePath(sourcePath, directory);
+  symlinkSync(sourcePath, outputPath, directory ? 'dir' : 'file');
+};
+
+const fingerprintTree = (rootDirectory: string): ReadonlyMap<string, string> => {
+  const fingerprints = new Map<string, string>();
+
+  if (existsSync(rootDirectory)) {
+    addFingerprint(rootDirectory, '', fingerprints);
+  }
+
+  return fingerprints;
+};
+
+const addFingerprint = (absolutePath: string, relativePath: string, fingerprints: Map<string, string>): void => {
+  const stat = lstatSync(absolutePath);
+
+  if (stat.isSymbolicLink()) {
+    return;
+  }
+
+  if (relativePath !== '') {
+    fingerprints.set(
+      relativePath,
+      stat.isDirectory() ? 'dir' : `file:${readFileSync(absolutePath).toString('base64')}`,
+    );
+  }
+
+  if (stat.isDirectory()) {
+    for (const entryName of readdirSync(absolutePath).sort()) {
+      addFingerprint(
+        join(absolutePath, entryName),
+        relativePath === '' ? entryName : join(relativePath, entryName),
+        fingerprints,
+      );
+    }
+  }
+};
+
+const resolveTackStateOutputPath = (rootDirectory: string, relativePath: string): string => {
+  const normalizedRelativePath = relativePath.endsWith('/') ? relativePath.slice(0, -1) : relativePath;
+  const resolvedRootDirectory = resolve(rootDirectory);
+  const resolvedOutputPath = resolve(rootDirectory, normalizedRelativePath);
+  const relativeOutputPath = relative(resolvedRootDirectory, resolvedOutputPath);
+
+  if (relativeOutputPath.startsWith('..') || isAbsolute(relativeOutputPath)) {
+    throw new Error(`State path '${relativePath}' must stay under tack root '${rootDirectory}'.`);
+  }
+
+  return resolvedOutputPath;
+};
+
+const isWithinStatePath = (changedPath: string, statePath: TackStatePath): boolean => {
+  const stateRelativePath = statePath.relativePath.endsWith('/')
+    ? statePath.relativePath.slice(0, -1)
+    : statePath.relativePath;
+
+  return changedPath === stateRelativePath || changedPath.startsWith(`${stateRelativePath}${sep}`);
+};
+
+const isUserWritePath = (relativePath: string): boolean =>
+  relativePath !== 'bridl' && !relativePath.startsWith(`bridl${sep}`);

--- a/src/tack/Tack.ts
+++ b/src/tack/Tack.ts
@@ -1,12 +1,19 @@
 // Defines an assembled tack directory description before it is written to disk.
+import type { TackStatePath } from './StatePersistence.js';
 import type { TackFile } from './TackFile.js';
 
 export interface Tack {
   readonly rootDirectory: string;
   readonly files: readonly TackFile[];
+  readonly statePaths: readonly TackStatePath[];
 }
 
-export const createTack = (rootDirectory: string, files: readonly TackFile[]): Tack => ({
+export const createTack = (
+  rootDirectory: string,
+  files: readonly TackFile[],
+  statePaths: readonly TackStatePath[] = [],
+): Tack => ({
   rootDirectory,
   files,
+  statePaths,
 });

--- a/src/tack/TackAssembler.ts
+++ b/src/tack/TackAssembler.ts
@@ -13,19 +13,27 @@ export interface TackAssemblyInput {
   readonly files: readonly TackFile[];
 }
 
+export interface TackWriteOptions {
+  readonly materializeStatePaths?: boolean;
+}
+
 export const createTackRootDirectory = (profileId: string, agentId: string): string =>
   mkdtempSync(join(tmpdir(), `bridl-${profileId}-${agentId}-`));
 
 export const assembleTack = (input: TackAssemblyInput): Tack =>
   createTack(input.rootDirectory ?? createTackRootDirectory('profile', 'agent'), input.files);
 
-export const writeTack = (tack: Tack): void => {
+export const writeTack = (tack: Tack, options: TackWriteOptions = {}): void => {
   mkdirSync(tack.rootDirectory, { recursive: true });
 
   for (const file of tack.files) {
     const outputPath = resolveTackFileOutputPath(tack.rootDirectory, file.outputPath);
     mkdirSync(dirname(outputPath), { recursive: true });
     writeFileSync(outputPath, file.content);
+  }
+
+  if (options.materializeStatePaths === false) {
+    return;
   }
 
   for (const statePath of tack.statePaths.filter((statePath) => statePath.relativePath !== 'unknown')) {

--- a/src/tack/TackAssembler.ts
+++ b/src/tack/TackAssembler.ts
@@ -5,6 +5,7 @@ import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 
 import type { Tack } from './Tack.js';
 import { createTack } from './Tack.js';
+import { materializeTackStatePath } from './StatePersistence.js';
 import type { TackFile } from './TackFile.js';
 
 export interface TackAssemblyInput {
@@ -25,6 +26,10 @@ export const writeTack = (tack: Tack): void => {
     const outputPath = resolveTackFileOutputPath(tack.rootDirectory, file.outputPath);
     mkdirSync(dirname(outputPath), { recursive: true });
     writeFileSync(outputPath, file.content);
+  }
+
+  for (const statePath of tack.statePaths.filter((statePath) => statePath.relativePath !== 'unknown')) {
+    materializeTackStatePath(tack.rootDirectory, statePath);
   }
 };
 

--- a/src/tack/TackWatcher.ts
+++ b/src/tack/TackWatcher.ts
@@ -18,6 +18,7 @@ export interface WatchTackInput {
   readonly tack: Tack;
   readonly warn: (message: string) => void;
   readonly refreshTack?: () => Tack;
+  readonly onTackWritten?: (tack: Tack) => void;
 }
 
 export const createTackWatchPlan = (paths: readonly string[]): TackWatchPlan => ({
@@ -62,7 +63,9 @@ export const tackFileOutputPath = (tack: Tack, relativePath: string): string => 
 
 const updateTackFromWatchedInput = (input: WatchTackInput, watchPath: string): void => {
   try {
-    writeTack(input.refreshTack?.() ?? input.tack, { materializeStatePaths: false });
+    const tack = input.refreshTack?.() ?? input.tack;
+    writeTack(tack, { materializeStatePaths: false });
+    input.onTackWritten?.(tack);
   } catch (error) {
     /* v8 ignore next -- unsafe live-update failures are reported defensively; normal refresh behavior is covered. */
     input.warn(`Could not safely update tack from ${watchPath}: ${formatError(error)}`);

--- a/src/tack/TackWatcher.ts
+++ b/src/tack/TackWatcher.ts
@@ -62,7 +62,7 @@ export const tackFileOutputPath = (tack: Tack, relativePath: string): string => 
 
 const updateTackFromWatchedInput = (input: WatchTackInput, watchPath: string): void => {
   try {
-    writeTack(input.refreshTack?.() ?? input.tack);
+    writeTack(input.refreshTack?.() ?? input.tack, { materializeStatePaths: false });
   } catch (error) {
     /* v8 ignore next -- unsafe live-update failures are reported defensively; normal refresh behavior is covered. */
     input.warn(`Could not safely update tack from ${watchPath}: ${formatError(error)}`);

--- a/tests/unit/state-live-update.test.ts
+++ b/tests/unit/state-live-update.test.ts
@@ -1,4 +1,5 @@
 // Tests state-write accounting when live tack updates regenerate files.
+import { execFileSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -127,6 +128,48 @@ describe('live tack update state accounting', () => {
     ).toEqual([{ relativePath: 'generated.txt', strategy: 'warn', unknown: true }]);
     expect(
       detectTackStateWrites(root, [{ relativePath: 'unknown', strategy: 'warn', directory: false }], updatedBaseline),
+    ).toEqual([]);
+  });
+
+  it('fingerprints special state entries without reading them as files', () => {
+    const root = createTemporaryRoot();
+    const pipePath = join(root, 'cache', 'pipe');
+    mkdirSync(join(root, 'cache'), { recursive: true });
+    const baseline = createTackStateBaseline(root);
+
+    execFileSync('mkfifo', [pipePath]);
+
+    expect(
+      detectTackStateWrites(root, [{ relativePath: 'cache/', strategy: 'warn', directory: true }], baseline),
+    ).toEqual([{ relativePath: 'cache/', strategy: 'warn', unknown: false }]);
+  });
+
+  it('skips discard state subtrees while creating and comparing snapshots', () => {
+    const root = createTemporaryRoot();
+    const pipePath = join(root, 'cache', 'pipe');
+    const statePaths = [
+      { relativePath: 'cache/', strategy: 'discard' as const, directory: true },
+      { relativePath: 'unknown', strategy: 'warn' as const, directory: false },
+    ];
+    mkdirSync(join(root, 'cache'), { recursive: true });
+    writeFileSync(join(root, 'discarded.txt'), 'before\n');
+    execFileSync('mkfifo', [pipePath]);
+
+    const baseline = createTackStateBaseline(root, statePaths);
+    writeFileSync(join(root, 'outside.txt'), 'reported\n');
+
+    expect(detectTackStateWrites(root, statePaths, baseline)).toEqual([
+      { relativePath: 'outside.txt', strategy: 'warn', unknown: true },
+    ]);
+
+    const unfilteredBaseline = createTackStateBaseline(root);
+    writeFileSync(join(root, 'discarded.txt'), 'after\n');
+    expect(
+      detectTackStateWrites(
+        root,
+        [{ relativePath: 'discarded.txt', strategy: 'discard', directory: false }],
+        unfilteredBaseline,
+      ),
     ).toEqual([]);
   });
 });

--- a/tests/unit/state-live-update.test.ts
+++ b/tests/unit/state-live-update.test.ts
@@ -1,0 +1,132 @@
+// Tests state-write accounting when live tack updates regenerate files.
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { executeRunCommand } from '../../src/cli/commands/RunCommand.js';
+import { createTack } from '../../src/tack/Tack.js';
+import {
+  createTackStateBaseline,
+  detectTackStateWrites,
+  updateTackStateBaselinePaths,
+} from '../../src/tack/StatePersistence.js';
+import { createTackFile } from '../../src/tack/TackFile.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'bridl-state-live-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const writeSettings = (homeDirectory: string, content: string): void => {
+  mkdirSync(join(homeDirectory, '.bridl'), { recursive: true });
+  writeFileSync(join(homeDirectory, '.bridl', 'settings.yml'), content);
+};
+
+const writeProfile = (root: string, id: string, content: string): string => {
+  const profileDirectory = join(root, id);
+  mkdirSync(profileDirectory, { recursive: true });
+  const profilePath = join(profileDirectory, 'profile.yml');
+  writeFileSync(profilePath, content);
+  return profilePath;
+};
+
+const waitForFileContent = async (path: string, content: string): Promise<void> => {
+  for (let attempts = 0; attempts < 40; attempts += 1) {
+    try {
+      if (readFileSync(path, 'utf8') === content) {
+        return;
+      }
+    } catch {
+      // Retry until fs.watch has had a chance to write the generated file.
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+
+  expect(readFileSync(path, 'utf8')).toBe(content);
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('live tack update state accounting', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.4, BRIDL-REQ-005.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('does not report live-regenerated tack files as agent state writes', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const profilesDirectory = join(homeDirectory, '.bridl', 'profiles');
+    const profilePath = writeProfile(profilesDirectory, 'default', 'id: default\nlabel: Initial\ncontrols: {}\n');
+    writeSettings(homeDirectory, 'default_profile: default\nprofile_sources:\n  - path: ./profiles\n');
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        adapter: {
+          id: 'mock-agent',
+          supportedControls: [],
+          createTack(profile, tackInput) {
+            return {
+              tack: createTack(
+                tackInput.rootDirectory,
+                [
+                  createTackFile({
+                    relativePath: 'generated.txt',
+                    content: `${profile.label}\n`,
+                    sourceInputs: tackInput.profilePaths,
+                  }),
+                ],
+                [{ relativePath: 'unknown', strategy: 'warn', directory: false }],
+              ),
+              warnings: [],
+            };
+          },
+          createLaunchPlan(tack) {
+            return { command: 'mock-agent', args: [], env: { MOCK_AGENT_DIR: tack.rootDirectory } };
+          },
+          getUnsupportedControls() {
+            return [];
+          },
+        },
+        launcher: {
+          async launch(plan) {
+            expect(readFileSync(join(plan.env.MOCK_AGENT_DIR, 'generated.txt'), 'utf8')).toBe('Initial\n');
+            await new Promise((resolve) => setTimeout(resolve, 25));
+            writeFileSync(profilePath, 'id: default\nlabel: Updated\ncontrols: {}\n');
+            await waitForFileContent(join(plan.env.MOCK_AGENT_DIR, 'generated.txt'), 'Updated\n');
+            return 0;
+          },
+        },
+      },
+    );
+
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('removes deleted generated files from refreshed state baselines', () => {
+    const root = createTemporaryRoot();
+    const generatedPath = join(root, 'generated.txt');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(generatedPath, 'generated\n');
+    const baseline = createTackStateBaseline(root);
+
+    rmSync(generatedPath);
+    const updatedBaseline = updateTackStateBaselinePaths(root, baseline, ['generated.txt']);
+
+    expect(
+      detectTackStateWrites(root, [{ relativePath: 'unknown', strategy: 'warn', directory: false }], baseline),
+    ).toEqual([{ relativePath: 'generated.txt', strategy: 'warn', unknown: true }]);
+    expect(
+      detectTackStateWrites(root, [{ relativePath: 'unknown', strategy: 'warn', directory: false }], updatedBaseline),
+    ).toEqual([]);
+  });
+});

--- a/tests/unit/state-persistence.test.ts
+++ b/tests/unit/state-persistence.test.ts
@@ -293,6 +293,52 @@ describe('state persistence', () => {
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.6).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('formats state write diagnostics with the selected adapter id', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    writeSettings(homeDirectory, 'default_profile: default\nprofile_sources:\n  - path: ./profiles\n');
+    writeProfile(join(homeDirectory, '.bridl', 'profiles'), 'default', 'id: default\ncontrols: {}\n');
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        adapter: {
+          id: 'mock-agent',
+          supportedControls: [],
+          createTack(_profile, tackInput) {
+            return {
+              tack: createTack(
+                tackInput.rootDirectory,
+                [],
+                [{ relativePath: 'state.json', strategy: 'warn', directory: false }],
+              ),
+              warnings: [],
+            };
+          },
+          createLaunchPlan(tack) {
+            return { command: 'mock-agent', args: [], env: { MOCK_AGENT_DIR: tack.rootDirectory } };
+          },
+          getUnsupportedControls() {
+            return [];
+          },
+        },
+        launcher: {
+          launch(plan) {
+            writeFileSync(join(plan.env.MOCK_AGENT_DIR, 'state.json'), 'changed\n');
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(result.warnings).toContain(
+      "mock-agent wrote 'state.json' with state_persistence 'warn' and it was not persisted.",
+    );
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('fails after launch when an error-strategy state path changes', async () => {
     const root = createTemporaryRoot();
     const homeDirectory = join(root, 'home');
@@ -344,6 +390,33 @@ describe('state persistence', () => {
         },
       ),
     ).rejects.toThrow('state_persistence strategy \'symlink\' is not allowed for "unknown"');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('rejects state persistence keys inherited from Object.prototype', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    writeSettings(homeDirectory, 'default_profile: default\nprofile_sources:\n  - path: ./profiles\n');
+    writeProfile(
+      join(homeDirectory, '.bridl', 'profiles'),
+      'default',
+      ['id: default', 'state_persistence:', '  toString: warn', 'controls: {}', ''].join('\n'),
+    );
+
+    await expect(
+      executeRunCommand(
+        { homeDirectory, projectDirectory },
+        {
+          launcher: {
+            launch() {
+              return Promise.resolve(0);
+            },
+          },
+        },
+      ),
+    ).rejects.toThrow("state_persistence path 'toString' is not declared by the pi adapter");
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.6).

--- a/tests/unit/state-persistence.test.ts
+++ b/tests/unit/state-persistence.test.ts
@@ -67,6 +67,11 @@ describe('state persistence', () => {
     if (!('message' in profile)) {
       expect(profile.statePersistence).toEqual({ 'settings.json': 'warn', 'cache/': 'discard', unknown: 'error' });
     }
+
+    expect(parseProfileYaml('id: invalid\nstate_persistence:\n  settings.json: persist\n', 'fallback')).toEqual({
+      path: '/state_persistence/settings.json',
+      message: 'must be equal to one of the allowed values',
+    });
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.6).

--- a/tests/unit/state-persistence.test.ts
+++ b/tests/unit/state-persistence.test.ts
@@ -7,6 +7,7 @@ import {
   readFileSync,
   readlinkSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -14,6 +15,7 @@ import { join } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { createPiAdapter } from '../../src/agents/pi/PiAdapter.js';
 import { executeRunCommand } from '../../src/cli/commands/RunCommand.js';
 import { parseProfileYaml } from '../../src/profiles/ProfileLoader.js';
 import {
@@ -80,7 +82,15 @@ describe('state persistence', () => {
     writeProfile(
       profilesDirectory,
       'default',
-      ['id: default', 'state_persistence:', '  cache/: warn', '  unknown: warn', 'controls: {}', ''].join('\n'),
+      [
+        'id: default',
+        'state_persistence:',
+        '  cache/: warn',
+        '  mcp.json: prompt',
+        '  unknown: warn',
+        'controls: {}',
+        '',
+      ].join('\n'),
     );
     mkdirSync(join(profilesDirectory, 'default', 'cli_specific', 'pi'), { recursive: true });
     mkdirSync(join(homeDirectory, '.pi', 'agent'), { recursive: true });
@@ -100,6 +110,7 @@ describe('state persistence', () => {
             expect(readlinkSync(join(tackPiDirectory, 'auth.json'))).toBe(nativeAuthPath);
             writeFileSync(join(tackPiDirectory, 'settings.json'), '{"theme":"light"}\n');
             writeFileSync(join(tackPiDirectory, 'cache', 'entry.txt'), 'discarded cache\n');
+            writeFileSync(join(tackPiDirectory, 'mcp.json'), '{"servers":{}}\n');
             writeFileSync(join(tackPiDirectory, 'unexpected.txt'), 'unknown write\n');
             return Promise.resolve(0);
           },
@@ -109,6 +120,7 @@ describe('state persistence', () => {
 
     expect(readFileSync(settingsPath, 'utf8')).toBe('{"theme":"light"}\n');
     expect(result.warnings).toContain("pi wrote 'cache/' with state_persistence 'warn' and it was not persisted.");
+    expect(result.warnings).toContain("pi wrote 'mcp.json' with state_persistence 'prompt' and it was not persisted.");
     expect(result.warnings).toContain("pi wrote undeclared tack state 'unexpected.txt' and it was not persisted.");
     expect(warnings).toEqual(result.warnings);
   });
@@ -166,7 +178,47 @@ describe('state persistence', () => {
     expect(() =>
       materializeTackStatePath(root, { relativePath: 'bad.json', strategy: 'symlink', directory: false }),
     ).toThrow('uses symlink without a source path');
+    symlinkSync(join(root, 'deleted-target.json'), join(root, 'broken.json'));
+    materializeTackStatePath(root, {
+      relativePath: 'broken.json',
+      strategy: 'symlink',
+      sourcePath: sourceFile,
+      directory: false,
+    });
+    expect(readlinkSync(join(root, 'broken.json'))).toBe(sourceFile);
     expect(createTackStateBaseline(join(root, 'missing')).fingerprints.size).toBe(0);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('resolves state sources using profile stack order rather than loaded folder order', () => {
+    const root = createTemporaryRoot();
+    const baseFolder = join(root, 'zbase');
+    const explicitFolder = join(root, 'alpha');
+    const baseSettings = join(baseFolder, 'cli_specific', 'pi', 'settings.json');
+    const explicitSettings = join(explicitFolder, 'cli_specific', 'pi', 'settings.json');
+    mkdirSync(join(baseFolder, 'cli_specific', 'pi'), { recursive: true });
+    mkdirSync(join(explicitFolder, 'cli_specific', 'pi'), { recursive: true });
+    writeFileSync(baseSettings, '{"source":"base"}\n');
+    writeFileSync(explicitSettings, '{"source":"explicit"}\n');
+
+    const tack = createPiAdapter().createTack(
+      {
+        id: 'alpha',
+        inherits: ['zbase'],
+        controls: {},
+      },
+      {
+        rootDirectory: join(root, 'tack'),
+        profilePaths: [join(baseFolder, 'profile.yml'), join(explicitFolder, 'profile.yml')],
+        profileFolders: [baseFolder, explicitFolder],
+        homeDirectory: join(root, 'home'),
+      },
+    ).tack;
+
+    expect(tack.statePaths.find((statePath) => statePath.relativePath === 'settings.json')?.sourcePath).toBe(
+      explicitSettings,
+    );
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.6).

--- a/tests/unit/state-persistence.test.ts
+++ b/tests/unit/state-persistence.test.ts
@@ -153,12 +153,14 @@ describe('state persistence', () => {
       directory: true,
     });
     materializeTackStatePath(root, { relativePath: 'cache/', strategy: 'prompt', directory: true });
+    materializeTackStatePath(root, { relativePath: 'logs/cache/', strategy: 'warn', directory: true });
     materializeTackStatePath(root, { relativePath: 'notes.txt', strategy: 'warn', directory: false });
     expect(existsSync(join(root, 'source', 'plugins'))).toBe(true);
     expect(lstatSync(join(root, 'plugins')).isSymbolicLink()).toBe(true);
     const baseline = createTackStateBaseline(root);
 
     writeFileSync(join(root, 'cache', 'entry.txt'), 'changed\n');
+    writeFileSync(join(root, 'logs', 'cache', 'entry.txt'), 'changed\n');
     writeFileSync(join(root, 'notes.txt'), 'changed\n');
     mkdirSync(join(root, 'bridl'), { recursive: true });
     writeFileSync(join(root, 'bridl', 'profile.json'), '{}\n');
@@ -168,6 +170,7 @@ describe('state persistence', () => {
         root,
         [
           { relativePath: 'cache/', strategy: 'prompt', directory: true },
+          { relativePath: 'logs/cache/', strategy: 'warn', directory: true },
           { relativePath: 'notes.txt', strategy: 'warn', directory: false },
           { relativePath: 'unknown', strategy: 'discard', directory: false },
         ],
@@ -175,6 +178,7 @@ describe('state persistence', () => {
       ),
     ).toEqual([
       { relativePath: 'cache/', strategy: 'prompt', unknown: false },
+      { relativePath: 'logs/cache/', strategy: 'warn', unknown: false },
       { relativePath: 'notes.txt', strategy: 'warn', unknown: false },
     ]);
     expect(

--- a/tests/unit/state-persistence.test.ts
+++ b/tests/unit/state-persistence.test.ts
@@ -180,6 +180,8 @@ describe('state persistence', () => {
     expect(
       detectTackStateWrites(root, [{ relativePath: 'notes.txt', strategy: 'discard', directory: false }], baseline),
     ).toEqual([]);
+    materializeTackStatePath(root, { relativePath: '..cache', strategy: 'warn', directory: false });
+    expect(existsSync(join(root, '..cache'))).toBe(false);
     expect(() =>
       materializeTackStatePath(root, { relativePath: '../outside.txt', strategy: 'warn', directory: false }),
     ).toThrow('must stay under tack root');

--- a/tests/unit/state-persistence.test.ts
+++ b/tests/unit/state-persistence.test.ts
@@ -26,6 +26,7 @@ import {
   detectTackStateWrites,
   ensureStateSourcePath,
   materializeTackStatePath,
+  updateTackStateBaselinePaths,
 } from '../../src/tack/StatePersistence.js';
 
 const temporaryRoots: string[] = [];
@@ -229,6 +230,8 @@ describe('state persistence', () => {
     expect(() => ensureStateSourcePath(join(root, 'source-directory.json'), false)).toThrow('must be a file');
     writeFileSync(join(root, 'source-file'), 'not a directory\n');
     expect(() => ensureStateSourcePath(join(root, 'source-file'), true)).toThrow('must be a directory');
+    rmSync(join(root, 'notes.txt'));
+    expect(updateTackStateBaselinePaths(root, baseline, ['notes.txt']).fingerprints.has('notes.txt')).toBe(false);
     expect(createTackStateBaseline(join(root, 'missing')).fingerprints.size).toBe(0);
   });
 

--- a/tests/unit/state-persistence.test.ts
+++ b/tests/unit/state-persistence.test.ts
@@ -135,6 +135,31 @@ describe('state persistence', () => {
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.6).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('assembles pi fallback state source paths without mutating native state directories', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const tack = createPiAdapter().createTack(
+      { id: 'default', inherits: [], controls: {} },
+      {
+        rootDirectory: join(root, 'tack'),
+        profilePaths: [join(root, 'profile.yml')],
+        profileFolders: [],
+        homeDirectory,
+      },
+    ).tack;
+
+    expect(tack.statePaths.find((statePath) => statePath.relativePath === 'settings.json')?.sourcePath).toBe(
+      join(homeDirectory, '.pi', 'agent', 'settings.json'),
+    );
+    expect(existsSync(join(homeDirectory, '.pi'))).toBe(false);
+
+    writeTack(tack);
+
+    expect(existsSync(join(homeDirectory, '.pi', 'agent', 'settings.json'))).toBe(true);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('detects changed temporary state paths and protects tack path boundaries', () => {
     const root = createTemporaryRoot();
     const sourceFile = ensureStateSourcePath(join(root, 'source', 'settings.json'), false);
@@ -205,6 +230,28 @@ describe('state persistence', () => {
     writeFileSync(join(root, 'source-file'), 'not a directory\n');
     expect(() => ensureStateSourcePath(join(root, 'source-file'), true)).toThrow('must be a directory');
     expect(createTackStateBaseline(join(root, 'missing')).fingerprints.size).toBe(0);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('does not create native fallback state paths while planning a pi tack', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+
+    const tack = createPiAdapter().createTack(
+      { id: 'default', controls: {} },
+      {
+        rootDirectory: join(root, 'tack'),
+        profilePaths: [],
+        profileFolders: [],
+        homeDirectory,
+      },
+    ).tack;
+
+    expect(tack.statePaths.find((statePath) => statePath.relativePath === 'settings.json')?.sourcePath).toBe(
+      join(homeDirectory, '.pi', 'agent', 'settings.json'),
+    );
+    expect(existsSync(join(homeDirectory, '.pi'))).toBe(false);
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.6).

--- a/tests/unit/state-persistence.test.ts
+++ b/tests/unit/state-persistence.test.ts
@@ -194,6 +194,10 @@ describe('state persistence', () => {
       directory: false,
     });
     expect(readlinkSync(join(root, 'broken.json'))).toBe(sourceFile);
+    mkdirSync(join(root, 'source-directory.json'));
+    expect(() => ensureStateSourcePath(join(root, 'source-directory.json'), false)).toThrow('must be a file');
+    writeFileSync(join(root, 'source-file'), 'not a directory\n');
+    expect(() => ensureStateSourcePath(join(root, 'source-file'), true)).toThrow('must be a directory');
     expect(createTackStateBaseline(join(root, 'missing')).fingerprints.size).toBe(0);
   });
 

--- a/tests/unit/state-persistence.test.ts
+++ b/tests/unit/state-persistence.test.ts
@@ -1,0 +1,223 @@
+// Tests profile state persistence parsing and pi tack state materialization.
+import {
+  existsSync,
+  lstatSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { executeRunCommand } from '../../src/cli/commands/RunCommand.js';
+import { parseProfileYaml } from '../../src/profiles/ProfileLoader.js';
+import {
+  createTackStateBaseline,
+  detectTackStateWrites,
+  ensureStateSourcePath,
+  materializeTackStatePath,
+} from '../../src/tack/StatePersistence.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'bridl-state-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const writeSettings = (homeDirectory: string, content: string): void => {
+  mkdirSync(join(homeDirectory, '.bridl'), { recursive: true });
+  writeFileSync(join(homeDirectory, '.bridl', 'settings.yml'), content);
+};
+
+const writeProfile = (root: string, id: string, content: string): string => {
+  const profileDirectory = join(root, id);
+  mkdirSync(profileDirectory, { recursive: true });
+  const profilePath = join(profileDirectory, 'profile.yml');
+  writeFileSync(profilePath, content);
+  return profilePath;
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('state persistence', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.2, BRIDL-REQ-005.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('parses state persistence overrides from profile YAML', () => {
+    const profile = parseProfileYaml(
+      ['id: stateful', 'state_persistence:', '  settings.json: warn', '  cache/: discard', '  unknown: error', ''].join(
+        '\n',
+      ),
+      'fallback',
+    );
+
+    expect('message' in profile).toBe(false);
+    if (!('message' in profile)) {
+      expect(profile.statePersistence).toEqual({ 'settings.json': 'warn', 'cache/': 'discard', unknown: 'error' });
+    }
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.2, BRIDL-REQ-005.3, BRIDL-REQ-005.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('materializes pi state paths as symlinks and reports non-persistent writes', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const profilesDirectory = join(homeDirectory, '.bridl', 'profiles');
+    const settingsPath = join(profilesDirectory, 'default', 'cli_specific', 'pi', 'settings.json');
+    const nativeAuthPath = join(homeDirectory, '.pi', 'agent', 'auth.json');
+    writeSettings(homeDirectory, 'default_profile: default\nprofile_sources:\n  - path: ./profiles\n');
+    writeProfile(
+      profilesDirectory,
+      'default',
+      ['id: default', 'state_persistence:', '  cache/: warn', '  unknown: warn', 'controls: {}', ''].join('\n'),
+    );
+    mkdirSync(join(profilesDirectory, 'default', 'cli_specific', 'pi'), { recursive: true });
+    mkdirSync(join(homeDirectory, '.pi', 'agent'), { recursive: true });
+    writeFileSync(settingsPath, '{"theme":"dark"}\n');
+    writeFileSync(nativeAuthPath, '{"openai-codex":{"type":"oauth"}}\n');
+    const warnings: string[] = [];
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        writeError: (message) => warnings.push(message),
+        launcher: {
+          launch(plan) {
+            const tackPiDirectory = plan.env.PI_CODING_AGENT_DIR;
+            expect(lstatSync(join(tackPiDirectory, 'settings.json')).isSymbolicLink()).toBe(true);
+            expect(readlinkSync(join(tackPiDirectory, 'settings.json'))).toBe(settingsPath);
+            expect(readlinkSync(join(tackPiDirectory, 'auth.json'))).toBe(nativeAuthPath);
+            writeFileSync(join(tackPiDirectory, 'settings.json'), '{"theme":"light"}\n');
+            writeFileSync(join(tackPiDirectory, 'cache', 'entry.txt'), 'discarded cache\n');
+            writeFileSync(join(tackPiDirectory, 'unexpected.txt'), 'unknown write\n');
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(readFileSync(settingsPath, 'utf8')).toBe('{"theme":"light"}\n');
+    expect(result.warnings).toContain("pi wrote 'cache/' with state_persistence 'warn' and it was not persisted.");
+    expect(result.warnings).toContain("pi wrote undeclared tack state 'unexpected.txt' and it was not persisted.");
+    expect(warnings).toEqual(result.warnings);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.2, BRIDL-REQ-005.3, BRIDL-REQ-005.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('detects changed temporary state paths and protects tack path boundaries', () => {
+    const root = createTemporaryRoot();
+    const sourceFile = ensureStateSourcePath(join(root, 'source', 'settings.json'), false);
+    const sourceDirectory = ensureStateSourcePath(join(root, 'source', 'plugins'), true);
+    writeFileSync(sourceFile, '{}\n');
+    materializeTackStatePath(root, {
+      relativePath: 'settings.json',
+      strategy: 'symlink',
+      sourcePath: sourceFile,
+      directory: false,
+    });
+    materializeTackStatePath(root, {
+      relativePath: 'plugins/',
+      strategy: 'symlink',
+      sourcePath: sourceDirectory,
+      directory: true,
+    });
+    materializeTackStatePath(root, { relativePath: 'cache/', strategy: 'prompt', directory: true });
+    materializeTackStatePath(root, { relativePath: 'notes.txt', strategy: 'warn', directory: false });
+    expect(existsSync(join(root, 'source', 'plugins'))).toBe(true);
+    expect(lstatSync(join(root, 'plugins')).isSymbolicLink()).toBe(true);
+    const baseline = createTackStateBaseline(root);
+
+    writeFileSync(join(root, 'cache', 'entry.txt'), 'changed\n');
+    writeFileSync(join(root, 'notes.txt'), 'changed\n');
+    mkdirSync(join(root, 'bridl'), { recursive: true });
+    writeFileSync(join(root, 'bridl', 'profile.json'), '{}\n');
+
+    expect(
+      detectTackStateWrites(
+        root,
+        [
+          { relativePath: 'cache/', strategy: 'prompt', directory: true },
+          { relativePath: 'notes.txt', strategy: 'warn', directory: false },
+          { relativePath: 'unknown', strategy: 'warn', directory: false },
+        ],
+        baseline,
+      ),
+    ).toEqual([
+      { relativePath: 'cache/', strategy: 'prompt', unknown: false },
+      { relativePath: 'notes.txt', strategy: 'warn', unknown: false },
+    ]);
+    expect(() =>
+      materializeTackStatePath(root, { relativePath: '../outside.txt', strategy: 'warn', directory: false }),
+    ).toThrow('must stay under tack root');
+    expect(() =>
+      materializeTackStatePath(root, { relativePath: 'bad.json', strategy: 'symlink', directory: false }),
+    ).toThrow('uses symlink without a source path');
+    expect(createTackStateBaseline(join(root, 'missing')).fingerprints.size).toBe(0);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.2, BRIDL-REQ-005.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('fails after launch when an error-strategy state path changes', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    writeSettings(homeDirectory, 'default_profile: default\nprofile_sources:\n  - path: ./profiles\n');
+    writeProfile(
+      join(homeDirectory, '.bridl', 'profiles'),
+      'default',
+      ['id: default', 'state_persistence:', '  settings.json: error', 'controls: {}', ''].join('\n'),
+    );
+
+    await expect(
+      executeRunCommand(
+        { homeDirectory, projectDirectory },
+        {
+          launcher: {
+            launch(plan) {
+              writeFileSync(join(plan.env.PI_CODING_AGENT_DIR, 'settings.json'), 'changed\n');
+              return Promise.resolve(0);
+            },
+          },
+        },
+      ),
+    ).rejects.toThrow("pi wrote 'settings.json' with state_persistence 'error' and it was not persisted.");
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.2, BRIDL-REQ-005.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('rejects state persistence strategies that are disallowed for a pi state path', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    writeSettings(homeDirectory, 'default_profile: default\nprofile_sources:\n  - path: ./profiles\n');
+    writeProfile(
+      join(homeDirectory, '.bridl', 'profiles'),
+      'default',
+      ['id: default', 'state_persistence:', '  unknown: symlink', 'controls: {}', ''].join('\n'),
+    );
+
+    await expect(
+      executeRunCommand(
+        { homeDirectory, projectDirectory },
+        {
+          launcher: {
+            launch() {
+              return Promise.resolve(0);
+            },
+          },
+        },
+      ),
+    ).rejects.toThrow('state_persistence strategy \'symlink\' is not allowed for "unknown"');
+  });
+});

--- a/tests/unit/state-persistence.test.ts
+++ b/tests/unit/state-persistence.test.ts
@@ -18,6 +18,9 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { createPiAdapter } from '../../src/agents/pi/PiAdapter.js';
 import { executeRunCommand } from '../../src/cli/commands/RunCommand.js';
 import { parseProfileYaml } from '../../src/profiles/ProfileLoader.js';
+import { createTack } from '../../src/tack/Tack.js';
+import { writeTack } from '../../src/tack/TackAssembler.js';
+import { createTackFile } from '../../src/tack/TackFile.js';
 import {
   createTackStateBaseline,
   detectTackStateWrites,
@@ -255,6 +258,41 @@ describe('state persistence', () => {
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.6).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('can rewrite generated files without rematerializing state paths during live updates', () => {
+    const root = createTemporaryRoot();
+    const sourceFile = ensureStateSourcePath(join(root, 'source', 'settings.json'), false);
+    const tackRoot = join(root, 'tack');
+    const statePath = {
+      relativePath: 'settings.json',
+      strategy: 'symlink' as const,
+      sourcePath: sourceFile,
+      directory: false,
+    };
+    const initialTack = createTack(
+      tackRoot,
+      [createTackFile({ relativePath: 'bridl/profile.json', content: '{"version":1}\n' })],
+      [statePath],
+    );
+    writeTack(initialTack);
+    rmSync(join(tackRoot, 'settings.json'));
+    writeFileSync(join(tackRoot, 'settings.json'), 'agent replacement\n');
+
+    writeTack(
+      createTack(
+        tackRoot,
+        [createTackFile({ relativePath: 'bridl/profile.json', content: '{"version":2}\n' })],
+        [statePath],
+      ),
+      { materializeStatePaths: false },
+    );
+
+    expect(readFileSync(join(tackRoot, 'bridl', 'profile.json'), 'utf8')).toBe('{"version":2}\n');
+    expect(lstatSync(join(tackRoot, 'settings.json')).isSymbolicLink()).toBe(false);
+    expect(readFileSync(join(tackRoot, 'settings.json'), 'utf8')).toBe('agent replacement\n');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('fails after launch when an error-strategy state path changes', async () => {
     const root = createTemporaryRoot();
     const homeDirectory = join(root, 'home');
@@ -306,5 +344,32 @@ describe('state persistence', () => {
         },
       ),
     ).rejects.toThrow('state_persistence strategy \'symlink\' is not allowed for "unknown"');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('rejects state persistence keys that are undeclared by the pi adapter', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    writeSettings(homeDirectory, 'default_profile: default\nprofile_sources:\n  - path: ./profiles\n');
+    writeProfile(
+      join(homeDirectory, '.bridl', 'profiles'),
+      'default',
+      ['id: default', 'state_persistence:', '  setting.json: warn', 'controls: {}', ''].join('\n'),
+    );
+
+    await expect(
+      executeRunCommand(
+        { homeDirectory, projectDirectory },
+        {
+          launcher: {
+            launch() {
+              return Promise.resolve(0);
+            },
+          },
+        },
+      ),
+    ).rejects.toThrow("state_persistence path 'setting.json' is not declared by the pi adapter");
   });
 });


### PR DESCRIPTION
## Summary
- add profile-level state_persistence parsing and schema validation
- materialize Pi tack state paths with symlink/non-persistent strategies
- detect warn/error/unknown writes after agent runs
- update state writeback docs to describe current behavior

## Validation
- npm run check-ci