### PR TITLE
docs: add profile and state update examples

### DIFF
--- a/.deepreview
+++ b/.deepreview
@@ -158,27 +158,40 @@ test_file_quality:
         concise description.
 
 doc_consistency:
-  description: "Verify architecture and file structure documentation stay consistent."
+  description: "Verify architecture, file structure, state writeback, and public docs stay current when requirements change."
   match:
     include:
-      - "doc/architecture.md"
-      - "doc/file_structure.md"
+      - "requirements/BRIDL-REQ-*.md"
   review:
     strategy: matches_together
     additional_context:
       unchanged_matching_files: true
     instructions: |
-      Review doc/architecture.md and doc/file_structure.md together for consistency.
+      Review changed requirements and verify that the documentation stays current.
+
+      Documentation files to keep updated:
+      - doc/architecture.md
+      - doc/file_structure.md
+      - doc/state_writeback_strategy.md
+      - doc/controllable-elements.md
+      - doc_site/app/page.mdx
+      - doc_site/app/state-persistence/page.mdx
+
+      Implementation file to consult when requirements affect Pi state path behavior:
+      - src/agents/pi/PiAdapter.ts
 
       Check that:
       1. doc/file_structure.md stays limited to repository file structure, not runtime instance file conventions.
       2. Runtime file conventions such as settings directories, profile folders, and tack paths live in doc/architecture.md.
-      3. Cross-document links and filenames are accurate.
-      4. Terminology such as profile, tack, settings, adapter, and pi is used consistently.
+      3. State writeback and state updating details in doc/architecture.md stay consistent with doc/state_writeback_strategy.md, including tack/state terminology, strategy names, Pi path policy, and cross-document links.
+      4. Pi state path declarations and special Pi path resolution behavior documented in doc/state_writeback_strategy.md match src/agents/pi/PiAdapter.ts when Pi state path requirements change.
+      5. Public documentation site claims in doc_site/app/page.mdx and doc_site/app/state-persistence/page.mdx stay aligned with architecture and support boundaries.
+      6. Cross-document links and filenames are accurate.
+      7. Terminology such as profile, tack, settings, adapter, and pi is used consistently.
 
       Output Format:
-      - PASS: The documents are consistent and links are accurate.
-      - FAIL: Issues found. List each conflicting statement, missing update, or broken reference with a line reference.
+      - PASS: The documentation is current with the changed requirements and links are accurate.
+      - FAIL: Issues found. List each stale, missing, conflicting, or broken documentation statement with a line reference.
 
 doc_site_product_consistency:
   description: "Verify public documentation site claims stay aligned with Bridl architecture and controllable element support."
@@ -187,6 +200,7 @@ doc_site_product_consistency:
       - "doc_site/app/**/*.mdx"
       - "doc_site/app/layout.tsx"
       - "doc/architecture.md"
+      - "doc/state_writeback_strategy.md"
       - "doc/controllable-elements.md"
   review:
     strategy: matches_together
@@ -195,18 +209,19 @@ doc_site_product_consistency:
     instructions: |
       Review public documentation site MDX pages against Bridl's architecture and
       controllable element documentation. This rule provides judgment-based
-      review coverage for public claims related to BRIDL-REQ-006.2 adapter
-      support boundaries and BRIDL-REQ-007 cross-agent controllable-element
-      support documentation.
+      review coverage for public claims related to BRIDL-REQ-005.6 tack state
+      persistence, BRIDL-REQ-006.2 adapter support boundaries, and
+      BRIDL-REQ-007 cross-agent controllable-element support documentation.
 
       Check that:
       1. Public docs do not overstate implemented adapter support, especially for
          non-pi agents that are roadmap-only.
       2. Claims about profile precedence, tack behavior, setup repositories,
          remote profile sources, and adapter translation match doc/architecture.md.
-      3. Claims about cross-agent or generic controls match doc/controllable-elements.md
+      3. Claims about state persistence, state update scenarios, and Pi path policy match doc/state_writeback_strategy.md.
+      4. Claims about cross-agent or generic controls match doc/controllable-elements.md
          and distinguish supported, roadmap, and unsupported behavior accurately.
