### PR TITLE
Add BSL license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,53 @@
+# Business Source License 1.1
+
+## Parameters
+
+**Licensor:** Unsupervised.com, Inc.
+
+**Licensed Work:** Bridl  
+The Licensed Work is © 2026 Unsupervised.com, Inc.
+
+**Additional Use Grant:** You may use the Licensed Work without a commercial license only when it is used with or for:
+
+- repositories that are publicly available under an open source license approved by the Open Source Initiative; or
+- repositories with fewer than 10 contributors.
+
+Use of the Licensed Work with or for a private repository with 10 or more contributors requires a commercial license from the Licensor.
+
+**Change Date:** 2030-01-14
+
+**Change License:** Apache License, Version 2.0
+
+---
+
+## License Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative works, redistribute, and make non-production use of the Licensed Work. The Licensor may make an Additional Use Grant, above, permitting limited production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly available distribution of a specific version of the Licensed Work under this License, whichever comes first, the Licensor hereby grants you rights under the terms of the Change License, and the rights granted in the paragraph above terminate.
+
+If your use of the Licensed Work does not comply with the requirements currently in effect as described in this License, you must purchase a commercial license from the Licensor, its affiliated entities, or authorized resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works of the Licensed Work, are subject to this License. This License applies separately for each version of the Licensed Work and the Change Date may vary for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy of the Licensed Work. If you receive the Licensed Work in original or modified form from a third party, the terms and conditions set forth in this License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically terminate your rights under this License for the current and all other versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of Licensor or its affiliates (provided that you may use a trademark or logo of Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+
+---
+
+## Prohibited Uses
+
+You may not use the Licensed Work with or for a private repository with 10 or more contributors unless you have purchased a commercial license from the Licensor, its affiliated entities, or authorized resellers.
+
+For purposes of this License, a repository's contributor count is the number of people who have made commits or other accepted contributions to that repository, or who otherwise have permission to contribute code to that repository, whichever is greater.
+
+**Clarification**: This prohibition does not prevent you from using the Licensed Work without a commercial license with or for:
+
+- repositories that are publicly available under an open source license approved by the Open Source Initiative, regardless of contributor count;
+- private repositories with fewer than 10 contributors;
+- educational or research contexts that satisfy one of the preceding repository-use allowances.

--- a/doc_site/app/layout.tsx
+++ b/doc_site/app/layout.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
 };
 
 const navbar = <Navbar logo={<strong>Bridl</strong>} projectLink="https://github.com/Unsupervisedcom/bridl" />;
-const footer = <Footer>MIT {new Date().getFullYear()} © Bridl.</Footer>;
+const footer = <Footer>BUSL-1.1 {new Date().getFullYear()} © Bridl.</Footer>;
 
 export default async function RootLayout({ children }: { children: ReactNode }): Promise<ReactNode> {
   return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "bridl",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "BUSL-1.1",
       "dependencies": {
         "ajv": "^8.20.0",
         "chalk": "^5.6.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "requirements",
     "src/schemas",
     "doc",
-    "README.md"
+    "README.md",
+    "LICENSE.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json && shx rm -rf dist/schemas && shx mkdir -p dist/schemas && shx cp src/schemas/*.json dist/schemas/ && shx chmod +x dist/cli.js",
@@ -63,5 +64,5 @@
     "pi",
     "profiles"
   ],
-  "license": "MIT"
+  "license": "BUSL-1.1"
 }


### PR DESCRIPTION
## Summary
- add a Business Source License for Bridl based on DeepWork's license
- allow free use for OSI-approved open source repos and repos with fewer than 10 contributors
- require commercial licenses for private repos with 10+ contributors
- update npm package license metadata to BUSL-1.1

## Testing
- Not run (license/metadata-only change)