### PR TITLE
Persist pi package stores across tack runs

### DIFF
--- a/recommendation.md
+++ b/recommendation.md
@@ -26,6 +26,8 @@ Bridl currently declares and materializes a narrower day-one state set for pi:
 - `plugins/`
 - `cache/`
 - `sessions/`
+- `npm/`
+- `git/`
 - `utilities/`
 - `bin/`
 
@@ -45,7 +47,7 @@ Launch shape:
 PI_CODING_AGENT_DIR=/tmp/bridl-default-pi-... pi
 ```
 
-This keeps the runtime tack disposable while preserving intentional credentials, settings, MCP configuration, plugins, caches, sessions, and pi-managed utilities through declared state paths. Bridl maps both tack `utilities/` and tack `bin/` to `<cache_directory>/utilities` by default so helper binaries such as `fd` and `rg` are reused across runs even though each tack directory is temporary.
+This keeps the runtime tack disposable while preserving intentional credentials, settings, MCP configuration, plugins, caches, sessions, pi package stores, and pi-managed utilities through declared state paths. Bridl maps native pi package directories such as `npm/` and `git/` back to `~/.pi/agent/` so user-scoped `pi install` packages survive across runs. Bridl maps both tack `utilities/` and tack `bin/` to `<cache_directory>/utilities` by default so helper binaries such as `fd` and `rg` are reused across runs even though each tack directory is temporary.
 
 ### Other native launch controls
 

--- a/src/agents/pi/PiAdapter.ts
+++ b/src/agents/pi/PiAdapter.ts
@@ -37,6 +37,12 @@ const piStatePathDeclarations = {
   'plugins/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error', 'prompt'] },
   'cache/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error'] },
   'sessions/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error'] },
+  // Pi installs npm-sourced packages here for user-scoped `pi install npm:...` entries.
+  // Persisting it keeps package updates across Bridl's temporary tack directories.
+  'npm/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error'] },
+  // Pi clones git-sourced packages here for user-scoped `pi install git:...` entries.
+  // Persisting it prevents every Bridl run from re-cloning or using stale temporary checkouts.
+  'git/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error'] },
   'utilities/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error'] },
   'bin/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error'] },
   unknown: { defaultStrategy: 'warn', allowedStrategies: ['discard', 'warn', 'error', 'prompt'] },

--- a/tests/unit/state-persistence.test.ts
+++ b/tests/unit/state-persistence.test.ts
@@ -161,6 +161,34 @@ describe('state persistence', () => {
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.6).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('persists pi package install directories across temporary tack directories', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const tack = createPiAdapter().createTack(
+      { id: 'default', controls: {} },
+      {
+        rootDirectory: join(root, 'tack'),
+        profilePaths: [],
+        profileFolders: [],
+        homeDirectory,
+      },
+    ).tack;
+
+    expect(tack.statePaths.find((statePath) => statePath.relativePath === 'npm/')?.sourcePath).toBe(
+      join(homeDirectory, '.pi', 'agent', 'npm'),
+    );
+    expect(tack.statePaths.find((statePath) => statePath.relativePath === 'git/')?.sourcePath).toBe(
+      join(homeDirectory, '.pi', 'agent', 'git'),
+    );
+
+    writeTack(tack);
+
+    expect(readlinkSync(join(tack.rootDirectory, 'npm'))).toBe(join(homeDirectory, '.pi', 'agent', 'npm'));
+    expect(readlinkSync(join(tack.rootDirectory, 'git'))).toBe(join(homeDirectory, '.pi', 'agent', 'git'));
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('detects changed temporary state paths and protects tack path boundaries', () => {
     const root = createTemporaryRoot();
     const sourceFile = ensureStateSourcePath(join(root, 'source', 'settings.json'), false);


### PR DESCRIPTION
## Summary
- Persist pi-managed npm and git package directories through symlinked tack state paths
- Document why the pi adapter keeps those directories stable across temporary Bridl tacks
- Add coverage for npm/ and git/ tack materialization

## Validation
- npm test -- tests/unit/state-persistence.test.ts
- npm run check-ci