### PR TITLE
Add npm release publishing workflow

### DIFF
--- a/.deepreview
+++ b/.deepreview
@@ -337,6 +337,53 @@ typescript_code_review:
         documentation still accurate after the changes? Flag any comments that
         describe behavior that no longer matches the code.
 
+release_workflow_safety:
+  description: "Review Bridl npm release workflow safety."
+  match:
+    include:
+      - ".github/workflows/release.yml"
+  review:
+    strategy: individual
+    instructions: |
+      Review the Bridl npm release workflow for release-safety concerns that
+      complement deterministic workflow tests.
+
+      Check that the workflow:
+      - Does not expose npm tokens or other secrets through logs, command-line
+        arguments, checked-in files, or environment variables beyond the npm
+        publish step.
+      - Uses release triggers intentionally and does not publish from pull
+        requests, arbitrary pushes, or untrusted forks.
+      - Avoids git mutation, repository write credentials, or unrelated network
+        side effects that are not required for dependency installation, CI, or
+        npm publishing.
+      - Keeps maintainer-facing step names, comments, and assumptions accurate
+        enough to diagnose release failures.
+
+release_metadata_sync:
+  description: "Review Bridl release metadata synchronization automation."
+  match:
+    include:
+      - "scripts/sync-release-version.mjs"
+  review:
+    strategy: individual
+    instructions: |
+      Review the Bridl release metadata synchronization script for correctness
+      and release safety.
+
+      Focus on judgment-based release safety concerns that complement the
+      deterministic unit tests for this script.
+
+      Check that the script:
+      - Keeps its mutation scope limited to release metadata files under the
+        configured project root.
+      - Avoids network access, npm publishing, git mutation, credential access,
+        or other side effects that belong in the GitHub Actions workflow.
+      - Produces actionable errors rather than silent success when release
+        metadata is malformed or unsafe to publish.
+      - Keeps implementation comments and workflow assumptions accurate enough
+        for a release maintainer to diagnose failures.
+
 suggest_new_reviews:
   description: "Analyze all changes and suggest new review rules that would catch issues going forward."
   match:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+
+jobs:
+  publish-npm:
+    name: Publish npm package
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.19.0'
+          registry-url: https://registry.npmjs.org/
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Sync release version
+        run: node scripts/sync-release-version.mjs "${GITHUB_REF_NAME}"
+
+      - name: Format synchronized release metadata
+        run: npx prettier --write package.json package-lock.json
+
+      - name: Run CI checks
+        run: npm run check-ci
+
+      - name: Build package
+        run: npm run build
+
+      - name: Publish package to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         run: node scripts/sync-release-version.mjs "${GITHUB_REF_NAME}"
 
       - name: Format synchronized release metadata
-        run: npx prettier --write package.json package-lock.json
+        run: npm exec -- prettier --write package.json package-lock.json
 
       - name: Run CI checks
         run: npm run check-ci

--- a/requirements/BRIDL-REQ-009-release-publishing.md
+++ b/requirements/BRIDL-REQ-009-release-publishing.md
@@ -1,0 +1,25 @@
+# BRIDL-REQ-009: Release Publishing
+
+## Overview
+
+Bridl release publishing prepares package metadata from a GitHub release tag and publishes the `bridl` npm package through GitHub Actions.
+
+## Requirements
+
+### BRIDL-REQ-009.1: Release Metadata Synchronization
+
+1. The release metadata synchronization script MUST accept a release version from an explicit argument, `BRIDL_RELEASE_VERSION`, or `GITHUB_REF_NAME`, in that precedence order.
+2. The release metadata synchronization script MUST normalize a leading `v` from release tags before writing package metadata.
+3. The release metadata synchronization script MUST reject invalid Semantic Versioning values before mutating package metadata.
+4. The release metadata synchronization script MUST update the root `package.json` version, root `package-lock.json` version, and `package-lock.json` root package entry version to the same normalized release version.
+5. The release metadata synchronization script MUST verify that the root package metadata it prepares belongs to the `bridl` npm package.
+6. The release metadata synchronization script MUST fail with an actionable error when required package-lock root package metadata is missing.
+
+### BRIDL-REQ-009.2: Npm Release Workflow
+
+1. The npm release workflow MUST run when a GitHub release is published.
+2. The npm release workflow MUST install dependencies with `npm ci` before publishing.
+3. The npm release workflow MUST synchronize package metadata from the GitHub release tag before publishing.
+4. The npm release workflow MUST run CI checks before publishing.
+5. The npm release workflow MUST build the package before publishing.
+6. The npm release workflow MUST publish the public `bridl` package to the npm registry using an npm token secret.

