### PR TITLE
Add remote settings and source subpaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,27 @@ bridl run --profile engineering-default
 bridl run -p support -- --cwd ~/work/customer-issue
 bridl sync
 bridl setup
+bridl setup https://github.com/my_account/bridl_config
 bridl create_profile regulated --scope user
 ```
 
 Under the hood, `bridl` will translate a selected profile into the appropriate `pi` launch environment, such as `PI_CODING_AGENT_DIR`, CLI flags, injected extensions, prompts, model settings, session directories, and environment variables.
+
+`settings.yml` can point at local profiles, full Git URIs, or GitHub shorthand sources with optional refs and repository subpaths:
+
+```yaml
+remote_settings:
+  - github: my_account/bridl_config
+    ref: main
+    path: settings.yml
+
+profile_sources:
+  - github: my_account/bridl_config
+    ref: main
+    path: profiles
+```
+
+Run `bridl sync` to fetch/update remote settings and profiles before using them.
 
 ## Profile model sketch
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,75 @@ profile_sources:
 
 Run `bridl sync` to fetch/update remote settings and profiles before using them.
 
+## Setup from a settings repository
+
+You can bootstrap a machine from a Git repository:
+
+```bash
+bridl setup https://github.com/my_account/bridl_config
+```
+
+`bridl setup <repo>` clones or updates the repository in Bridl's shared repository cache, then uses it as a non-overwriting starting point:
+
+- if `~/.bridl/settings.yml` does not exist, Bridl copies the starter `settings.yml`;
+- if starter profiles exist, Bridl copies missing profile files into `~/.bridl/profiles/`;
+- existing user settings and profile files are left unchanged;
+- after setup, Bridl runs the same sync behavior used by `bridl sync`.
+
+A setup repository can use either root-level Bridl files:
+
+```text
+bridl_config/
+  settings.yml
+  profiles/
+    engineering-default/
+      profile.yml
+    support/
+      profile.yml
+```
+
+or a `.bridl/` layout:
+
+```text
+bridl_config/
+  .bridl/
+    settings.yml
+    profiles/
+      engineering-default/
+        profile.yml
+      support/
+        profile.yml
+```
+
+Example `settings.yml` for a setup repository:
+
+```yaml
+default_profile: engineering-default
+
+profile_sources:
+  - path: ./profiles
+
+  # Optional: keep loading future updates from this same repo.
+  - github: my_account/bridl_config
+    ref: main
+    path: profiles
+```
+
+If you want ongoing centralized settings, use a small local `~/.bridl/settings.yml` that points at remote settings:
+
+```yaml
+remote_settings:
+  - github: my_account/bridl_config
+    ref: main
+    path: settings.yml
+```
+
+Then run:
+
+```bash
+bridl sync
+```
+
 ## Profile model sketch
 
 A profile will use YAML.

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -391,7 +391,7 @@ Requirements:
 Responsibilities:
 
 - create `~/.bridl/settings.yml` when missing;
-- accept an optional setup source URI, for example `bridl setup https://github.com/example/bridl-config`, and clone/update it under `~/.bridl/cache/setup/<encoded-uri>/`;
+- accept an optional setup source URI, for example `bridl setup https://github.com/example/bridl-config`, and clone/update it under `~/.bridl/cache/repos/<encoded-uri-and-ref>/`;
 - when a setup source is provided, use its root `settings.yml` or `.bridl/settings.yml` and `profiles/` or `.bridl/profiles/` as the initial non-overwriting user setup starting point;
 - create a default profile when missing;
 - validate all discovered settings files and any starter settings file;
@@ -404,9 +404,10 @@ Responsibilities:
 
 - read settings;
 - validate profile sources;
-- fetch/update URI-based profile sources;
-- store them under `~/.bridl/cache/profiles/<encoded-uri>/`;
-- validate fetched profiles.
+- fetch/update URI-based, GitHub shorthand, and remote settings sources;
+- store plain URI profile sources without `ref` or repository subpaths under `~/.bridl/cache/profiles/<encoded-uri>/` for compatibility;
+- store GitHub shorthand sources and sources with `ref` or repository subpaths under `~/.bridl/cache/repos/<encoded-uri-and-ref>/`;
+- validate fetched remote settings files and profiles.
 
 ### `bridl create_profile`
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -137,8 +137,19 @@ profile_sources:
       - support
 
   - uri: git+https://github.com/example/company-bridl-profiles.git
+    ref: main
+    path: profiles/team
     except:
       - experimental
+
+  - github: example/bridl-config
+    ref: main
+    path: profiles
+
+remote_settings:
+  - github: example/bridl-config
+    ref: main
+    path: settings.yml
 
 profiles:
   engineering:
@@ -148,14 +159,16 @@ profiles:
 Rules:
 
 - Every settings file MUST validate against `settings.schema.json`.
-- `profile_sources` entries MUST specify exactly one of `path` or `uri`.
+- `profile_sources` entries MUST specify a local `path`, a remote `uri`, or a `github` shorthand.
 - `only` and `except` are optional filters; without either, all profiles from the source are loaded.
-- Relative `path` values are resolved relative to the settings file containing them.
-- `uri` sources are fetched/cached by `bridl sync`.
+- Local-only relative `path` values are resolved relative to the settings file containing them.
+- Remote `uri` and `github` profile sources can specify `ref` and repository-subdirectory `path` values.
+- `remote_settings` entries point at settings-style YAML files inside synced remote repositories.
+- `uri`, `github`, and `remote_settings` sources are fetched/cached by `bridl sync`.
 
 ## Profile Sources and Sync
 
-A profile source can be local or URI-based.
+A profile source can be local, URI-based, or GitHub shorthand-based.
 
 ### Local Source
 
@@ -166,20 +179,43 @@ profile_sources:
 
 The path points to a folder containing profile folders, not a specific profile folder.
 
-### URI Source
+### URI or GitHub Source
 
 ```yaml
 profile_sources:
-  - uri: git+ssh://git@github.com/example/company-profiles.git#main
+  - uri: git+ssh://git@github.com/example/company-profiles.git
+    ref: main
+    path: profiles/team
+
+  - github: example/company-profiles
+    ref: main
+    path: profiles/team
 ```
 
-`bridl sync` fetches URI sources into:
+The `github: owner/repo` shorthand normalizes to `git+https://github.com/owner/repo.git` internally. Remote sources without `ref` or repository subpaths retain the original profile cache location for compatibility:
 
 ```text
 ~/.bridl/cache/profiles/<encoded-uri>/
 ```
 
-The encoded path must be filesystem-safe and deterministic for arbitrary URI strings, including non-GitHub URIs.
+Remote sources that specify `ref`, repository-subdirectory `path`, or `github` are fetched into the shared repository cache:
+
+```text
+~/.bridl/cache/repos/<encoded-uri-and-ref>/
+```
+
+Profile loading then reads from the requested subdirectory inside the cached repository.
+
+### Remote Settings Source
+
+```yaml
+remote_settings:
+  - github: example/bridl-config
+    ref: main
+    path: settings.yml
+```
+
+`bridl sync` fetches remote settings repositories into the shared repository cache, validates that the requested settings file exists, then loads cached remote settings as lower-precedence settings sources during later settings resolution.
 
 ## Profile Layout
 
@@ -355,8 +391,10 @@ Requirements:
 Responsibilities:
 
 - create `~/.bridl/settings.yml` when missing;
+- accept an optional setup source URI, for example `bridl setup https://github.com/example/bridl-config`, and clone/update it under `~/.bridl/cache/setup/<encoded-uri>/`;
+- when a setup source is provided, use its root `settings.yml` or `.bridl/settings.yml` and `profiles/` or `.bridl/profiles/` as the initial non-overwriting user setup starting point;
 - create a default profile when missing;
-- validate all discovered settings files;
+- validate all discovered settings files and any starter settings file;
 - run `bridl sync` behavior for URI profile sources;
 - report actionable next steps.
 

--- a/requirements/BRIDL-REQ-002-settings.md
+++ b/requirements/BRIDL-REQ-002-settings.md
@@ -38,10 +38,21 @@ The internal Settings object is the single source of resolved configuration for 
 ### BRIDL-REQ-002.5: Profile Sources in Settings
 
 1. `settings.yml` MAY contain a `profile_sources` array.
-2. Each `profile_sources` entry MUST specify exactly one of `path` or `uri`.
-3. A `path` profile source MUST resolve relative to the settings file containing it when the path is relative.
-4. A `path` profile source MUST point to a folder containing profile folders rather than to one specific profile folder.
-5. A `uri` profile source MUST be syncable by `bridl sync`.
-6. A profile source MAY specify `only` to allow only named profiles from that source.
-7. A profile source MAY specify `except` to exclude named profiles from that source.
-8. If neither `only` nor `except` is specified, Bridl MUST load all profiles from the source.
+2. Each `profile_sources` entry MUST specify either a local `path`, a remote `uri`, or a `github` shorthand.
+3. A local-only `path` profile source MUST resolve relative to the settings file containing it when the path is relative.
+4. A local-only `path` profile source MUST point to a folder containing profile folders rather than to one specific profile folder.
+5. A `uri` or `github` profile source MUST be syncable by `bridl sync`.
+6. A `uri` or `github` profile source MAY specify `ref` to select a branch, tag, or commit.
+7. A `uri` or `github` profile source MAY specify `path` to load profiles from a repository subdirectory.
+8. A profile source MAY specify `only` to allow only named profiles from that source.
+9. A profile source MAY specify `except` to exclude named profiles from that source.
+10. If neither `only` nor `except` is specified, Bridl MUST load all profiles from the source.
+
+### BRIDL-REQ-002.6: Remote Settings Sources
+
+1. `settings.yml` MAY contain a `remote_settings` array.
+2. Each `remote_settings` entry MUST specify either a remote `uri` or a `github` shorthand.
+3. Each `remote_settings` entry MUST specify `path` to a settings-style YAML file inside the remote repository.
+4. A `remote_settings` entry MAY specify `ref` to select a branch, tag, or commit.
+5. Bridl MUST load cached remote settings files from their repository subpaths when resolving settings.
+6. Local discovered settings MUST take precedence over remote settings when both define the same setting.

--- a/requirements/BRIDL-REQ-004-sync-and-setup.md
+++ b/requirements/BRIDL-REQ-004-sync-and-setup.md
@@ -26,6 +26,7 @@ Bridl provides setup and maintenance commands that create initial configuration,
 6. The `sync` command MUST validate profiles loaded from synchronized sources.
 7. The `sync` command SHOULD report whether each source was updated, unchanged, skipped, or failed.
 8. The first version of `sync` MUST NOT require lockfile-based profile source reproducibility.
+9. The `sync` command MUST redact credentials embedded in source URIs from user-facing output.
 
 ### BRIDL-REQ-004.3: Create Profile Command
 

--- a/requirements/BRIDL-REQ-004-sync-and-setup.md
+++ b/requirements/BRIDL-REQ-004-sync-and-setup.md
@@ -21,7 +21,7 @@ Bridl provides setup and maintenance commands that create initial configuration,
 1. Bridl MUST provide a `sync` command.
 2. The `sync` command MUST read and validate settings before synchronizing sources.
 3. The `sync` command MUST fetch or update URI-based profile sources.
-4. The `sync` command MUST store URI-based profile sources under `~/.bridl/cache/profiles/<encoded-uri>/`.
+4. The `sync` command MUST store plain URI-based profile sources without `ref` or repository subpaths under `~/.bridl/cache/profiles/<encoded-uri>/`, and MUST store URI or GitHub sources with `ref` or repository subpaths under `~/.bridl/cache/repos/<encoded-uri-and-ref>/`.
 5. The encoded URI cache path MUST support non-GitHub URIs.
 6. The `sync` command MUST validate profiles loaded from synchronized sources.
 7. The `sync` command SHOULD report whether each source was updated, unchanged, skipped, or failed.

--- a/requirements/BRIDL-REQ-004-sync-and-setup.md
+++ b/requirements/BRIDL-REQ-004-sync-and-setup.md
@@ -14,6 +14,7 @@ Bridl provides setup and maintenance commands that create initial configuration,
 4. The `setup` command MUST validate discovered settings files.
 5. The `setup` command MUST run sync behavior for URI-based profile sources.
 6. The `setup` command SHOULD avoid overwriting existing user files unless a future explicit force option authorizes replacement.
+7. When provided a setup source URI, the `setup` command MUST use that source repository's Bridl `settings.yml` and profiles as the initial user setup starting point.
 
 ### BRIDL-REQ-004.2: Sync Command
 

--- a/src/cli/commands/RunCommand.ts
+++ b/src/cli/commands/RunCommand.ts
@@ -9,13 +9,13 @@ import spawn from 'cross-spawn';
 
 import type { AgentAdapter, AgentLaunchPlan } from '../../agents/AgentAdapter.js';
 import { createPiAdapter } from '../../agents/pi/PiAdapter.js';
-import { createProfileSourceCachePath } from '../../profiles/ProfileCache.js';
+import { createProfileSourceCachePath, createRemoteRepositoryCachePath } from '../../profiles/ProfileCache.js';
 import { loadLocalProfileSource } from '../../profiles/ProfileLoader.js';
 import type { LoadedProfile } from '../../profiles/ProfileLoader.js';
 import type { Profile } from '../../profiles/Profile.js';
 import type { ProfileSourceReference } from '../../profiles/ProfileSource.js';
 import { resolveProfile } from '../../profiles/ProfileMerger.js';
-import { discoverSettingsLoadPlan, loadSettings } from '../../settings/SettingsLoader.js';
+import { loadSettingsWithCachedRemoteSettings } from '../../settings/SettingsLoader.js';
 import { createTackRootDirectory, writeTack } from '../../tack/TackAssembler.js';
 import { watchTackInputs } from '../../tack/TackWatcher.js';
 import type { CommandObject } from './CommandObject.js';