-      4. Marketing copy may be aspirational, but it MUST NOT present roadmap-only
+      5. Marketing copy may be aspirational, but it MUST NOT present roadmap-only
          capabilities as already implemented.
 
       Output Format:
@@ -220,6 +235,7 @@ doc_site_requirements_sync:
       - "requirements/BRIDL-REQ-*.md"
       - "doc_site/app/**/*.mdx"
       - "doc_site/app/layout.tsx"
+      - "doc_site/app/_meta.js"
   review:
     strategy: matches_together
     additional_context:

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -125,6 +125,18 @@ profile_sources:
   - path: ./profiles
 ```
 
+A minimal user profile tree for that settings file looks like this:
+
+```text
+~/.bridl/
+  settings.yml
+  profiles/
+    user_default/
+      profile.yml
+      prompts/
+        system.md
+```
+
 ## Settings Schema
 
 `settings.yml` supports:
@@ -169,11 +181,62 @@ Rules:
 - Remote `uri` and `github` profile sources can specify `ref` and repository-subdirectory `path` values.
 - `remote_settings` entries point at settings-style YAML files inside synced remote repositories.
 - `uri`, `github`, and `remote_settings` sources are fetched/cached by `bridl sync`.
-- `custom_settings` may contain arbitrary YAML-compatible nested data. Bridl deep-merges custom settings objects using normal settings precedence; arrays and scalar values are replaced by the higher-precedence settings layer.
+- `custom_settings` may contain arbitrary YAML-compatible nested data.
+  Bridl deep-merges custom settings objects using normal settings precedence; arrays and scalar values are replaced by the higher-precedence settings layer.
+
+### Settings File Examples
+
+A user settings file can select a default profile and expose user-managed profiles:
+
+```yaml
+# ~/.bridl/settings.yml
+default_profile: personal-engineering
+cache_directory: ./cache
+
+profile_sources:
+  - path: ./profiles
+
+custom_settings:
+  build_commands:
+    lint: npm run lint
+    test: npm test
+```
+
+A project settings file can add checked-in project profiles and remote organizational profiles:
+
+```yaml
+# <project>/.bridl/settings.yml
+default_profile: project-engineering
+
+profile_sources:
+  - path: ./profiles
+  - github: example/company-bridl-config
+    ref: main
+    path: profiles/shared
+    only:
+      - base-typescript
+      - secure-review
+
+remote_settings:
+  - github: example/company-bridl-config
+    ref: main
+    path: settings.yml
+```
+
+A project-local settings file can override the default profile without changing checked-in files:
+
+```yaml
+# <project>/.bridl/local/settings.yml
+default_profile: local-sandbox
+
+profile_sources:
+  - path: ./profiles
+```
 
 ## Tack Template Rendering
 
-Bridl renders Bridl-time templates in generated tack files after profile and settings resolution and before writing the tack directory to disk. Source settings files are never rewritten.
+Bridl renders Bridl-time templates in generated tack files after profile and settings resolution and before writing the tack directory to disk.
+Source settings files are never rewritten.
 
 Bridl uses LiquidJS with custom delimiters rather than common `{{ ... }}` / `{% ... %}` delimiters so templates do not collide with common agent prompt, skill, command, Handlebars, Mustache, Jinja, or Claude Code syntaxes.
 
@@ -229,7 +292,9 @@ commands:
 [[% endfor %]]
 ```
 
-Undefined output variables and unknown filters are template errors. Undefined variables in `if`, `elsif`, and `unless` conditions are allowed and evaluate as falsy so templates can test optional custom settings. Template errors identify the tack file being rendered and stop tack assembly.
+Undefined output variables and unknown filters are template errors.
+Undefined variables in `if`, `elsif`, and `unless` conditions are allowed and evaluate as falsy so templates can test optional custom settings.
+Template errors identify the tack file being rendered and stop tack assembly.
 
 ## Profile Sources and Sync
 
@@ -257,7 +322,8 @@ profile_sources:
     path: profiles/team
 ```
 
-The `github: owner/repo` shorthand normalizes to `git+https://github.com/owner/repo.git` internally. Remote sources without `ref` or repository subpaths retain the original profile cache location for compatibility:
+The `github: owner/repo` shorthand normalizes to `git+https://github.com/owner/repo.git` internally.
+Remote sources without `ref` or repository subpaths retain the original profile cache location for compatibility:
 
 ```text
 ~/.bridl/cache/profiles/<encoded-uri>/
@@ -301,29 +367,26 @@ profiles/
 Example `profile.yml`:
 
 ```yaml
