### PR TITLE
Polish documentation landing page

### DIFF
--- a/doc/controllable-elements.md
+++ b/doc/controllable-elements.md
@@ -1,7 +1,7 @@
 # Controllable Elements
 
 This document defines cross-agent-CLI concepts that Bridl profiles may control.
-Pi is the planned first supported CLI, but this project skeleton does not yet implement runtime adapter support.
+Pi is the first supported CLI.
 Other CLIs are listed to keep the model generic and to clarify future adapter work.
 
 Status values:
@@ -126,27 +126,27 @@ An early-startup customization used to register providers, tools, hooks, or addi
 
 ## Support Matrix
 
-| Controllable Element        | Pi      | Claude  |
-| --------------------------- | ------- | ------- |
-| Agent Config Directory      | Roadmap | Roadmap |
-| Session Directory           | Roadmap | Roadmap |
-| Extensions                  | Roadmap | Roadmap |
-| Skills                      | Roadmap | Roadmap |
-| Prompt Templates            | Roadmap | Roadmap |
-| System Prompt               | Roadmap | Roadmap |
-| Appended System Prompt      | Roadmap | Roadmap |
-| Model Selection             | Roadmap | Roadmap |
-| Credentials and Environment | Roadmap | Roadmap |
-| Tool Availability           | Roadmap | Roadmap |
-| Context Files               | Roadmap | Roadmap |
-| Theme / UI Presentation     | Roadmap | Roadmap |
-| Project Override Policy     | Roadmap | Roadmap |
-| Working Directory           | Roadmap | Roadmap |
-| Pass-through Arguments      | Roadmap | Roadmap |
-| Bootstrap Hook              | Roadmap | Roadmap |
+| Controllable Element        | Pi        | Claude  |
+| --------------------------- | --------- | ------- |
+| Agent Config Directory      | Supported | Roadmap |
+| Session Directory           | Supported | Roadmap |
+| Extensions                  | Supported | Roadmap |
+| Skills                      | Supported | Roadmap |
+| Prompt Templates            | Supported | Roadmap |
+| System Prompt               | Supported | Roadmap |
+| Appended System Prompt      | Supported | Roadmap |
+| Model Selection             | Supported | Roadmap |
+| Credentials and Environment | Supported | Roadmap |
+| Tool Availability           | Roadmap   | Roadmap |
+| Context Files               | Roadmap   | Roadmap |
+| Theme / UI Presentation     | Roadmap   | Roadmap |
+| Project Override Policy     | Roadmap   | Roadmap |
+| Working Directory           | Roadmap   | Roadmap |
+| Pass-through Arguments      | Supported | Roadmap |
+| Bootstrap Hook              | Supported | Roadmap |
 
 ## Day-One Interpretation
 
 For v1, a Bridl profile may describe all defined terms generically.
-The Pi adapter is the first implementation target, and its matrix entries should move from Roadmap to Supported only as tested adapter behavior lands.
+The Pi adapter is the first implementation, and its Supported matrix entries identify tested adapter behavior.
 Any non-Pi adapter should be considered experimental until its matrix entries are upgraded from Roadmap to Supported.

--- a/doc_site/app/globals.css
+++ b/doc_site/app/globals.css
@@ -1,169 +1,764 @@
+@import url('https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700;800&family=Geist+Mono:wght@400;500;600&family=Instrument+Serif:ital@0;1&display=swap');
+
 :root {
-  --bridl-accent: #6d5dfc;
-  --bridl-accent-2: #00a6a6;
-  --bridl-border: color-mix(in srgb, currentColor 18%, transparent);
-  --bridl-muted-bg: color-mix(in srgb, currentColor 5%, transparent);
+  --bridl-bg: #09090b;
+  --bridl-bg-2: #0d0d11;
+  --bridl-panel: #111116;
+  --bridl-panel-2: #16161d;
+  --bridl-border: rgba(255, 255, 255, 0.09);
+  --bridl-border-2: rgba(255, 255, 255, 0.15);
+  --bridl-fg: #fafafa;
+  --bridl-muted: #c7c7d1;
+  --bridl-dim: #8b8b97;
+  --bridl-indigo: #7c6dff;
+  --bridl-indigo-2: #9a8cff;
+  --bridl-cyan: #34e3e3;
+  --bridl-teal: #18b8a6;
+  --bridl-green: #46d39a;
+  --bridl-amber: #f5b657;
+  --bridl-font: 'Geist', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --bridl-mono: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  --bridl-serif: 'Instrument Serif', Georgia, serif;
+}
+
+.bridl-landing {
+  width: min(100vw, calc(100vw - var(--removed-body-scroll-bar-size, 0px)));
+  margin: -2rem calc(50% - 50vw) 0;
+  overflow: hidden;
+  background: var(--bridl-bg);
+  color: var(--bridl-fg);
+  font-family: var(--bridl-font);
+  line-height: 1.5;
+}
+
+.bridl-landing * {
+  box-sizing: border-box;
+}
+
+.bridl-landing a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.bridl-wrap {
+  width: min(1180px, calc(100% - 56px));
+  margin: 0 auto;
 }
 
 .bridl-hero {
-  display: grid;
-  gap: 1.5rem;
-  margin: 2rem 0 3rem;
-  padding: 2rem;
-  border: 1px solid var(--bridl-border);
-  border-radius: 1.5rem;
-  background:
-    radial-gradient(circle at top left, color-mix(in srgb, var(--bridl-accent) 22%, transparent), transparent 34rem),
-    radial-gradient(
-      circle at bottom right,
-      color-mix(in srgb, var(--bridl-accent-2) 18%, transparent),
-      transparent 28rem
-    ),
-    var(--bridl-muted-bg);
+  position: relative;
+  overflow: hidden;
+  border-bottom: 1px solid var(--bridl-border);
 }
 
-.bridl-eyebrow {
+.bridl-hero-bg,
+.bridl-hero-bg > * {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.bridl-dots {
+  background-image: radial-gradient(rgba(255, 255, 255, 0.075) 1px, transparent 1px);
+  background-size: 24px 24px;
+  mask-image: radial-gradient(ellipse 70% 60% at 50% 30%, #000 35%, transparent 78%);
+}
+
+.bridl-glow {
+  left: 50%;
+  top: -16%;
+  width: min(1000px, 120vw);
+  height: 560px;
+  transform: translateX(-50%);
+  border-radius: 999px;
+  background: radial-gradient(
+    ellipse at center,
+    rgba(124, 109, 255, 0.34),
+    rgba(52, 227, 227, 0.11) 42%,
+    transparent 70%
+  );
+  filter: blur(20px);
+}
+
+.bridl-beam {
+  width: 1.5px;
+  height: 900px;
+  margin-top: -90px;
+  background: linear-gradient(transparent, rgba(124, 109, 255, 0.7), rgba(52, 227, 227, 0.35), transparent);
+  animation: bridl-beam 9s ease-in-out infinite alternate;
+}
+
+.beam-one {
+  left: 20%;
+  transform: rotate(-16deg);
+}
+.beam-two {
+  left: 52%;
+  transform: rotate(-11deg);
+  animation-delay: -3s;
+}
+.beam-three {
+  left: 78%;
+  transform: rotate(-18deg);
+  animation-delay: -6s;
+}
+
+@keyframes bridl-beam {
+  from {
+    opacity: 0.35;
+  }
+  to {
+    opacity: 0.9;
+  }
+}
+
+.bridl-hero-inner {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 1.05fr 0.95fr;
+  gap: 54px;
+  align-items: center;
+  padding: 72px 0 84px;
+}
+
+.bridl-copy {
+  display: grid;
+  gap: 24px;
+}
+
+.bridl-badge {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  gap: 9px;
   margin: 0;
-  color: var(--bridl-accent);
-  font-size: 0.78rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  padding: 6px 14px 6px 12px;
+  border: 1px solid var(--bridl-border-2);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--bridl-muted);
+  font-size: 13px;
+}
+
+.bridl-badge span {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--bridl-green);
+  box-shadow: 0 0 0 4px rgba(70, 211, 154, 0.18);
 }
 
 .bridl-hero h1 {
-  max-width: 14ch;
+  max-width: 13ch;
   margin: 0;
-  font-size: clamp(2.6rem, 8vw, 5.25rem);
-  line-height: 0.95;
-  letter-spacing: -0.06em;
+  font-size: clamp(42px, 6.4vw, 76px);
+  font-weight: 600;
+  letter-spacing: -0.05em;
+  line-height: 1.02;
+}
+
+.bridl-hero h1 span,
+.bridl-cta em {
+  background: linear-gradient(100deg, var(--bridl-indigo-2), var(--bridl-cyan));
+  background-clip: text;
+  color: transparent;
 }
 
 .bridl-lede {
-  max-width: 54rem;
+  max-width: 48ch;
   margin: 0;
-  font-size: clamp(1.1rem, 2vw, 1.35rem);
-  line-height: 1.55;
+  color: var(--bridl-muted);
+  font-size: clamp(16px, 1.6vw, 19px);
+  line-height: 1.62;
 }
 
 .bridl-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 12px;
+  align-items: center;
 }
 
 .bridl-button {
   display: inline-flex;
+  height: 46px;
   align-items: center;
-  justify-content: center;
-  padding: 0.7rem 1rem;
-  border-radius: 999px;
-  background: var(--bridl-accent);
-  color: white;
-  font-weight: 700;
-  text-decoration: none;
+  border-radius: 11px;
+  padding: 0 20px;
+  font-size: 15px;
+  font-weight: 650;
+  transition:
+    transform 0.14s ease,
+    box-shadow 0.2s ease,
+    background 0.2s ease;
 }
 