@@ -168,7 +168,7 @@ const runSetupIfNeeded = (input: RunCommandInput, dependencies: RunCommandDepend
 };
 
 const loadResolvedProfile = (input: RunCommandInput): ResolvedRunProfile => {
-  const loadedSettings = loadSettings(discoverSettingsLoadPlan(input));
+  const loadedSettings = loadSettingsWithCachedRemoteSettings(input);
 
   if (loadedSettings.issues.length > 0) {
     throw new Error(`Cannot run with invalid settings: ${loadedSettings.issues.map(formatSettingsIssue).join('; ')}`);
@@ -228,11 +228,19 @@ const loadProfileSources = (
 };
 
 const materializeSource = (homeDirectory: string, source: ProfileSourceReference): ProfileSourceReference => {
-  if (source.uri === undefined) {
+  if (source.uri === undefined && source.github === undefined) {
     return source;
   }
 
-  return { path: createProfileSourceCachePath(homeDirectory, source.uri), only: source.only, except: source.except };
+  if (source.uri !== undefined && source.ref === undefined && source.path === undefined) {
+    return { path: createProfileSourceCachePath(homeDirectory, source.uri), only: source.only, except: source.except };
+  }
+
+  return {
+    path: join(createRemoteRepositoryCachePath(homeDirectory, source), source.path ?? ''),
+    only: source.only,
+    except: source.except,
+  };
 };
 
 /* v8 ignore start -- the real child-process launcher is direct runtime behavior; tests inject a launcher. */

--- a/src/cli/commands/RunCommand.ts
+++ b/src/cli/commands/RunCommand.ts
@@ -184,7 +184,7 @@ const loadResolvedProfile = (input: RunCommandInput): ResolvedRunProfile => {
     throw new Error(`Cannot run with invalid profiles: ${loadedProfiles.issues.map(formatProfileIssue).join('; ')}`);
   }
 
-  const profileId = input.profileId ?? loadedSettings.settings.defaultProfile ?? 'default';
+  const profileId = selectRunProfileId(input.profileId, loadedSettings.settings.defaultProfile);
   const resolution = resolveProfile({
     profiles: loadedProfiles.profiles,
     profileId,
@@ -199,6 +199,20 @@ const loadResolvedProfile = (input: RunCommandInput): ResolvedRunProfile => {
     profile: resolution.profile,
     profilePaths: findContributingProfilePaths(resolution.profileStack, loadedProfiles.profiles),
   };
+};
+
+const selectRunProfileId = (selectedProfileId: string | undefined, defaultProfileId: string | undefined): string => {
+  if (selectedProfileId !== undefined) {
+    return selectedProfileId;
+  }
+
+  if (defaultProfileId !== undefined) {
+    return defaultProfileId;
+  }
+
+  throw new Error(
+    'Cannot run without a selected profile or default_profile in settings.yml; pass --profile or run `bridl setup`.',
+  );
 };
 
 const findContributingProfilePaths = (

--- a/src/cli/commands/RunCommand.ts
+++ b/src/cli/commands/RunCommand.ts
@@ -9,7 +9,11 @@ import spawn from 'cross-spawn';
 
 import type { AgentAdapter, AgentLaunchPlan } from '../../agents/AgentAdapter.js';
 import { createPiAdapter } from '../../agents/pi/PiAdapter.js';
-import { createProfileSourceCachePath, createRemoteRepositoryCachePath } from '../../profiles/ProfileCache.js';
+import {
+  createProfileSourceCachePath,
+  createRemoteRepositoryCachePath,
+  resolveRemoteRepositorySubpath,
+} from '../../profiles/ProfileCache.js';
 import { loadLocalProfileSource } from '../../profiles/ProfileLoader.js';
 import type { LoadedProfile } from '../../profiles/ProfileLoader.js';
 import type { Profile } from '../../profiles/Profile.js';
@@ -237,7 +241,7 @@ const materializeSource = (homeDirectory: string, source: ProfileSourceReference
   }
 
   return {
-    path: join(createRemoteRepositoryCachePath(homeDirectory, source), source.path ?? ''),
+    path: resolveRemoteRepositorySubpath(createRemoteRepositoryCachePath(homeDirectory, source), source.path),
     only: source.only,
     except: source.except,
   };

--- a/src/cli/commands/RunCommand.ts
+++ b/src/cli/commands/RunCommand.ts
@@ -178,7 +178,7 @@ const loadResolvedProfile = (input: RunCommandInput): ResolvedRunProfile => {
     throw new Error(`Cannot run with invalid settings: ${loadedSettings.issues.map(formatSettingsIssue).join('; ')}`);
   }
 
-  const loadedProfiles = loadProfileSources(input.homeDirectory, loadedSettings.settings.profileSources);
+  const loadedProfiles = loadProfileSources(input.homeDirectory, loadedSettings.settings.profileSources!);
 
   if (loadedProfiles.issues.length > 0) {
     throw new Error(`Cannot run with invalid profiles: ${loadedProfiles.issues.map(formatProfileIssue).join('; ')}`);

--- a/src/cli/commands/SetupCommand.ts
+++ b/src/cli/commands/SetupCommand.ts
@@ -340,7 +340,7 @@ const copyDirectoryContentsWithoutOverwriting = (sourceDirectory: string, target
       continue;
     }
 
-    if (!existsSync(targetPath)) {
+    if (entry.isFile() && !existsSync(targetPath)) {
       mkdirSync(dirname(targetPath), { recursive: true });
       cpSync(sourcePath, targetPath, { force: false });
       copiedFiles += 1;

--- a/src/cli/commands/SetupCommand.ts
+++ b/src/cli/commands/SetupCommand.ts
@@ -283,9 +283,20 @@ const createInitialSettingsIfMissing = (settingsPath: string, starterSettingsPat
     settingsPath,
     starterSettingsPath === undefined
       ? 'default_profile: default\nprofile_sources:\n  - path: ./profiles\n'
-      : readFileSync(starterSettingsPath, 'utf8'),
+      : readStarterSettingsContent(starterSettingsPath),
   );
   return true;
+};
+
+const readStarterSettingsContent = (starterSettingsPath: string): string => {
+  const content = readFileSync(starterSettingsPath, 'utf8');
+  const loaded = loadSettingsFiles(createSettingsLoadPlan([{ scope: 'user', path: starterSettingsPath }]));
+
+  if (loaded.files[0]?.settings.defaultProfile !== undefined) {
+    return content;
+  }
+
+  return `default_profile: default\n${content}`;
 };
 
 const copyStarterProfileFilesIfPresent = (

--- a/src/cli/commands/SetupCommand.ts
+++ b/src/cli/commands/SetupCommand.ts
@@ -1,12 +1,19 @@
 // Provides the command object for first-run Bridl setup.
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
 import type { Command } from 'commander';
+import spawn from 'cross-spawn';
 
+import { createRemoteRepositoryCachePath, normalizeGitUri } from '../../profiles/ProfileCache.js';
 import { isValidProfileId } from '../../profiles/ProfileLoader.js';
-import { discoverSettingsLoadPlan, loadSettings } from '../../settings/SettingsLoader.js';
+import {
+  createSettingsLoadPlan,
+  discoverSettingsLoadPlan,
+  loadSettings,
+  loadSettingsFiles,
+} from '../../settings/SettingsLoader.js';
 import type { CommandObject } from './CommandObject.js';
 import type { SyncCommandDependencies, SyncCommandResult } from './SyncCommand.js';
 import { executeSyncCommand } from './SyncCommand.js';
@@ -14,18 +21,32 @@ import { executeSyncCommand } from './SyncCommand.js';
 export interface SetupCommandInput {
   readonly homeDirectory: string;
   readonly projectDirectory: string;
+  readonly setupSourceUri?: string;
 }
 
 export interface SetupCommandResult {
   readonly settingsPath: string;
   readonly defaultProfilePath: string;
   readonly createdSettings: boolean;
+  readonly copiedStarterProfileFiles: number;
   readonly createdDefaultProfile: boolean;
   readonly syncResult: SyncCommandResult;
   readonly messages: readonly string[];
 }
 
-export type SetupCommandDependencies = SyncCommandDependencies;
+export interface SetupSourceSynchronizer {
+  sync(uri: string, cachePath: string): void;
+}
+
+export type SetupCommandDependencies = SyncCommandDependencies & {
+  readonly setupSourceSynchronizer?: SetupSourceSynchronizer;
+};
+
+interface StarterLayout {
+  readonly cachePath: string;
+  readonly settingsPath?: string;
+  readonly profilesPath?: string;
+}
 
 export const executeSetupCommand = (
   input: SetupCommandInput,
@@ -33,16 +54,25 @@ export const executeSetupCommand = (
 ): SetupCommandResult => {
   const settingsPath = join(input.homeDirectory, '.bridl', 'settings.yml');
   const initialSettingsMissing = !existsSync(settingsPath);
+  const starterLayout = input.setupSourceUri
+    ? prepareStarterLayout(input.homeDirectory, input.setupSourceUri, dependencies.setupSourceSynchronizer)
+    : undefined;
   const loadedSettings = loadSettings(discoverSettingsLoadPlan(input));
 
   if (loadedSettings.issues.length > 0) {
     throw new Error(`Cannot setup with invalid settings: ${loadedSettings.issues.map(formatSettingsIssue).join('; ')}`);
   }
 
-  const defaultProfileId = initialSettingsMissing ? 'default' : readUserDefaultProfileId(loadedSettings.files);
+  const defaultProfileId = initialSettingsMissing
+    ? readStarterDefaultProfileId(starterLayout?.settingsPath)
+    : readUserDefaultProfileId(loadedSettings.files);
   assertValidDefaultProfileId(defaultProfileId);
 
-  const createdSettings = createInitialSettingsIfMissing(settingsPath);
+  const createdSettings = createInitialSettingsIfMissing(settingsPath, starterLayout?.settingsPath);
+  const copiedStarterProfileFiles = copyStarterProfileFilesIfPresent(
+    starterLayout?.profilesPath,
+    join(input.homeDirectory, '.bridl', 'profiles'),
+  );
   const defaultProfilePath = join(input.homeDirectory, '.bridl', 'profiles', defaultProfileId, 'profile.yml');
   const createdDefaultProfile = createDefaultProfileIfMissing(defaultProfilePath, defaultProfileId);
   const syncResult = executeSyncCommand(input, dependencies);
@@ -51,18 +81,66 @@ export const executeSetupCommand = (
     settingsPath,
     defaultProfilePath,
     createdSettings,
+    copiedStarterProfileFiles,
     createdDefaultProfile,
     syncResult,
-    messages: [
-      createdSettings
-        ? `Created user settings at ${settingsPath}.`
-        : `User settings already exists at ${settingsPath}; left unchanged.`,
-      createdDefaultProfile
-        ? `Created default user profile '${defaultProfileId}' at ${defaultProfilePath}.`
-        : `Default user profile '${defaultProfileId}' already exists at ${defaultProfilePath}; left unchanged.`,
-      ...syncResult.messages,
-    ],
+    messages: buildSetupMessages({
+      input,
+      starterLayout,
+      settingsPath,
+      createdSettings,
+      copiedStarterProfileFiles,
+      defaultProfileId,
+      defaultProfilePath,
+      createdDefaultProfile,
+      syncResult,
+    }),
   };
+};
+
+interface SetupMessageInput {
+  readonly input: SetupCommandInput;
+  readonly starterLayout?: StarterLayout;
+  readonly settingsPath: string;
+  readonly createdSettings: boolean;
+  readonly copiedStarterProfileFiles: number;
+  readonly defaultProfileId: string;
+  readonly defaultProfilePath: string;
+  readonly createdDefaultProfile: boolean;
+  readonly syncResult: SyncCommandResult;
+}
+
+const buildSetupMessages = (input: SetupMessageInput): readonly string[] => {
+  const messages: string[] = [];
+
+  if (input.input.setupSourceUri !== undefined && input.starterLayout !== undefined) {
+    messages.push(`Prepared setup source ${input.input.setupSourceUri} at ${input.starterLayout.cachePath}.`);
+  }
+
+  messages.push(
+    input.createdSettings
+      ? `Created user settings at ${input.settingsPath}.`
+      : `User settings already exists at ${input.settingsPath}; left unchanged.`,
+  );
+
+  if (input.starterLayout?.profilesPath !== undefined) {
+    messages.push(
+      `Copied ${input.copiedStarterProfileFiles} starter profile file(s) into ${join(
+        input.input.homeDirectory,
+        '.bridl',
+        'profiles',
+      )}.`,
+    );
+  }
+
+  messages.push(
+    input.createdDefaultProfile
+      ? `Created default user profile '${input.defaultProfileId}' at ${input.defaultProfilePath}.`
+      : `Default user profile '${input.defaultProfileId}' already exists at ${input.defaultProfilePath}; left unchanged.`,
+    ...input.syncResult.messages,
+  );
+
+  return messages;
 };
 
 export const createSetupCommand = (dependencies: SetupCommandDependencies = {}): CommandObject => {
@@ -71,15 +149,16 @@ export const createSetupCommand = (dependencies: SetupCommandDependencies = {}):
     description: 'Create initial Bridl settings and a default profile.',
     register(program: Command): void {
       program
-        .command(command.name)
+        .command(`${command.name} [source]`)
         .description(command.description)
-        .action(() => {
+        .action((source?: string) => {
           const result = executeSetupCommand(
             {
               /* v8 ignore next -- default process home is exercised by the direct CLI entrypoint, not unit tests. */
               homeDirectory: dependencies.homeDirectory ?? homedir(),
               /* v8 ignore next -- default process cwd is exercised by the direct CLI entrypoint, not unit tests. */
               projectDirectory: dependencies.projectDirectory ?? process.cwd(),
+              setupSourceUri: source,
             },
             dependencies,
           );
@@ -95,6 +174,77 @@ export const createSetupCommand = (dependencies: SetupCommandDependencies = {}):
   return command;
 };
 
+const prepareStarterLayout = (
+  homeDirectory: string,
+  setupSourceUri: string,
+  synchronizer: SetupSourceSynchronizer = createGitSetupSourceSynchronizer(),
+): StarterLayout => {
+  const cachePath = createSetupSourceCachePath(homeDirectory, setupSourceUri);
+  synchronizer.sync(setupSourceUri, cachePath);
+
+  const settingsPath = firstExistingPath(join(cachePath, 'settings.yml'), join(cachePath, '.bridl', 'settings.yml'));
+  validateStarterSettingsIfPresent(settingsPath);
+
+  const preferredProfilesPath = settingsPath?.endsWith(join('.bridl', 'settings.yml'))
+    ? join(cachePath, '.bridl', 'profiles')
+    : join(cachePath, 'profiles');
+  const profilesPath = firstExistingPath(
+    preferredProfilesPath,
+    join(cachePath, 'profiles'),
+    join(cachePath, '.bridl', 'profiles'),
+  );
+
+  return { cachePath, settingsPath, profilesPath };
+};
+
+const createSetupSourceCachePath = (homeDirectory: string, setupSourceUri: string): string =>
+  createRemoteRepositoryCachePath(homeDirectory, { uri: setupSourceUri });
+
+const createGitSetupSourceSynchronizer = (): SetupSourceSynchronizer => ({
+  sync(uri, cachePath) {
+    mkdirSync(dirname(cachePath), { recursive: true });
+
+    if (existsSync(cachePath)) {
+      runGit(['-C', cachePath, 'pull', '--ff-only']);
+      return;
+    }
+
+    runGit(['clone', normalizeGitUri(uri), cachePath]);
+  },
+});
+
+const runGit = (args: readonly string[]): void => {
+  const result = spawn.sync('git', args, { stdio: 'pipe', encoding: 'utf8' });
+
+  if (result.status !== 0) {
+    /* v8 ignore next -- the final fallback only applies if git emits no stdout or stderr. */
+    throw new Error((result.stderr || result.stdout || `git ${args.join(' ')} failed`).trim());
+  }
+};
+
+const firstExistingPath = (...paths: readonly string[]): string | undefined => paths.find((path) => existsSync(path));
+
+const validateStarterSettingsIfPresent = (settingsPath?: string): void => {
+  if (settingsPath === undefined) {
+    return;
+  }
+
+  const loaded = loadSettingsFiles(createSettingsLoadPlan([{ scope: 'user', path: settingsPath }]));
+
+  if (loaded.issues.length > 0) {
+    throw new Error(`Cannot setup from invalid starter settings: ${loaded.issues.map(formatSettingsIssue).join('; ')}`);
+  }
+};
+
+const readStarterDefaultProfileId = (settingsPath?: string): string => {
+  if (settingsPath === undefined) {
+    return 'default';
+  }
+
+  const loaded = loadSettingsFiles(createSettingsLoadPlan([{ scope: 'user', path: settingsPath }]));
+  return loaded.files[0]?.settings.defaultProfile ?? 'default';
+};
+
 const readUserDefaultProfileId = (
   files: readonly {
     readonly location: { readonly scope: string };
@@ -108,14 +258,53 @@ const assertValidDefaultProfileId = (profileId: string): void => {
   }
 };
 
-const createInitialSettingsIfMissing = (settingsPath: string): boolean => {
+const createInitialSettingsIfMissing = (settingsPath: string, starterSettingsPath?: string): boolean => {
   if (existsSync(settingsPath)) {
     return false;
   }
 
   mkdirSync(dirname(settingsPath), { recursive: true });
-  writeFileSync(settingsPath, 'default_profile: default\nprofile_sources:\n  - path: ./profiles\n');
+  writeFileSync(
+    settingsPath,
+    starterSettingsPath === undefined
+      ? 'default_profile: default\nprofile_sources:\n  - path: ./profiles\n'
+      : readFileSync(starterSettingsPath, 'utf8'),
+  );
   return true;
+};
+
+const copyStarterProfileFilesIfPresent = (
+  sourceProfilesPath: string | undefined,
+  targetProfilesPath: string,
+): number => {
+  if (sourceProfilesPath === undefined) {
+    return 0;
+  }
+
+  return copyDirectoryContentsWithoutOverwriting(sourceProfilesPath, targetProfilesPath);
+};
+
+const copyDirectoryContentsWithoutOverwriting = (sourceDirectory: string, targetDirectory: string): number => {
+  mkdirSync(targetDirectory, { recursive: true });
+  let copiedFiles = 0;
+
+  for (const entry of readdirSync(sourceDirectory, { withFileTypes: true })) {
+    const sourcePath = join(sourceDirectory, entry.name);
+    const targetPath = join(targetDirectory, entry.name);
+
+    if (entry.isDirectory()) {
+      copiedFiles += copyDirectoryContentsWithoutOverwriting(sourcePath, targetPath);
+      continue;
+    }
+
+    if (!existsSync(targetPath)) {
+      mkdirSync(dirname(targetPath), { recursive: true });
+      cpSync(sourcePath, targetPath, { force: false });
+      copiedFiles += 1;
+    }
+  }
+
+  return copiedFiles;
 };
 
 const createDefaultProfileIfMissing = (profilePath: string, profileId: string): boolean => {

--- a/src/cli/commands/SetupCommand.ts
+++ b/src/cli/commands/SetupCommand.ts
@@ -215,7 +215,7 @@ const createGitSetupSourceSynchronizer = (): SetupSourceSynchronizer => ({
       return;
     }
 
-    runGit(['clone', normalizeGitUri(uri), cachePath], uri);
+    runGit(['clone', '--', normalizeGitUri(uri), cachePath], uri);
   },
 });
 

--- a/src/cli/commands/SetupCommand.ts
+++ b/src/cli/commands/SetupCommand.ts
@@ -73,6 +73,7 @@ export const executeSetupCommand = (
   assertValidDefaultProfileId(defaultProfileId);
 
   const createdSettings = createInitialSettingsIfMissing(settingsPath, starterLayout?.settingsPath);
+  ensureExistingUserSettingsDefaultProfile(settingsPath, loadedSettings.files, defaultProfileId);
   const copiedStarterProfileFiles = copyStarterProfileFilesIfPresent(
     starterLayout?.profilesPath,
     join(input.homeDirectory, '.bridl', 'profiles'),
@@ -260,12 +261,28 @@ const readStarterDefaultProfileId = (settingsPath?: string): string => {
   return loaded.files[0]?.settings.defaultProfile ?? 'default';
 };
 
-const readUserDefaultProfileId = (
-  files: readonly {
-    readonly location: { readonly scope: string };
-    readonly settings: { readonly defaultProfile?: string };
-  }[],
-): string => files.find((file) => file.location.scope === 'user')?.settings.defaultProfile ?? 'default';
+type LoadedSetupSettingsFile = {
+  readonly location: { readonly scope: string };
+  readonly settings: { readonly defaultProfile?: string };
+};
+
+const readUserDefaultProfileId = (files: readonly LoadedSetupSettingsFile[]): string =>
+  files.find((file) => file.location.scope === 'user')?.settings.defaultProfile ?? 'default';
+
+const ensureExistingUserSettingsDefaultProfile = (
+  settingsPath: string,
+  files: readonly LoadedSetupSettingsFile[],
+  defaultProfileId: string,
+): void => {
+  const userSettings = files.find((file) => file.location.scope === 'user');
+
+  if (userSettings === undefined || userSettings.settings.defaultProfile !== undefined) {
+    return;
+  }
+
+  const content = readFileSync(settingsPath, 'utf8');
+  writeFileSync(settingsPath, `${content}\ndefault_profile: ${defaultProfileId}\n`);
+};
 
 const assertValidDefaultProfileId = (profileId: string): void => {
   if (!isValidProfileId(profileId)) {

--- a/src/cli/commands/SetupCommand.ts
+++ b/src/cli/commands/SetupCommand.ts
@@ -6,7 +6,11 @@ import { dirname, join } from 'node:path';
 import type { Command } from 'commander';
 import spawn from 'cross-spawn';
 
-import { createRemoteRepositoryCachePath, normalizeGitUri } from '../../profiles/ProfileCache.js';
+import {
+  createRemoteRepositoryCachePath,
+  normalizeGitUri,
+  redactProfileSourceUriCredentials,
+} from '../../profiles/ProfileCache.js';
 import { isValidProfileId } from '../../profiles/ProfileLoader.js';
 import {
   createSettingsLoadPlan,
@@ -114,13 +118,15 @@ const buildSetupMessages = (input: SetupMessageInput): readonly string[] => {
   const messages: string[] = [];
 
   if (input.input.setupSourceUri !== undefined && input.starterLayout !== undefined) {
-    messages.push(`Prepared setup source ${input.input.setupSourceUri} at ${input.starterLayout.cachePath}.`);
+    messages.push(
+      `Prepared setup source ${redactProfileSourceUriCredentials(input.input.setupSourceUri)} at ${input.starterLayout.cachePath}.`,
+    );
   }
 
   messages.push(
     input.createdSettings
       ? `Created user settings at ${input.settingsPath}.`
-      : `User settings already exists at ${input.settingsPath}; left unchanged.`,
+      : `User settings already exist at ${input.settingsPath}; left unchanged.`,
   );
 
   if (input.starterLayout?.profilesPath !== undefined) {
@@ -205,22 +211,31 @@ const createGitSetupSourceSynchronizer = (): SetupSourceSynchronizer => ({
     mkdirSync(dirname(cachePath), { recursive: true });
 
     if (existsSync(cachePath)) {
-      runGit(['-C', cachePath, 'pull', '--ff-only']);
+      runGit(['-C', cachePath, 'pull', '--ff-only'], uri);
       return;
     }
 
-    runGit(['clone', normalizeGitUri(uri), cachePath]);
+    runGit(['clone', normalizeGitUri(uri), cachePath], uri);
   },
 });
 
-const runGit = (args: readonly string[]): void => {
+const runGit = (args: readonly string[], sensitiveUri: string): void => {
   const result = spawn.sync('git', args, { stdio: 'pipe', encoding: 'utf8' });
 
   if (result.status !== 0) {
     /* v8 ignore next -- the final fallback only applies if git emits no stdout or stderr. */
-    throw new Error((result.stderr || result.stdout || `git ${args.join(' ')} failed`).trim());
+    throw new Error(
+      redactSensitiveText((result.stderr || result.stdout || `git ${args.join(' ')} failed`).trim(), sensitiveUri),
+    );
   }
 };
+
+const redactSensitiveText = (message: string, uri: string): string =>
+  message
+    .split(uri)
+    .join(redactProfileSourceUriCredentials(uri))
+    .split(normalizeGitUri(uri))
+    .join(redactProfileSourceUriCredentials(normalizeGitUri(uri)));
 
 const firstExistingPath = (...paths: readonly string[]): string | undefined => paths.find((path) => existsSync(path));
 

--- a/src/cli/commands/SyncCommand.ts
+++ b/src/cli/commands/SyncCommand.ts
@@ -1,19 +1,29 @@
-// Provides the command object for synchronizing URI-backed profile sources.
+// Provides the command object for synchronizing URI-backed profile and settings sources.
 import { existsSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { dirname } from 'node:path';
+import { dirname, resolve } from 'node:path';
 
 import type { Command } from 'commander';
 import spawn from 'cross-spawn';
 
 import {
   createProfileSourceCachePath,
+  createRemoteRepositoryCachePath,
   normalizeGitUri,
   redactProfileSourceUriCredentials,
 } from '../../profiles/ProfileCache.js';
 import { loadLocalProfileSource } from '../../profiles/ProfileLoader.js';
-import type { ProfileSourceReference } from '../../profiles/ProfileSource.js';
-import { discoverSettingsLoadPlan, loadSettings } from '../../settings/SettingsLoader.js';
+import {
+  normalizeRemoteSourceUri,
+  type ProfileSourceReference,
+  type RemoteSourceReference,
+} from '../../profiles/ProfileSource.js';
+import type { RemoteSettingsReference } from '../../settings/Settings.js';
+import {
+  discoverSettingsLoadPlan,
+  loadSettings,
+  loadSettingsWithCachedRemoteSettings,
+} from '../../settings/SettingsLoader.js';
 import type { CommandObject } from './CommandObject.js';
 
 export type SyncSourceStatus = 'updated' | 'unchanged' | 'skipped' | 'failed';
@@ -36,7 +46,7 @@ export interface SyncCommandResult {
 }
 
 export interface UriProfileSourceSynchronizer {
-  sync(source: ProfileSourceReference & { readonly uri: string }, cachePath: string): SyncSourceStatus;
+  sync(source: RemoteSourceReference, cachePath: string): SyncSourceStatus;
 }
 
 export interface SyncCommandDependencies {
@@ -50,15 +60,25 @@ export const executeSyncCommand = (
   input: SyncCommandInput,
   dependencies: SyncCommandDependencies = {},
 ): SyncCommandResult => {
-  const loadedSettings = loadSettings(discoverSettingsLoadPlan(input));
+  const localSettings = loadSettings(discoverSettingsLoadPlan(input));
+
+  if (localSettings.issues.length > 0) {
+    throw new Error(`Cannot sync with invalid settings: ${localSettings.issues.map(formatSettingsIssue).join('; ')}`);
+  }
+
+  const synchronizer = dependencies.synchronizer ?? createGitSynchronizer();
+  const remoteSettingsResults = localSettings.settings.remoteSettings.map((source) =>
+    syncRemoteSettingsSource(input.homeDirectory, source, synchronizer),
+  );
+  const loadedSettings = loadSettingsWithCachedRemoteSettings(input);
 
   if (loadedSettings.issues.length > 0) {
     throw new Error(`Cannot sync with invalid settings: ${loadedSettings.issues.map(formatSettingsIssue).join('; ')}`);
   }
 
-  const uriSources = loadedSettings.settings.profileSources.filter(hasUri);
-  const synchronizer = dependencies.synchronizer ?? createGitSynchronizer();
-  const sourceResults = uriSources.map((source) => syncUriSource(input.homeDirectory, source, synchronizer));
+  const uriSources = loadedSettings.settings.profileSources.filter(isRemoteProfileSource);
+  const profileSourceResults = uriSources.map((source) => syncUriSource(input.homeDirectory, source, synchronizer));
+  const sourceResults = [...remoteSettingsResults, ...profileSourceResults];
 
   return {
     sources: sourceResults,
@@ -99,17 +119,48 @@ export const createSyncCommand = (dependencies: SyncCommandDependencies = {}): C
   return command;
 };
 
-const syncUriSource = (
+const syncRemoteSettingsSource = (
   homeDirectory: string,
-  source: ProfileSourceReference & { readonly uri: string },
+  source: RemoteSettingsReference,
   synchronizer: UriProfileSourceSynchronizer,
 ): SyncSourceResult => {
-  const cachePath = createProfileSourceCachePath(homeDirectory, source.uri);
-  const displayUri = redactProfileSourceUriCredentials(source.uri);
+  const cachePath = createRemoteRepositoryCachePath(homeDirectory, source);
+  const displayUri = formatDisplayUri(source);
 
   try {
     const status = synchronizer.sync(source, cachePath);
-    const validation = loadLocalProfileSource({ path: cachePath, only: source.only, except: source.except });
+    const settingsPath = resolve(cachePath, source.path);
+
+    if (!existsSync(settingsPath)) {
+      return {
+        uri: displayUri,
+        cachePath,
+        status: 'failed',
+        message: `Remote settings file not found: ${settingsPath}`,
+      };
+    }
+
+    return { uri: displayUri, cachePath, status, message: `Remote settings file available at ${settingsPath}.` };
+  } catch (error) {
+    return formatSyncFailure(displayUri, cachePath, source, error);
+  }
+};
+
+const syncUriSource = (
+  homeDirectory: string,
+  source: RemoteProfileSource,
+  synchronizer: UriProfileSourceSynchronizer,
+): SyncSourceResult => {
+  const cachePath = remoteCachePathForProfileSource(homeDirectory, source);
+  const displayUri = formatDisplayUri(source);
+
+  try {
+    const status = synchronizer.sync(source, cachePath);
+    const validation = loadLocalProfileSource({
+      path: resolve(cachePath, source.path ?? ''),
+      only: source.only,
+      except: source.except,
+    });
 
     if (validation.issues.length > 0) {
       return {
@@ -128,14 +179,7 @@ const syncUriSource = (
         validation.profiles.length === 1 ? '1 profile validated.' : `${validation.profiles.length} profiles validated.`,
     };
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-
-    return {
-      uri: displayUri,
-      cachePath,
-      status: 'failed',
-      message: redactSensitiveText(message, source.uri),
-    };
+    return formatSyncFailure(displayUri, cachePath, source, error);
   }
 };
 
@@ -144,14 +188,27 @@ const createGitSynchronizer = (): UriProfileSourceSynchronizer => ({
     mkdirSync(dirname(cachePath), { recursive: true });
 
     if (existsSync(cachePath)) {
+      runGit(['-C', cachePath, 'fetch', '--all', '--tags']);
+      checkoutRefIfPresent(cachePath, source.ref);
       runGit(['-C', cachePath, 'pull', '--ff-only']);
       return 'updated';
     }
 
-    runGit(['clone', normalizeGitUri(source.uri), cachePath]);
+    const cloneArgs = ['clone'];
+    if (source.ref !== undefined) {
+      cloneArgs.push('--branch', source.ref);
+    }
+    cloneArgs.push(normalizeGitUri(normalizeRemoteSourceUri(source)), cachePath);
+    runGit(cloneArgs);
     return 'updated';
   },
 });
+
+const checkoutRefIfPresent = (cachePath: string, ref: string | undefined): void => {
+  if (ref !== undefined) {
+    runGit(['-C', cachePath, 'checkout', ref]);
+  }
+};
 
 const runGit = (args: readonly string[]): void => {
   const result = spawn.sync('git', args, { stdio: 'pipe', encoding: 'utf8' });
@@ -162,8 +219,41 @@ const runGit = (args: readonly string[]): void => {
   }
 };
 
-const hasUri = (source: ProfileSourceReference): source is ProfileSourceReference & { readonly uri: string } =>
-  source.uri !== undefined;
+type RemoteProfileSource = ProfileSourceReference & ({ readonly uri: string } | { readonly github: string });
+
+const isRemoteProfileSource = (source: ProfileSourceReference): source is RemoteProfileSource =>
+  source.uri !== undefined || source.github !== undefined;
+
+const remoteCachePathForProfileSource = (homeDirectory: string, source: RemoteProfileSource): string => {
+  if (source.ref === undefined && source.path === undefined && source.uri !== undefined) {
+    return createProfileSourceCachePath(homeDirectory, source.uri);
+  }
+
+  return createRemoteRepositoryCachePath(homeDirectory, source);
+};
+
+const formatDisplayUri = (source: RemoteSourceReference): string => {
+  const uri = redactProfileSourceUriCredentials(normalizeRemoteSourceUri(source));
+  const ref = source.ref === undefined ? '' : `#${source.ref}`;
+  const path = source.path === undefined ? '' : `:${source.path}`;
+  return `${uri}${ref}${path}`;
+};
+
+const formatSyncFailure = (
+  displayUri: string,
+  cachePath: string,
+  source: RemoteSourceReference,
+  error: unknown,
+): SyncSourceResult => {
+  const message = error instanceof Error ? error.message : String(error);
+
+  return {
+    uri: displayUri,
+    cachePath,
+    status: 'failed',
+    message: redactSensitiveText(message, normalizeRemoteSourceUri(source)),
+  };
+};
 
 const redactSensitiveText = (message: string, uri: string): string =>
   message

--- a/src/cli/commands/SyncCommand.ts
+++ b/src/cli/commands/SyncCommand.ts
@@ -1,7 +1,7 @@
 // Provides the command object for synchronizing URI-backed profile and settings sources.
 import { existsSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { dirname, resolve } from 'node:path';
+import { dirname } from 'node:path';
 
 import type { Command } from 'commander';
 import spawn from 'cross-spawn';
@@ -11,6 +11,7 @@ import {
   createRemoteRepositoryCachePath,
   normalizeGitUri,
   redactProfileSourceUriCredentials,
+  resolveRemoteRepositorySubpath,
 } from '../../profiles/ProfileCache.js';
 import { loadLocalProfileSource } from '../../profiles/ProfileLoader.js';
 import {
@@ -128,8 +129,8 @@ const syncRemoteSettingsSource = (
   const displayUri = formatDisplayUri(source);
 
   try {
+    const settingsPath = resolveRemoteRepositorySubpath(cachePath, source.path);
     const status = synchronizer.sync(source, cachePath);
-    const settingsPath = resolve(cachePath, source.path);
 
     if (!existsSync(settingsPath)) {
       return {
@@ -155,9 +156,10 @@ const syncUriSource = (
   const displayUri = formatDisplayUri(source);
 
   try {
+    const profileSourcePath = resolveRemoteRepositorySubpath(cachePath, source.path);
     const status = synchronizer.sync(source, cachePath);
     const validation = loadLocalProfileSource({
-      path: resolve(cachePath, source.path ?? ''),
+      path: profileSourcePath,
       only: source.only,
       except: source.except,
     });
@@ -189,26 +191,35 @@ const createGitSynchronizer = (): UriProfileSourceSynchronizer => ({
 
     if (existsSync(cachePath)) {
       runGit(['-C', cachePath, 'fetch', '--all', '--tags']);
-      checkoutRefIfPresent(cachePath, source.ref);
-      runGit(['-C', cachePath, 'pull', '--ff-only']);
+      if (source.ref === undefined) {
+        runGit(['-C', cachePath, 'pull', '--ff-only']);
+      } else {
+        checkoutRefIfPresent(cachePath, source.ref);
+      }
       return 'updated';
     }
 
-    const cloneArgs = ['clone'];
-    if (source.ref !== undefined) {
-      cloneArgs.push('--branch', source.ref);
-    }
-    cloneArgs.push(normalizeGitUri(normalizeRemoteSourceUri(source)), cachePath);
-    runGit(cloneArgs);
+    runGit(['clone', normalizeGitUri(normalizeRemoteSourceUri(source)), cachePath]);
+    checkoutRefIfPresent(cachePath, source.ref);
     return 'updated';
   },
 });
 
 const checkoutRefIfPresent = (cachePath: string, ref: string | undefined): void => {
-  if (ref !== undefined) {
-    runGit(['-C', cachePath, 'checkout', ref]);
+  if (ref === undefined) {
+    return;
   }
+
+  if (gitSucceeds(['-C', cachePath, 'rev-parse', '--verify', '--quiet', `refs/remotes/origin/${ref}`])) {
+    runGit(['-C', cachePath, 'checkout', '-B', ref, `refs/remotes/origin/${ref}`]);
+    return;
+  }
+
+  runGit(['-C', cachePath, 'checkout', ref]);
 };
+
+const gitSucceeds = (args: readonly string[]): boolean =>
+  spawn.sync('git', args, { stdio: 'pipe', encoding: 'utf8' }).status === 0;
 
 const runGit = (args: readonly string[]): void => {
   const result = spawn.sync('git', args, { stdio: 'pipe', encoding: 'utf8' });

--- a/src/cli/commands/SyncCommand.ts
+++ b/src/cli/commands/SyncCommand.ts
@@ -68,7 +68,7 @@ export const executeSyncCommand = (
   }
 
   const synchronizer = dependencies.synchronizer ?? createGitSynchronizer();
-  const remoteSettingsResults = localSettings.settings.remoteSettings.map((source) =>
+  const remoteSettingsResults = localSettings.settings.remoteSettings!.map((source) =>
     syncRemoteSettingsSource(input.homeDirectory, source, synchronizer),
   );
   const loadedSettings = loadSettingsWithCachedRemoteSettings(input);
@@ -77,7 +77,7 @@ export const executeSyncCommand = (
     throw new Error(`Cannot sync with invalid settings: ${loadedSettings.issues.map(formatSettingsIssue).join('; ')}`);
   }
 
-  const uriSources = loadedSettings.settings.profileSources.filter(isRemoteProfileSource);
+  const uriSources = loadedSettings.settings.profileSources!.filter(isRemoteProfileSource);
   const profileSourceResults = uriSources.map((source) => syncUriSource(input.homeDirectory, source, synchronizer));
   const sourceResults = [...remoteSettingsResults, ...profileSourceResults];
 

--- a/src/cli/commands/SyncCommand.ts
+++ b/src/cli/commands/SyncCommand.ts
@@ -85,7 +85,7 @@ export const executeSyncCommand = (
     sources: sourceResults,
     messages:
       sourceResults.length === 0
-        ? ['No URI profile sources configured; nothing to sync.']
+        ? ['No URI profile or remote settings sources configured; nothing to sync.']
         : sourceResults.map((result) => `${result.status}: ${result.uri} -> ${result.cachePath} (${result.message})`),
   };
 };
@@ -93,7 +93,7 @@ export const executeSyncCommand = (
 export const createSyncCommand = (dependencies: SyncCommandDependencies = {}): CommandObject => {
   const command: CommandObject = {
     name: 'sync',
-    description: 'Synchronize URI-backed Bridl profile sources into the local cache.',
+    description: 'Synchronize URI-backed Bridl profile and remote settings sources into the local cache.',
     register(program: Command): void {
       program
         .command(command.name)
@@ -128,8 +128,9 @@ const syncRemoteSettingsSource = (
   const cachePath = createRemoteRepositoryCachePath(homeDirectory, source);
   const displayUri = formatDisplayUri(source);
 
+  const settingsPath = resolveRemoteRepositorySubpath(cachePath, source.path);
+
   try {
-    const settingsPath = resolveRemoteRepositorySubpath(cachePath, source.path);
     const status = synchronizer.sync(source, cachePath);
 
     if (!existsSync(settingsPath)) {
@@ -199,7 +200,7 @@ const createGitSynchronizer = (): UriProfileSourceSynchronizer => ({
       return 'updated';
     }
 
-    runGit(['clone', normalizeGitUri(normalizeRemoteSourceUri(source)), cachePath]);
+    runGit(['clone', '--', normalizeGitUri(normalizeRemoteSourceUri(source)), cachePath]);
     checkoutRefIfPresent(cachePath, source.ref);
     return 'updated';
   },
@@ -210,12 +211,20 @@ const checkoutRefIfPresent = (cachePath: string, ref: string | undefined): void 
     return;
   }
 
+  assertSafeGitRef(ref);
+
   if (gitSucceeds(['-C', cachePath, 'rev-parse', '--verify', '--quiet', `refs/remotes/origin/${ref}`])) {
     runGit(['-C', cachePath, 'checkout', '-B', ref, `refs/remotes/origin/${ref}`]);
     return;
   }
 
   runGit(['-C', cachePath, 'checkout', ref]);
+};
+
+const assertSafeGitRef = (ref: string): void => {
+  if (ref.startsWith('-')) {
+    throw new Error(`Git ref '${ref}' must not start with '-'.`);
+  }
 };
 
 const gitSucceeds = (args: readonly string[]): boolean =>

--- a/src/cli/commands/SyncCommand.ts
+++ b/src/cli/commands/SyncCommand.ts
@@ -68,10 +68,14 @@ export const executeSyncCommand = (
   }
 
   const synchronizer = dependencies.synchronizer ?? createGitSynchronizer();
-  const remoteSettingsResults = localSettings.settings.remoteSettings!.map((source) =>
+  const remoteSettingsSources = localSettings.settings.remoteSettings!;
+  const remoteSettingsResults = remoteSettingsSources.map((source) =>
     syncRemoteSettingsSource(input.homeDirectory, source, synchronizer),
   );
-  const loadedSettings = loadSettingsWithCachedRemoteSettings(input);
+  const syncedRemoteSettingsSources = remoteSettingsSources.filter(
+    (_source, index) => remoteSettingsResults[index]?.status !== 'failed',
+  );
+  const loadedSettings = loadSettingsWithCachedRemoteSettings(input, syncedRemoteSettingsSources);
 
   if (loadedSettings.issues.length > 0) {
     throw new Error(`Cannot sync with invalid settings: ${loadedSettings.issues.map(formatSettingsIssue).join('; ')}`);
@@ -128,9 +132,8 @@ const syncRemoteSettingsSource = (
   const cachePath = createRemoteRepositoryCachePath(homeDirectory, source);
   const displayUri = formatDisplayUri(source);
 
-  const settingsPath = resolveRemoteRepositorySubpath(cachePath, source.path);
-
   try {
+    const settingsPath = resolveRemoteRepositorySubpath(cachePath, source.path);
     const status = synchronizer.sync(source, cachePath);
 
     if (!existsSync(settingsPath)) {

--- a/src/profiles/ProfileCache.ts
+++ b/src/profiles/ProfileCache.ts
@@ -1,5 +1,5 @@
 // Encodes remote profile/source cache paths.
-import { join } from 'node:path';
+import { isAbsolute, join, relative, resolve } from 'node:path';
 
 import { normalizeRemoteSourceUri, type RemoteSourceReference } from './ProfileSource.js';
 
@@ -14,6 +14,21 @@ export const createProfileSourceCachePath = (homeDirectory: string, uri: string)
 
 export const createRemoteRepositoryCachePath = (homeDirectory: string, source: RemoteSourceReference): string =>
   join(homeDirectory, '.bridl', 'cache', 'repos', encodeRemoteSource(source));
+
+export const resolveRemoteRepositorySubpath = (repositoryPath: string, subpath = ''): string => {
+  if (isAbsolute(subpath)) {
+    throw new Error(`Remote repository path '${subpath}' must be relative.`);
+  }
+
+  const resolvedPath = resolve(repositoryPath, subpath);
+  const relativePath = relative(repositoryPath, resolvedPath);
+
+  if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
+    throw new Error(`Remote repository path '${subpath}' must stay inside the repository.`);
+  }
+
+  return resolvedPath;
+};
 
 export const redactProfileSourceUriCredentials = (uri: string): string => {
   const prefix = uri.startsWith('git+') ? 'git+' : '';

--- a/src/profiles/ProfileCache.ts
+++ b/src/profiles/ProfileCache.ts
@@ -23,7 +23,7 @@ export const resolveRemoteRepositorySubpath = (repositoryPath: string, subpath =
   const resolvedPath = resolve(repositoryPath, subpath);
   const relativePath = relative(repositoryPath, resolvedPath);
 
-  if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
+  if (relativePath === '..' || relativePath.startsWith('../') || isAbsolute(relativePath)) {
     throw new Error(`Remote repository path '${subpath}' must stay inside the repository.`);
   }
 

--- a/src/profiles/ProfileCache.ts
+++ b/src/profiles/ProfileCache.ts
@@ -1,11 +1,19 @@
-// Encodes URI-backed profile source cache paths.
+// Encodes remote profile/source cache paths.
 import { join } from 'node:path';
+
+import { normalizeRemoteSourceUri, type RemoteSourceReference } from './ProfileSource.js';
 
 export const encodeProfileSourceUri = (uri: string): string =>
   Buffer.from(redactProfileSourceUriCredentials(uri), 'utf8').toString('base64url');
 
+export const encodeRemoteSource = (source: RemoteSourceReference): string =>
+  encodeProfileSourceUri(`${normalizeRemoteSourceUri(source)}#${source.ref ?? ''}`);
+
 export const createProfileSourceCachePath = (homeDirectory: string, uri: string): string =>
   join(homeDirectory, '.bridl', 'cache', 'profiles', encodeProfileSourceUri(uri));
+
+export const createRemoteRepositoryCachePath = (homeDirectory: string, source: RemoteSourceReference): string =>
+  join(homeDirectory, '.bridl', 'cache', 'repos', encodeRemoteSource(source));
 
 export const redactProfileSourceUriCredentials = (uri: string): string => {
   const prefix = uri.startsWith('git+') ? 'git+' : '';

--- a/src/profiles/ProfileSource.ts
+++ b/src/profiles/ProfileSource.ts
@@ -1,12 +1,35 @@
-// Defines references to local or URI-backed profile sources.
+// Defines references to local, URI-backed, or GitHub-backed profile sources.
 interface ProfileSourceFilters {
   readonly only?: readonly string[];
   readonly except?: readonly string[];
 }
 
+export interface RemoteSourceReference {
+  readonly uri?: string;
+  readonly github?: string;
+  readonly ref?: string;
+  readonly path?: string;
+}
+
 export type ProfileSourceReference =
-  | (ProfileSourceFilters & { readonly path: string; readonly uri?: never })
-  | (ProfileSourceFilters & { readonly path?: never; readonly uri: string });
+  | (ProfileSourceFilters & {
+      readonly path: string;
+      readonly uri?: never;
+      readonly github?: never;
+      readonly ref?: never;
+    })
+  | (ProfileSourceFilters & {
+      readonly uri: string;
+      readonly github?: never;
+      readonly ref?: string;
+      readonly path?: string;
+    })
+  | (ProfileSourceFilters & {
+      readonly github: string;
+      readonly uri?: never;
+      readonly ref?: string;
+      readonly path?: string;
+    });
 
 export const createLocalProfileSource = (path: string): ProfileSourceReference => ({
   path,
@@ -15,3 +38,11 @@ export const createLocalProfileSource = (path: string): ProfileSourceReference =
 export const createUriProfileSource = (uri: string): ProfileSourceReference => ({
   uri,
 });
+
+export const normalizeRemoteSourceUri = (source: RemoteSourceReference): string => {
+  if (source.uri !== undefined) {
+    return source.uri;
+  }
+
+  return `git+https://github.com/${source.github}.git`;
+};

--- a/src/profiles/ProfileSource.ts
+++ b/src/profiles/ProfileSource.ts
@@ -4,12 +4,9 @@ interface ProfileSourceFilters {
   readonly except?: readonly string[];
 }
 
-export interface RemoteSourceReference {
-  readonly uri?: string;
-  readonly github?: string;
-  readonly ref?: string;
-  readonly path?: string;
-}
+export type RemoteSourceReference =
+  | { readonly uri: string; readonly github?: never; readonly ref?: string; readonly path?: string }
+  | { readonly github: string; readonly uri?: never; readonly ref?: string; readonly path?: string };
 
 export type ProfileSourceReference =
   | (ProfileSourceFilters & {

--- a/src/schemas/profile-source.schema.json
+++ b/src/schemas/profile-source.schema.json
@@ -4,12 +4,18 @@
   "title": "Bridl profile source",
   "type": "object",
   "oneOf": [
-    { "required": ["path"], "not": { "required": ["uri"] } },
-    { "required": ["uri"], "not": { "required": ["path"] } }
+    {
+      "required": ["path"],
+      "not": { "anyOf": [{ "required": ["uri"] }, { "required": ["github"] }, { "required": ["ref"] }] }
+    },
+    { "required": ["uri"], "not": { "required": ["github"] } },
+    { "required": ["github"], "not": { "required": ["uri"] } }
   ],
   "properties": {
     "path": { "type": "string", "minLength": 1 },
     "uri": { "type": "string", "minLength": 1 },
+    "github": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$" },
+    "ref": { "type": "string", "minLength": 1 },
     "only": {
       "type": "array",
       "items": { "type": "string", "minLength": 1 }

--- a/src/schemas/settings.schema.json
+++ b/src/schemas/settings.schema.json
@@ -8,6 +8,23 @@
     "profile_sources": {
       "type": "array",
       "items": { "$ref": "profile-source.schema.json" }
+    },
+    "remote_settings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "oneOf": [
+          { "required": ["uri", "path"], "not": { "required": ["github"] } },
+          { "required": ["github", "path"], "not": { "required": ["uri"] } }
+        ],
+        "properties": {
+          "path": { "type": "string", "minLength": 1 },
+          "uri": { "type": "string", "minLength": 1 },
+          "github": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$" },
+          "ref": { "type": "string", "minLength": 1 }
+        },
+        "additionalProperties": false
+      }
     }
   },
   "additionalProperties": true

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -1,11 +1,17 @@
 // Defines the internal Settings shape produced from Bridl settings files.
-import type { ProfileSourceReference } from '../profiles/ProfileSource.js';
+import type { ProfileSourceReference, RemoteSourceReference } from '../profiles/ProfileSource.js';
+
+export interface RemoteSettingsReference extends RemoteSourceReference {
+  readonly path: string;
+}
 
 export interface Settings {
   readonly defaultProfile?: string;
   readonly profileSources: readonly ProfileSourceReference[];
+  readonly remoteSettings: readonly RemoteSettingsReference[];
 }
 
 export const emptySettings = (): Settings => ({
   profileSources: [],
+  remoteSettings: [],
 });

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -1,14 +1,12 @@
 // Defines the internal Settings shape produced from Bridl settings files.
 import type { ProfileSourceReference, RemoteSourceReference } from '../profiles/ProfileSource.js';
 
-export interface RemoteSettingsReference extends RemoteSourceReference {
-  readonly path: string;
-}
+export type RemoteSettingsReference = RemoteSourceReference & { readonly path: string };
 
 export interface Settings {
   readonly defaultProfile?: string;
-  readonly profileSources: readonly ProfileSourceReference[];
-  readonly remoteSettings: readonly RemoteSettingsReference[];
+  readonly profileSources?: readonly ProfileSourceReference[];
+  readonly remoteSettings?: readonly RemoteSettingsReference[];
 }
 
 export const emptySettings = (): Settings => ({

--- a/src/settings/SettingsLoader.ts
+++ b/src/settings/SettingsLoader.ts
@@ -111,13 +111,13 @@ export const loadSettings = (plan: SettingsLoadPlan): LoadedSettings => {
 export const loadSettingsWithCachedRemoteSettings = (input: SettingsDiscoveryInput): LoadedSettings => {
   const localSettings = loadSettings(discoverSettingsLoadPlan(input));
 
-  if (localSettings.issues.length > 0 || localSettings.settings.remoteSettings.length === 0) {
+  const remoteSettingsReferences = localSettings.settings.remoteSettings!;
+
+  if (localSettings.issues.length > 0 || remoteSettingsReferences.length === 0) {
     return localSettings;
   }
 
-  const remoteSettings = loadSettings(
-    discoverRemoteSettingsLoadPlan(input.homeDirectory, localSettings.settings.remoteSettings),
-  );
+  const remoteSettings = loadSettings(discoverRemoteSettingsLoadPlan(input.homeDirectory, remoteSettingsReferences));
   const files = [...remoteSettings.files, ...localSettings.files];
   const issues = [...remoteSettings.issues, ...localSettings.issues];
 
@@ -155,9 +155,17 @@ const addSettingsFile = (
 
 const convertSettingsDocument = (document: SettingsDocument, settingsDirectory: string): Settings => ({
   defaultProfile: document.default_profile,
-  profileSources: (document.profile_sources ?? []).map((source) => convertProfileSource(source, settingsDirectory)),
-  remoteSettings: document.remote_settings ?? [],
+  profileSources: document.profile_sources?.map((source) => convertProfileSource(source, settingsDirectory)),
+  remoteSettings: document.remote_settings?.map(convertRemoteSettingsSource),
 });
+
+const convertRemoteSettingsSource = (source: RemoteSettingsDocument): RemoteSettingsReference => {
+  if (source.uri !== undefined) {
+    return { uri: source.uri, ref: source.ref, path: source.path };
+  }
+
+  return { github: source.github!, ref: source.ref, path: source.path };
+};
 
 const convertProfileSource = (source: ProfileSourceDocument, settingsDirectory: string): ProfileSourceReference => {
   const filters = {

--- a/src/settings/SettingsLoader.ts
+++ b/src/settings/SettingsLoader.ts
@@ -78,13 +78,7 @@ export const discoverSettingsLoadPlan = (input: SettingsDiscoveryInput): Setting
 export const discoverRemoteSettingsLoadPlan = (
   homeDirectory: string,
   remoteSettings: readonly RemoteSettingsReference[],
-): SettingsLoadPlan =>
-  createSettingsLoadPlan(
-    remoteSettings.map((source) => ({
-      scope: 'remote' as const,
-      path: resolveRemoteRepositorySubpath(createRemoteRepositoryCachePath(homeDirectory, source), source.path),
-    })),
-  );
+): SettingsLoadPlan => discoverRemoteSettingsLocations(homeDirectory, remoteSettings).plan;
 
 export const loadSettingsFiles = (plan: SettingsLoadPlan): SettingsLoadResult => {
   const files: LoadedSettingsFile[] = [];
@@ -120,9 +114,10 @@ export const loadSettingsWithCachedRemoteSettings = (
     return localSettings;
   }
 
-  const remoteSettings = loadSettings(discoverRemoteSettingsLoadPlan(input.homeDirectory, remoteSettingsReferences));
+  const remoteSettingsLocations = discoverRemoteSettingsLocations(input.homeDirectory, remoteSettingsReferences);
+  const remoteSettings = loadSettings(remoteSettingsLocations.plan);
   const files = [...remoteSettings.files, ...localSettings.files];
-  const issues = [...remoteSettings.issues, ...localSettings.issues];
+  const issues = [...remoteSettingsLocations.issues, ...remoteSettings.issues, ...localSettings.issues];
 
   return {
     files,
@@ -130,6 +125,45 @@ export const loadSettingsWithCachedRemoteSettings = (
     settings: mergeSettingsStack(files.map((file) => file.settings)),
   };
 };
+
+const discoverRemoteSettingsLocations = (
+  homeDirectory: string,
+  remoteSettings: readonly RemoteSettingsReference[],
+): SettingsLocationDiscoveryResult => {
+  const locations: SettingsLocation[] = [];
+  const issues: SettingsLoadIssue[] = [];
+
+  for (const [index, source] of remoteSettings.entries()) {
+    try {
+      locations.push({
+        scope: 'remote',
+        path: resolveRemoteRepositorySubpath(createRemoteRepositoryCachePath(homeDirectory, source), source.path),
+      });
+    } catch (error) {
+      issues.push({
+        filePath: `remote_settings[${index}]`,
+        path: `/remote_settings/${index}/path`,
+        message: formatRemoteSettingsPathError(error),
+      });
+    }
+  }
+
+  return { plan: createSettingsLoadPlan(locations), issues };
+};
+
+const formatRemoteSettingsPathError = (error: unknown): string => {
+  /* v8 ignore next -- repository subpath validation throws Error instances. */
+  if (!(error instanceof Error)) {
+    return String(error);
+  }
+
+  return error.message;
+};
+
+interface SettingsLocationDiscoveryResult {
+  readonly plan: SettingsLoadPlan;
+  readonly issues: readonly SettingsLoadIssue[];
+}
 
 const addSettingsFile = (
   location: SettingsLocation,

--- a/src/settings/SettingsLoader.ts
+++ b/src/settings/SettingsLoader.ts
@@ -2,15 +2,16 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 
+import { createRemoteRepositoryCachePath } from '../profiles/ProfileCache.js';
 import type { ProfileSourceReference } from '../profiles/ProfileSource.js';
 import type { ValidationIssue } from '../validation/SchemaValidator.js';
 import { validateSchema } from '../validation/SchemaValidator.js';
 import { parseYamlDocument } from '../validation/YamlDocument.js';
-import type { Settings } from './Settings.js';
+import type { RemoteSettingsReference, Settings } from './Settings.js';
 import { mergeSettingsStack } from './SettingsMerger.js';
 
 export interface SettingsLocation {
-  readonly scope: 'user' | 'project' | 'project-local';
+  readonly scope: 'user' | 'project' | 'project-local' | 'remote';
   readonly path: string;
 }
 
@@ -39,13 +40,23 @@ export interface SettingsLoadIssue extends ValidationIssue {
 interface SettingsDocument {
   readonly default_profile?: string;
   readonly profile_sources?: readonly ProfileSourceDocument[];
+  readonly remote_settings?: readonly RemoteSettingsDocument[];
 }
 
 interface ProfileSourceDocument {
   readonly path?: string;
   readonly uri?: string;
+  readonly github?: string;
+  readonly ref?: string;
   readonly only?: readonly string[];
   readonly except?: readonly string[];
+}
+
+interface RemoteSettingsDocument {
+  readonly path: string;
+  readonly uri?: string;
+  readonly github?: string;
+  readonly ref?: string;
 }
 
 export interface SettingsDiscoveryInput {
@@ -63,6 +74,17 @@ export const discoverSettingsLoadPlan = (input: SettingsDiscoveryInput): Setting
     { scope: 'project', path: join(input.projectDirectory, '.bridl', 'settings.yml') },
     { scope: 'project-local', path: join(input.projectDirectory, '.bridl', 'local', 'settings.yml') },
   ]);
+
+export const discoverRemoteSettingsLoadPlan = (
+  homeDirectory: string,
+  remoteSettings: readonly RemoteSettingsReference[],
+): SettingsLoadPlan =>
+  createSettingsLoadPlan(
+    remoteSettings.map((source) => ({
+      scope: 'remote' as const,
+      path: resolve(createRemoteRepositoryCachePath(homeDirectory, source), source.path),
+    })),
+  );
 
 export const loadSettingsFiles = (plan: SettingsLoadPlan): SettingsLoadResult => {
   const files: LoadedSettingsFile[] = [];
@@ -83,6 +105,26 @@ export const loadSettings = (plan: SettingsLoadPlan): LoadedSettings => {
   return {
     ...result,
     settings: mergeSettingsStack(result.files.map((file) => file.settings)),
+  };
+};
+
+export const loadSettingsWithCachedRemoteSettings = (input: SettingsDiscoveryInput): LoadedSettings => {
+  const localSettings = loadSettings(discoverSettingsLoadPlan(input));
+
+  if (localSettings.issues.length > 0 || localSettings.settings.remoteSettings.length === 0) {
+    return localSettings;
+  }
+
+  const remoteSettings = loadSettings(
+    discoverRemoteSettingsLoadPlan(input.homeDirectory, localSettings.settings.remoteSettings),
+  );
+  const files = [...remoteSettings.files, ...localSettings.files];
+  const issues = [...remoteSettings.issues, ...localSettings.issues];
+
+  return {
+    files,
+    issues,
+    settings: mergeSettingsStack(files.map((file) => file.settings)),
   };
 };
 
@@ -114,6 +156,7 @@ const addSettingsFile = (
 const convertSettingsDocument = (document: SettingsDocument, settingsDirectory: string): Settings => ({
   defaultProfile: document.default_profile,
   profileSources: (document.profile_sources ?? []).map((source) => convertProfileSource(source, settingsDirectory)),
+  remoteSettings: document.remote_settings ?? [],
 });
 
 const convertProfileSource = (source: ProfileSourceDocument, settingsDirectory: string): ProfileSourceReference => {
@@ -122,11 +165,15 @@ const convertProfileSource = (source: ProfileSourceDocument, settingsDirectory: 
     except: source.except,
   };
 
-  if (source.path !== undefined) {
-    return { ...filters, path: resolveProfileSourcePath(source.path, settingsDirectory) };
+  if (source.uri !== undefined) {
+    return { ...filters, uri: source.uri, ref: source.ref, path: source.path };
   }
 
-  return { ...filters, uri: source.uri! };
+  if (source.github !== undefined) {
+    return { ...filters, github: source.github, ref: source.ref, path: source.path };
+  }
+
+  return { ...filters, path: resolveProfileSourcePath(source.path!, settingsDirectory) };
 };
 
 const resolveProfileSourcePath = (sourcePath: string, settingsDirectory: string): string => {

--- a/src/settings/SettingsLoader.ts
+++ b/src/settings/SettingsLoader.ts
@@ -2,7 +2,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 
-import { createRemoteRepositoryCachePath } from '../profiles/ProfileCache.js';
+import { createRemoteRepositoryCachePath, resolveRemoteRepositorySubpath } from '../profiles/ProfileCache.js';
 import type { ProfileSourceReference } from '../profiles/ProfileSource.js';
 import type { ValidationIssue } from '../validation/SchemaValidator.js';
 import { validateSchema } from '../validation/SchemaValidator.js';
@@ -82,7 +82,7 @@ export const discoverRemoteSettingsLoadPlan = (
   createSettingsLoadPlan(
     remoteSettings.map((source) => ({
       scope: 'remote' as const,
-      path: resolve(createRemoteRepositoryCachePath(homeDirectory, source), source.path),
+      path: resolveRemoteRepositorySubpath(createRemoteRepositoryCachePath(homeDirectory, source), source.path),
     })),
   );
 

--- a/src/settings/SettingsLoader.ts
+++ b/src/settings/SettingsLoader.ts
@@ -108,10 +108,13 @@ export const loadSettings = (plan: SettingsLoadPlan): LoadedSettings => {
   };
 };
 
-export const loadSettingsWithCachedRemoteSettings = (input: SettingsDiscoveryInput): LoadedSettings => {
+export const loadSettingsWithCachedRemoteSettings = (
+  input: SettingsDiscoveryInput,
+  remoteSettingsReferencesOverride?: readonly RemoteSettingsReference[],
+): LoadedSettings => {
   const localSettings = loadSettings(discoverSettingsLoadPlan(input));
 
-  const remoteSettingsReferences = localSettings.settings.remoteSettings!;
+  const remoteSettingsReferences = remoteSettingsReferencesOverride ?? localSettings.settings.remoteSettings!;
 
   if (localSettings.issues.length > 0 || remoteSettingsReferences.length === 0) {
     return localSettings;

--- a/src/settings/SettingsMerger.ts
+++ b/src/settings/SettingsMerger.ts
@@ -1,8 +1,28 @@
-// Provides deterministic Settings merge scaffolding for future config loading.
-import { defu } from 'defu';
-
+// Provides deterministic Settings merge scaffolding.
 import type { Settings } from './Settings.js';
 import { emptySettings } from './Settings.js';
 
-export const mergeSettingsStack = (settingsStack: readonly Settings[]): Settings =>
-  settingsStack.reduce<Settings>((mergedSettings, settings) => defu({}, settings, mergedSettings), emptySettings());
+export const mergeSettingsStack = (settingsStack: readonly Settings[]): Settings => {
+  let defaultProfile: string | undefined;
+  let profileSources: Settings['profileSources'];
+  let remoteSettings: Settings['remoteSettings'];
+
+  for (const settings of settingsStack) {
+    defaultProfile = settings.defaultProfile ?? defaultProfile;
+
+    if (settings.profileSources !== undefined) {
+      profileSources = settings.profileSources;
+    }
+
+    if (settings.remoteSettings !== undefined) {
+      remoteSettings = settings.remoteSettings;
+    }
+  }
+
+  return {
+    ...emptySettings(),
+    defaultProfile,
+    profileSources: profileSources ?? [],
+    remoteSettings: remoteSettings ?? [],
+  };
+};

--- a/tests/unit/phase4-commands.test.ts
+++ b/tests/unit/phase4-commands.test.ts
@@ -15,6 +15,7 @@ import { createSetupCommand, executeSetupCommand } from '../../src/cli/commands/
 import { createSyncCommand, executeSyncCommand } from '../../src/cli/commands/SyncCommand.js';
 import {
   createProfileSourceCachePath,
+  createRemoteRepositoryCachePath,
   encodeProfileSourceUri,
   normalizeGitUri,
 } from '../../src/profiles/ProfileCache.js';
@@ -91,13 +92,13 @@ describe('phase 4 setup and sync commands', () => {
     expect(readFileSync(defaultProfilePath, 'utf8')).toBe('id: default\nlabel: Custom\n');
   });
 
-  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-004.1, BRIDL-REQ-004.7).
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-004.1).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('uses a setup source repository as the initial user settings and profiles without overwriting files', () => {
     const root = createTemporaryRoot();
     const homeDirectory = join(root, 'home');
     const projectDirectory = join(root, 'project');
-    const setupSourceUri = 'https://github.com/example/bridl-config';
+    const setupSourceUri = 'https://user:secret@example.test/bridl-config';
     const sourceCachePath = join(root, 'starter-cache');
     mkdirSync(join(sourceCachePath, 'profiles', 'team'), { recursive: true });
     writeFileSync(
@@ -126,6 +127,7 @@ describe('phase 4 setup and sync commands', () => {
 
     expect(result.createdSettings).toBe(true);
     expect(result.copiedStarterProfileFiles).toBe(1);
+    expect(result.messages.join('\n')).not.toContain('secret');
     expect(result.createdDefaultProfile).toBe(false);
     expect(readFileSync(join(homeDirectory, '.bridl', 'settings.yml'), 'utf8')).toBe(
       'default_profile: team\nprofile_sources:\n  - path: ./profiles\n',
@@ -269,6 +271,8 @@ describe('phase 4 setup and sync commands', () => {
     expect(result.messages[0]).toContain(`${firstUri} -> ${createProfileSourceCachePath(homeDirectory, firstUri)}`);
   });
 
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-004.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('redacts URI credentials from sync results and messages', () => {
     const root = createTemporaryRoot();
     const homeDirectory = join(root, 'home');
@@ -327,7 +331,17 @@ describe('phase 4 setup and sync commands', () => {
     const secondResult = executeSyncCommand({ homeDirectory, projectDirectory });
     writeSettings(homeDirectory, `profile_sources:\n  - uri: ${uri}\n    ref: main\n    path: .\n`);
     const refResult = executeSyncCommand({ homeDirectory, projectDirectory });
+    writeFileSync(join(repositoryPath, 'remote', 'profile.yml'), 'id: remote\nlabel: Updated\ncontrols: {}\n');
+    execFileSync('git', ['add', '.'], { cwd: repositoryPath, stdio: 'pipe' });
+    execFileSync(
+      'git',
+      ['-c', 'user.name=Bridl Test', '-c', 'user.email=bridl@example.test', 'commit', '-m', 'update profiles'],
+      { cwd: repositoryPath, stdio: 'pipe' },
+    );
     const secondRefResult = executeSyncCommand({ homeDirectory, projectDirectory });
+    const commitRef = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repositoryPath, encoding: 'utf8' }).trim();
+    writeSettings(homeDirectory, `profile_sources:\n  - uri: ${uri}\n    ref: ${commitRef}\n    path: .\n`);
+    const commitRefResult = executeSyncCommand({ homeDirectory, projectDirectory });
     const failedUri = `file://${join(root, 'missing-repository')}`;
     writeSettings(homeDirectory, `profile_sources:\n  - uri: ${failedUri}\n`);
     const failedResult = executeSyncCommand({ homeDirectory, projectDirectory });
@@ -342,7 +356,14 @@ describe('phase 4 setup and sync commands', () => {
     ]);
     expect(secondResult.sources[0]?.status).toBe('updated');
     expect(refResult.sources[0]?.message).toBe('1 profile validated.');
+    expect(commitRefResult.sources[0]?.message).toBe('1 profile validated.');
     expect(secondRefResult.sources[0]?.message).toBe('1 profile validated.');
+    expect(
+      readFileSync(
+        join(createRemoteRepositoryCachePath(homeDirectory, { uri, ref: 'main' }), 'remote', 'profile.yml'),
+        'utf8',
+      ),
+    ).toContain('label: Updated');
     expect(failedResult.sources[0]?.status).toBe('failed');
     expect(failedResult.sources[0]?.message).toContain('does not appear to be a git repository');
   });

--- a/tests/unit/phase4-commands.test.ts
+++ b/tests/unit/phase4-commands.test.ts
@@ -199,6 +199,9 @@ describe('phase 4 setup and sync commands', () => {
     expect(fallbackDefaultResult.defaultProfilePath).toBe(
       join(fallbackHomeDirectory, '.bridl', 'profiles', 'default', 'profile.yml'),
     );
+    expect(readFileSync(join(fallbackHomeDirectory, '.bridl', 'settings.yml'), 'utf8')).toContain(
+      'default_profile: default',
+    );
 
     const projectDefaultHomeDirectory = join(root, 'project-default-home');
     const projectDefaultDirectory = join(root, 'project-default');

--- a/tests/unit/phase4-commands.test.ts
+++ b/tests/unit/phase4-commands.test.ts
@@ -516,6 +516,7 @@ describe('phase 4 setup and sync commands', () => {
 
     const missingNameProgram = new Command();
     missingNameProgram.exitOverride();
+    missingNameProgram.configureOutput({ writeErr: () => undefined });
     createCreateProfileCommand({ homeDirectory, projectDirectory }).register(missingNameProgram);
     await expect(missingNameProgram.parseAsync(['node', 'bridl', 'create_profile', '--scope', 'user'])).rejects.toThrow(
       "missing required argument 'name'",

--- a/tests/unit/phase4-commands.test.ts
+++ b/tests/unit/phase4-commands.test.ts
@@ -82,7 +82,7 @@ describe('phase 4 setup and sync commands', () => {
       'default_profile: default\nprofile_sources:\n  - path: ./profiles\n',
     );
     expect(readFileSync(defaultProfilePath, 'utf8')).toBe('id: default\nlabel: Default\ncontrols: {}\n');
-    expect(firstResult.messages).toContain('No URI profile sources configured; nothing to sync.');
+    expect(firstResult.messages).toContain('No URI profile or remote settings sources configured; nothing to sync.');
 
     writeFileSync(defaultProfilePath, 'id: default\nlabel: Custom\n');
     const secondResult = executeSetupCommand({ homeDirectory, projectDirectory });
@@ -345,6 +345,8 @@ describe('phase 4 setup and sync commands', () => {
     const failedUri = `file://${join(root, 'missing-repository')}`;
     writeSettings(homeDirectory, `profile_sources:\n  - uri: ${failedUri}\n`);
     const failedResult = executeSyncCommand({ homeDirectory, projectDirectory });
+    writeSettings(homeDirectory, `profile_sources:\n  - uri: ${uri}\n    ref: --bad\n    path: .\n`);
+    const unsafeRefResult = executeSyncCommand({ homeDirectory, projectDirectory });
 
     expect(firstResult.sources).toEqual([
       {
@@ -366,6 +368,8 @@ describe('phase 4 setup and sync commands', () => {
     ).toContain('label: Updated');
     expect(failedResult.sources[0]?.status).toBe('failed');
     expect(failedResult.sources[0]?.message).toContain('does not appear to be a git repository');
+    expect(unsafeRefResult.sources[0]?.status).toBe('failed');
+    expect(unsafeRefResult.sources[0]?.message).toContain("must not start with '-'");
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-004.2).
@@ -422,7 +426,7 @@ describe('phase 4 setup and sync commands', () => {
 
     writeSettings(homeDirectory, 'default_profile: default\n');
     expect(executeSyncCommand({ homeDirectory, projectDirectory }).messages).toEqual([
-      'No URI profile sources configured; nothing to sync.',
+      'No URI profile or remote settings sources configured; nothing to sync.',
     ]);
   });
 
@@ -521,7 +525,7 @@ describe('phase 4 setup and sync commands', () => {
       syncProgram,
     );
     await syncProgram.parseAsync(['node', 'bridl', 'sync']);
-    expect(syncMessages).toEqual(['No URI profile sources configured; nothing to sync.']);
+    expect(syncMessages).toEqual(['No URI profile or remote settings sources configured; nothing to sync.']);
 
     const setupMessages: string[] = [];
     const setupProgram = new Command();

--- a/tests/unit/phase4-commands.test.ts
+++ b/tests/unit/phase4-commands.test.ts
@@ -39,10 +39,10 @@ const writeCachedProfile = (cachePath: string, profileId = 'remote'): void => {
   writeFileSync(join(profileDirectory, 'profile.yml'), `id: ${profileId}\ncontrols: {}\n`);
 };
 
-const createGitProfileRepository = (root: string): string => {
-  const repositoryPath = join(root, 'remote-profiles');
+const createGitProfileRepository = (root: string, repositoryName = 'remote-profiles'): string => {
+  const repositoryPath = join(root, repositoryName);
   writeCachedProfile(repositoryPath, 'remote');
-  execFileSync('git', ['init'], { cwd: repositoryPath, stdio: 'pipe' });
+  execFileSync('git', ['init', '--initial-branch', 'main'], { cwd: repositoryPath, stdio: 'pipe' });
   execFileSync('git', ['add', '.'], { cwd: repositoryPath, stdio: 'pipe' });
   execFileSync(
     'git',
@@ -89,6 +89,73 @@ describe('phase 4 setup and sync commands', () => {
     expect(secondResult.createdSettings).toBe(false);
     expect(secondResult.createdDefaultProfile).toBe(false);
     expect(readFileSync(defaultProfilePath, 'utf8')).toBe('id: default\nlabel: Custom\n');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-004.1, BRIDL-REQ-004.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('uses a setup source repository as the initial user settings and profiles without overwriting files', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const setupSourceUri = 'https://github.com/example/bridl-config';
+    const sourceCachePath = join(root, 'starter-cache');
+    mkdirSync(join(sourceCachePath, 'profiles', 'team'), { recursive: true });
+    writeFileSync(
+      join(sourceCachePath, 'settings.yml'),
+      'default_profile: team\nprofile_sources:\n  - path: ./profiles\n',
+    );
+    writeFileSync(join(sourceCachePath, 'profiles', 'team', 'profile.yml'), 'id: team\nlabel: Team\ncontrols: {}\n');
+
+    const result = executeSetupCommand(
+      { homeDirectory, projectDirectory, setupSourceUri },
+      {
+        setupSourceSynchronizer: {
+          sync(uri, cachePath) {
+            expect(uri).toBe(setupSourceUri);
+            mkdirSync(cachePath, { recursive: true });
+            writeFileSync(join(cachePath, 'settings.yml'), readFileSync(join(sourceCachePath, 'settings.yml'), 'utf8'));
+            mkdirSync(join(cachePath, 'profiles', 'team'), { recursive: true });
+            writeFileSync(
+              join(cachePath, 'profiles', 'team', 'profile.yml'),
+              readFileSync(join(sourceCachePath, 'profiles', 'team', 'profile.yml'), 'utf8'),
+            );
+          },
+        },
+      },
+    );
+
+    expect(result.createdSettings).toBe(true);
+    expect(result.copiedStarterProfileFiles).toBe(1);
+    expect(result.createdDefaultProfile).toBe(false);
+    expect(readFileSync(join(homeDirectory, '.bridl', 'settings.yml'), 'utf8')).toBe(
+      'default_profile: team\nprofile_sources:\n  - path: ./profiles\n',
+    );
+    expect(readFileSync(join(homeDirectory, '.bridl', 'profiles', 'team', 'profile.yml'), 'utf8')).toBe(
+      'id: team\nlabel: Team\ncontrols: {}\n',
+    );
+
+    writeFileSync(join(homeDirectory, '.bridl', 'settings.yml'), 'default_profile: custom\n');
+    writeFileSync(join(homeDirectory, '.bridl', 'profiles', 'team', 'profile.yml'), 'id: team\nlabel: Custom\n');
+    const secondResult = executeSetupCommand(
+      { homeDirectory, projectDirectory, setupSourceUri },
+      {
+        setupSourceSynchronizer: {
+          sync(_uri, cachePath) {
+            mkdirSync(cachePath, { recursive: true });
+            writeFileSync(join(cachePath, 'settings.yml'), 'default_profile: team\n');
+            mkdirSync(join(cachePath, 'profiles', 'team'), { recursive: true });
+            writeFileSync(join(cachePath, 'profiles', 'team', 'profile.yml'), 'id: team\nlabel: Starter\n');
+          },
+        },
+      },
+    );
+
+    expect(secondResult.createdSettings).toBe(false);
+    expect(secondResult.copiedStarterProfileFiles).toBe(0);
+    expect(readFileSync(join(homeDirectory, '.bridl', 'settings.yml'), 'utf8')).toBe('default_profile: custom\n');
+    expect(readFileSync(join(homeDirectory, '.bridl', 'profiles', 'team', 'profile.yml'), 'utf8')).toBe(
+      'id: team\nlabel: Custom\n',
+    );
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-004.1).
@@ -185,7 +252,7 @@ describe('phase 4 setup and sync commands', () => {
       {
         synchronizer: {
           sync(source, cachePath) {
-            syncedUris.push(source.uri);
+            syncedUris.push(source.uri!);
             writeCachedProfile(cachePath);
             return source.uri === firstUri ? 'updated' : 'skipped';
           },
@@ -258,6 +325,9 @@ describe('phase 4 setup and sync commands', () => {
 
     const firstResult = executeSyncCommand({ homeDirectory, projectDirectory });
     const secondResult = executeSyncCommand({ homeDirectory, projectDirectory });
+    writeSettings(homeDirectory, `profile_sources:\n  - uri: ${uri}\n    ref: main\n    path: .\n`);
+    const refResult = executeSyncCommand({ homeDirectory, projectDirectory });
+    const secondRefResult = executeSyncCommand({ homeDirectory, projectDirectory });
     const failedUri = `file://${join(root, 'missing-repository')}`;
     writeSettings(homeDirectory, `profile_sources:\n  - uri: ${failedUri}\n`);
     const failedResult = executeSyncCommand({ homeDirectory, projectDirectory });
@@ -271,6 +341,8 @@ describe('phase 4 setup and sync commands', () => {
       },
     ]);
     expect(secondResult.sources[0]?.status).toBe('updated');
+    expect(refResult.sources[0]?.message).toBe('1 profile validated.');
+    expect(secondRefResult.sources[0]?.message).toBe('1 profile validated.');
     expect(failedResult.sources[0]?.status).toBe('failed');
     expect(failedResult.sources[0]?.message).toContain('does not appear to be a git repository');
   });

--- a/tests/unit/phase5-6-run.test.ts
+++ b/tests/unit/phase5-6-run.test.ts
@@ -471,20 +471,21 @@ describe('phase 5 tack assembly and phase 6 pi run support', () => {
     const fallbackHome = join(root, 'fallback-home');
     writeSettings(fallbackHome, 'profile_sources:\n  - path: ./profiles\n');
     writeProfile(join(fallbackHome, '.bridl', 'profiles'), 'default', 'id: default\ncontrols: {}\n');
-    const fallbackResult = await executeRunCommand(
-      { homeDirectory: fallbackHome, projectDirectory },
-      {
-        launcher: {
-          launch() {
-            return Promise.resolve(0);
+    await expect(
+      executeRunCommand(
+        { homeDirectory: fallbackHome, projectDirectory },
+        {
+          launcher: {
+            launch() {
+              return Promise.resolve(0);
+            },
           },
         },
-      },
-    );
-    expect(fallbackResult.profileId).toBe('default');
+      ),
+    ).rejects.toThrow('Cannot run without a selected profile or default_profile');
 
     const spawnedHome = join(root, 'spawned-home');
-    writeSettings(spawnedHome, 'profile_sources:\n  - path: ./profiles\n');
+    writeSettings(spawnedHome, 'default_profile: default\nprofile_sources:\n  - path: ./profiles\n');
     writeProfile(join(spawnedHome, '.bridl', 'profiles'), 'default', 'id: default\ncontrols: {}\n');
     const spawnedResult = await executeRunCommand(
       { homeDirectory: spawnedHome, projectDirectory },

--- a/tests/unit/remote-sources.test.ts
+++ b/tests/unit/remote-sources.test.ts
@@ -103,40 +103,6 @@ describe('remote source settings', () => {
     expect(thrownResult.sources[0]?.status).toBe('failed');
     expect(thrownResult.sources[0]?.message).toBe('network unavailable');
 
-    const unsafeSyncCalls: string[] = [];
-    writeSettings(homeDirectory, `remote_settings:\n  - github: example/absolute\n    path: /tmp/settings.yml\n`);
-    expect(() =>
-      executeSyncCommand(
-        { homeDirectory, projectDirectory },
-        {
-          synchronizer: {
-            sync(source, cachePath) {
-              unsafeSyncCalls.push(source.github ?? source.uri);
-              mkdirSync(cachePath, { recursive: true });
-              return 'updated';
-            },
-          },
-        },
-      ),
-    ).toThrow('must be relative');
-
-    writeSettings(homeDirectory, `remote_settings:\n  - github: example/escape\n    path: ../settings.yml\n`);
-    expect(() =>
-      executeSyncCommand(
-        { homeDirectory, projectDirectory },
-        {
-          synchronizer: {
-            sync(source, cachePath) {
-              unsafeSyncCalls.push(source.github ?? source.uri);
-              mkdirSync(cachePath, { recursive: true });
-              return 'updated';
-            },
-          },
-        },
-      ),
-    ).toThrow('must stay inside the repository');
-    expect(unsafeSyncCalls).toEqual([]);
-
     writeSettings(homeDirectory, `remote_settings:\n  - github: example/invalid\n    path: settings.yml\n`);
     expect(() =>
       executeSyncCommand(
@@ -152,6 +118,43 @@ describe('remote source settings', () => {
         },
       ),
     ).toThrow('Cannot sync with invalid settings');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.5, BRIDL-REQ-004.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('reports unsafe remote settings subpaths as per-source sync failures', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const unsafeSyncCalls: string[] = [];
+    const synchronizer = {
+      sync(source: { readonly github?: string; readonly uri?: string }, cachePath: string) {
+        unsafeSyncCalls.push(source.github ?? source.uri ?? 'unknown');
+        mkdirSync(cachePath, { recursive: true });
+        return 'updated' as const;
+      },
+    };
+
+    writeSettings(homeDirectory, `remote_settings:\n  - github: example/absolute\n    path: /tmp/settings.yml\n`);
+    const absolutePathResult = executeSyncCommand(
+      { homeDirectory, projectDirectory },
+      {
+        synchronizer,
+      },
+    );
+    expect(absolutePathResult.sources[0]?.status).toBe('failed');
+    expect(absolutePathResult.sources[0]?.message).toContain('must be relative');
+
+    writeSettings(homeDirectory, `remote_settings:\n  - github: example/escape\n    path: ../settings.yml\n`);
+    const escapingPathResult = executeSyncCommand(
+      { homeDirectory, projectDirectory },
+      {
+        synchronizer,
+      },
+    );
+    expect(escapingPathResult.sources[0]?.status).toBe('failed');
+    expect(escapingPathResult.sources[0]?.message).toContain('must stay inside the repository');
+    expect(unsafeSyncCalls).toEqual([]);
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.5, BRIDL-REQ-004.2, BRIDL-REQ-005.1).

--- a/tests/unit/remote-sources.test.ts
+++ b/tests/unit/remote-sources.test.ts
@@ -154,7 +154,7 @@ describe('remote source settings', () => {
     ).toThrow('Cannot sync with invalid settings');
   });
 
-  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.5, BRIDL-REQ-005.1).
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.5, BRIDL-REQ-004.2, BRIDL-REQ-005.1).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('runs profiles loaded from GitHub shorthand repository subpaths', async () => {
     const root = createTemporaryRoot();

--- a/tests/unit/remote-sources.test.ts
+++ b/tests/unit/remote-sources.test.ts
@@ -120,7 +120,7 @@ describe('remote source settings', () => {
     ).toThrow('Cannot sync with invalid settings');
   });
 
-  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.5, BRIDL-REQ-004.2).
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.6, BRIDL-REQ-004.2).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('reports unsafe remote settings subpaths as per-source sync failures', () => {
     const root = createTemporaryRoot();

--- a/tests/unit/remote-sources.test.ts
+++ b/tests/unit/remote-sources.test.ts
@@ -103,6 +103,40 @@ describe('remote source settings', () => {
     expect(thrownResult.sources[0]?.status).toBe('failed');
     expect(thrownResult.sources[0]?.message).toBe('network unavailable');
 
+    const unsafeSyncCalls: string[] = [];
+    writeSettings(homeDirectory, `remote_settings:\n  - github: example/absolute\n    path: /tmp/settings.yml\n`);
+    expect(() =>
+      executeSyncCommand(
+        { homeDirectory, projectDirectory },
+        {
+          synchronizer: {
+            sync(source, cachePath) {
+              unsafeSyncCalls.push(source.github ?? source.uri!);
+              mkdirSync(cachePath, { recursive: true });
+              return 'updated';
+            },
+          },
+        },
+      ),
+    ).toThrow('must be relative');
+
+    writeSettings(homeDirectory, `remote_settings:\n  - github: example/escape\n    path: ../settings.yml\n`);
+    expect(() =>
+      executeSyncCommand(
+        { homeDirectory, projectDirectory },
+        {
+          synchronizer: {
+            sync(source, cachePath) {
+              unsafeSyncCalls.push(source.github ?? source.uri!);
+              mkdirSync(cachePath, { recursive: true });
+              return 'updated';
+            },
+          },
+        },
+      ),
+    ).toThrow('must stay inside the repository');
+    expect(unsafeSyncCalls).toEqual([]);
+
     writeSettings(homeDirectory, `remote_settings:\n  - github: example/invalid\n    path: settings.yml\n`);
     expect(() =>
       executeSyncCommand(
@@ -160,5 +194,39 @@ describe('remote source settings', () => {
       { launcher: { launch: () => Promise.resolve(0) } },
     );
     expect(rootProfileResult.profileId).toBe('remote');
+
+    const escapedProfileHomeDirectory = join(root, 'escaped-profile-home');
+    writeSettings(
+      escapedProfileHomeDirectory,
+      `default_profile: remote\nprofile_sources:\n  - github: example/bridl-config\n    path: ../profiles\n`,
+    );
+    await expect(
+      executeRunCommand(
+        { homeDirectory: escapedProfileHomeDirectory, projectDirectory },
+        { launcher: { launch: () => Promise.resolve(0) } },
+      ),
+    ).rejects.toThrow('must stay inside the repository');
+
+    const escapedProfileSyncHomeDirectory = join(root, 'escaped-profile-sync-home');
+    writeSettings(
+      escapedProfileSyncHomeDirectory,
+      `profile_sources:\n  - github: example/escape\n    path: ../profiles\n`,
+    );
+    const unsafeProfileSyncCalls: string[] = [];
+    const escapedProfileSyncResult = executeSyncCommand(
+      { homeDirectory: escapedProfileSyncHomeDirectory, projectDirectory },
+      {
+        synchronizer: {
+          sync(source, cachePath) {
+            unsafeProfileSyncCalls.push(source.github ?? source.uri!);
+            mkdirSync(cachePath, { recursive: true });
+            return 'updated';
+          },
+        },
+      },
+    );
+    expect(escapedProfileSyncResult.sources[0]?.status).toBe('failed');
+    expect(escapedProfileSyncResult.sources[0]?.message).toContain('must stay inside the repository');
+    expect(unsafeProfileSyncCalls).toEqual([]);
   });
 });

--- a/tests/unit/remote-sources.test.ts
+++ b/tests/unit/remote-sources.test.ts
@@ -1,0 +1,164 @@
+// Tests remote settings and repository subpath source behavior.
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { executeRunCommand } from '../../src/cli/commands/RunCommand.js';
+import { executeSyncCommand } from '../../src/cli/commands/SyncCommand.js';
+import { createRemoteRepositoryCachePath } from '../../src/profiles/ProfileCache.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'bridl-remote-sources-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const writeSettings = (homeDirectory: string, content: string): void => {
+  const settingsDirectory = join(homeDirectory, '.bridl');
+  mkdirSync(settingsDirectory, { recursive: true });
+  writeFileSync(join(settingsDirectory, 'settings.yml'), content);
+};
+
+const writeCachedProfile = (cachePath: string, profileId = 'remote'): void => {
+  const profileDirectory = join(cachePath, profileId);
+  mkdirSync(profileDirectory, { recursive: true });
+  writeFileSync(join(profileDirectory, 'profile.yml'), `id: ${profileId}\ncontrols: {}\n`);
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('remote source settings', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.5, BRIDL-REQ-002.6, BRIDL-REQ-004.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('syncs remote settings and profile sources from repository subpaths', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    writeSettings(
+      homeDirectory,
+      `remote_settings:\n  - github: example/bridl-config\n    ref: main\n    path: settings.yml\n`,
+    );
+
+    const syncedSources: string[] = [];
+    const result = executeSyncCommand(
+      { homeDirectory, projectDirectory },
+      {
+        synchronizer: {
+          sync(source, cachePath) {
+            syncedSources.push(source.github ?? source.uri!);
+            if (source.github === 'example/bridl-config' && source.path === 'settings.yml') {
+              mkdirSync(cachePath, { recursive: true });
+              writeFileSync(
+                join(cachePath, 'settings.yml'),
+                `default_profile: remote\nprofile_sources:\n  - github: example/bridl-config\n    ref: main\n    path: profiles/team\n`,
+              );
+            } else {
+              writeCachedProfile(join(cachePath, source.path ?? ''), 'remote');
+            }
+            return 'updated';
+          },
+        },
+      },
+    );
+
+    expect(syncedSources).toEqual(['example/bridl-config', 'example/bridl-config']);
+    expect(result.sources).toHaveLength(2);
+    expect(result.sources[0]?.message).toContain('Remote settings file available');
+    expect(result.sources[1]?.message).toBe('1 profile validated.');
+
+    writeSettings(homeDirectory, `remote_settings:\n  - github: example/missing\n    path: missing.yml\n`);
+    const missingFileResult = executeSyncCommand(
+      { homeDirectory, projectDirectory },
+      {
+        synchronizer: {
+          sync(_source, cachePath) {
+            mkdirSync(cachePath, { recursive: true });
+            return 'updated';
+          },
+        },
+      },
+    );
+    expect(missingFileResult.sources[0]?.status).toBe('failed');
+    expect(missingFileResult.sources[0]?.message).toContain('Remote settings file not found');
+
+    writeSettings(homeDirectory, `remote_settings:\n  - github: example/fail\n    path: settings.yml\n`);
+    const thrownResult = executeSyncCommand(
+      { homeDirectory, projectDirectory },
+      {
+        synchronizer: {
+          sync() {
+            throw new Error('network unavailable');
+          },
+        },
+      },
+    );
+    expect(thrownResult.sources[0]?.status).toBe('failed');
+    expect(thrownResult.sources[0]?.message).toBe('network unavailable');
+
+    writeSettings(homeDirectory, `remote_settings:\n  - github: example/invalid\n    path: settings.yml\n`);
+    expect(() =>
+      executeSyncCommand(
+        { homeDirectory, projectDirectory },
+        {
+          synchronizer: {
+            sync(_source, cachePath) {
+              mkdirSync(cachePath, { recursive: true });
+              writeFileSync(join(cachePath, 'settings.yml'), 'profile_sources:\n  - only: [missing]\n');
+              return 'updated';
+            },
+          },
+        },
+      ),
+    ).toThrow('Cannot sync with invalid settings');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.5, BRIDL-REQ-005.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('runs profiles loaded from GitHub shorthand repository subpaths', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    writeSettings(
+      homeDirectory,
+      `default_profile: remote\nprofile_sources:\n  - github: example/bridl-config\n    ref: main\n    path: profiles/team\n`,
+    );
+    writeCachedProfile(
+      join(
+        createRemoteRepositoryCachePath(homeDirectory, { github: 'example/bridl-config', ref: 'main' }),
+        'profiles',
+        'team',
+      ),
+      'remote',
+    );
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      { launcher: { launch: () => Promise.resolve(0) } },
+    );
+
+    expect(result.profileId).toBe('remote');
+
+    const rootProfileHomeDirectory = join(root, 'root-profile-home');
+    writeSettings(
+      rootProfileHomeDirectory,
+      `default_profile: remote\nprofile_sources:\n  - github: example/root-profiles\n`,
+    );
+    writeCachedProfile(
+      createRemoteRepositoryCachePath(rootProfileHomeDirectory, { github: 'example/root-profiles' }),
+      'remote',
+    );
+    const rootProfileResult = await executeRunCommand(
+      { homeDirectory: rootProfileHomeDirectory, projectDirectory },
+      { launcher: { launch: () => Promise.resolve(0) } },
+    );
+    expect(rootProfileResult.profileId).toBe('remote');
+  });
+});

--- a/tests/unit/remote-sources.test.ts
+++ b/tests/unit/remote-sources.test.ts
@@ -53,7 +53,7 @@ describe('remote source settings', () => {
       {
         synchronizer: {
           sync(source, cachePath) {
-            syncedSources.push(source.github ?? source.uri!);
+            syncedSources.push(source.github ?? source.uri);
             if (source.github === 'example/bridl-config' && source.path === 'settings.yml') {
               mkdirSync(cachePath, { recursive: true });
               writeFileSync(
@@ -111,7 +111,7 @@ describe('remote source settings', () => {
         {
           synchronizer: {
             sync(source, cachePath) {
-              unsafeSyncCalls.push(source.github ?? source.uri!);
+              unsafeSyncCalls.push(source.github ?? source.uri);
               mkdirSync(cachePath, { recursive: true });
               return 'updated';
             },
@@ -127,7 +127,7 @@ describe('remote source settings', () => {
         {
           synchronizer: {
             sync(source, cachePath) {
-              unsafeSyncCalls.push(source.github ?? source.uri!);
+              unsafeSyncCalls.push(source.github ?? source.uri);
               mkdirSync(cachePath, { recursive: true });
               return 'updated';
             },
@@ -218,7 +218,7 @@ describe('remote source settings', () => {
       {
         synchronizer: {
           sync(source, cachePath) {
-            unsafeProfileSyncCalls.push(source.github ?? source.uri!);
+            unsafeProfileSyncCalls.push(source.github ?? source.uri);
             mkdirSync(cachePath, { recursive: true });
             return 'updated';
           },

--- a/tests/unit/settings-loader.test.ts
+++ b/tests/unit/settings-loader.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { createRemoteRepositoryCachePath } from '../../src/profiles/ProfileCache.js';
 import {
   createSettingsLoadPlan,
+  discoverRemoteSettingsLoadPlan,
   discoverSettingsLoadPlan,
   loadSettings,
   loadSettingsFiles,
@@ -171,6 +172,38 @@ describe('settings loading', () => {
     const localOverrideLoaded = loadSettingsWithCachedRemoteSettings({ homeDirectory, projectDirectory });
     expect(localOverrideLoaded.settings.profileSources).toEqual([
       { path: join(homeDirectory, '.bridl', 'local-profiles') },
+    ]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('reports invalid cached remote settings subpaths as settings issues', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    writeSettings(
+      join(homeDirectory, '.bridl', 'settings.yml'),
+      'remote_settings:\n  - github: example/absolute\n    path: /tmp/settings.yml\n  - github: example/escape\n    path: ../settings.yml\n',
+    );
+
+    const loaded = loadSettingsWithCachedRemoteSettings({ homeDirectory, projectDirectory });
+    const invalidPlan = discoverRemoteSettingsLoadPlan(homeDirectory, [
+      { github: 'example/absolute', path: '/tmp/settings.yml' },
+    ]);
+
+    expect(invalidPlan.locations).toEqual([]);
+    expect(loaded.files.map((file) => file.location.scope)).toEqual(['user']);
+    expect(loaded.issues).toEqual([
+      {
+        filePath: 'remote_settings[0]',
+        path: '/remote_settings/0/path',
+        message: "Remote repository path '/tmp/settings.yml' must be relative.",
+      },
+      {
+        filePath: 'remote_settings[1]',
+        path: '/remote_settings/1/path',
+        message: "Remote repository path '../settings.yml' must stay inside the repository.",
+      },
     ]);
   });
 });

--- a/tests/unit/settings-loader.test.ts
+++ b/tests/unit/settings-loader.test.ts
@@ -5,11 +5,13 @@ import { dirname, join } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { createRemoteRepositoryCachePath } from '../../src/profiles/ProfileCache.js';
 import {
   createSettingsLoadPlan,
   discoverSettingsLoadPlan,
   loadSettings,
   loadSettingsFiles,
+  loadSettingsWithCachedRemoteSettings,
 } from '../../src/settings/SettingsLoader.js';
 import { validateSchema } from '../../src/validation/SchemaValidator.js';
 import { parseYamlDocument } from '../../src/validation/YamlDocument.js';
@@ -68,6 +70,7 @@ describe('settings loading', () => {
     expect(loaded.files.map((file) => file.location.scope)).toEqual(['user', 'project', 'project-local']);
     expect(loaded.settings.defaultProfile).toBe('local-default');
     expect(loaded.settings.profileSources).toEqual([{ path: join(homeDirectory, '.bridl', 'profiles') }]);
+    expect(loaded.settings.remoteSettings).toEqual([]);
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.3).
@@ -96,14 +99,14 @@ describe('settings loading', () => {
     });
   });
 
-  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.5).
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.5, BRIDL-REQ-002.6).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('validates profile source entries and resolves relative paths from the settings file', () => {
+  it('validates local, URI, GitHub, and remote settings entries from settings files', () => {
     const root = createTemporaryRoot();
     const settingsPath = join(root, '.bridl', 'settings.yml');
     writeSettings(
       settingsPath,
-      `profile_sources:\n  - path: ./profiles\n    only: [engineering]\n  - path: ${join(root, 'absolute-profiles')}\n  - uri: git+https://example.test/profiles.git\n    except: [sandbox]\n`,
+      `profile_sources:\n  - path: ./profiles\n    only: [engineering]\n  - path: ${join(root, 'absolute-profiles')}\n  - uri: git+https://example.test/profiles.git\n    path: team/profiles\n    ref: main\n    except: [sandbox]\n  - github: example/bridl-config\n    path: profiles\nremote_settings:\n  - github: example/bridl-config\n    ref: main\n    path: settings.yml\n`,
     );
 
     const result = loadSettingsFiles(createSettingsLoadPlan([{ scope: 'user', path: settingsPath }]));
@@ -112,7 +115,11 @@ describe('settings loading', () => {
     expect(result.files[0]?.settings.profileSources).toEqual([
       { path: join(root, '.bridl', 'profiles'), only: ['engineering'] },
       { path: join(root, 'absolute-profiles') },
-      { uri: 'git+https://example.test/profiles.git', except: ['sandbox'] },
+      { uri: 'git+https://example.test/profiles.git', path: 'team/profiles', ref: 'main', except: ['sandbox'] },
+      { github: 'example/bridl-config', path: 'profiles' },
+    ]);
+    expect(result.files[0]?.settings.remoteSettings).toEqual([
+      { github: 'example/bridl-config', ref: 'main', path: 'settings.yml' },
     ]);
   });
 
@@ -127,5 +134,31 @@ describe('settings loading', () => {
     expect(parseYamlDocument('answer: 42\n', '/inline')).toEqual({ ok: true, document: { answer: 42 } });
     expect(validateSchema('profile-source', { path: './profiles' })).toEqual({ valid: true, issues: [] });
     expect(validateSchema('settings', null).issues[0]?.path).toBe('/');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('loads cached remote settings from repository subpaths with local settings precedence', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    writeSettings(
+      join(homeDirectory, '.bridl', 'settings.yml'),
+      'default_profile: local\nremote_settings:\n  - github: example/bridl-config\n    ref: main\n    path: settings.yml\n',
+    );
+    const remoteSettingsPath = join(
+      createRemoteRepositoryCachePath(homeDirectory, { github: 'example/bridl-config', ref: 'main' }),
+      'settings.yml',
+    );
+    writeSettings(
+      remoteSettingsPath,
+      'default_profile: remote\nprofile_sources:\n  - github: example/bridl-config\n    path: profiles\n',
+    );
+
+    const loaded = loadSettingsWithCachedRemoteSettings({ homeDirectory, projectDirectory });
+
+    expect(loaded.issues).toEqual([]);
+    expect(loaded.settings.defaultProfile).toBe('local');
+    expect(loaded.settings.profileSources).toEqual([{ github: 'example/bridl-config', path: 'profiles' }]);
   });
 });

--- a/tests/unit/settings-loader.test.ts
+++ b/tests/unit/settings-loader.test.ts
@@ -144,21 +144,33 @@ describe('settings loading', () => {
     const projectDirectory = join(root, 'project');
     writeSettings(
       join(homeDirectory, '.bridl', 'settings.yml'),
-      'default_profile: local\nremote_settings:\n  - github: example/bridl-config\n    ref: main\n    path: settings.yml\n',
+      'default_profile: local\nremote_settings:\n  - uri: git+https://github.com/example/bridl-config.git\n    ref: main\n    path: settings.yml\n',
     );
     const remoteSettingsPath = join(
-      createRemoteRepositoryCachePath(homeDirectory, { github: 'example/bridl-config', ref: 'main' }),
+      createRemoteRepositoryCachePath(homeDirectory, {
+        uri: 'git+https://github.com/example/bridl-config.git',
+        ref: 'main',
+      }),
       'settings.yml',
     );
     writeSettings(
       remoteSettingsPath,
-      'default_profile: remote\nprofile_sources:\n  - github: example/bridl-config\n    path: profiles\n',
+      'default_profile: remote\nprofile_sources:\n  - github: example/bridl-config\n    path: remote-profiles\n',
     );
 
     const loaded = loadSettingsWithCachedRemoteSettings({ homeDirectory, projectDirectory });
 
     expect(loaded.issues).toEqual([]);
     expect(loaded.settings.defaultProfile).toBe('local');
-    expect(loaded.settings.profileSources).toEqual([{ github: 'example/bridl-config', path: 'profiles' }]);
+    expect(loaded.settings.profileSources).toEqual([{ github: 'example/bridl-config', path: 'remote-profiles' }]);
+
+    writeSettings(
+      join(homeDirectory, '.bridl', 'settings.yml'),
+      'default_profile: local\nprofile_sources:\n  - path: ./local-profiles\nremote_settings:\n  - uri: git+https://github.com/example/bridl-config.git\n    ref: main\n    path: settings.yml\n',
+    );
+    const localOverrideLoaded = loadSettingsWithCachedRemoteSettings({ homeDirectory, projectDirectory });
+    expect(localOverrideLoaded.settings.profileSources).toEqual([
+      { path: join(homeDirectory, '.bridl', 'local-profiles') },
+    ]);
   });
 });

--- a/tests/unit/setup-sources.test.ts
+++ b/tests/unit/setup-sources.test.ts
@@ -1,6 +1,6 @@
 // Tests setup source repository behavior.
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -85,6 +85,10 @@ describe('setup sources', () => {
       join(nestedRepositoryPath, '.bridl', 'profiles', 'default', 'profile.yml'),
       'id: default\ncontrols: {}\n',
     );
+    symlinkSync(
+      join(root, 'outside-profile.yml'),
+      join(nestedRepositoryPath, '.bridl', 'profiles', 'default', 'linked.yml'),
+    );
     commitAll(nestedRepositoryPath, 'nested-setup');
     const nestedSourceResult = executeSetupCommand({
       homeDirectory: nestedHomeDirectory,
@@ -106,6 +110,7 @@ describe('setup sources', () => {
     expect(readFileSync(join(nestedHomeDirectory, '.bridl', 'settings.yml'), 'utf8')).toContain(
       'default_profile: default',
     );
+    expect(existsSync(join(nestedHomeDirectory, '.bridl', 'profiles', 'default', 'linked.yml'))).toBe(false);
     expect(() =>
       executeSetupCommand({
         homeDirectory: join(root, 'missing-source-home'),

--- a/tests/unit/setup-sources.test.ts
+++ b/tests/unit/setup-sources.test.ts
@@ -1,6 +1,6 @@
 // Tests setup source repository behavior.
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -103,6 +103,9 @@ describe('setup sources', () => {
       join(emptySourceHomeDirectory, '.bridl', 'profiles', 'default', 'profile.yml'),
     );
     expect(nestedSourceResult.copiedStarterProfileFiles).toBe(1);
+    expect(readFileSync(join(nestedHomeDirectory, '.bridl', 'settings.yml'), 'utf8')).toContain(
+      'default_profile: default',
+    );
     expect(() =>
       executeSetupCommand({
         homeDirectory: join(root, 'missing-source-home'),

--- a/tests/unit/setup-sources.test.ts
+++ b/tests/unit/setup-sources.test.ts
@@ -50,7 +50,7 @@ afterEach(() => {
 });
 
 describe('setup sources', () => {
-  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-004.7).
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-004.1).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('fetches setup source repositories with the default git synchronizer', () => {
     const root = createTemporaryRoot();
@@ -109,7 +109,7 @@ describe('setup sources', () => {
         projectDirectory,
         setupSourceUri: join(root, 'missing-source'),
       }),
-    ).toThrow();
+    ).toThrow('does not exist');
     expect(() =>
       executeSetupCommand({
         homeDirectory: invalidHomeDirectory,

--- a/tests/unit/setup-sources.test.ts
+++ b/tests/unit/setup-sources.test.ts
@@ -1,0 +1,121 @@
+// Tests setup source repository behavior.
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { executeSetupCommand } from '../../src/cli/commands/SetupCommand.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'bridl-setup-sources-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const writeCachedProfile = (cachePath: string, profileId = 'remote'): void => {
+  const profileDirectory = join(cachePath, profileId);
+  mkdirSync(profileDirectory, { recursive: true });
+  writeFileSync(join(profileDirectory, 'profile.yml'), `id: ${profileId}\ncontrols: {}\n`);
+};
+
+const createGitProfileRepository = (root: string, repositoryName: string): string => {
+  const repositoryPath = join(root, repositoryName);
+  writeCachedProfile(repositoryPath, 'remote');
+  execFileSync('git', ['init', '--initial-branch', 'main'], { cwd: repositoryPath, stdio: 'pipe' });
+  execFileSync('git', ['add', '.'], { cwd: repositoryPath, stdio: 'pipe' });
+  execFileSync(
+    'git',
+    ['-c', 'user.name=Bridl Test', '-c', 'user.email=bridl@example.test', 'commit', '-m', 'profiles'],
+    { cwd: repositoryPath, stdio: 'pipe' },
+  );
+  return repositoryPath;
+};
+
+const commitAll = (repositoryPath: string, message: string): void => {
+  execFileSync('git', ['add', '.'], { cwd: repositoryPath, stdio: 'pipe' });
+  execFileSync('git', ['-c', 'user.name=Bridl Test', '-c', 'user.email=bridl@example.test', 'commit', '-m', message], {
+    cwd: repositoryPath,
+    stdio: 'pipe',
+  });
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('setup sources', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-004.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('fetches setup source repositories with the default git synchronizer', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const repositoryPath = createGitProfileRepository(root, 'setup-source');
+    writeFileSync(
+      join(repositoryPath, 'settings.yml'),
+      'default_profile: remote\nprofile_sources:\n  - path: ./profiles\n',
+    );
+    mkdirSync(join(repositoryPath, 'profiles', 'remote'), { recursive: true });
+    writeFileSync(
+      join(repositoryPath, 'profiles', 'remote', 'profile.yml'),
+      'id: remote\nlabel: Remote\ncontrols: {}\n',
+    );
+    commitAll(repositoryPath, 'setup');
+
+    const firstResult = executeSetupCommand({ homeDirectory, projectDirectory, setupSourceUri: repositoryPath });
+    const secondResult = executeSetupCommand({ homeDirectory, projectDirectory, setupSourceUri: repositoryPath });
+    const emptySourceHomeDirectory = join(root, 'empty-source-home');
+    const emptyRepositoryPath = createGitProfileRepository(root, 'empty-setup-source');
+    const emptySourceResult = executeSetupCommand({
+      homeDirectory: emptySourceHomeDirectory,
+      projectDirectory,
+      setupSourceUri: emptyRepositoryPath,
+    });
+    const nestedHomeDirectory = join(root, 'nested-home');
+    const nestedRepositoryPath = createGitProfileRepository(root, 'nested-setup-source');
+    mkdirSync(join(nestedRepositoryPath, '.bridl', 'profiles', 'default'), { recursive: true });
+    writeFileSync(join(nestedRepositoryPath, '.bridl', 'settings.yml'), 'profile_sources:\n  - path: ./profiles\n');
+    writeFileSync(
+      join(nestedRepositoryPath, '.bridl', 'profiles', 'default', 'profile.yml'),
+      'id: default\ncontrols: {}\n',
+    );
+    commitAll(nestedRepositoryPath, 'nested-setup');
+    const nestedSourceResult = executeSetupCommand({
+      homeDirectory: nestedHomeDirectory,
+      projectDirectory,
+      setupSourceUri: nestedRepositoryPath,
+    });
+    const invalidHomeDirectory = join(root, 'invalid-home');
+    const invalidRepositoryPath = createGitProfileRepository(root, 'invalid-setup-source');
+    writeFileSync(join(invalidRepositoryPath, 'settings.yml'), 'profile_sources:\n  - only: [missing]\n');
+    commitAll(invalidRepositoryPath, 'invalid-setup');
+
+    expect(firstResult.createdSettings).toBe(true);
+    expect(firstResult.createdDefaultProfile).toBe(false);
+    expect(secondResult.createdSettings).toBe(false);
+    expect(emptySourceResult.defaultProfilePath).toBe(
+      join(emptySourceHomeDirectory, '.bridl', 'profiles', 'default', 'profile.yml'),
+    );
+    expect(nestedSourceResult.copiedStarterProfileFiles).toBe(1);
+    expect(() =>
+      executeSetupCommand({
+        homeDirectory: join(root, 'missing-source-home'),
+        projectDirectory,
+        setupSourceUri: join(root, 'missing-source'),
+      }),
+    ).toThrow();
+    expect(() =>
+      executeSetupCommand({
+        homeDirectory: invalidHomeDirectory,
+        projectDirectory,
+        setupSourceUri: invalidRepositoryPath,
+      }),
+    ).toThrow('Cannot setup from invalid starter settings');
+  });
+});

--- a/tests/unit/source-layout.test.ts
+++ b/tests/unit/source-layout.test.ts
@@ -60,14 +60,17 @@ describe('source layout scaffolding', () => {
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.5).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('validates profile source entries with exactly one source location', () => {
+  it('validates profile source entries for local, URI, and GitHub source locations', () => {
     const ajv = new Ajv2020();
     const profileSourceSchema = readJson<AnySchema>('../../src/schemas/profile-source.schema.json');
     const validate = ajv.compile(profileSourceSchema);
 
     expect(validate({ path: './profiles' })).toBe(true);
     expect(validate({ uri: 'git+https://example.test/profiles.git' })).toBe(true);
-    expect(validate({ path: './profiles', uri: 'git+https://example.test/profiles.git' })).toBe(false);
+    expect(validate({ uri: 'git+https://example.test/profiles.git', path: 'profiles/team', ref: 'main' })).toBe(true);
+    expect(validate({ github: 'example/bridl-config', path: 'profiles' })).toBe(true);
+    expect(validate({ path: './profiles', ref: 'main' })).toBe(false);
+    expect(validate({ uri: 'git+https://example.test/profiles.git', github: 'example/profiles' })).toBe(false);
     expect(validate({ only: ['engineering'] })).toBe(false);
   });
 
@@ -77,7 +80,7 @@ describe('source layout scaffolding', () => {
     const settings = emptySettings();
     const mergedSettings = mergeSettingsStack([
       settings,
-      { defaultProfile: 'engineering', profileSources: [localSource] },
+      { defaultProfile: 'engineering', profileSources: [localSource], remoteSettings: [] },
     ]);
     const settingsLoadPlan = createSettingsLoadPlan([
       { scope: 'user', path: '~/.bridl/settings.yml' },

--- a/tests/unit/source-layout.test.ts
+++ b/tests/unit/source-layout.test.ts
@@ -17,7 +17,11 @@ import { createSyncCommand } from '../../src/cli/commands/SyncCommand.js';
 import { createEmptyProfile } from '../../src/profiles/Profile.js';
 import { createProfileLoadPlan } from '../../src/profiles/ProfileLoader.js';
 import { mergeProfileStack } from '../../src/profiles/ProfileMerger.js';
-import { createLocalProfileSource, createUriProfileSource } from '../../src/profiles/ProfileSource.js';
+import {
+  createLocalProfileSource,
+  createUriProfileSource,
+  normalizeRemoteSourceUri,
+} from '../../src/profiles/ProfileSource.js';
 import {
   profileSchemaDocument,
   profileSourceSchemaDocument,
@@ -80,6 +84,7 @@ describe('source layout scaffolding', () => {
     const settings = emptySettings();
     const mergedSettings = mergeSettingsStack([
       settings,
+      { defaultProfile: 'remote', profileSources: [uriSource], remoteSettings: [] },
       { defaultProfile: 'engineering', profileSources: [localSource], remoteSettings: [] },
     ]);
     const settingsLoadPlan = createSettingsLoadPlan([
@@ -91,6 +96,19 @@ describe('source layout scaffolding', () => {
 
     expect(mergedSettings.defaultProfile).toBe('engineering');
     expect(mergedSettings.profileSources).toEqual([localSource]);
+    expect(
+      mergeSettingsStack([
+        {
+          defaultProfile: 'remote',
+          profileSources: [uriSource],
+          remoteSettings: [{ github: 'example/remote', path: 'settings.yml' }],
+        },
+        { profileSources: [], remoteSettings: [] },
+      ]),
+    ).toEqual({ profileSources: [], remoteSettings: [], defaultProfile: 'remote' });
+    expect(normalizeRemoteSourceUri({ github: 'example/bridl-config' })).toBe(
+      'git+https://github.com/example/bridl-config.git',
+    );
     expect(settingsLoadPlan.locations.map((location) => location.scope)).toEqual(['user', 'project', 'project-local']);
     expect(profileLoadPlan.sources).toEqual([localSource, uriSource]);
   });

--- a/tests/unit/source-layout.test.ts
+++ b/tests/unit/source-layout.test.ts
@@ -1,4 +1,4 @@
-// Tests the initial source layout scaffolding for Bridl modules.
+// Tests source layout, command registration, schemas, and small boundary helpers.
 import { readFileSync } from 'node:fs';
 
 import type { AnySchema } from 'ajv';


### PR DESCRIPTION
## Summary
- add GitHub shorthand, refs, and repository subpaths for remote profile sources
- add remote_settings support that loads settings-style YAML from synced remote repositories
- add setup source repository support using the shared repository cache
- document new settings syntax and add requirement-backed tests

## Validation
- npm run check-ci