-name: engineering
+id: engineering
+label: Engineering
 inherits:
   - base-typescript
-
-agent:
-  default_cli: pi
 
 controls:
   model: anthropic/claude-sonnet-4
   system_prompt: ./prompts/system.md
-  append_system_prompts:
-    - ./prompts/company-policy.md
+  append_system_prompt: ./prompts/company-policy.md
   skills:
     - ./skills/debugging
   extensions:
     - ./extensions/company-bootstrap
-  env:
-    ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
-
-pi:
-  args:
-    - --thinking
-    - medium
+  environment:
+    TEAM_MODE: engineering
+    # Omit provider API keys here to inherit them from the parent environment.
+  pi:
+    args:
+      - --thinking
+      - medium
 ```
 
 Rules:
@@ -332,6 +395,119 @@ Rules:
 - `inherits` is an ordered array of profile names.
 - `cli_specific/<cli-name>/` contains files copied or translated directly into the generated tack for that CLI.
 - CLI-specific configuration wins over generic controls when both apply to the same generated artifact.
+
+### Profile Directory Examples
+
+A small user-level profile set can keep a base profile and a specialized profile side by side:
+
+```text
+~/.bridl/profiles/
+  base-typescript/
+    profile.yml
+    prompts/
+      system.md
+  personal-engineering/
+    profile.yml
+    prompts/
+      system.md
+    skills/
+      debugging/
+        SKILL.md
+```
+
+```yaml
+# ~/.bridl/profiles/base-typescript/profile.yml
+id: base-typescript
+label: Base TypeScript
+
+controls:
+  provider: anthropic
+  model: anthropic/claude-sonnet-4
+  thinking: medium
+  system_prompt: ./prompts/system.md
+  environment:
+    NODE_ENV: development
+```
+
+```yaml
+# ~/.bridl/profiles/personal-engineering/profile.yml
+id: personal-engineering
+label: Personal Engineering
+inherits:
+  - base-typescript
+
+controls:
+  append_system_prompt: ./prompts/system.md
+  skills:
+    - ./skills/debugging
+  pi:
+    args:
+      - --no-themes
+```
+
+A checked-in project profile set can add project-specific prompts and pi resources:
+
+```text
+<project>/.bridl/profiles/
+  project-engineering/
+    profile.yml
+    prompts/
+      system.md
+      review.md
+    extensions/
+      project-bootstrap/
+        package.json
+        src/
+          index.ts
+    cli_specific/
+      pi/
+        settings.json
+```
+
+```yaml
+# <project>/.bridl/profiles/project-engineering/profile.yml
+id: project-engineering
+label: Project Engineering
+inherits:
+  - base-typescript
+
+controls:
+  system_prompt: ./prompts/system.md
+  append_system_prompt: ./prompts/review.md
+  extensions:
+    - ./extensions/project-bootstrap
+  session_directory: ./.bridl/sessions/project-engineering
+  pi:
+    prompt_template: code-review
+    args:
+      - --model
+      - anthropic/claude-sonnet-4
+```
+
+A local-only sandbox profile can use the highest-precedence project-local layer:
+
+```text
+<project>/.bridl/local/
+  settings.yml
+  profiles/
+    local-sandbox/
+      profile.yml
+      prompts/
+        sandbox.md
+```
+
+```yaml
+# <project>/.bridl/local/profiles/local-sandbox/profile.yml
+id: local-sandbox
+label: Local Sandbox
+
+controls:
+  system_prompt: ./prompts/sandbox.md
+  environment:
+    BRIDL_EXPERIMENTAL_MODE: '1'
+  pi:
+    thinking: high
+```
 
 ## Profile Resolution and Inheritance
 
@@ -369,6 +545,31 @@ The pi adapter uses this state model for native pi state and for pi-managed util
 
 During `bridl run`, the Bridl process remains alive while the child agent CLI runs.
 It owns the tack lifecycle.
+
+### Functional State Updating Model
+
+Bridl treats agent state updates as an explicit product behavior rather than an accidental side effect of temporary tack files.
+Before launch, the selected adapter names the paths the agent CLI is expected to mutate, such as authentication files, settings files, plugin folders, caches, and sessions.
+The resolved profile then chooses a functional persistence strategy for each path:
+
+- `symlink`: writes are durable because the tack path points at a profile-managed or native CLI state path.
+- `discard`: writes are allowed for the run but thrown away with the temporary tack.
+- `warn`: writes are allowed and discarded, then reported after exit.
+- `error`: writes are allowed during the run but make the Bridl command fail after exit.
+- `prompt`: reserved for future interactive handling; currently treated as a non-persistent diagnostic.
+
+Unknown writes are handled separately from declared state paths.
+They are never silently persisted because Bridl has no declared durable destination for them.
+The adapter's `unknown` policy decides whether to discard, warn, error, or eventually prompt.
+
+The practical user model is:
+
+1. Put durable, editable CLI state under `cli_specific/<agent>/` in a profile, or let Bridl fall back to the native CLI state location.
+2. Use `state_persistence` in `profile.yml` only for paths that should deviate from the adapter defaults.
+3. Use `warn` or `error` for strict profiles and CI when unexpected state mutation should be visible.
+4. Use `discard` for caches, sessions, or experimental state that should not outlive the run.
+
+See `doc/state_writeback_strategy.md` for the complete functional contract and the current pi path policy.
 
 ### Tack Assembly
 

--- a/doc/state_writeback_strategy.md
+++ b/doc/state_writeback_strategy.md
@@ -2,7 +2,36 @@
 
 This document describes Bridl's current model for handling writes that agent CLIs make inside a tack.
 
-A tack is temporary, but agent CLIs sometimes perform intentionally durable writes, such as logging in, installing plugins, changing settings, or updating MCP configuration. Bridl makes those paths explicit: adapter-declared writable paths are materialized with a resolved `state_persistence` strategy before the child CLI starts, and non-persistent or unknown writes are diagnosed after the child exits.
+A tack is temporary, but agent CLIs sometimes perform intentionally durable writes, such as logging in, installing plugins, changing settings, or updating MCP configuration.
+Bridl makes those paths explicit: adapter-declared writable paths are materialized with a resolved `state_persistence` strategy before the child CLI starts, and non-persistent or unknown writes are diagnosed after the child exits.
+
+## Functional model
+
+Bridl separates three kinds of files that may exist in a tack:
+
+1. **Generated runtime files**: files Bridl assembles from settings, profiles, templates, and adapter rules.
+   Bridl may regenerate these while the child agent is running when their source inputs change.
+2. **Declared state paths**: adapter-known files or directories the agent CLI may update intentionally, such as auth, settings, MCP config, plugins, caches, and sessions.
+3. **Unknown writes**: files or directories the agent creates outside the adapter-declared state paths.
+
+Only declared state paths can be made durable automatically.
+Unknown writes are never silently persisted because Bridl does not know their intended owner, merge rules, or durable destination.
+Generated runtime files and declared state paths are deliberately handled separately so live profile/template updates do not erase or re-baseline agent state changes made during the same run.
+
+The user-facing state update lifecycle is:
+
+1. **Choose a profile**.
+   Profile resolution determines the effective `state_persistence` map using normal profile precedence.
+2. **Resolve adapter defaults**.
+   For each path the selected adapter declares, Bridl uses the profile override when present and otherwise uses the adapter default.
+3. **Prepare the tack**.
+   Durable paths are connected to a profile-managed or native CLI location; non-durable paths are created as normal temporary tack paths.
+4. **Run the agent**.
+   The agent CLI reads and writes the tack as if it were its normal configuration directory.
+5. **Classify changes after exit**.
+   Bridl checks non-durable declared paths and unknown paths and reports or fails according to their strategies.
+6. **Clean up temporary state**.
+   Temporary tack contents are discarded; durable symlink targets remain in their profile or native CLI location.
 
 ## Current behavior
 
@@ -13,7 +42,8 @@ A tack is temporary, but agent CLIs sometimes perform intentionally durable writ
 - Invalid or disallowed strategies fail before launch.
 - Non-persistent `warn` and `error` strategies are checked after the child CLI exits.
 - Unknown writes outside adapter-declared paths are checked with the adapter's `unknown` pseudo-path strategy.
-- `prompt` is reserved for a future interactive/control-plane workflow. When accepted by a declaration today, it is treated as a non-persistent diagnostic like `warn`.
+- `prompt` is reserved for a future interactive/control-plane workflow.
+  When accepted by a declaration today, it is treated as a non-persistent diagnostic like `warn`.
 
 ## Non-goals
 
@@ -21,9 +51,10 @@ A tack is temporary, but agent CLIs sometimes perform intentionally durable writ
 - Bridl does not implement generic structured merge-back.
 - Bridl does not silently persist unknown writes.
 
-## Profile stack
+## Profile stack and native fallback
 
-State persistence is a normal profile setting. It resolves through the same profile stack as other profile data, with one adapter-provided native fallback layer for symlink sources:
+State persistence is a normal profile setting.
+Its strategy overrides resolve through the same profile stack as other profile data:
 
 ```text
 project-local profile