-.bridl-button.secondary {
-  border: 1px solid var(--bridl-border);
+.bridl-button:hover {
+  transform: translateY(-1px);
+}
+
+.bridl-button.primary {
+  background: linear-gradient(180deg, var(--bridl-indigo-2), var(--bridl-indigo));
+  box-shadow:
+    0 0 0 1px rgba(124, 109, 255, 0.5),
+    0 14px 40px -10px rgba(124, 109, 255, 0.75),
+    inset 0 1px 0 rgba(255, 255, 255, 0.25);
+  color: white;
+}
+
+.bridl-button.ghost {
+  border: 1px solid var(--bridl-border-2);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--bridl-fg);
+}
+
+.bridl-sub {
+  margin: 0;
+  color: #6f6f7b;
+  font-family: var(--bridl-mono);
+  font-size: 13px;
+}
+
+.bridl-sub code,
+.bridl-landing code {
+  font-family: var(--bridl-mono);
+}
+
+.bridl-terminal,
+.bridl-config-card {
+  overflow: hidden;
+  border: 1px solid var(--bridl-border-2);
+  border-radius: 14px;
+  background: linear-gradient(180deg, #0c0c12, #0a0a0e);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.05) inset,
+    0 30px 80px -30px rgba(0, 0, 0, 0.9),
+    0 0 60px -20px rgba(124, 109, 255, 0.4);
+}
+
+.bridl-float {
+  animation: bridl-float 7s ease-in-out infinite;
+}
+
+@keyframes bridl-float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-9px);
+  }
+}
+
+.bridl-termbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 11px 14px;
+  border-bottom: 1px solid var(--bridl-border);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.bridl-termbar i {
+  width: 11px;
+  height: 11px;
+  border-radius: 999px;
+}
+
+.bridl-termbar i:nth-child(1) {
+  background: #ff5f57;
+}
+.bridl-termbar i:nth-child(2) {
+  background: #febc2e;
+}
+.bridl-termbar i:nth-child(3) {
+  background: #28c840;
+}
+.bridl-termbar span {
+  margin-left: 8px;
+  color: #6f6f7b;
+  font: 12px var(--bridl-mono);
+}
+
+.bridl-terminal pre,
+.bridl-config-card pre {
+  margin: 0;
+  padding: 18px 20px 22px;
+  overflow: auto;
   background: transparent;
-  color: inherit;
+  color: var(--bridl-muted);
+  font: 13px/1.8 var(--bridl-mono);
 }
 
-.bridl-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
-  gap: 1rem;
-  margin: 1.5rem 0 2rem;
+.prompt,
+.arrow {
+  color: var(--bridl-indigo-2);
+}
+.flag,
+.ok {
+  color: var(--bridl-cyan);
+}
+.value {
+  color: var(--bridl-amber);
+}
+.dim {
+  color: #6f6f7b;
+}
+.cursor {
+  display: inline-block;
+  width: 8px;
+  height: 15px;
+  margin-left: 2px;
+  background: var(--bridl-cyan);
+  vertical-align: -2px;
+  animation: bridl-blink 1s steps(1) infinite;
 }
 