--- a/scripts/sync-release-version.mjs
+++ b/scripts/sync-release-version.mjs
@@ -17,22 +17,26 @@ if (version === undefined) {
   throw new Error('Usage: node scripts/sync-release-version.mjs <version|vversion> [--root=<path>]');
 }
 
-await updateJson('package.json', (packageJson) => {
-  assertPackageName(packageJson);
-  packageJson.version = version;
-});
+const packageJsonPath = path.join(projectRoot, 'package.json');
+const packageLockPath = path.join(projectRoot, 'package-lock.json');
+const packageJson = await readJson(packageJsonPath);
+const lockfile = await readJson(packageLockPath);
 
-await updateJson('package-lock.json', (lockfile) => {
-  assertPackageName(lockfile);
-  lockfile.version = version;
+assertPackageName(packageJson);
+assertPackageName(lockfile);
 
-  if (lockfile.packages?.[''] === undefined) {
-    throw new Error("Expected package-lock.json to include packages[''] root package metadata.");
-  }
+if (lockfile.packages?.[''] === undefined) {
+  throw new Error("Expected package-lock.json to include packages[''] root package metadata.");
+}
 
-  assertPackageName(lockfile.packages['']);
-  lockfile.packages[''].version = version;
-});
+assertPackageName(lockfile.packages['']);
+
+packageJson.version = version;
+lockfile.version = version;
+lockfile.packages[''].version = version;
+
+await writeJson(packageLockPath, lockfile);
+await writeJson(packageJsonPath, packageJson);
 
 console.log(`Synchronized Bridl release metadata to ${version}.`);
 
@@ -66,9 +70,10 @@ function assertPackageName(packageJson) {
   }
 }
 