@@ -33,14 +64,16 @@ URI/cache profiles
 explicit inheritance
 implicit user default profile
 Bridl default profile
-native-cli-settings-profile
 ```
 
-The `native-cli-settings-profile` is synthesized by the adapter as a fallback source for native CLI files, such as `~/.pi/...`. It is not a user-editable Bridl profile.
+Native CLI state is not represented as an extra profile layer.
+For `symlink` paths without a profile-provided source, the selected adapter resolves a native fallback location directly, such as `~/.pi/agent/...` for most Pi state paths or `<cache_directory>/utilities` for Pi `utilities/` and `bin/`.
 
 ## Path-keyed adapter declarations
 
-Adapters declare writable state paths directly, using relative file paths as keys. Directory paths use a trailing slash. The same key is used for adapter coverage, `state_persistence` overrides, profile resource lookup, native fallback lookup, and tack materialization.
+Adapters declare writable state paths directly, using relative file paths as keys.
+Directory paths use a trailing slash.
+The same key is used for adapter coverage, `state_persistence` overrides, profile resource lookup, native fallback lookup, and tack materialization.
 
 The Pi adapter currently declares:
 
@@ -70,6 +103,22 @@ state_paths:
     default_strategy: symlink
     allowed_strategies: [symlink, discard, warn, error]
 
+  npm/:
+    default_strategy: symlink
+    allowed_strategies: [symlink, discard, warn, error]
+
+  git/:
+    default_strategy: symlink
+    allowed_strategies: [symlink, discard, warn, error]
+
+  utilities/:
+    default_strategy: symlink
+    allowed_strategies: [symlink, discard, warn, error]
+
+  bin/:
+    default_strategy: symlink
+    allowed_strategies: [symlink, discard, warn, error]
+
   unknown:
     default_strategy: warn
     allowed_strategies: [discard, warn, error, prompt]
@@ -90,9 +139,14 @@ profiles/
         plugins/
 ```
 
