### PR TITLE
Add utilities persistence store

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ profile_sources:
 
 Run `bridl sync` to fetch/update remote settings and profiles before using them.
 
+By default, Bridl keeps reusable runtime cache files under `~/.bridl/cache`. Set `cache_directory` in `settings.yml` to choose a different cache root; relative values resolve from the settings file that declares them. The pi adapter symlinks tack `utilities/` and `bin/` paths into this cache so pi-managed utilities such as `fd` and `rg` survive across temporary tack directories.
+
 ## Setup from a settings repository
 
 You can bootstrap a machine from a Git repository:
@@ -149,7 +151,7 @@ The exact stable schema is governed by the requirements in `requirements/` and t
 The current recommendation is to build `bridl` around pi's existing native configuration mechanisms:
 
 1. Use a temporary tack directory as `PI_CODING_AGENT_DIR` for each run.
-2. Persist intentional pi state through adapter-declared symlinks to profile or native pi files.
+2. Persist intentional pi state through adapter-declared symlinks to profile, native pi, or Bridl cache files.
 3. Layer profile-controlled environment variables and pi CLI flags on top.
 4. Use explicit `--extension` / `-e` injection for bootstrap behavior that needs to run inside pi.
 5. Decide per profile whether project-local `.pi` overrides are allowed.

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -82,6 +82,7 @@ Bridl uses a `.bridl` folder convention at multiple scopes:
   profiles
   cache/
     profiles/
+    utilities/
 
 <project>/.bridl/
   settings.yml
@@ -129,6 +130,7 @@ profile_sources:
 
 ```yaml
 default_profile: engineering
+cache_directory: ./cache
 
 profile_sources:
   - path: ./profiles
@@ -162,6 +164,7 @@ Rules:
 - `profile_sources` entries MUST specify a local `path`, a remote `uri`, or a `github` shorthand.
 - `only` and `except` are optional filters; without either, all profiles from the source are loaded.
 - Local-only relative `path` values are resolved relative to the settings file containing them.
+- `cache_directory` optionally selects the Bridl cache root; relative values are resolved relative to the settings file containing them.
 - Remote `uri` and `github` profile sources can specify `ref` and repository-subdirectory `path` values.
 - `remote_settings` entries point at settings-style YAML files inside synced remote repositories.
 - `uri`, `github`, and `remote_settings` sources are fetched/cached by `bridl sync`.
@@ -294,11 +297,13 @@ A **tack** is the dynamically assembled runtime configuration directory for a sp
 
 Example term usage: “the tack for `data-analyst` on `claude`”.
 
-Tacks are generated under the system temp directory so they can be reclaimed trivially:
+Tacks are generated under the system temp directory so they can be reclaimed trivially, while adapter-declared state paths can be symlinked to durable profile, native CLI, or Bridl cache locations:
 
 ```text
 $TMPDIR/bridl/tacks/<run-id>/
 ```
+
+The pi adapter uses this state model for native pi state and for pi-managed utilities: tack `utilities/` and `bin/` both symlink to `<cache_directory>/utilities` by default, so temporary tack cleanup does not force pi to redownload helper binaries such as `fd` and `rg`.
 
 During `bridl run`, the Bridl process remains alive while the child agent CLI runs.
 It owns the tack lifecycle.

--- a/recommendation.md
+++ b/recommendation.md
@@ -26,6 +26,8 @@ Bridl currently declares and materializes a narrower day-one state set for pi:
 - `plugins/`
 - `cache/`
 - `sessions/`
+- `utilities/`
+- `bin/`
 
 Native pi can be isolated by pointing `PI_CODING_AGENT_DIR` at a different directory. Bridl's implemented model uses that same boundary with a temporary tack directory for each run, then symlinks adapter-declared durable state paths back to profile files or native pi files such as `~/.pi/agent/auth.json`.
 
@@ -43,7 +45,7 @@ Launch shape:
 PI_CODING_AGENT_DIR=/tmp/bridl-default-pi-... pi
 ```
 
-This keeps the runtime tack disposable while preserving intentional credentials, settings, MCP configuration, plugins, caches, and sessions through declared state paths.
+This keeps the runtime tack disposable while preserving intentional credentials, settings, MCP configuration, plugins, caches, sessions, and pi-managed utilities through declared state paths. Bridl maps both tack `utilities/` and tack `bin/` to `<cache_directory>/utilities` by default so helper binaries such as `fd` and `rg` are reused across runs even though each tack directory is temporary.
 
 ### Other native launch controls
 