-async function updateJson(relativePath, update) {
-  const filePath = path.join(projectRoot, relativePath);
-  const value = JSON.parse(await fs.readFile(filePath, 'utf8'));
-  update(value);
+async function readJson(filePath) {
+  return JSON.parse(await fs.readFile(filePath, 'utf8'));
+}
+
+async function writeJson(filePath, value) {
   await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
 }

--- a/scripts/sync-release-version.mjs
+++ b/scripts/sync-release-version.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+// Synchronizes package metadata to the GitHub release version before npm publishing.
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const args = process.argv.slice(2);
+const versionArg = args.find((arg) => !arg.startsWith('--'));
+const rootArg = args.find((arg) => arg.startsWith('--root='));
+const projectRoot = path.resolve(
+  rootArg ? rootArg.slice('--root='.length) : path.dirname(dirnameFromImportMeta(import.meta.url)),
+);
+const version = normalizeVersion(versionArg ?? process.env.BRIDL_RELEASE_VERSION ?? process.env.GITHUB_REF_NAME);
+
+if (version === undefined) {
+  throw new Error('Usage: node scripts/sync-release-version.mjs <version|vversion> [--root=<path>]');
+}
+
+await updateJson('package.json', (packageJson) => {
+  assertPackageName(packageJson);
+  packageJson.version = version;
+});
+
+await updateJson('package-lock.json', (lockfile) => {
+  assertPackageName(lockfile);
+  lockfile.version = version;
+
+  if (lockfile.packages?.[''] === undefined) {
+    throw new Error("Expected package-lock.json to include packages[''] root package metadata.");
+  }
+
+  assertPackageName(lockfile.packages['']);
+  lockfile.packages[''].version = version;
+});
+
+console.log(`Synchronized Bridl release metadata to ${version}.`);
+
+function dirnameFromImportMeta(importMetaUrl) {
+  return path.dirname(fileURLToPath(importMetaUrl));
+}
+
+function normalizeVersion(rawVersion) {
+  if (rawVersion === undefined || rawVersion === '') {
+    return undefined;
+  }
+
+  const version = rawVersion.startsWith('v') ? rawVersion.slice(1) : rawVersion;
+
+  if (!isSemanticVersion(version)) {
+    throw new Error(`Invalid Bridl release version: ${rawVersion}`);
+  }
+
+  return version;
+}
+
+function isSemanticVersion(version) {
+  return /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/.test(
+    version,
+  );
+}
+
+function assertPackageName(packageJson) {
+  if (packageJson.name !== 'bridl') {
+    throw new Error(`Expected package name 'bridl' but found '${packageJson.name}'.`);
+  }
+}
+
+async function updateJson(relativePath, update) {
+  const filePath = path.join(projectRoot, relativePath);
+  const value = JSON.parse(await fs.readFile(filePath, 'utf8'));
+  update(value);
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}

--- a/tests/unit/release-version-script.test.ts
+++ b/tests/unit/release-version-script.test.ts
@@ -86,15 +86,26 @@ describe('release version synchronization script', () => {
     delete (missingRootPackageLockfile.packages as Record<string, unknown>)[''];
     writeJson(join(missingLockfileRootPackageRoot, 'package-lock.json'), missingRootPackageLockfile);
 
-    const originalPackageJson = readFileSync(join(invalidVersionRoot, 'package.json'), 'utf8');
-    const originalPackageLockJson = readFileSync(join(invalidVersionRoot, 'package-lock.json'), 'utf8');
+    const originalInvalidVersionPackageJson = readFileSync(join(invalidVersionRoot, 'package.json'), 'utf8');
+    const originalInvalidVersionPackageLockJson = readFileSync(join(invalidVersionRoot, 'package-lock.json'), 'utf8');
+    const originalLockfileMismatchPackageJson = readFileSync(join(lockfileMismatchRoot, 'package.json'), 'utf8');
+    const originalLockfileMismatchPackageLockJson = readFileSync(
+      join(lockfileMismatchRoot, 'package-lock.json'),
+      'utf8',
+    );
 
     expect(() => runScript(invalidVersionRoot, '01.2.3')).toThrow('Invalid Bridl release version: 01.2.3');
-    expect(readFileSync(join(invalidVersionRoot, 'package.json'), 'utf8')).toBe(originalPackageJson);
-    expect(readFileSync(join(invalidVersionRoot, 'package-lock.json'), 'utf8')).toBe(originalPackageLockJson);
+    expect(readFileSync(join(invalidVersionRoot, 'package.json'), 'utf8')).toBe(originalInvalidVersionPackageJson);
+    expect(readFileSync(join(invalidVersionRoot, 'package-lock.json'), 'utf8')).toBe(
+      originalInvalidVersionPackageLockJson,
+    );
     expect(() => runScript(invalidVersionRoot, '1.2.3-a..b')).toThrow('Invalid Bridl release version: 1.2.3-a..b');
     expect(() => runScript(packageMismatchRoot, '1.2.3')).toThrow("Expected package name 'bridl'");
     expect(() => runScript(lockfileMismatchRoot, '1.2.3')).toThrow("Expected package name 'bridl'");
+    expect(readFileSync(join(lockfileMismatchRoot, 'package.json'), 'utf8')).toBe(originalLockfileMismatchPackageJson);
+    expect(readFileSync(join(lockfileMismatchRoot, 'package-lock.json'), 'utf8')).toBe(
+      originalLockfileMismatchPackageLockJson,
+    );
     expect(() => runScript(missingLockfileRootPackageRoot, '1.2.3')).toThrow(
       "Expected package-lock.json to include packages[''] root package metadata.",
     );

--- a/tests/unit/release-version-script.test.ts
+++ b/tests/unit/release-version-script.test.ts
@@ -1,0 +1,102 @@
+// Tests the release metadata synchronization script used by the npm publish workflow.
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const temporaryRoots: string[] = [];
+const scriptPath = resolve('scripts/sync-release-version.mjs');
+
+const createTemporaryPackageRoot = (packageName = 'bridl', lockfilePackageName = packageName): string => {
+  const root = mkdtempSync(join(tmpdir(), 'bridl-release-version-'));
+  temporaryRoots.push(root);
+  writeJson(join(root, 'package.json'), { name: packageName, version: '0.1.0' });
+  writeJson(join(root, 'package-lock.json'), {
+    name: lockfilePackageName,
+    version: '0.1.0',
+    lockfileVersion: 3,
+    packages: {
+      '': { name: lockfilePackageName, version: '0.1.0' },
+    },
+  });
+  return root;
+};
+
+const writeJson = (path: string, value: unknown): void => {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+};
+
+const readJson = (path: string): Record<string, unknown> =>
+  JSON.parse(readFileSync(path, 'utf8')) as Record<string, unknown>;
+
+const runScript = (root: string, version?: string, env: NodeJS.ProcessEnv = {}): string =>
+  execFileSync(process.execPath, [scriptPath, ...(version === undefined ? [] : [version]), `--root=${root}`], {
+    encoding: 'utf8',
+    env: { ...process.env, BRIDL_RELEASE_VERSION: undefined, GITHUB_REF_NAME: undefined, ...env },
+  });
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('release version synchronization script', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-009.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('normalizes release tags and updates package metadata consistently', () => {
+    const root = createTemporaryPackageRoot();
+
+    expect(runScript(root, 'v1.2.3-alpha.1+build.5')).toContain(
+      'Synchronized Bridl release metadata to 1.2.3-alpha.1+build.5.',
+    );
+
+    expect(readJson(join(root, 'package.json')).version).toBe('1.2.3-alpha.1+build.5');
+    const lockfile = readJson(join(root, 'package-lock.json'));
+    expect(lockfile.version).toBe('1.2.3-alpha.1+build.5');
+    expect((lockfile.packages as Record<string, Record<string, unknown>>)['']?.version).toBe('1.2.3-alpha.1+build.5');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-009.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('uses release version sources in precedence order', () => {
+    const explicitRoot = createTemporaryPackageRoot();
+    const bridlEnvRoot = createTemporaryPackageRoot();
+    const githubEnvRoot = createTemporaryPackageRoot();
+
+    runScript(explicitRoot, '1.0.0', { BRIDL_RELEASE_VERSION: '2.0.0', GITHUB_REF_NAME: 'v3.0.0' });
+    runScript(bridlEnvRoot, undefined, { BRIDL_RELEASE_VERSION: '2.0.0', GITHUB_REF_NAME: 'v3.0.0' });
+    runScript(githubEnvRoot, undefined, { GITHUB_REF_NAME: 'v3.0.0' });
+
+    expect(readJson(join(explicitRoot, 'package.json')).version).toBe('1.0.0');
+    expect(readJson(join(bridlEnvRoot, 'package.json')).version).toBe('2.0.0');
+    expect(readJson(join(githubEnvRoot, 'package.json')).version).toBe('3.0.0');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-009.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('rejects invalid versions and package metadata mismatches', () => {
+    const invalidVersionRoot = createTemporaryPackageRoot();
+    const packageMismatchRoot = createTemporaryPackageRoot('not-bridl');
+    const lockfileMismatchRoot = createTemporaryPackageRoot('bridl', 'not-bridl');
+    const missingLockfileRootPackageRoot = createTemporaryPackageRoot();
+    const missingRootPackageLockfile = readJson(join(missingLockfileRootPackageRoot, 'package-lock.json'));
+    delete (missingRootPackageLockfile.packages as Record<string, unknown>)[''];
+    writeJson(join(missingLockfileRootPackageRoot, 'package-lock.json'), missingRootPackageLockfile);
+
+    const originalPackageJson = readFileSync(join(invalidVersionRoot, 'package.json'), 'utf8');
+    const originalPackageLockJson = readFileSync(join(invalidVersionRoot, 'package-lock.json'), 'utf8');
+
+    expect(() => runScript(invalidVersionRoot, '01.2.3')).toThrow('Invalid Bridl release version: 01.2.3');
+    expect(readFileSync(join(invalidVersionRoot, 'package.json'), 'utf8')).toBe(originalPackageJson);
+    expect(readFileSync(join(invalidVersionRoot, 'package-lock.json'), 'utf8')).toBe(originalPackageLockJson);
+    expect(() => runScript(invalidVersionRoot, '1.2.3-a..b')).toThrow('Invalid Bridl release version: 1.2.3-a..b');
+    expect(() => runScript(packageMismatchRoot, '1.2.3')).toThrow("Expected package name 'bridl'");
+    expect(() => runScript(lockfileMismatchRoot, '1.2.3')).toThrow("Expected package name 'bridl'");
+    expect(() => runScript(missingLockfileRootPackageRoot, '1.2.3')).toThrow(
+      "Expected package-lock.json to include packages[''] root package metadata.",
+    );
+  });
+});

--- a/tests/unit/release-workflow.test.ts
+++ b/tests/unit/release-workflow.test.ts
@@ -53,6 +53,9 @@ describe('release workflow', () => {
     expect(findStep(workflow, 'Sync release version').run).toBe(
       'node scripts/sync-release-version.mjs "${GITHUB_REF_NAME}"',
     );
+    expect(findStep(workflow, 'Format synchronized release metadata').run).toBe(
+      'npm exec -- prettier --write package.json package-lock.json',
+    );
     expect(findStep(workflow, 'Run CI checks').run).toBe('npm run check-ci');
     expect(findStep(workflow, 'Build package').run).toBe('npm run build');
     expect(findStep(workflow, 'Publish package to npm')).toMatchObject({

--- a/tests/unit/release-workflow.test.ts
+++ b/tests/unit/release-workflow.test.ts
@@ -1,0 +1,73 @@
+// Tests the GitHub Actions workflow that publishes Bridl to npm.
+import { readFileSync } from 'node:fs';
+
+import { parse } from 'yaml';
+import { describe, expect, it } from 'vitest';
+
+interface WorkflowStep {
+  readonly name?: string;
+  readonly uses?: string;
+  readonly run?: string;
+  readonly with?: Readonly<Record<string, string | boolean>>;
+  readonly env?: Readonly<Record<string, string>>;
+}
+
+interface WorkflowJob {
+  readonly steps: readonly WorkflowStep[];
+}
+
+interface WorkflowDocument {
+  readonly on: {
+    readonly release: {
+      readonly types: readonly string[];
+    };
+  };
+  readonly jobs: {
+    readonly 'publish-npm': WorkflowJob;
+  };
+}
+
+const loadReleaseWorkflow = (): WorkflowDocument =>
+  parse(readFileSync('.github/workflows/release.yml', 'utf8')) as WorkflowDocument;
+
+const findStep = (workflow: WorkflowDocument, stepName: string): WorkflowStep => {
+  const step = workflow.jobs['publish-npm'].steps.find((step) => step.name === stepName);
+
+  if (step === undefined) {
+    throw new Error(`Missing release workflow step '${stepName}'.`);
+  }
+
+  return step;
+};
+
+describe('release workflow', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-009.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('publishes the bridl npm package only after release preparation and checks', () => {
+    const workflow = loadReleaseWorkflow();
+    const stepNames = workflow.jobs['publish-npm'].steps.map((step) => step.name);
+
+    expect(workflow.on.release.types).toEqual(['published']);
+    expect(findStep(workflow, 'Setup Node.js').with?.['registry-url']).toBe('https://registry.npmjs.org/');
+    expect(findStep(workflow, 'Install dependencies').run).toBe('npm ci');
+    expect(findStep(workflow, 'Sync release version').run).toBe(
+      'node scripts/sync-release-version.mjs "${GITHUB_REF_NAME}"',
+    );
+    expect(findStep(workflow, 'Run CI checks').run).toBe('npm run check-ci');
+    expect(findStep(workflow, 'Build package').run).toBe('npm run build');
+    expect(findStep(workflow, 'Publish package to npm')).toMatchObject({
+      run: 'npm publish --access public',
+      env: { NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}' },
+    });
+    expect(stepNames).toEqual([
+      'Checkout',
+      'Setup Node.js',
+      'Install dependencies',
+      'Sync release version',
+      'Format synchronized release metadata',
+      'Run CI checks',
+      'Build package',
+      'Publish package to npm',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a release-published GitHub Actions workflow that builds and publishes the public bridl npm package
- add release metadata synchronization from release tags into package.json and package-lock.json
- add BRIDL-REQ-009 release publishing requirements plus tests for metadata sync and workflow structure
- add DeepReview rules for release workflow and metadata sync safety

## Validation
- npm test -- tests/unit/release-version-script.test.ts tests/unit/release-workflow.test.ts
- npm run check-ci
- DeepWork /review completed with no remaining review tasks