-When a selected strategy is `symlink`, Bridl searches the resolved profile folders from highest to lowest precedence for `cli_specific/<adapter>/<state-path>`. If a profile contains the file or directory, Bridl symlinks the tack path to that source.
+Except for cache-backed utility paths described below, when a selected strategy is `symlink`, Bridl searches the resolved profile folders from highest to lowest precedence for `cli_specific/<adapter>/<state-path>`.
+If a profile contains the file or directory, Bridl symlinks the tack path to that source.
 
-If no profile source exists for a Pi path, Bridl falls back to the corresponding native Pi agent path under `~/.pi/agent`. Missing native fallback files/directories are created so the tack symlink has a durable destination.
+For most Pi paths, if no profile source exists, Bridl falls back to the corresponding native Pi agent path under `~/.pi/agent`.
+Missing native fallback files/directories are created so the tack symlink has a durable destination.
+
+Pi `utilities/` and `bin/` are special cache-backed paths: both resolve to `<cache_directory>/utilities` instead of profile or native Pi state.
+This keeps pi-managed helper binaries reusable across temporary tacks without treating them as user-editable profile files.
 
 ## `state_persistence`
 
@@ -108,9 +162,38 @@ state_persistence:
   unknown: warn
 ```
 
-The values are concrete strategy names. `state_persistence` only needs overrides; omitted paths use the adapter declaration's `default_strategy`.
+The values are concrete strategy names.
+`state_persistence` only needs overrides; omitted paths use the adapter declaration's `default_strategy`.
 
-`state_persistence` is validated by the profile JSON Schema at read boundaries. Bridl also validates the resolved strategy against the adapter declaration before launch.
+`state_persistence` is validated by the profile JSON Schema at read boundaries.
+Bridl also validates the resolved strategy against the adapter declaration before launch.
+
+Functional examples:
+
+```yaml
+# Persist logins and settings, but make caches and sessions run-local.
+state_persistence:
+  auth.json: symlink
+  settings.json: symlink
+  cache/: discard
+  sessions/: discard
+```
+
+```yaml
+# CI profile: fail if pi changes settings, MCP config, or unknown files.
+state_persistence:
+  settings.json: error
+  mcp.json: error
+  plugins/: error
+  unknown: error
+```
+
+```yaml
+# Exploratory profile: allow plugin experiments but report them after exit.
+state_persistence:
+  plugins/: warn
+  unknown: warn
+```
 
 ## Tack materialization
 
@@ -144,27 +227,40 @@ Supported `unknown` strategies are non-persistent only:
 
 `unknown` does not support `symlink`, because there is no declared durable destination.
 
+## Strategy selection guide
+
+Use `symlink` when a write is part of durable agent setup, such as logging in, editing native settings, updating MCP config, or installing plugins that should be reused.
+Use `discard` when the data is useful only during the current run, such as cache entries or throwaway sessions.
+Use `warn` when mutation is acceptable but should be visible to the user.
+Use `error` when mutation means the run was not reproducible enough, especially in CI or locked-down project profiles.
+Use `prompt` only as a forward-compatible declaration for future interactive handling.
+
 ## Strategies
 
 ### `symlink`
 
-Bridl resolves the state path through the profile hierarchy, then the native CLI fallback, and symlinks that source into the tack. Persistence happens because the CLI writes through the symlink to an intentional file or directory.
+Bridl resolves the state path through the profile hierarchy, then the native CLI fallback, and symlinks that source into the tack.
+Persistence happens because the CLI writes through the symlink to an intentional file or directory.
 
 ### `discard`
 
-Writes are allowed in the tack and are thrown away when the tack is deleted. Bridl does not emit diagnostics for changed `discard` paths.
+Writes are allowed in the tack and are thrown away when the tack is deleted.
+Bridl does not emit diagnostics for changed `discard` paths.
 
 ### `warn`
 
-Writes are allowed, discarded, and reported after the child exits. `--hard-tack` makes these warnings fatal.
+Writes are allowed, discarded, and reported after the child exits.
+`--hard-tack` makes these warnings fatal.
 
 ### `error`
 
-Writes are allowed during the child process but cause Bridl to fail after the child exits if the path changed. This is useful for CI and strict reproducibility.
+Writes are allowed during the child process but cause Bridl to fail after the child exits if the path changed.
+This is useful for CI and strict reproducibility.
 
 ### `prompt`
 
-`prompt` is reserved for a future interactive/control-plane workflow. Current implementations that allow it treat writes as non-persistent diagnostics, equivalent to `warn`, with the strategy name preserved in the message.
+`prompt` is reserved for a future interactive/control-plane workflow.
+Current implementations that allow it treat writes as non-persistent diagnostics, equivalent to `warn`, with the strategy name preserved in the message.
 
 ## Rationale
 

--- a/doc_site/app/_meta.js
+++ b/doc_site/app/_meta.js
@@ -3,4 +3,8 @@ export default {
     title: 'Home',
     type: 'page',
   },
+  'state-persistence': {
+    title: 'State Persistence',
+    type: 'page',
+  },
 };

--- a/doc_site/app/state-persistence/page.mdx
+++ b/doc_site/app/state-persistence/page.mdx
@@ -1,0 +1,107 @@
+---
+title: State Persistence
+description: How Bridl handles agent state writes inside temporary tacks
+---
+
+# State Persistence
+
+Bridl creates a temporary runtime directory, called a **tack**, each time it launches an agent profile. The tack should be disposable, but agent CLIs also write durable state such as logins, settings, plugins, caches, and sessions.
+
+Bridl makes those writes explicit with `state_persistence` rules. Each selected adapter declares the state paths it knows about and the strategies each path allows, then the resolved profile can override paths with an allowed strategy such as persisting, discarding, warning, or failing after the run.
+
+## The lifecycle
+
+1. Bridl resolves the profile and its `state_persistence` overrides.
+2. The selected adapter fills in defaults for every declared state path.
+3. Durable paths are connected to a profile-managed file/directory or to a native fallback location.
+4. The agent runs inside the tack and reads/writes those paths normally.
+5. After the agent exits, Bridl checks non-durable and unknown writes.
+6. Temporary tack contents are deleted; durable symlink targets remain.
+
+## Strategies
+
+| Strategy  | Behavior                                                                 |
+| --------- | ------------------------------------------------------------------------ |
+| `symlink` | Persist writes by pointing the tack path at a durable destination.       |
+| `discard` | Allow writes for this run and throw them away when the tack is deleted.  |
+| `warn`    | Allow and discard writes, then report them after the agent exits.        |
+| `error`   | Allow writes during the run, then fail if the path changed.              |
+| `prompt`  | Reserved for future interactive handling; currently treated like `warn`. |
+
+Unknown writes outside adapter-declared paths are never silently persisted. They are governed by the adapter's `unknown` policy.
+
+## Example: persist login and settings
+
+Use this when a profile should keep authentication and settings updates across runs.
+
+```yaml
+# profile.yml
+id: engineering
+label: Engineering
+
+state_persistence:
+  auth.json: symlink
+  settings.json: symlink
+  mcp.json: symlink
+  plugins/: symlink
+```
+
+Update scenario: you run `bridl run --profile engineering`, complete a provider login, and pi writes `auth.json`. Because the path is symlinked, the login lands in the profile-provided or native pi state location rather than disappearing with the tack.
+
+## Example: strict CI profile
+
+Use `error` for state that must not change during a reproducibility-sensitive run.
+
+```yaml
+# profile.yml
+id: ci-review
+label: CI Review
+
+state_persistence:
+  settings.json: error
+  mcp.json: error
+  plugins/: error
+  unknown: error
+```
+
+Update scenario: a CI run unexpectedly edits `mcp.json` or creates an undeclared state file. The agent process can finish, but Bridl fails afterward because the profile declared those changes unacceptable.
+
+## Example: exploratory plugin work
+
+Use `warn` when mutation is allowed but should be visible.
+
+```yaml
+# profile.yml
+id: plugin-sandbox
+label: Plugin Sandbox
+
+state_persistence:
+  plugins/: warn
+  unknown: warn
+```
+
+Update scenario: you experiment with plugin installation during a run. Bridl lets the agent continue, discards the temporary plugin changes afterward, and reports what changed so you can decide whether to promote it into a profile.
+
+## Example: keep caches out of profiles
+
+Use `discard` for state that is useful only during a run.
+
+```yaml
+# profile.yml
+id: clean-room
+label: Clean Room
+
+state_persistence:
+  cache/: discard
+  sessions/: discard
+```
+
+Update scenario: pi writes session transcripts and cache entries while investigating a problem. Those files help during the run, but Bridl deletes them with the tack so the profile stays clean.
+
+## Pi defaults and special paths
+
+Pi is Bridl's day-one adapter. Most symlinked pi state paths resolve to profile files under `cli_specific/pi/` when present, or to the native pi agent directory as a fallback.
+
+Pi `utilities/` and `bin/` are special cache-backed paths. Both resolve to `<cache_directory>/utilities` so helper binaries such as `fd` and `rg` are reused across temporary tacks without becoming profile-editable state.
+
+See `doc/state_writeback_strategy.md` in the repository for the complete path policy.


### PR DESCRIPTION
## Summary
- add concrete settings and profile directory examples to architecture docs
- document the functional state update model for tacks
- add state_persistence examples and strategy guidance
- add a public docs site page for state persistence update scenarios
- adjust DeepWork doc consistency review to trigger from requirements docs and list documentation files to keep updated

## Validation
- npm run check-ci
- DeepWork /review passed after addressing findings