--- a/requirements/BRIDL-REQ-002-settings.md
+++ b/requirements/BRIDL-REQ-002-settings.md
@@ -56,3 +56,10 @@ The internal Settings object is the single source of resolved configuration for 
 4. A `remote_settings` entry MAY specify `ref` to select a branch, tag, or commit.
 5. Bridl MUST load cached remote settings files from their repository subpaths when resolving settings.
 6. Local discovered settings MUST take precedence over remote settings when both define the same setting.
+
+### BRIDL-REQ-002.7: Cache Directory Setting
+
+1. `settings.yml` MAY contain a `cache_directory` path.
+2. Relative `cache_directory` values MUST resolve relative to the settings file containing them.
+3. When `cache_directory` is not configured, Bridl MUST use `~/.bridl/cache` as the default cache directory.
+4. Agent adapters MUST receive the resolved cache directory when assembling a tack so persistent tack links use the configured cache location.

--- a/src/agents/AgentAdapter.ts
+++ b/src/agents/AgentAdapter.ts
@@ -25,6 +25,7 @@ export interface AgentAdapter {
       readonly profilePaths: readonly string[];
       readonly profileFolders?: readonly string[];
       readonly homeDirectory?: string;
+      readonly cacheDirectory?: string;
     },
   ): AgentTackPlan;
   createLaunchPlan(tack: Tack, profile?: Profile, passThroughArgs?: readonly string[]): AgentLaunchPlan;

--- a/src/agents/pi/PiAdapter.ts
+++ b/src/agents/pi/PiAdapter.ts
@@ -37,6 +37,8 @@ const piStatePathDeclarations = {
   'plugins/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error', 'prompt'] },
   'cache/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error'] },
   'sessions/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error'] },
+  'utilities/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error'] },
+  'bin/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error'] },
   unknown: { defaultStrategy: 'warn', allowedStrategies: ['discard', 'warn', 'error', 'prompt'] },
 } as const satisfies Readonly<Record<string, StatePathDeclaration>>;
 