-.bridl-card,
-.bridl-layer-card {
-  border: 1px solid var(--bridl-border);
-  border-radius: 1rem;
-  background: var(--bridl-muted-bg);
+@keyframes bridl-blink {
+  50% {
+    opacity: 0;
+  }
 }
 
-.bridl-card {
-  padding: 1.15rem;
+.bridl-strip {
+  border-bottom: 1px solid var(--bridl-border);
+  background: var(--bridl-bg-2);
 }
 
-.bridl-card h3,
-.bridl-layer-card h3 {
-  margin-top: 0;
-}
-
-.bridl-layer-illustration {
-  display: grid;
-  gap: 1rem;
-  margin: 1.5rem 0 2rem;
-}
-
-.bridl-layer-card {
-  position: relative;
-  padding: 1rem;
-}
-
-.bridl-layer-card::before {
-  display: inline-flex;
-  width: 2rem;
-  height: 2rem;
+.bridl-strip .bridl-wrap {
+  display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  justify-content: center;
-  margin-right: 0.5rem;
+  gap: 24px;
+  padding: 22px 0;
+  color: var(--bridl-dim);
+}
+
+.bridl-strip strong {
+  color: #686875;
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.bridl-strip span {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--bridl-muted);
+  font-weight: 550;
+}
+.bridl-strip i {
+  width: 7px;
+  height: 7px;
   border-radius: 999px;
-  background: var(--bridl-accent);
-  color: white;
-  content: attr(data-step);
+}
+.bridl-strip .indigo {
+  background: var(--bridl-indigo-2);
+}
+.bridl-strip .cyan {
+  background: var(--bridl-cyan);
+}
+.bridl-strip .teal {
+  background: var(--bridl-teal);
+}
+.bridl-strip em {
+  color: #686875;
+  font-style: normal;
+}
+
+.bridl-section {
+  padding: 96px 0;
+}
+.bridl-eyebrow {
+  margin: 0 0 14px;
+  color: var(--bridl-indigo-2);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.bridl-section-head {
+  max-width: 720px;
+}
+.bridl-section h2,
+.bridl-cta h2,
+.bridl-showcase h2 {
+  margin: 0 0 14px;
+  font-size: clamp(29px, 3.7vw, 44px);
+  font-weight: 600;
+  letter-spacing: -0.04em;
+  line-height: 1.08;
+}
+.bridl-section-head p {
+  margin: 0;
+  color: var(--bridl-dim);
+  font-size: 17px;
+  line-height: 1.6;
+}
+
+.bridl-cards {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 18px;
+  margin-top: 52px;
+}
+.bridl-card {
+  position: relative;
+  overflow: hidden;
+  min-height: 230px;
+  padding: 24px 22px 26px;
+  border: 1px solid var(--bridl-border);
+  border-radius: 14px;
+  background: linear-gradient(180deg, var(--bridl-panel), var(--bridl-bg-2));
+  transition:
+    transform 0.25s ease,
+    border-color 0.25s ease;
+}
+.bridl-card:hover {
+  transform: translateY(-3px);
+  border-color: var(--bridl-border-2);
+}
+.bridl-card::after {
+  content: '';
+  position: absolute;
+  inset: auto -40% -55% -40%;
+  height: 140px;
+  background: radial-gradient(ellipse, rgba(124, 109, 255, 0.25), transparent 70%);
+}
+.bridl-card div {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  place-items: center;
+  margin-bottom: 18px;
+  border: 1px solid var(--bridl-border-2);
+  border-radius: 11px;
+  background: linear-gradient(160deg, rgba(124, 109, 255, 0.22), rgba(52, 227, 227, 0.12));
+  color: var(--bridl-indigo-2);
+  font-size: 20px;
+}
+.bridl-card h3 {
+  margin: 0 0 9px;
+  font-size: 17px;
+  font-weight: 650;
+}
+.bridl-card p {
+  margin: 0;
+  color: var(--bridl-dim);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.bridl-layers-band {
+  border-block: 1px solid var(--bridl-border);
+  background: var(--bridl-bg-2);
+}
+.bridl-layers {
+  display: grid;
+  grid-template-columns: 1fr 1.1fr;
+  gap: 56px;
+  align-items: center;
+  margin-top: 54px;
+}
+.bridl-layer-list {
+  display: grid;
+  gap: 14px;
+}
+.bridl-layer-list > div {
+  display: grid;
+  grid-template-columns: 30px 1fr;
+  gap: 14px 16px;
+  padding: 18px;
+  border: 1px solid var(--bridl-border);
+  border-radius: 14px;
+  background: var(--bridl-panel);
+}
+.bridl-layer-list span {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border: 1px solid var(--bridl-border-2);
+  border-radius: 9px;
+  background: rgba(124, 109, 255, 0.13);
+  color: var(--bridl-indigo-2);
+  font: 600 13px var(--bridl-mono);
+}
+.bridl-layer-list h3 {
+  margin: 0 0 5px;
+  font-size: 15px;
+}
+.bridl-layer-list p {
+  margin: 0;
+  color: var(--bridl-dim);
+  font-size: 13.5px;
+  line-height: 1.55;
+}
+.bridl-layer-list code {
+  padding: 1px 6px;
+  border: 1px solid rgba(52, 227, 227, 0.16);
+  border-radius: 6px;
+  background: rgba(52, 227, 227, 0.08);
+  color: var(--bridl-cyan);
+}
+
+.bridl-stack {
+  display: grid;
+  justify-items: center;
+}
+.stack-card,
+.stack-result {
+  width: min(380px, 88%);
+  padding: 15px 18px;
+  border: 1px solid var(--bridl-border-2);
+  border-radius: 13px;
+  background: linear-gradient(180deg, var(--bridl-panel-2), var(--bridl-panel));
+  box-shadow: 0 16px 40px -24px rgba(0, 0, 0, 0.9);
+}
+.stack-card small,
+.stack-result small {
+  display: block;
+  margin-bottom: 7px;
+  color: #70707b;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.stack-card b,
+.stack-result b {
+  color: var(--bridl-muted);
+  font: 500 13px var(--bridl-mono);
+}
+.stack-card.a {
+  transform: rotate(-1.4deg);
+}
+.stack-card.b {
+  z-index: 2;
+  margin-top: -7px;
+  transform: rotate(0.7deg);
+}
+.stack-card.c {
+  z-index: 3;
+  margin-top: -7px;
+  transform: rotate(1.4deg);
+}
+.stack-plus {
+  z-index: 4;
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  margin: 12px 0;
+  border: 1px solid var(--bridl-border-2);
+  border-radius: 999px;
+  background: var(--bridl-bg);
+  color: var(--bridl-indigo-2);
+  box-shadow: 0 0 24px -6px rgba(124, 109, 255, 0.7);
   font-weight: 800;
 }
-
-.bridl-layer-card h3 {
-  display: inline;
+.stack-result {
+  border-color: rgba(124, 109, 255, 0.45);
+  background: linear-gradient(180deg, rgba(124, 109, 255, 0.14), rgba(52, 227, 227, 0.05));
+  box-shadow:
+    0 0 0 1px rgba(124, 109, 255, 0.25),
+    0 22px 60px -28px rgba(124, 109, 255, 0.7);
+}
+.stack-result small {
+  color: var(--bridl-indigo-2);
+}
+.stack-result b {
+  color: var(--bridl-fg);
+}
+.stack-launch {
+  margin-top: 18px;
+  padding: 10px 17px;
+  border-radius: 999px;
+  background: linear-gradient(100deg, var(--bridl-cyan), var(--bridl-indigo-2));
+  color: var(--bridl-bg);
+  font: 700 13px var(--bridl-mono);
 }
 
-.bridl-layer-text {
-  margin-top: 1rem;
+.bridl-showcase {
+  display: grid;
+  grid-template-columns: 0.9fr 1.1fr;
+  gap: 54px;
+  align-items: center;
+}
+.bridl-feature-list {
+  display: grid;
+  gap: 20px;
+  margin-top: 28px;
+}
+.bridl-feature-list p {
+  margin: 0;
+  color: var(--bridl-dim);
+  font-size: 14px;
+  line-height: 1.6;
+}
+.bridl-feature-list strong {
+  color: var(--bridl-fg);
+  font-size: 15px;
+}
+.bridl-feature-list code {
+  color: var(--bridl-cyan);
+}
+.bridl-config-card > div {
+  display: flex;
+  border-bottom: 1px solid var(--bridl-border);
+}
+.bridl-config-card > div span {
+  padding: 11px 15px;
+  color: #70707b;
+  font: 12px var(--bridl-mono);
+}
+.bridl-config-card > div .active {
+  border-bottom: 2px solid var(--bridl-indigo);
+  background: rgba(124, 109, 255, 0.07);
+  color: var(--bridl-fg);
 }
 
-.bridl-layer-text p,
-.bridl-layer-text :last-child {
-  margin-bottom: 0;
+.bridl-matrix-wrap {
+  margin-top: 52px;
+  overflow: auto;
+  border: 1px solid var(--bridl-border);
+  border-radius: 14px;
+  background: var(--bridl-panel);
 }
-
-.bridl-merge-arrow {
-  justify-self: center;
-  color: var(--bridl-accent);
-  font-size: 1.5rem;
-  font-weight: 900;
-}
-
 .bridl-matrix {
   width: 100%;
-  margin: 1.5rem 0 2rem;
+  min-width: 720px;
   border-collapse: collapse;
-  font-size: 0.92rem;
+  font-size: 14.5px;
 }
-
 .bridl-matrix th,
 .bridl-matrix td {
-  padding: 0.85rem;
-  border: 1px solid var(--bridl-border);
-  vertical-align: top;
-}
-
-.bridl-matrix th {
-  background: var(--bridl-muted-bg);
+  padding: 15px 18px;
+  border-bottom: 1px solid var(--bridl-border);
   text-align: left;
 }
-
-.bridl-matrix td:nth-child(n + 2) {
+.bridl-matrix th {
+  background: var(--bridl-bg-2);
+  color: var(--bridl-dim);
+  font-size: 13px;
+  font-weight: 650;
+}
+.bridl-matrix tr:last-child td {
+  border-bottom: 0;
+}
+.bridl-matrix td:first-child,
+.bridl-matrix th:first-child {
+  width: 38%;
+  color: var(--bridl-fg);
+  font-weight: 550;
+}
+.bridl-matrix td:not(:first-child),
+.bridl-matrix th:not(:first-child) {
   text-align: center;
 }
+.bridl-matrix td:nth-child(2),
+.bridl-matrix th:nth-child(2) {
+  background: linear-gradient(180deg, rgba(124, 109, 255, 0.12), rgba(124, 109, 255, 0.05));
+  color: var(--bridl-indigo-2);
+  font-weight: 800;
+}
+.bridl-matrix td:not(:first-child):not(:nth-child(2)) {
+  color: var(--bridl-green);
+}
+.bridl-matrix td:not(:first-child) {
+  font-size: 18px;
+}
+.bridl-matrix td:not(:first-child):has(+ td) {
+  white-space: nowrap;
+}
 
-.bridl-note {
-  padding: 1rem 1.2rem;
-  border-left: 4px solid var(--bridl-accent-2);
-  border-radius: 0.75rem;
-  background: var(--bridl-muted-bg);
+.bridl-cta {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: 420px;
+  overflow: hidden;
+  border-top: 1px solid var(--bridl-border);
+  text-align: center;
+}
+.bridl-cta::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  bottom: -55%;
+  width: 900px;
+  height: 560px;
+  transform: translateX(-50%);
+  border-radius: 999px;
+  background: radial-gradient(ellipse, rgba(124, 109, 255, 0.3), rgba(52, 227, 227, 0.08) 45%, transparent 72%);
+  filter: blur(10px);
+}
+.bridl-cta > div:not(.bridl-dots) {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  justify-items: center;
+  gap: 20px;
+  width: min(760px, calc(100% - 56px));
+}
+.bridl-cta h2 {
+  margin: 0;
+  font-size: clamp(34px, 4.7vw, 54px);
+}
+.bridl-cta em {
+  font-family: var(--bridl-serif);
+  font-style: italic;
+  font-weight: 400;
+}
+.bridl-cta p:not(.bridl-eyebrow) {
+  margin: 0;
+  color: var(--bridl-muted);
+  font-size: 18px;
+}
+.bridl-cta code {
+  padding: 12px 18px;
+  border: 1px solid var(--bridl-border-2);
+  border-radius: 11px;
+  background: rgba(255, 255, 255, 0.035);
+  color: var(--bridl-muted);
+  font-size: 14px;
+}
+
+@media (max-width: 980px) {
+  .bridl-hero-inner,
+  .bridl-layers,
+  .bridl-showcase {
+    grid-template-columns: 1fr;
+    gap: 40px;
+  }
+  .bridl-cards {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .bridl-terminal {
+    max-width: 720px;
+  }
+}
+
+@media (max-width: 640px) {
+  .bridl-landing {
+    margin-top: -1rem;
+  }
+  .bridl-wrap {
+    width: min(100% - 32px, 1180px);
+  }
+  .bridl-hero-inner {
+    padding: 54px 0 64px;
+  }
+  .bridl-cards {
+    grid-template-columns: 1fr;
+  }
+  .bridl-section {
+    padding: 72px 0;
+  }
+  .bridl-terminal pre,
+  .bridl-config-card pre {
+    font-size: 12px;
+  }
 }

--- a/doc_site/app/globals.css
+++ b/doc_site/app/globals.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700;800&family=Geist+Mono:wght@400;500;600&family=Instrument+Serif:ital@0;1&display=swap');
-
 :root {
   --bridl-bg: #09090b;
   --bridl-bg-2: #0d0d11;
@@ -16,9 +14,9 @@
   --bridl-teal: #18b8a6;
   --bridl-green: #46d39a;
   --bridl-amber: #f5b657;
-  --bridl-font: 'Geist', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
-  --bridl-mono: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  --bridl-serif: 'Instrument Serif', Georgia, serif;
+  --bridl-font: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --bridl-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  --bridl-serif: Georgia, serif;
 }
 
 .bridl-landing {
@@ -391,7 +389,8 @@
   letter-spacing: -0.04em;
   line-height: 1.08;
 }
-.bridl-section-head p {
+.bridl-section-head p,
+.bridl-section-copy {
   margin: 0;
   color: var(--bridl-dim);
   font-size: 17px;
@@ -444,7 +443,8 @@
   font-size: 17px;
   font-weight: 650;
 }
-.bridl-card p {
+.bridl-card p,
+.bridl-card-copy {
   margin: 0;
   color: var(--bridl-dim);
   font-size: 14px;
@@ -490,13 +490,15 @@
   margin: 0 0 5px;
   font-size: 15px;
 }
-.bridl-layer-list p {
+.bridl-layer-list p,
+.bridl-layer-copy {
   margin: 0;
   color: var(--bridl-dim);
   font-size: 13.5px;
   line-height: 1.55;
 }
-.bridl-layer-list code {
+.bridl-layer-list code,
+.bridl-layer-copy code {
   padding: 1px 6px;
   border: 1px solid rgba(52, 227, 227, 0.16);
   border-radius: 6px;
@@ -746,7 +748,7 @@
     margin-top: -1rem;
   }
   .bridl-wrap {
-    width: min(100% - 32px, 1180px);
+    width: min(calc(100% - 32px), 1180px);
   }
   .bridl-hero-inner {
     padding: 54px 0 64px;

--- a/doc_site/app/globals.css
+++ b/doc_site/app/globals.css
@@ -500,6 +500,7 @@
 }
 .bridl-layer-list p,
 .bridl-layer-copy {
+  grid-column: 2;
   margin: 0;
   color: var(--bridl-dim);
   font-size: 13.5px;

--- a/doc_site/app/globals.css
+++ b/doc_site/app/globals.css
@@ -49,11 +49,19 @@
   border-bottom: 1px solid var(--bridl-border);
 }
 
-.bridl-hero-bg,
-.bridl-hero-bg > * {
+.bridl-hero-bg {
   position: absolute;
   inset: 0;
   pointer-events: none;
+}
+
+.bridl-hero-bg > * {
+  position: absolute;
+  pointer-events: none;
+}
+
+.bridl-dots {
+  inset: 0;
 }
 
 .bridl-dots {
@@ -426,7 +434,7 @@
   height: 140px;
   background: radial-gradient(ellipse, rgba(124, 109, 255, 0.25), transparent 70%);
 }
-.bridl-card div {
+.bridl-card > div[aria-hidden='true'] {
   display: grid;
   width: 42px;
   height: 42px;
@@ -672,7 +680,7 @@
 .bridl-matrix td:not(:first-child) {
   font-size: 18px;
 }
-.bridl-matrix td:not(:first-child):has(+ td) {
+.bridl-matrix td:nth-child(n + 2):not(:last-child) {
   white-space: nowrap;
 }
 

--- a/doc_site/app/layout.tsx
+++ b/doc_site/app/layout.tsx
@@ -22,15 +22,14 @@ const footer = <Footer>BUSL-1.1 {new Date().getFullYear()} © Bridl.</Footer>;
 export default async function RootLayout({ children }: { children: ReactNode }): Promise<ReactNode> {
   return (
     <html lang="en" dir="ltr" suppressHydrationWarning>
-      <head>
-        <Head>{null}</Head>
-      </head>
+      <Head faviconGlyph="◇" />
       <body>
         <Layout
           navbar={navbar}
           pageMap={await getPageMap('/')}
           docsRepositoryBase="https://github.com/Unsupervisedcom/bridl/tree/main/doc_site/app"
           footer={footer}
+          nextThemes={{ forcedTheme: 'dark' }}
           sidebar={{ defaultMenuCollapseLevel: 1 }}
           toc={{ backToTop: true }}
         >

--- a/doc_site/app/page.mdx
+++ b/doc_site/app/page.mdx
@@ -3,188 +3,268 @@ title: Bridl Agent Harness Manager
 description: Making your AI Harness manageable, composable and portable
 ---
 
-<div className="bridl-hero">
-  <p className="bridl-eyebrow">Agent harness profiles</p>
-  <h1>Manageable, Composable and Portable Agent Harnesses</h1>
-  <p className="bridl-lede">
-    {
-      'Bridl is the missing layer for agent harness management. It gives you reusable profiles that travel with you between machines, adapt per repository, combine in useful ways, and even work cross-agent.'
-    }
-  </p>
-  <div className="bridl-actions">
-    <a className="bridl-button" href="#why-bridl">
-      Why Bridl?
-    </a>
-    <a className="bridl-button secondary" href="#feature-comparison">
-      Compare the gaps
-    </a>
+<div className="bridl-landing">
+  <section className="bridl-hero">
+    <div className="bridl-hero-bg" aria-hidden="true">
+      <div className="bridl-dots" />
+      <div className="bridl-glow" />
+      <div className="bridl-beam beam-one" />
+      <div className="bridl-beam beam-two" />
+      <div className="bridl-beam beam-three" />
+    </div>
+    <div className="bridl-wrap bridl-hero-inner">
+      <div className="bridl-copy">
+        <p className="bridl-badge"><span /> Agent harness profiles</p>
+        <h1>Your agent harness, <span>finally manageable</span></h1>
+        <p className="bridl-lede">
+          Bridl is the control layer for AI coding agents. Define reusable profiles that travel between machines,
+          adapt per repo, compose in layers, and launch through native agent mechanisms.
+        </p>
+        <div className="bridl-actions">
+          <a className="bridl-button primary" href="#get-started">Get started →</a>
+          <a className="bridl-button ghost" href="#feature-comparison">Compare the gaps</a>
+        </div>
+        <p className="bridl-sub"><code>$ npm i -g bridl</code> · pi-first · profile-driven · deterministic</p>
+      </div>
+      <div className="bridl-terminal bridl-float">
+        <div className="bridl-termbar"><i /><i /><i /><span>bridl — run</span></div>
+        <pre>{`$ bridl run --profile engineering-default
+→ resolving profile  engineering-default
+  ✓ user source      github:nhorton/agent-profiles@main
+  ✓ repo overlay     .bridl/profiles/engineer
+  ✓ merged controls  model=claude-sonnet-4
+  ✓ prepared tack    /tmp/bridl-tack-a91f
+↳ launching pi …`}</pre>
+      </div>
+    </div>
+  </section>
+
+<div className="bridl-strip">
+  <div className="bridl-wrap">
+    <strong>Adapts to</strong>
+    <span>
+      <i className="indigo" /> pi
+    </span>
+    <span>
+      <i className="cyan" /> Claude Code roadmap
+    </span>
+    <span>
+      <i className="teal" /> your own adapters
+    </span>
+    <em>one profile vocabulary, many harnesses</em>
   </div>
 </div>
 
-## Why Bridl?
-
-Today, agent harness configuration is powerful but fragmented:
-
-- **Machine-global settings** are easy to create, but they are tied to a workstation and tend to become a personal junk drawer.
-- **Project-global settings** are useful for repo-specific guidance, but they force every role, language, and task intent through the same defaults.
-- **Some project-global resources are cross-agent**, such as skills lists, but the surrounding settings still often remain harness-specific.
-- **Organization-wide settings exist in limited forms**, but they are usually per-agent and often reserved for enterprise subscriptions.
-
-Bridl fills the gap with **profiles**: portable, composable configuration bundles that express what you want at the product boundary and then let adapters translate those choices into the right files, flags, environment variables, and native agent concepts.
-
-<div className="bridl-grid">
-  <div className="bridl-card">
-    <h3>Dotfile-esque defaults</h3>
+<section className="bridl-section bridl-wrap" id="why-bridl">
+  <p className="bridl-eyebrow">Why Bridl</p>
+  <div className="bridl-section-head">
+    <h2>Agent config is powerful — and fragmented</h2>
     <p>
-      {
-        "Keep user-global settings in source-controlled profile repos instead of burying them in a single machine's home directory."
-      }
+      Machine-global settings rot into a junk drawer. Project settings force every role and language through one
+      default. Bridl fills the gap with portable, composable profiles.
     </p>
   </div>
-  <div className="bridl-card">
-    <h3>Language-specific setups</h3>
-    <p>{'Switch between TypeScript, Python, Rust, docs, or data profiles without rewriting project configuration.'}</p>
+  <div className="bridl-cards">
+    <div className="bridl-card">
+      <div>◇</div>
+      <h3>Like dotfiles, but shared</h3>
+      <p>
+        Keep user-global settings in source-controlled profile repos instead of burying them in one machine's home
+        directory.
+      </p>
+    </div>
+    <div className="bridl-card">
+      <div>⌘</div>
+      <h3>Per-stack setups</h3>
+      <p>Switch between TypeScript, Python, Rust, docs, or data profiles without rewriting project configuration.</p>
+    </div>
+    <div className="bridl-card">
+      <div>◌</div>
+      <h3>Intent-specific modes</h3>
+      <p>Use a PM profile for planning, DevOps for deployment work, and engineering for implementation.</p>
+    </div>
+    <div className="bridl-card">
+      <div>✓</div>
+      <h3>Cross-agent policy</h3>
+      <p>Describe common profile controls once, then let adapters map them into supported native mechanisms.</p>
+    </div>
   </div>
-  <div className="bridl-card">
-    <h3>Intent-specific modes</h3>
-    <p>
-      {
-        'Use a PM profile for planning, a DevOps profile for deployment work, and an engineer profile for implementation.'
-      }
-    </p>
+</section>
+
+<section className="bridl-section bridl-layers-band">
+  <div className="bridl-wrap">
+    <p className="bridl-eyebrow">Layered profiles in practice</p>
+    <div className="bridl-section-head">
+      <h2>Dotfiles, team standards, and repo overrides — resolved into one tack</h2>
+      <p>
+        Bridl combines the relevant layers deterministically, warns when a requested control is unsupported, and
+        prepares a clean runtime tack before launch.
+      </p>
+    </div>
+    <div className="bridl-layers">
+      <div className="bridl-layer-list">
+        <div>
+          <span>1</span>
+          <h3>User profile source</h3>
+          <p>
+            <code>github:nhorton/agent-profiles</code> provides shared skills and machine-independent policy.
+          </p>
+        </div>
+        <div>
+          <span>2</span>
+          <h3>Organization standard</h3>
+          <p>
+            <code>github:acme/agent-standards</code> sets approved defaults and common controls.
+          </p>
+        </div>
+        <div>
+          <span>3</span>
+          <h3>Repository-local profile</h3>
+          <p>
+            <code>.bridl/profiles/engineer</code> adds repo prompts, tools, and safety rules.
+          </p>
+        </div>
+        <div>
+          <span>4</span>
+          <h3>Native agent launch</h3>
+          <p>Adapters translate controls into files, flags, environment variables, skills, prompts, and sessions.</p>
+        </div>
+      </div>
+      <div className="bridl-stack" aria-label="Profile layer stack">
+        <div className="stack-card a">
+          <small>User profile source</small>
+          <b>github:nhorton/agent-profiles</b>
+        </div>
+        <div className="stack-card b">
+          <small>Organization standard</small>
+          <b>github:acme/agent-standards</b>
+        </div>
+        <div className="stack-card c">
+          <small>Repository overlay</small>
+          <b>.bridl/profiles/engineer</b>
+        </div>
+        <div className="stack-plus">＋</div>
+        <div className="stack-result">
+          <small>Resolved profile</small>
+          <b>17 controls merged · 0 conflicts</b>
+        </div>
+        <div className="stack-launch">▶ native agent launch</div>
+      </div>
+    </div>
   </div>
-  <div className="bridl-card">
-    <h3>Cross-agent policy</h3>
-    <p>{'Describe common profile controls once, then let Bridl map them into supported agent-specific mechanisms.'}</p>
-  </div>
+</section>
+
+  <section className="bridl-section bridl-wrap bridl-showcase">
+    <div>
+      <p className="bridl-eyebrow">One command</p>
+      <h2>Select a profile. Launch consistently.</h2>
+      <div className="bridl-feature-list">
+        <p><strong>Pick the right loadout</strong><br />One flag selects language, role, risk level, or intent.</p>
+        <p><strong>Sync from anywhere</strong><br /><code>bridl sync</code> pulls remote settings and profiles before a run.</p>
+        <p><strong>Deterministic every time</strong><br />The same profile resolves to the same tack: reviewable and reproducible.</p>
+      </div>
+    </div>
+    <div className="bridl-config-card">
+      <div><span className="active">profile.yml</span><span>settings.yml</span></div>
+      <pre>{`id: engineering-default
+label: Engineering Default
+inherits:
+  - base-typescript
+
+controls:
+model: anthropic/claude-sonnet-4
+environment:
+TEAM_MODE: engineering
+allow_project_overrides: true`}</pre>
 </div>
 
-## Layered profiles in practice
+  </section>
 
-A Bridl setup can look like a dotfiles repo, a team starter repo, and a project-local override all working together. Functionally, Bridl resolves the relevant layers and launches the agent with one coherent tack of settings.
+<section className="bridl-section bridl-wrap" id="feature-comparison">
+  <p className="bridl-eyebrow">Feature comparison</p>
+  <div className="bridl-section-head">
+    <h2>The configuration gaps Bridl closes</h2>
+  </div>
+  <div className="bridl-matrix-wrap">
+    <table className="bridl-matrix">
+      <thead>
+        <tr>
+          <th>Capability</th>
+          <th>Bridl</th>
+          <th>Claude Enterprise</th>
+          <th>Claude Personal</th>
+          <th>Pi.dev</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>User-wide settings on one machine</td>
+          <td>✓</td>
+          <td>✓</td>
+          <td>✓</td>
+          <td>✓</td>
+        </tr>
+        <tr>
+          <td>Repo-specific guidance and controls</td>
+          <td>✓</td>
+          <td>✓</td>
+          <td>✓</td>
+          <td>✓</td>
+        </tr>
+        <tr>
+          <td>Organization-wide defaults</td>
+          <td>✓</td>
+          <td>✓</td>
+          <td>—</td>
+          <td>—</td>
+        </tr>
+        <tr>
+          <td>Machine-independent user defaults</td>
+          <td>✓</td>
+          <td>—</td>
+          <td>—</td>
+          <td>—</td>
+        </tr>
+        <tr>
+          <td>Different settings by language or stack</td>
+          <td>✓</td>
+          <td>—</td>
+          <td>—</td>
+          <td>—</td>
+        </tr>
+        <tr>
+          <td>Different settings by work intent</td>
+          <td>✓</td>
+          <td>—</td>
+          <td>—</td>
+          <td>—</td>
+        </tr>
+        <tr>
+          <td>Cross-agent settings vocabulary</td>
+          <td>✓</td>
+          <td>—</td>
+          <td>—</td>
+          <td>—</td>
+        </tr>
+        <tr>
+          <td>Deterministic precedence across layers</td>
+          <td>✓</td>
+          <td>—</td>
+          <td>—</td>
+          <td>—</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
 
-<div className="bridl-layer-illustration">
-  <div className="bridl-layer-card" data-step="1">
-    <h3>User profile source</h3>
-    <div className="bridl-layer-text">
-      <code>github: nhorton/agent-profiles</code> provides <code>engineer</code>, shared skills, preferred defaults, and
-      machine-independent personal policy.
+  <section className="bridl-cta" id="get-started">
+    <div className="bridl-dots" aria-hidden="true" />
+    <div>
+      <p className="bridl-eyebrow">Get started</p>
+      <h2>Treat agent setup like <em>real</em> infrastructure</h2>
+      <p>Documented, reviewable, reusable. Put defaults in a profile repo, override only where it matters, and launch consistently.</p>
+      <code>$ npm i -g bridl</code>
     </div>
-  </div>
-  <div className="bridl-merge-arrow">＋</div>
-  <div className="bridl-layer-card" data-step="2">
-    <h3>Repository-local profile</h3>
-    <div className="bridl-layer-text">
-      <code>my_project/.bridl/profiles/engineer/profile.yml</code> adds repo-specific prompts, required tools, language
-      conventions, and project safety rules.
-    </div>
-  </div>
-  <div className="bridl-merge-arrow">↓</div>
-  <div className="bridl-layer-card" data-step="3">
-    <h3>Resolved Bridl profile</h3>
-    <div className="bridl-layer-text">
-      {
-        'Bridl combines these layers deterministically, warns when a requested control is unsupported, and prepares a temporary runtime tack.'
-      }
-    </div>
-  </div>
-  <div className="bridl-merge-arrow">↓</div>
-  <div className="bridl-layer-card" data-step="4">
-    <h3>Native agent launch</h3>
-    <div className="bridl-layer-text">
-      {
-        "Adapters translate the profile into the harness' native files, flags, environment variables, skills, prompts, and session behavior."
-      }
-    </div>
-  </div>
+  </section>
 </div>
-
-<div className="bridl-note">
-  <strong>The point is not to replace native agent configuration.</strong> The point is to make native configuration
-  reproducible, selectable, and shareable across users, repositories, roles, and eventually agent harnesses.
-</div>
-
-## Feature comparison
-
-The table below focuses on the configuration gaps Bridl profiles are designed to close.
-
-<table className="bridl-matrix" id="feature-comparison">
-  <thead>
-    <tr>
-      <th>Capability</th>
-      <th>Bridl</th>
-      <th>Claude Code Personal</th>
-      <th>Claude Code Enterprise</th>
-      <th>Pi.dev</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>User-wide settings on one machine</td>
-      <td>Yes</td>
-      <td>Yes</td>
-      <td>Yes</td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td>Machine-independent user defaults</td>
-      <td>Yes</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <td>Repo-specific guidance and controls</td>
-      <td>Yes</td>
-      <td>Yes</td>
-      <td>Yes</td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td>Organization-wide defaults</td>
-      <td>Yes</td>
-      <td>No</td>
-      <td>Yes</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <td>Different settings by language or stack</td>
-      <td>Yes</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <td>Different settings by work intent</td>
-      <td>Yes</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <td>Cross-agent settings vocabulary</td>
-      <td>Yes</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <td>Deterministic precedence between user, remote, project, and local policy</td>
-      <td>Yes</td>
-      <td>No</td>
-      <td>No</td>
-      <td>No</td>
-    </tr>
-  </tbody>
-</table>
-
-## What this enables
-
-With Bridl, teams and individual developers can treat agent harness setup like real development infrastructure:
-
-1. Put reusable defaults in a profile repo such as <code>agent-profiles</code>.
-2. Add project-local overrides only where the repository truly has unique needs.
-3. Select the profile that matches the work: language, role, risk level, or intent.
-4. Let Bridl assemble the runtime configuration and launch the agent harness consistently.
-
-The result is a workflow where agent customization is no longer a pile of hidden local state. It becomes a documented, reviewable, and reusable part of how work gets done.

--- a/doc_site/app/page.mdx
+++ b/doc_site/app/page.mdx
@@ -1,6 +1,11 @@
 ---
 title: Bridl Agent Harness Manager
 description: Making your AI Harness manageable, composable and portable
+theme:
+  layout: full
+  toc: false
+  sidebar: false
+  pagination: false
 ---
 
 <div className="bridl-landing">
@@ -14,12 +19,11 @@ description: Making your AI Harness manageable, composable and portable
     </div>
     <div className="bridl-wrap bridl-hero-inner">
       <div className="bridl-copy">
-        <p className="bridl-badge"><span /> Agent harness profiles</p>
+        <p className="bridl-badge"><span aria-hidden="true" /> Agent harness profiles</p>
         <h1>Your agent harness, <span>finally manageable</span></h1>
-        <p className="bridl-lede">
-          Bridl is the control layer for AI coding agents. Define reusable profiles that travel between machines,
-          adapt per repo, compose in layers, and launch through native agent mechanisms.
-        </p>
+        <div className="bridl-lede">
+          Bridl is the pi-first control layer for AI coding agents. Define reusable profiles that travel between machines, adapt per repo, compose in layers, and launch through native pi configuration.
+        </div>
         <div className="bridl-actions">
           <a className="bridl-button primary" href="#get-started">Get started →</a>
           <a className="bridl-button ghost" href="#feature-comparison">Compare the gaps</a>
@@ -27,7 +31,7 @@ description: Making your AI Harness manageable, composable and portable
         <p className="bridl-sub"><code>$ npm i -g bridl</code> · pi-first · profile-driven · deterministic</p>
       </div>
       <div className="bridl-terminal bridl-float">
-        <div className="bridl-termbar"><i /><i /><i /><span>bridl — run</span></div>
+        <div className="bridl-termbar"><i aria-hidden="true" /><i aria-hidden="true" /><i aria-hidden="true" /><span>bridl — run</span></div>
         <pre>{`$ bridl run --profile engineering-default
 → resolving profile  engineering-default
   ✓ user source      github:nhorton/agent-profiles@main
@@ -41,17 +45,17 @@ description: Making your AI Harness manageable, composable and portable
 
 <div className="bridl-strip">
   <div className="bridl-wrap">
-    <strong>Adapts to</strong>
+    <strong>Built for</strong>
     <span>
-      <i className="indigo" /> pi
+      <i className="indigo" aria-hidden="true" /> pi today
     </span>
     <span>
-      <i className="cyan" /> Claude Code roadmap
+      <i className="cyan" aria-hidden="true" /> Claude Code roadmap
     </span>
     <span>
-      <i className="teal" /> your own adapters
+      <i className="teal" aria-hidden="true" /> custom adapters future
     </span>
-    <em>one profile vocabulary, many harnesses</em>
+    <em>generic profile vocabulary with a pi-first implementation</em>
   </div>
 </div>
 
@@ -59,34 +63,36 @@ description: Making your AI Harness manageable, composable and portable
   <p className="bridl-eyebrow">Why Bridl</p>
   <div className="bridl-section-head">
     <h2>Agent config is powerful — and fragmented</h2>
-    <p>
+    <div className="bridl-section-copy">
       Machine-global settings rot into a junk drawer. Project settings force every role and language through one
       default. Bridl fills the gap with portable, composable profiles.
-    </p>
+    </div>
   </div>
   <div className="bridl-cards">
     <div className="bridl-card">
-      <div>◇</div>
+      <div aria-hidden="true">◇</div>
       <h3>Like dotfiles, but shared</h3>
-      <p>
+      <div className="bridl-card-copy">
         Keep user-global settings in source-controlled profile repos instead of burying them in one machine's home
         directory.
-      </p>
+      </div>
     </div>
     <div className="bridl-card">
-      <div>⌘</div>
+      <div aria-hidden="true">⌘</div>
       <h3>Per-stack setups</h3>
       <p>Switch between TypeScript, Python, Rust, docs, or data profiles without rewriting project configuration.</p>
     </div>
     <div className="bridl-card">
-      <div>◌</div>
+      <div aria-hidden="true">◌</div>
       <h3>Intent-specific modes</h3>
       <p>Use a PM profile for planning, DevOps for deployment work, and engineering for implementation.</p>
     </div>
     <div className="bridl-card">
-      <div>✓</div>
-      <h3>Cross-agent policy</h3>
-      <p>Describe common profile controls once, then let adapters map them into supported native mechanisms.</p>
+      <div aria-hidden="true">✓</div>
+      <h3>Pi-first policy</h3>
+      <div className="bridl-card-copy">
+        Describe generic profile controls once, then let the pi adapter map supported controls into native settings.
+      </div>
     </div>
   </div>
 </section>
@@ -96,41 +102,41 @@ description: Making your AI Harness manageable, composable and portable
     <p className="bridl-eyebrow">Layered profiles in practice</p>
     <div className="bridl-section-head">
       <h2>Dotfiles, team standards, and repo overrides — resolved into one tack</h2>
-      <p>
+      <div className="bridl-section-copy">
         Bridl combines the relevant layers deterministically, warns when a requested control is unsupported, and
         prepares a clean runtime tack before launch.
-      </p>
+      </div>
     </div>
     <div className="bridl-layers">
       <div className="bridl-layer-list">
         <div>
           <span>1</span>
           <h3>User profile source</h3>
-          <p>
-            <code>github:nhorton/agent-profiles</code> provides shared skills and machine-independent policy.
-          </p>
+          <div className="bridl-layer-copy">
+            <code>github:nhorton/agent-profiles</code> provides shared defaults and machine-independent policy.
+          </div>
         </div>
         <div>
           <span>2</span>
           <h3>Organization standard</h3>
-          <p>
+          <div className="bridl-layer-copy">
             <code>github:acme/agent-standards</code> sets approved defaults and common controls.
-          </p>
+          </div>
         </div>
         <div>
           <span>3</span>
           <h3>Repository-local profile</h3>
-          <p>
-            <code>.bridl/profiles/engineer</code> adds repo prompts, tools, and safety rules.
-          </p>
+          <div className="bridl-layer-copy">
+            <code>.bridl/profiles/engineer</code> adds repo-specific guidance and safety rules.
+          </div>
         </div>
         <div>
           <span>4</span>
-          <h3>Native agent launch</h3>
-          <p>Adapters translate controls into files, flags, environment variables, skills, prompts, and sessions.</p>
+          <h3>Native pi launch</h3>
+          <p>The pi adapter translates supported controls into the runtime tack and native pi launch inputs.</p>
         </div>
       </div>
-      <div className="bridl-stack" aria-label="Profile layer stack">
+      <div className="bridl-stack" role="img" aria-label="Profile layer stack">
         <div className="stack-card a">
           <small>User profile source</small>
           <b>github:nhorton/agent-profiles</b>
@@ -148,7 +154,7 @@ description: Making your AI Harness manageable, composable and portable
           <small>Resolved profile</small>
           <b>17 controls merged · 0 conflicts</b>
         </div>
-        <div className="stack-launch">▶ native agent launch</div>
+        <div className="stack-launch">▶ native pi launch</div>
       </div>
     </div>
   </div>
@@ -166,17 +172,8 @@ description: Making your AI Harness manageable, composable and portable
     </div>
     <div className="bridl-config-card">
       <div><span className="active">profile.yml</span><span>settings.yml</span></div>
-      <pre>{`id: engineering-default
-label: Engineering Default
-inherits:
-  - base-typescript
-
-controls:
-model: anthropic/claude-sonnet-4
-environment:
-TEAM_MODE: engineering
-allow_project_overrides: true`}</pre>
-</div>
+      <pre>{'id: engineering-default\nlabel: Engineering Default\ninherits:\n  - base-typescript\n\ncontrols:\n  model: anthropic/claude-sonnet-4\n  environment:\n    TEAM_MODE: engineering\n  allow_project_overrides: true'}</pre>
+    </div>
 
   </section>
 
@@ -240,7 +237,7 @@ allow_project_overrides: true`}</pre>
           <td>—</td>
         </tr>
         <tr>
-          <td>Cross-agent settings vocabulary</td>
+          <td>Generic settings vocabulary, pi-first implementation</td>
           <td>✓</td>
           <td>—</td>
           <td>—</td>
@@ -263,7 +260,7 @@ allow_project_overrides: true`}</pre>
     <div>
       <p className="bridl-eyebrow">Get started</p>
       <h2>Treat agent setup like <em>real</em> infrastructure</h2>
-      <p>Documented, reviewable, reusable. Put defaults in a profile repo, override only where it matters, and launch consistently.</p>
+      <p>{'Documented, reviewable, reusable. Put defaults in a profile repo, override only where it matters, and launch consistently.'}</p>
       <code>$ npm i -g bridl</code>
     </div>
   </section>

--- a/doc_site/app/page.mdx
+++ b/doc_site/app/page.mdx
@@ -22,32 +22,32 @@ theme:
         <p className="bridl-badge"><span aria-hidden="true" /> Agent harness profiles</p>
         <h1>Your agent harness, <span>finally manageable</span></h1>
         <div className="bridl-lede">
-          Bridl is a planned pi-first control layer for AI coding agents. Define reusable profiles that travel between machines, adapt per repo, compose in layers, and prepare for native agent integration as adapter support lands.
+          Bridl is the pi-first control layer for AI coding agents. Define reusable profiles that travel between machines, adapt per repo, compose in layers, and launch through native pi configuration.
         </div>
         <div className="bridl-actions">
           <a className="bridl-button primary" href="#get-started">Get started →</a>
           <a className="bridl-button ghost" href="#feature-comparison">Compare the gaps</a>
         </div>
-        <p className="bridl-sub"><code>$ npm i -g bridl</code> · pi-first roadmap · profile-driven · deterministic</p>
+        <p className="bridl-sub"><code>$ npm i -g bridl</code> · pi-first · profile-driven · deterministic</p>
       </div>
       <div className="bridl-terminal bridl-float">
         <div className="bridl-termbar"><i aria-hidden="true" /><i aria-hidden="true" /><i aria-hidden="true" /><span>bridl — run</span></div>
         <pre>{`$ bridl run --profile engineering-default
-→ planned profile flow  engineering-default
-  ✓ user source         github:nhorton/agent-profiles@main
-  ✓ repo overlay        .bridl/profiles/engineer
-  ✓ deterministic merge profile layers
-  • adapter support     pi-first roadmap
-↳ launch integration follows support matrix`}</pre>
+→ resolving profile  engineering-default
+  ✓ user source      github:nhorton/agent-profiles@main
+  ✓ repo overlay     .bridl/profiles/engineer
+  ✓ merged controls  model=claude-sonnet-4
+  ✓ prepared tack    /tmp/bridl-tack-a91f
+↳ launching pi …`}</pre>
       </div>
     </div>
   </section>
 
 <div className="bridl-strip">
   <div className="bridl-wrap">
-    <strong>Roadmap</strong>
+    <strong>Built for</strong>
     <span>
-      <i className="indigo" aria-hidden="true" /> pi first
+      <i className="indigo" aria-hidden="true" /> pi today
     </span>
     <span>
       <i className="cyan" aria-hidden="true" /> Claude Code roadmap
@@ -55,7 +55,7 @@ theme:
     <span>
       <i className="teal" aria-hidden="true" /> custom adapters future
     </span>
-    <em>generic profile vocabulary with pi as the first planned adapter</em>
+    <em>generic profile vocabulary with a pi-first implementation</em>
   </div>
 </div>
 
@@ -89,10 +89,9 @@ theme:
     </div>
     <div className="bridl-card">
       <div aria-hidden="true">✓</div>
-      <h3>Pi-first roadmap</h3>
+      <h3>Pi-first policy</h3>
       <div className="bridl-card-copy">
-        Describe generic profile controls once, with pi planned as the first adapter to map supported controls into
-        native settings.
+        Describe generic profile controls once, then let the pi adapter map supported controls into native settings.
       </div>
     </div>
   </div>
@@ -133,8 +132,8 @@ theme:
         </div>
         <div>
           <span>4</span>
-          <h3>Planned pi adapter</h3>
-          <p>Pi is the first planned adapter; supported runtime controls should follow the published support matrix.</p>
+          <h3>Native pi launch</h3>
+          <p>The pi adapter translates supported controls into the runtime tack and native pi launch inputs.</p>
         </div>
       </div>
       <div className="bridl-stack" role="img" aria-label="Profile layer stack">
@@ -155,7 +154,7 @@ theme:
           <small>Resolved profile</small>
           <b>17 controls merged · 0 conflicts</b>
         </div>
-        <div className="stack-launch">▶ pi adapter roadmap</div>
+        <div className="stack-launch">▶ native pi launch</div>
       </div>
     </div>
   </div>
@@ -238,7 +237,7 @@ theme:
           <td>—</td>
         </tr>
         <tr>
-          <td>Generic settings vocabulary, pi-first roadmap</td>
+          <td>Generic settings vocabulary, pi-first implementation</td>
           <td>✓</td>
           <td>—</td>
           <td>—</td>

--- a/doc_site/app/page.mdx
+++ b/doc_site/app/page.mdx
@@ -22,32 +22,32 @@ theme:
         <p className="bridl-badge"><span aria-hidden="true" /> Agent harness profiles</p>
         <h1>Your agent harness, <span>finally manageable</span></h1>
         <div className="bridl-lede">
-          Bridl is the pi-first control layer for AI coding agents. Define reusable profiles that travel between machines, adapt per repo, compose in layers, and launch through native pi configuration.
+          Bridl is a planned pi-first control layer for AI coding agents. Define reusable profiles that travel between machines, adapt per repo, compose in layers, and prepare for native agent integration as adapter support lands.
         </div>
         <div className="bridl-actions">
           <a className="bridl-button primary" href="#get-started">Get started →</a>
           <a className="bridl-button ghost" href="#feature-comparison">Compare the gaps</a>
         </div>
-        <p className="bridl-sub"><code>$ npm i -g bridl</code> · pi-first · profile-driven · deterministic</p>
+        <p className="bridl-sub"><code>$ npm i -g bridl</code> · pi-first roadmap · profile-driven · deterministic</p>
       </div>
       <div className="bridl-terminal bridl-float">
         <div className="bridl-termbar"><i aria-hidden="true" /><i aria-hidden="true" /><i aria-hidden="true" /><span>bridl — run</span></div>
         <pre>{`$ bridl run --profile engineering-default
-→ resolving profile  engineering-default
-  ✓ user source      github:nhorton/agent-profiles@main
-  ✓ repo overlay     .bridl/profiles/engineer
-  ✓ merged controls  model=claude-sonnet-4
-  ✓ prepared tack    /tmp/bridl-tack-a91f
-↳ launching pi …`}</pre>
+→ planned profile flow  engineering-default
+  ✓ user source         github:nhorton/agent-profiles@main
+  ✓ repo overlay        .bridl/profiles/engineer
+  ✓ deterministic merge profile layers
+  • adapter support     pi-first roadmap
+↳ launch integration follows support matrix`}</pre>
       </div>
     </div>
   </section>
 
 <div className="bridl-strip">
   <div className="bridl-wrap">
-    <strong>Built for</strong>
+    <strong>Roadmap</strong>
     <span>
-      <i className="indigo" aria-hidden="true" /> pi today
+      <i className="indigo" aria-hidden="true" /> pi first
     </span>
     <span>
       <i className="cyan" aria-hidden="true" /> Claude Code roadmap
@@ -55,7 +55,7 @@ theme:
     <span>
       <i className="teal" aria-hidden="true" /> custom adapters future
     </span>
-    <em>generic profile vocabulary with a pi-first implementation</em>
+    <em>generic profile vocabulary with pi as the first planned adapter</em>
   </div>
 </div>
 
@@ -89,9 +89,10 @@ theme:
     </div>
     <div className="bridl-card">
       <div aria-hidden="true">✓</div>
-      <h3>Pi-first policy</h3>
+      <h3>Pi-first roadmap</h3>
       <div className="bridl-card-copy">
-        Describe generic profile controls once, then let the pi adapter map supported controls into native settings.
+        Describe generic profile controls once, with pi planned as the first adapter to map supported controls into
+        native settings.
       </div>
     </div>
   </div>
@@ -132,8 +133,8 @@ theme:
         </div>
         <div>
           <span>4</span>
-          <h3>Native pi launch</h3>
-          <p>The pi adapter translates supported controls into the runtime tack and native pi launch inputs.</p>
+          <h3>Planned pi adapter</h3>
+          <p>Pi is the first planned adapter; supported runtime controls should follow the published support matrix.</p>
         </div>
       </div>
       <div className="bridl-stack" role="img" aria-label="Profile layer stack">
@@ -154,7 +155,7 @@ theme:
           <small>Resolved profile</small>
           <b>17 controls merged · 0 conflicts</b>
         </div>
-        <div className="stack-launch">▶ native pi launch</div>
+        <div className="stack-launch">▶ pi adapter roadmap</div>
       </div>
     </div>
   </div>
@@ -172,7 +173,7 @@ theme:
     </div>
     <div className="bridl-config-card">
       <div><span className="active">profile.yml</span><span>settings.yml</span></div>
-      <pre>{'id: engineering-default\nlabel: Engineering Default\ninherits:\n  - base-typescript\n\ncontrols:\n  model: anthropic/claude-sonnet-4\n  environment:\n    TEAM_MODE: engineering\n  allow_project_overrides: true'}</pre>
+      <pre>{'id: engineering-default\nlabel: Engineering Default\ninherits:\n  - base-typescript\n\ncontrols:\n  model: anthropic/claude-sonnet-4\n  environment:\n    TEAM_MODE: engineering'}</pre>
     </div>
 
   </section>
@@ -237,7 +238,7 @@ theme:
           <td>—</td>
         </tr>
         <tr>
-          <td>Generic settings vocabulary, pi-first implementation</td>
+          <td>Generic settings vocabulary, pi-first roadmap</td>
           <td>✓</td>
           <td>—</td>
           <td>—</td>


### PR DESCRIPTION
## Summary
- Rebuild the docs homepage into a polished marketing-style landing page based on the provided zip mockup
- Add dark visual system, hero terminal, feature cards, layered profile diagram, comparison table, and CTA
- Keep the provided zip untracked and out of source control

## Verification
- npm run docs:lint
- npm run docs:build