@@ -85,7 +87,11 @@ export const createPiAdapter = (): AgentAdapter => ({
 
 const createPiStatePaths = (
   profile: Profile,
-  input: { readonly profileFolders?: readonly string[]; readonly homeDirectory?: string },
+  input: {
+    readonly profileFolders?: readonly string[];
+    readonly homeDirectory?: string;
+    readonly cacheDirectory?: string;
+  },
 ): readonly TackStatePath[] => {
   assertDeclaredStatePersistenceKeys(profile);
 
@@ -99,7 +105,13 @@ const createPiStatePaths = (
       directory,
       sourcePath:
         strategy === 'symlink' && relativePath !== 'unknown'
-          ? resolvePiStateSourcePath(input.profileFolders ?? [], input.homeDirectory, relativePath, directory)
+          ? resolvePiStateSourcePath(
+              input.profileFolders ?? [],
+              input.homeDirectory,
+              input.cacheDirectory,
+              relativePath,
+              directory,
+            )
           : undefined,
     };
   });
@@ -135,10 +147,24 @@ const resolveStateStrategy = (
 const resolvePiStateSourcePath = (
   profileFolders: readonly string[],
   homeDirectory: string | undefined,
+  cacheDirectory: string | undefined,
   relativePath: string,
   directory: boolean,
 ): string => {
   const normalizedRelativePath = directory ? relativePath.slice(0, -1) : relativePath;
+  const configuredCacheDirectory =
+    cacheDirectory ??
+    join(
+      /* v8 ignore next -- run command always passes homeDirectory; environment fallbacks are defensive. */
+      homeDirectory ?? process.env.HOME ?? '.',
+      '.bridl',
+      'cache',
+    );
+
+  if (relativePath === 'utilities/' || relativePath === 'bin/') {
+    return join(configuredCacheDirectory, 'utilities');
+  }
+
   const profileSource = [...profileFolders]
     .reverse()
     .map((profileFolder) => join(profileFolder, 'cli_specific', 'pi', normalizedRelativePath))

--- a/src/cli/commands/RunCommand.ts
+++ b/src/cli/commands/RunCommand.ts
@@ -171,6 +171,7 @@ interface ResolvedRunProfile {
   readonly profilePaths: readonly string[];
   readonly profileFolders: readonly string[];
   readonly homeDirectory: string;
+  readonly cacheDirectory: string;
 }
 
 const failHardTackOnWarnings = (
@@ -197,6 +198,7 @@ const createAdapterTackPlan = (adapter: AgentAdapter, resolvedProfile: ResolvedR
     profilePaths: resolvedProfile.profilePaths,
     profileFolders: resolvedProfile.profileFolders,
     homeDirectory: resolvedProfile.homeDirectory,
+    cacheDirectory: resolvedProfile.cacheDirectory,
   });
 
 const handleTackStateWrites = (
@@ -271,6 +273,7 @@ const loadResolvedProfile = (input: RunCommandInput): ResolvedRunProfile => {
     profilePaths: findContributingProfilePaths(resolution.profileStack, loadedProfiles.profiles),
     profileFolders: findContributingProfileFolders(resolution.profileStack, loadedProfiles.profiles),
     homeDirectory: input.homeDirectory,
+    cacheDirectory: loadedSettings.settings.cacheDirectory ?? join(input.homeDirectory, '.bridl', 'cache'),
   };
 };
 

--- a/src/schemas/settings.schema.json
+++ b/src/schemas/settings.schema.json
@@ -5,6 +5,7 @@
   "type": "object",
   "properties": {
     "default_profile": { "type": "string", "minLength": 1 },
+    "cache_directory": { "type": "string", "minLength": 1 },
     "profile_sources": {
       "type": "array",
       "items": { "$ref": "profile-source.schema.json" }

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -7,6 +7,7 @@ export interface Settings {
   readonly defaultProfile?: string;
   readonly profileSources?: readonly ProfileSourceReference[];
   readonly remoteSettings?: readonly RemoteSettingsReference[];
+  readonly cacheDirectory?: string;
 }
 
 export const emptySettings = (): Settings => ({

--- a/src/settings/SettingsLoader.ts
+++ b/src/settings/SettingsLoader.ts
@@ -41,6 +41,7 @@ interface SettingsDocument {
   readonly default_profile?: string;
   readonly profile_sources?: readonly ProfileSourceDocument[];
   readonly remote_settings?: readonly RemoteSettingsDocument[];
+  readonly cache_directory?: string;
 }
 
 interface ProfileSourceDocument {
@@ -194,6 +195,10 @@ const convertSettingsDocument = (document: SettingsDocument, settingsDirectory: 
   defaultProfile: document.default_profile,
   profileSources: document.profile_sources?.map((source) => convertProfileSource(source, settingsDirectory)),
   remoteSettings: document.remote_settings?.map(convertRemoteSettingsSource),
+  cacheDirectory:
+    document.cache_directory === undefined
+      ? undefined
+      : resolveConfigDirectory(document.cache_directory, settingsDirectory),
 });
 
 const convertRemoteSettingsSource = (source: RemoteSettingsDocument): RemoteSettingsReference => {
@@ -221,10 +226,13 @@ const convertProfileSource = (source: ProfileSourceDocument, settingsDirectory: 
   return { ...filters, path: resolveProfileSourcePath(source.path!, settingsDirectory) };
 };
 
-const resolveProfileSourcePath = (sourcePath: string, settingsDirectory: string): string => {
-  if (isAbsolute(sourcePath)) {
-    return sourcePath;
+const resolveProfileSourcePath = (sourcePath: string, settingsDirectory: string): string =>
+  resolveConfigDirectory(sourcePath, settingsDirectory);
+
+const resolveConfigDirectory = (configuredPath: string, settingsDirectory: string): string => {
+  if (isAbsolute(configuredPath)) {
+    return configuredPath;
   }
 
-  return resolve(settingsDirectory, sourcePath);
+  return resolve(settingsDirectory, configuredPath);
 };

--- a/src/settings/SettingsMerger.ts
+++ b/src/settings/SettingsMerger.ts
@@ -6,6 +6,7 @@ export const mergeSettingsStack = (settingsStack: readonly Settings[]): Settings
   let defaultProfile: string | undefined;
   let profileSources: Settings['profileSources'];
   let remoteSettings: Settings['remoteSettings'];
+  let cacheDirectory: string | undefined;
 
   for (const settings of settingsStack) {
     defaultProfile = settings.defaultProfile ?? defaultProfile;
@@ -17,6 +18,8 @@ export const mergeSettingsStack = (settingsStack: readonly Settings[]): Settings
     if (settings.remoteSettings !== undefined) {
       remoteSettings = settings.remoteSettings;
     }
+
+    cacheDirectory = settings.cacheDirectory ?? cacheDirectory;
   }
 
   return {
@@ -24,5 +27,6 @@ export const mergeSettingsStack = (settingsStack: readonly Settings[]): Settings
     defaultProfile,
     profileSources: profileSources ?? [],
     remoteSettings: remoteSettings ?? [],
+    cacheDirectory,
   };
 };

--- a/tests/unit/run-cache.test.ts
+++ b/tests/unit/run-cache.test.ts
@@ -1,0 +1,77 @@
+// Tests run command cache directory forwarding into pi persistent state paths.
+import { mkdirSync, mkdtempSync, readlinkSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { executeRunCommand } from '../../src/cli/commands/RunCommand.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'bridl-run-cache-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const writeSettings = (homeDirectory: string, content: string): void => {
+  mkdirSync(join(homeDirectory, '.bridl'), { recursive: true });
+  writeFileSync(join(homeDirectory, '.bridl', 'settings.yml'), content);
+};
+
+const writeProfile = (profilesRoot: string, id: string, content: string): void => {
+  const profileDirectory = join(profilesRoot, id);
+  mkdirSync(profileDirectory, { recursive: true });
+  writeFileSync(join(profileDirectory, 'profile.yml'), content);
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('run command cache persistence', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('uses the default cache directory for pi utilities state paths during run command execution', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    writeSettings(homeDirectory, 'default_profile: default\nprofile_sources:\n  - path: ./profiles\n');
+    writeProfile(join(homeDirectory, '.bridl', 'profiles'), 'default', 'id: default\ncontrols: {}\n');
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      { launcher: { launch: () => Promise.resolve(0) } },
+    );
+
+    expect(readlinkSync(join(result.tackDirectory, 'utilities'))).toBe(
+      join(homeDirectory, '.bridl', 'cache', 'utilities'),
+    );
+    expect(readlinkSync(join(result.tackDirectory, 'bin'))).toBe(join(homeDirectory, '.bridl', 'cache', 'utilities'));
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('uses configured cache directories for pi utilities state paths during run command execution', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const cacheDirectory = join(homeDirectory, '.bridl', 'custom-cache');
+    writeSettings(
+      homeDirectory,
+      'default_profile: default\ncache_directory: ./custom-cache\nprofile_sources:\n  - path: ./profiles\n',
+    );
+    writeProfile(join(homeDirectory, '.bridl', 'profiles'), 'default', 'id: default\ncontrols: {}\n');
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      { launcher: { launch: () => Promise.resolve(0) } },
+    );
+
+    expect(readlinkSync(join(result.tackDirectory, 'utilities'))).toBe(join(cacheDirectory, 'utilities'));
+    expect(readlinkSync(join(result.tackDirectory, 'bin'))).toBe(join(cacheDirectory, 'utilities'));
+  });
+});

--- a/tests/unit/settings-loader.test.ts
+++ b/tests/unit/settings-loader.test.ts
@@ -60,10 +60,16 @@ describe('settings loading', () => {
     const projectDirectory = join(root, 'project');
     writeSettings(
       join(homeDirectory, '.bridl', 'settings.yml'),
-      'default_profile: user-default\nprofile_sources:\n  - path: ./profiles\n',
+      'default_profile: user-default\ncache_directory: ./user-cache\nprofile_sources:\n  - path: ./profiles\n',
     );
-    writeSettings(join(projectDirectory, '.bridl', 'settings.yml'), 'default_profile: project-default\n');
-    writeSettings(join(projectDirectory, '.bridl', 'local', 'settings.yml'), 'default_profile: local-default\n');
+    writeSettings(
+      join(projectDirectory, '.bridl', 'settings.yml'),
+      'default_profile: project-default\ncache_directory: ./project-cache\n',
+    );
+    writeSettings(
+      join(projectDirectory, '.bridl', 'local', 'settings.yml'),
+      'default_profile: local-default\ncache_directory: ./local-cache\n',
+    );
 
     const loaded = loadSettings(discoverSettingsLoadPlan({ homeDirectory, projectDirectory }));
 
@@ -72,6 +78,7 @@ describe('settings loading', () => {
     expect(loaded.settings.defaultProfile).toBe('local-default');
     expect(loaded.settings.profileSources).toEqual([{ path: join(homeDirectory, '.bridl', 'profiles') }]);
     expect(loaded.settings.remoteSettings).toEqual([]);
+    expect(loaded.settings.cacheDirectory).toBe(join(projectDirectory, '.bridl', 'local', 'local-cache'));
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.3).
@@ -122,6 +129,19 @@ describe('settings loading', () => {
     expect(result.files[0]?.settings.remoteSettings).toEqual([
       { github: 'example/bridl-config', ref: 'main', path: 'settings.yml' },
     ]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('resolves configured cache directories relative to the containing settings file', () => {
+    const root = createTemporaryRoot();
+    const settingsPath = join(root, '.bridl', 'settings.yml');
+    writeSettings(settingsPath, 'cache_directory: ./cache\n');
+
+    const result = loadSettingsFiles(createSettingsLoadPlan([{ scope: 'user', path: settingsPath }]));
+
+    expect(result.issues).toEqual([]);
+    expect(result.files[0]?.settings.cacheDirectory).toBe(join(root, '.bridl', 'cache'));
   });
 
   it('skips missing settings files and exposes generic YAML and schema helpers', () => {


### PR DESCRIPTION
## Summary
- add tack persistence links with symlink support
- map pi utilities/bin to a persistent utilities store under the configured cache directory
- support cache_directory in settings parsing, schema validation, and merging

## Validation
- npm run check-ci
- npm run build