### PR TITLE
Add integration fixture framework

### DIFF
--- a/.deepreview
+++ b/.deepreview
@@ -437,3 +437,54 @@ suggest_new_reviews:
          - Slight additions to existing rules (adding a glob to an include list)
          - Catches an issue likely to recur and worth ongoing cost
       5. If no rules are warranted, say so. An empty suggestion list is valid.
+
+integration_fixture_readme:
+  description: "Review integration fixture README files for scenario accuracy and write-back expectations."
+  match:
+    include:
+      - "tests/fixtures/integration/*/README.md"
+  review:
+    strategy: individual
+    instructions: |
+      Review this integration fixture README against the files in the same fixture
+      directory. The README is the durable human contract for the fixture set.
+
+      Check that the README accurately explains:
+      - the user/project setup represented by home/ and project/;
+      - the selected profile or profiles and relevant inheritance/default behavior;
+      - any adapter-specific controls or cli_specific state files present;
+      - expected durable state ownership: profile, native fallback, cache, or temporary tack;
+      - mutation/write-back behavior that tests are expected to exercise.
+
+      Flag stale or missing README details when fixture files changed without a
+      matching explanation update. Do not require every expected JSON assertion to
+      be duplicated verbatim in prose.
+
+      Output Format:
+      - PASS: The README matches the fixture setup and write-back expectations.
+      - FAIL: Issues found. List each stale or missing detail with the fixture path.
+
+integration_fixture_catalog:
+  description: "Review the fixture catalog when integration fixture sets change."
+  match:
+    include:
+      - "INTEGRATION_TEST_FIXTURES.md"
+      - "tests/fixtures/integration/**"
+  review:
+    strategy: matches_together
+    instructions: |
+      Review integration fixture changes for catalog consistency.
+
+      Check that:
+      - every fixture set under tests/fixtures/integration/ is represented in
+        INTEGRATION_TEST_FIXTURES.md unless it is an intentionally shared helper
+        directory documented in tests/fixtures/integration/README.md;
+      - catalog entries describe scenarios rather than adapter-only mechanics;
+      - adapter-specific expectations are described as adapter-specific details,
+        not as the fixture's primary identity;
+      - adding, removing, or materially changing a fixture is reflected in both
+        the fixture README and the catalog.
+
+      Output Format:
+      - PASS: Fixture catalog and fixture directories are consistent.
+      - FAIL: Issues found. List each missing or stale catalog/README item.

--- a/.deepwork/schemas/integration_fixture_structure/deepschema.yml
+++ b/.deepwork/schemas/integration_fixture_structure/deepschema.yml
@@ -1,0 +1,39 @@
+summary: "Integration fixture directory structure."
+instructions: |
+  Integration fixtures are copied to temporary directories and then exercised by
+  Vitest integration tests. Their static filesystem layout must stay predictable
+  so tests can discover home, project, README, and optional expected outputs.
+
+  This schema validates the structural contract documented in
+  tests/fixtures/integration/README.md. Judgment-based README freshness is
+  handled by the integration_fixture_readme DeepReview rule.
+
+matchers:
+  - "tests/fixtures/integration/*/README.md"
+
+requirements:
+  fixture-readme-required: >
+    Every integration fixture set MUST have a README.md at its root.
+  fixture-home-required: >
+    Every integration fixture set MUST have a home/ directory at its root.
+  fixture-project-required: >
+    Every integration fixture set MUST have a project/ directory at its root.
+  no-adapter-prefix-required: >
+    Fixture directory names SHOULD describe the scenario rather than beginning
+    with an adapter-specific prefix such as pi_ or claude_.
+  optional-expected-shape: >
+    If expected/ exists, adapter-specific expectations SHOULD be grouped under
+    short adapter subdirectories such as expected/pi/ or expected/claude/ when
+    the expected output is not adapter-neutral.
+
+verification_bash_command:
+  - "root=$(dirname \"$1\"); test -f \"$root/README.md\" || { echo \"FAIL: missing fixture README.md\"; exit 1; }"
+  - "root=$(dirname \"$1\"); test -d \"$root/home\" || { echo \"FAIL: fixture missing home/ directory: $root\"; exit 1; }"
+  - "root=$(dirname \"$1\"); test -d \"$root/project\" || { echo \"FAIL: fixture missing project/ directory: $root\"; exit 1; }"
+  - "root=$(dirname \"$1\"); name=$(basename \"$root\"); case \"$name\" in pi_*|claude_*) echo \"FAIL: fixture name should not start with adapter prefix: $name\"; exit 1;; esac"
+
+references:
+  - path: "../../../tests/fixtures/integration/README.md"
+    description: "Integration fixture directory contract and authoring rules."
+  - path: "../../../INTEGRATION_TEST_FIXTURES.md"
+    description: "Scenario catalog for existing and proposed fixture sets."

--- a/.deepwork/schemas/integration_fixture_structure/deepschema.yml
+++ b/.deepwork/schemas/integration_fixture_structure/deepschema.yml
@@ -19,7 +19,7 @@ requirements:
   fixture-project-required: >
     Every integration fixture set MUST have a project/ directory at its root.
   no-adapter-prefix-required: >
-    Fixture directory names SHOULD describe the scenario rather than beginning
+    Fixture directory names MUST describe the scenario rather than beginning
     with an adapter-specific prefix such as pi_ or claude_.
   optional-expected-shape: >
     If expected/ exists, adapter-specific expectations SHOULD be grouped under

--- a/INTEGRATION_TEST_FIXTURES.md
+++ b/INTEGRATION_TEST_FIXTURES.md
@@ -1,0 +1,193 @@
+# Integration Test Fixture Catalog
+
+This catalog has two groups:
+
+1. Existing small profile-resolution fixtures already under `tests/fixtures/scenarios/`.
+2. Proposed full-directory integration fixtures for tack generation and state persistence under `tests/fixtures/integration/`.
+
+The proposed integration fixture names should usually describe the user/project situation, not the agent CLI. The same fixture should be usable from pi, Claude Code, and future adapter tests when possible. Adapter-specific expectations can live under `expected/pi/`, `expected/claude/`, or be asserted directly by adapter-specific test cases.
+
+## Existing profile-resolution fixtures
+
+### `profile-precedence`
+
+Location: `tests/fixtures/scenarios/profile-precedence/`
+
+A compact fixture where user, project, and project-local profile sources all define the same `engineering` profile id.
+
+Use it to verify same-id profile merge precedence and environment deep merge behavior. It is already used by current unit tests and does not need to move before integration tests are added.
+
+### `profile-inheritance-chain`
+
+Location: `tests/fixtures/scenarios/profile-inheritance-chain/`
+
+A compact fixture where `engineering` inherits `base`, and the implicit `default` profile also inherits `base`.
+
+Use it to verify explicit inheritance plus implicit user-default inclusion without duplicate base profiles.
+
+### `profile-multiple-inheritance`
+
+Location: `tests/fixtures/scenarios/profile-multiple-inheritance/`
+
+A compact fixture where `composite` inherits both `first` and `second`, and all three profiles define overlapping environment values.
+
+Use it to verify deterministic multiple-inheritance stack order and override behavior.
+
+### `profile-cycle`
+
+Location: `tests/fixtures/scenarios/profile-cycle/`
+
+A compact negative fixture where profiles `a` and `b` inherit each other.
+
+Use it to verify inheritance cycle diagnostics.
+
+### `profile-missing-inheritance`
+
+Location: `tests/fixtures/scenarios/profile-missing-inheritance/`
+
+A compact negative fixture where `engineering` inherits a missing profile id.
+
+Use it to verify missing inherited profile diagnostics.
+
+## Proposed integration fixtures
+
+### `trivial_repo_only_profile`
+
+Location: `tests/fixtures/integration/trivial_repo_only_profile/`
+
+This is the ordinary happy path: the repository defines one checked-in profile, while the user has a normal `default` profile in `~/.bridl/profiles/default`.
+
+The selected repo profile should compose with the user's implicit default profile. The fixture should intentionally omit profile-owned CLI state files so adapter defaults fall through to native standard locations, such as each adapter's normal config/state directory.
+
+Use it as the first integration smoke test. It should run under multiple adapters and assert the selected profile, launch plan, generated tack basics, and native fallback state ownership.
+
+Write-back focus: generated tack files must not rewrite repo or user profile YAML. Durable CLI state should go only to adapter-declared native fallback paths.
+
+### `heavily_overridden_engineering`
+
+Location: `tests/fixtures/integration/heavily_overridden_engineering/`
+
+This is the stress case for source precedence. The profile id `engineering` should exist in several places:
+
+- a pre-seeded cached GitHub/team source;
+- a repo-declared supplemental source;
+- the user's profile source;
+- the checked-in repo profile source;
+- project-local overrides.
+
+Each layer should use obvious values such as `REMOTE_ONLY`, `USER_ONLY`, `REPO_ONLY`, `LOCAL_ONLY`, and `SHARED` so failures identify the wrong winning layer immediately.
+
+Use it to verify same-id profile precedence, source ordering, implicit defaults, inherited defaults, profile-folder attribution, and generated tack output when many sources contribute.
+
+Write-back focus: if a highest-precedence profile-owned state file exists, writes through that declared state path should update only that source file. Mutating a generated file in the tack must not be ambiguously written back to any source layer.
+
+### `remote_baseline_local_selection`
+
+Location: `tests/fixtures/integration/remote_baseline_local_selection/`
+
+This fixture should include pre-seeded cached remote settings and profile sources, plus local user/project settings. Project-local settings selects the active profile without editing checked-in project settings.
+
+Use it to exercise remote settings composition while keeping tests offline and deterministic.
+
+Write-back focus: expected output should make it obvious whether a value came from remote, user, project, or project-local input. Tack mutations should not blur that source ownership.
+
+### `language_stack_with_personal_default`
+
+Location: `tests/fixtures/integration/language_stack_with_personal_default/`
+
+This fixture should model a real repo profile such as `typescript-review` that inherits repo language/tooling profiles. The user's implicit `default` profile contributes personal environment, prompt, or session defaults below the repo stack.
+
+Use it to verify realistic inheritance plus implicit user-default composition.
+
+Write-back focus: inherited generated controls should not be written back to any parent profile. If profile-owned CLI state is absent, adapter state should use native or cache fallback.
+
+### `local_sandbox_overrides`
+
+Location: `tests/fixtures/integration/local_sandbox_overrides/`
+
+This fixture should have stable checked-in repo profiles, plus `.bridl/local/settings.yml` selecting a local-only sandbox profile. The sandbox can add experimental args, environment, prompts, and selected `state_persistence` overrides.
+
+Use it to cover developer-local customization without changing repo files.
+
+Write-back focus: writes to sandbox temporary paths should follow local `discard` or `warn` strategies and must not modify checked-in profiles.
+
+### `strict_ci_profile`
+
+Location: `tests/fixtures/integration/strict_ci_profile/`
+
+This fixture should model a locked CI profile. It should use strict `state_persistence` values such as `unknown: error`, important settings/config paths as `error`, and caches/sessions as `discard`.
+
+Use it to test reproducibility enforcement, post-run diagnostics, and `--hard-tack` behavior.
+
+Write-back focus: the fake launcher should attempt both declared and unknown writes. Tests should assert failure or warnings without durable persistence for non-persistent paths.
+
+### `profile_owned_cli_state`
+
+Location: `tests/fixtures/integration/profile_owned_cli_state/`
+
+This fixture should include a selected profile with generic controls plus adapter-specific state files under paths such as `cli_specific/pi/` and `cli_specific/claude/`.
+
+Use it to let each adapter prove it selects its own profile-owned state without putting an adapter name in the fixture name.
+
+Write-back focus: writes through declared symlinked state paths should update the selected profile-owned state for that adapter only.
+
+### `native_fallback_cli_state`
+
+Location: `tests/fixtures/integration/native_fallback_cli_state/`
+
+This fixture should intentionally omit profile-owned CLI state files. The synthetic home/native directories can be empty or partially seeded.
+
+Use it to verify the underlying adapter default behavior where declared state symlinks point at standard native CLI locations.
+
+Write-back focus: writes persist only through declared native fallback symlinks. Missing fallback files or directories are created intentionally.
+
+### `cache_backed_tooling_state`
+
+Location: `tests/fixtures/integration/cache_backed_tooling_state/`
+
+This fixture should configure an explicit `cache_directory`. Adapters with reusable helper, tooling, utility, or cache paths should use that cache rather than profile folders.
+
+Use it to verify cache reuse across temporary tacks.
+
+Write-back focus: cache-backed writes persist to the configured cache and should not appear in profile or native settings locations.
+
+### `adapter_specific_overrides`
+
+Location: `tests/fixtures/integration/adapter_specific_overrides/`
+
+This fixture should have one selected profile with generic controls plus adapter-specific controls, such as `controls.pi` and `controls.claude`. It can also include adapter-specific `cli_specific/` files.
+
+Use it to run the same profile under multiple adapters and verify that generic controls plus adapter-specific overrides translate correctly.
+
+Write-back focus: adapter-specific state writes affect only that adapter's declared state paths. Generic generated tack content remains non-write-back unless explicitly persistent.
+
+### `state_path_replaced_by_agent`
+
+Location: `tests/fixtures/integration/state_path_replaced_by_agent/`
+
+This fixture should start with one or more declared persistent state symlinks. The fake launcher replaces a symlink itself with a regular file or directory instead of writing through it.
+
+Use it as regression coverage for accidental symlink replacement by child CLIs.
+
+Write-back focus: replacement should be diagnosed as not persisted, and the original durable source should remain unchanged.
+
+## Summary matrix
+
+| Fixture                                | Status   | Settings layers     | Same-id defs | Inherit depth    | Adapters       | State owner     | Mutation focus   |
+| -------------------------------------- | -------- | ------------------- | ------------ | ---------------- | -------------- | --------------- | ---------------- |
+| `profile-precedence`                   | Existing | none                | 3            | 0                | none           | none            | none             |
+| `profile-inheritance-chain`            | Existing | none                | 1            | 1 + default      | none           | none            | none             |
+| `profile-multiple-inheritance`         | Existing | none                | 1            | 2 parents        | none           | none            | none             |
+| `profile-cycle`                        | Existing | none                | 1            | cycle            | none           | none            | diagnostics      |
+| `profile-missing-inheritance`          | Existing | none                | 1            | missing          | none           | none            | diagnostics      |
+| `trivial_repo_only_profile`            | Proposed | user + repo         | 1            | implicit default | all            | native fallback | generated files  |
+| `heavily_overridden_engineering`       | Proposed | remote + 3          | 5            | 1-2              | all            | highest profile | source ownership |
+| `remote_baseline_local_selection`      | Proposed | remote + 3          | 1-2          | implicit default | all            | mixed           | source ownership |
+| `language_stack_with_personal_default` | Proposed | user + repo         | 1            | 2-3              | all            | native fallback | inherited output |
+| `local_sandbox_overrides`              | Proposed | user + repo + local | 1-2          | 1                | all            | temporary       | local overrides  |
+| `strict_ci_profile`                    | Proposed | repo                | 1            | 0-1              | all            | temporary       | errors           |
+| `profile_owned_cli_state`              | Proposed | user + repo         | 1            | 0-1              | all            | profile state   | symlink writes   |
+| `native_fallback_cli_state`            | Proposed | user + repo         | 1            | 0-1              | all            | native fallback | fallback writes  |
+| `cache_backed_tooling_state`           | Proposed | user + repo         | 1            | 0                | adapter subset | cache           | cache writes     |
+| `adapter_specific_overrides`           | Proposed | user + repo         | 1            | 0-1              | all            | mixed           | adapter controls |
+| `state_path_replaced_by_agent`         | Proposed | user + repo         | 1            | 0                | all            | profile/native  | symlink replaced |

--- a/doc/file_structure.md
+++ b/doc/file_structure.md
@@ -13,6 +13,7 @@ Bridl is organized around clear TypeScript source boundaries, requirement docume
 │   ├── architecture.md                # architectural rationale and runtime file conventions
 │   ├── controllable-elements.md       # controllable element terminology and support matrix
 │   ├── file_structure.md              # repository file structure overview
+│   ├── integration_test_system.md     # fixture-backed integration test design
 │   ├── state_writeback_strategy.md    # tack state persistence and writeback design
 │   └── specs/                         # detailed supporting specs
 ├── doc_site/                          # Nextra/Next.js documentation website
@@ -28,6 +29,7 @@ Bridl is organized around clear TypeScript source boundaries, requirement docume
 ├── .prettierignore                    # Prettier ignore rules
 ├── .prettierrc.json                   # Prettier formatting configuration
 ├── .snapperrc.toml                    # Snapper Markdown formatting configuration
+├── INTEGRATION_TEST_FIXTURES.md       # integration fixture catalog and planning table
 ├── plan.md                            # implementation plan
 ├── contributor.md                     # local install and contributor workflow guide
 ├── src/                               # production TypeScript source

--- a/doc/integration_test_system.md
+++ b/doc/integration_test_system.md
@@ -1,10 +1,10 @@
-# Integration Test System Design
+# Integration Test System
 
 ## Purpose
 
-Bridl needs integration tests that exercise real settings/profile directory trees rather than constructing every input inside individual tests. This is especially important for tack generation and state persistence because the effective runtime tack can be composed from multiple settings files, multiple profile sources, inherited profiles, adapter defaults, and CLI-specific profile state files.
+Bridl uses fixture-backed integration tests to exercise real settings/profile directory trees rather than constructing every input inside individual tests. This is especially important for tack generation and state persistence because the effective runtime tack can be composed from multiple settings files, multiple profile sources, inherited profiles, adapter defaults, and CLI-specific profile state files.
 
-The core risk is that a generated tack may look correct in isolated unit tests while write-back/state-persistence behavior is ambiguous or unsafe when the tack came from four or more durable sources. Integration fixtures should make those source relationships visible and testable.
+The core risk is that a generated tack can look correct in isolated unit tests while write-back/state-persistence behavior remains ambiguous or unsafe when the tack came from four or more durable sources. Integration fixtures make those source relationships visible and testable.
 
 ## Goals
 
@@ -12,27 +12,28 @@ The core risk is that a generated tack may look correct in isolated unit tests w
 - Copy each fixture into a temporary directory before the test mutates it.
 - Traverse fixtures through the same public loading, resolution, tack assembly, and run/write detection paths used by commands.
 - Assert the resulting tack shape, symlinks, generated files, argv/env launch plan, warnings, and durable write results.
-- Make source ownership explicit enough that tests can prove Bridl does not perform unsupported generic write-back into composed settings/profile inputs.
-- Keep fixtures reusable across tests and documented in a root-level fixture catalog.
+- Make source ownership explicit enough that tests prove Bridl does not perform unsupported generic write-back into composed settings/profile inputs.
+- Keep fixtures reusable across tests and documented in the root-level fixture catalog.
 
 ## Non-goals
 
-- Do not replace focused unit tests for schema validation, merge algorithms, adapter helpers, or path-safety checks.
-- Do not implement generic structured merge-back from generated tack files into settings or profiles.
-- Do not require real pi or Claude Code binaries. Integration tests should inject a fake launcher that reads/writes the tack.
-- Do not depend on the developer machine's real home directory, native CLI config, or network state.
+- Integration tests do not replace focused unit tests for schema validation, merge algorithms, adapter helpers, or path-safety checks.
+- Bridl does not implement generic structured merge-back from generated tack files into settings or profiles.
+- Integration tests do not require real pi or Claude Code binaries. Tests inject fake launchers that read/write the tack.
+- Integration tests do not depend on the developer machine's real home directory, native CLI config, or network state.
 
-## Proposed repository layout
+## Repository layout
 
 ```text
 tests/
   integration/
     tack-generation.test.ts
-    state-writeback.test.ts
     fixtureHarness.ts
   fixtures/
     integration/
+      README.md
       trivial_repo_only_profile/
+        README.md
         home/
           .bridl/settings.yml
           .bridl/profiles/default/profile.yml
@@ -40,51 +41,56 @@ tests/
           .bridl/settings.yml
           .bridl/profiles/repo-review/profile.yml
         expected/
-          tack-summary.json
-          warnings.json
-      heavily_overridden_engineering/
-        ...
-      strict_ci_profile/
-        ...
+          pi/
+            tack-summary.json
+            warnings.json
 ```
 
-The existing `tests/fixtures/scenarios/` directory already contains small profile-resolution fixtures used by current unit tests. This design does not replace or move those fixtures initially. New end-to-end fixtures should use `tests/fixtures/integration/` because they model full home/project/cache/native trees and expected tack effects. If an existing scenario is useful for an integration test, prefer copying or expanding it into a new integration fixture instead of changing the existing unit-test fixture in place.
+The existing `tests/fixtures/scenarios/` directory contains small profile-resolution fixtures used by current unit tests. The integration framework does not replace or move those fixtures. End-to-end fixtures live in `tests/fixtures/integration/` because they model full home/project/cache/native trees and expected tack effects. When an existing scenario is useful for an integration test, copy or expand it into a new integration fixture instead of changing the existing unit-test fixture in place.
+
+Additional fixture-set PRs target this framework branch and add more directories under `tests/fixtures/integration/`.
 
 ## Fixture directory contract
 
-Each integration fixture should be a complete synthetic filesystem tree. A fixture may include these top-level entries:
+Each integration fixture is a complete synthetic filesystem tree. A fixture uses these top-level entries:
 
 | Path        | Purpose                                                                                         |
 | ----------- | ----------------------------------------------------------------------------------------------- |
+| `README.md` | Human explanation of the scenario and the behavior it protects.                                 |
 | `home/`     | Synthetic user home directory passed to command execution.                                      |
 | `project/`  | Synthetic project directory passed to command execution.                                        |
-| `native/`   | Optional explicit native CLI state tree if a test maps adapter fallbacks away from `home/`.     |
-| `cache/`    | Optional pre-seeded Bridl cache or remote-profile cache.                                        |
 | `expected/` | Expected tack summaries, symlink targets, warnings, launch args/env, and durable file contents. |
-| `README.md` | Human explanation of the scenario and the behavior it protects.                                 |
 
-Settings and profiles inside `home/` and `project/` should use normal Bridl paths such as `.bridl/settings.yml`, `.bridl/local/settings.yml`, and `.bridl/profiles/<id>/profile.yml`. CLI-specific state should live under profile folders, for example `cli_specific/pi/settings.json` or `cli_specific/claude/settings.json`. Fixture names should usually describe the user/project scenario rather than the adapter; adapter-specific expected output can be nested under `expected/pi/`, `expected/claude/`, and similar directories when needed.
+A fixture may also include these top-level entries:
+
+| Path      | Purpose                                                                                     |
+| --------- | ------------------------------------------------------------------------------------------- |
+| `native/` | Explicit native CLI state tree for tests that map adapter fallbacks away from `home/`.      |
+| `cache/`  | Pre-seeded Bridl cache, remote-profile cache, or adapter cache/tooling state when required. |
+
+Settings and profiles inside `home/` and `project/` use normal Bridl paths such as `.bridl/settings.yml`, `.bridl/local/settings.yml`, and `.bridl/profiles/<id>/profile.yml`. CLI-specific state lives under profile folders, for example `cli_specific/pi/settings.json` or `cli_specific/claude/settings.json`. Fixture names describe the user/project scenario rather than the adapter; adapter-specific expected output is nested under `expected/pi/`, `expected/claude/`, and similar directories.
 
 ## Harness responsibilities
 
-`tests/integration/fixtureHarness.ts` should provide a small set of helpers:
+`tests/integration/fixtureHarness.ts` exports these helpers:
 
-- `copyFixtureToTemp(name)` copies `tests/fixtures/integration/<name>` into `mkdtemp` and returns paths for `home`, `project`, `cache`, and `expected`.
-- `runFixture(name, options)` executes `executeRunCommand` with the copied home/project and a fake launcher.
-- `summarizeTack(root)` returns stable, platform-safe facts about generated files, directories, symlinks, and selected file contents.
-- `readExpectedJson(name)` loads expected fixture output from the copied `expected/` tree.
-- `cleanupFixtureTemp()` removes copied fixtures after each test.
+- `copyFixtureToTemp(name)` copies `tests/fixtures/integration/<name>` into `mkdtemp` and returns an `IntegrationFixture` with `root`, `home`, `project`, `cache`, and `expected` paths.
+- `runFixture(fixture, options)` executes `executeRunCommand` with the copied home/project and the provided fake launcher.
+- `summarizePiTack(fixture, tackRoot)` returns stable pi-specific facts about generated profile content and selected state symlinks.
+- `readExpectedJson(fixture, relativePath)` loads expected fixture output from the copied `expected/` tree.
+- `readFixtureText(fixture, relativePath)` reads a text file from the copied fixture root.
+- `cleanupIntegrationFixtures()` removes copied fixtures after each test.
 
-The harness should normalize absolute paths in expected output using tokens such as `<fixture>`, `<home>`, `<project>`, `<cache>`, and `<tack>`. This keeps expected files readable and independent of temporary directory names.
+The harness normalizes absolute paths in expected output using tokens such as `<fixture>`, `<home>`, `<project>`, `<cache>`, and `<tack>`. This keeps expected files readable and independent of temporary directory names.
 
 ## Where mutations and assertions live
 
-Use a split model:
+The framework uses a split model:
 
 - **Fixture files encode inputs and expected stable outputs.** The fixture directory contains settings, profiles, CLI-specific state files, and optional `expected/*.json` snapshots such as expected symlink targets, warnings, or final durable file contents.
 - **Test code encodes behavior.** The Vitest test case chooses which fixture to run, defines the fake launcher's mutation script, and performs assertions against the copied fixture and any expected files.
 
-This keeps fixtures readable as normal Bridl directory trees while keeping active behavior in TypeScript where it can use filesystem APIs, helper functions, and precise assertions. Avoid hiding executable test behavior in ad hoc YAML unless the mutation script becomes highly repetitive across many fixtures.
+This keeps fixtures readable as normal Bridl directory trees while keeping active behavior in TypeScript where it can use filesystem APIs, helper functions, and precise assertions. Do not hide executable test behavior in ad hoc YAML unless a future mutation-script format is deliberately added.
 
 For example:
 
@@ -108,7 +114,7 @@ it('does not copy generated composed settings back to source layers', async () =
 });
 ```
 
-A fixture may include optional expectation files like:
+A fixture can include optional expectation files like:
 
 ```text
 expected/
@@ -118,18 +124,18 @@ expected/
   source-project-settings-after.yml
 ```
 
-The test should decide how much to snapshot. Prefer structured expected files for broad tack summaries and explicit inline assertions for the key write-back invariant the test protects.
+The test decides how much to snapshot. Use structured expected files for broad tack summaries and explicit inline assertions for the key write-back invariant the test protects.
 
 ## Test flow
 
-A typical integration test should:
+A typical integration test:
 
-1. Copy a named fixture to a temporary directory.
-2. Run Bridl command code with the copied `homeDirectory` and `projectDirectory`.
-3. Use a fake launcher defined in the Vitest test to inspect the tack while it exists.
-4. Mutate declared or undeclared tack paths from that fake launcher when the scenario requires it.
-5. Let normal post-run state detection classify the mutations.
-6. Assert warnings/errors and durable source files after the command completes, using fixture `expected/` files where snapshots improve readability.
+1. Copies a named fixture to a temporary directory.
+2. Runs Bridl command code with the copied `homeDirectory` and `projectDirectory`.
+3. Uses a fake launcher defined in the Vitest test to inspect the tack while it exists.
+4. Mutates declared or undeclared tack paths from that fake launcher when the scenario requires it.
+5. Lets normal post-run state detection classify the mutations.
+6. Asserts warnings/errors and durable source files after the command completes, using fixture `expected/` files where snapshots improve readability.
 
 Example fake-launcher responsibilities:
 
@@ -141,9 +147,9 @@ Example fake-launcher responsibilities:
 - Return exit code 0 unless the scenario is testing child failure handling.
 ```
 
-## What tack assertions should cover
+## Tack assertions
 
-Integration tests should assert stable behavior, not incidental implementation details. Useful tack assertions include:
+Integration tests assert stable behavior, not incidental implementation details. Useful tack assertions include:
 
 - selected adapter and profile id;
 - resolved profile stack order;
@@ -157,30 +163,34 @@ Integration tests should assert stable behavior, not incidental implementation d
 
 ## Write-back/state-persistence focus
 
-The integration suite should encode the product rule from `doc/state_writeback_strategy.md`: Bridl does not do generic post-run copy-back or structured merge-back. Durable writes happen only through declared state paths that have a persistent strategy, normally by symlink.
+The integration suite encodes the product rule from `doc/state_writeback_strategy.md`: Bridl does not do generic post-run copy-back or structured merge-back. Durable writes happen only through declared state paths that have a persistent strategy, normally by symlink.
 
 Important cases:
 
-- A generated tack file composed from several settings/profile layers is mutated in the tack. Current behavior should be made explicit: the mutation is not generically copied back to any source layer unless that path is an adapter-declared symlink.
+- A generated tack file composed from several settings/profile layers is mutated in the tack. Current behavior is explicit: the mutation is not generically copied back to any source layer unless that path is an adapter-declared symlink.
 - A state file supplied by a high-precedence profile is symlinked and receives writes directly.
 - A declared state path configured as `warn` or `error` is not persisted.
 - Unknown files written into the tack are classified by the adapter's `unknown` strategy and never silently persisted.
 - Cache-backed adapter paths, such as Pi `utilities/` and `bin/`, persist to the configured cache rather than to profile directories.
 
-## Fixture authoring guidelines
+## Fixture authoring rules
 
 - Prefer realistic fixtures with one clear user/project story.
 - Name fixtures after that story, such as `trivial_repo_only_profile` or `heavily_overridden_engineering`, rather than after an adapter.
 - Include enough settings/profile layers to demonstrate precedence when the scenario is about merging.
 - Use obvious values such as `REMOTE_ONLY`, `USER_ONLY`, `REPO_ONLY`, `LOCAL_ONLY`, and `SHARED` so failed assertions identify the wrong layer immediately.
 - Keep expected output as JSON when possible so tests can diff structured facts.
-- Avoid timestamps, random IDs, host-specific paths, or real credentials.
-- Use a fixture `README.md` for any non-obvious scenario.
+- Avoid timestamps, random IDs, host-specific paths, and real credentials.
+- Include a fixture-root `README.md` for every fixture set.
 
-## Migration path
+## Extension path
 
-1. Keep current unit tests unchanged.
-2. Add the fixture harness and a first realistic fixture, likely `trivial_repo_only_profile`, then add `heavily_overridden_engineering` for the multi-source write-back concern.
-3. Move repeated in-test filesystem construction from tack/writeback tests into integration fixtures when it improves readability.
-4. Add fixtures for regression cases before changing tack or state-persistence behavior.
-5. Update the root fixture catalog whenever fixtures are added, retired, or repurposed.
+The framework currently includes `trivial_repo_only_profile` as the first implemented fixture. Additional fixture-set PRs add the remaining cataloged scenarios under `tests/fixtures/integration/` and extend `tests/integration/tack-generation.test.ts` or add focused integration test files when needed.
+
+When adding or changing a fixture:
+
+1. Add or update the fixture root `README.md` in the same change.
+2. Add static fixture files under `home/`, `project/`, optional `cache/` or `native/`, and optional `expected/`.
+3. Add a Vitest integration test that copies the fixture, runs through command code, and asserts the tack/write-back behavior.
+4. Update `INTEGRATION_TEST_FIXTURES.md` when the fixture's scenario, status, or purpose changes.
+5. Run `npm run check-ci` before opening or updating the PR.

--- a/doc/integration_test_system.md
+++ b/doc/integration_test_system.md
@@ -1,0 +1,186 @@
+# Integration Test System Design
+
+## Purpose
+
+Bridl needs integration tests that exercise real settings/profile directory trees rather than constructing every input inside individual tests. This is especially important for tack generation and state persistence because the effective runtime tack can be composed from multiple settings files, multiple profile sources, inherited profiles, adapter defaults, and CLI-specific profile state files.
+
+The core risk is that a generated tack may look correct in isolated unit tests while write-back/state-persistence behavior is ambiguous or unsafe when the tack came from four or more durable sources. Integration fixtures should make those source relationships visible and testable.
+
+## Goals
+
+- Store realistic, pre-written Bridl projects as fixture directories.
+- Copy each fixture into a temporary directory before the test mutates it.
+- Traverse fixtures through the same public loading, resolution, tack assembly, and run/write detection paths used by commands.
+- Assert the resulting tack shape, symlinks, generated files, argv/env launch plan, warnings, and durable write results.
+- Make source ownership explicit enough that tests can prove Bridl does not perform unsupported generic write-back into composed settings/profile inputs.
+- Keep fixtures reusable across tests and documented in a root-level fixture catalog.
+
+## Non-goals
+
+- Do not replace focused unit tests for schema validation, merge algorithms, adapter helpers, or path-safety checks.
+- Do not implement generic structured merge-back from generated tack files into settings or profiles.
+- Do not require real pi or Claude Code binaries. Integration tests should inject a fake launcher that reads/writes the tack.
+- Do not depend on the developer machine's real home directory, native CLI config, or network state.
+
+## Proposed repository layout
+
+```text
+tests/
+  integration/
+    tack-generation.test.ts
+    state-writeback.test.ts
+    fixtureHarness.ts
+  fixtures/
+    integration/
+      trivial_repo_only_profile/
+        home/
+          .bridl/settings.yml
+          .bridl/profiles/default/profile.yml
+        project/
+          .bridl/settings.yml
+          .bridl/profiles/repo-review/profile.yml
+        expected/
+          tack-summary.json
+          warnings.json
+      heavily_overridden_engineering/
+        ...
+      strict_ci_profile/
+        ...
+```
+
+The existing `tests/fixtures/scenarios/` directory already contains small profile-resolution fixtures used by current unit tests. This design does not replace or move those fixtures initially. New end-to-end fixtures should use `tests/fixtures/integration/` because they model full home/project/cache/native trees and expected tack effects. If an existing scenario is useful for an integration test, prefer copying or expanding it into a new integration fixture instead of changing the existing unit-test fixture in place.
+
+## Fixture directory contract
+
+Each integration fixture should be a complete synthetic filesystem tree. A fixture may include these top-level entries:
+
+| Path        | Purpose                                                                                         |
+| ----------- | ----------------------------------------------------------------------------------------------- |
+| `home/`     | Synthetic user home directory passed to command execution.                                      |
+| `project/`  | Synthetic project directory passed to command execution.                                        |
+| `native/`   | Optional explicit native CLI state tree if a test maps adapter fallbacks away from `home/`.     |
+| `cache/`    | Optional pre-seeded Bridl cache or remote-profile cache.                                        |
+| `expected/` | Expected tack summaries, symlink targets, warnings, launch args/env, and durable file contents. |
+| `README.md` | Human explanation of the scenario and the behavior it protects.                                 |
+
+Settings and profiles inside `home/` and `project/` should use normal Bridl paths such as `.bridl/settings.yml`, `.bridl/local/settings.yml`, and `.bridl/profiles/<id>/profile.yml`. CLI-specific state should live under profile folders, for example `cli_specific/pi/settings.json` or `cli_specific/claude/settings.json`. Fixture names should usually describe the user/project scenario rather than the adapter; adapter-specific expected output can be nested under `expected/pi/`, `expected/claude/`, and similar directories when needed.
+
+## Harness responsibilities
+
+`tests/integration/fixtureHarness.ts` should provide a small set of helpers:
+
+- `copyFixtureToTemp(name)` copies `tests/fixtures/integration/<name>` into `mkdtemp` and returns paths for `home`, `project`, `cache`, and `expected`.
+- `runFixture(name, options)` executes `executeRunCommand` with the copied home/project and a fake launcher.
+- `summarizeTack(root)` returns stable, platform-safe facts about generated files, directories, symlinks, and selected file contents.
+- `readExpectedJson(name)` loads expected fixture output from the copied `expected/` tree.
+- `cleanupFixtureTemp()` removes copied fixtures after each test.
+
+The harness should normalize absolute paths in expected output using tokens such as `<fixture>`, `<home>`, `<project>`, `<cache>`, and `<tack>`. This keeps expected files readable and independent of temporary directory names.
+
+## Where mutations and assertions live
+
+Use a split model:
+
+- **Fixture files encode inputs and expected stable outputs.** The fixture directory contains settings, profiles, CLI-specific state files, and optional `expected/*.json` snapshots such as expected symlink targets, warnings, or final durable file contents.
+- **Test code encodes behavior.** The Vitest test case chooses which fixture to run, defines the fake launcher's mutation script, and performs assertions against the copied fixture and any expected files.
+
+This keeps fixtures readable as normal Bridl directory trees while keeping active behavior in TypeScript where it can use filesystem APIs, helper functions, and precise assertions. Avoid hiding executable test behavior in ad hoc YAML unless the mutation script becomes highly repetitive across many fixtures.
+
+For example:
+
+```ts
+it('does not copy generated composed settings back to source layers', async () => {
+  const fixture = copyFixtureToTemp('heavily_overridden_engineering');
+
+  const result = await runFixture(fixture, {
+    launcher(plan) {
+      const tackRoot = tackRootFromLaunchPlan(plan);
+      writeFileSync(join(tackRoot, 'bridl', 'profile.json'), '{"mutated":true}\n');
+      writeFileSync(join(tackRoot, 'unexpected.txt'), 'unknown write\n');
+      return Promise.resolve(0);
+    },
+  });
+
+  expect(result.warnings).toEqual(readExpectedJson(fixture, 'warnings.json'));
+  expect(readFileSync(join(fixture.project, '.bridl/settings.yml'), 'utf8')).toBe(
+    readExpectedText(fixture, 'source-project-settings-after.yml'),
+  );
+});
+```
+
+A fixture may include optional expectation files like:
+
+```text
+expected/
+  tack-summary.json
+  warnings.json
+  durable-files-after.json
+  source-project-settings-after.yml
+```
+
+The test should decide how much to snapshot. Prefer structured expected files for broad tack summaries and explicit inline assertions for the key write-back invariant the test protects.
+
+## Test flow
+
+A typical integration test should:
+
+1. Copy a named fixture to a temporary directory.
+2. Run Bridl command code with the copied `homeDirectory` and `projectDirectory`.
+3. Use a fake launcher defined in the Vitest test to inspect the tack while it exists.
+4. Mutate declared or undeclared tack paths from that fake launcher when the scenario requires it.
+5. Let normal post-run state detection classify the mutations.
+6. Assert warnings/errors and durable source files after the command completes, using fixture `expected/` files where snapshots improve readability.
+
+Example fake-launcher responsibilities:
+
+```text
+- Read the adapter config root from launch plan env, such as `PI_CODING_AGENT_DIR` or `CLAUDE_CONFIG_DIR`.
+- Assert generated tack files exist.
+- Assert declared persistent paths are symlinks to the expected profile/native/cache sources.
+- Write to declared state paths and unknown files according to the scenario.
+- Return exit code 0 unless the scenario is testing child failure handling.
+```
+
+## What tack assertions should cover
+
+Integration tests should assert stable behavior, not incidental implementation details. Useful tack assertions include:
+
+- selected adapter and profile id;
+- resolved profile stack order;
+- generated Bridl metadata files;
+- generated adapter-specific files such as profile/settings payloads;
+- launch argv and environment;
+- symlink versus temporary materialization for each declared state path;
+- symlink target precedence: project-local profile, project profile, user profile, cache, then native fallback as applicable;
+- non-persistent baseline paths and detected writes;
+- warnings becoming fatal under `--hard-tack`.
+
+## Write-back/state-persistence focus
+
+The integration suite should encode the product rule from `doc/state_writeback_strategy.md`: Bridl does not do generic post-run copy-back or structured merge-back. Durable writes happen only through declared state paths that have a persistent strategy, normally by symlink.
+
+Important cases:
+
+- A generated tack file composed from several settings/profile layers is mutated in the tack. Current behavior should be made explicit: the mutation is not generically copied back to any source layer unless that path is an adapter-declared symlink.
+- A state file supplied by a high-precedence profile is symlinked and receives writes directly.
+- A declared state path configured as `warn` or `error` is not persisted.
+- Unknown files written into the tack are classified by the adapter's `unknown` strategy and never silently persisted.
+- Cache-backed adapter paths, such as Pi `utilities/` and `bin/`, persist to the configured cache rather than to profile directories.
+
+## Fixture authoring guidelines
+
+- Prefer realistic fixtures with one clear user/project story.
+- Name fixtures after that story, such as `trivial_repo_only_profile` or `heavily_overridden_engineering`, rather than after an adapter.
+- Include enough settings/profile layers to demonstrate precedence when the scenario is about merging.
+- Use obvious values such as `REMOTE_ONLY`, `USER_ONLY`, `REPO_ONLY`, `LOCAL_ONLY`, and `SHARED` so failed assertions identify the wrong layer immediately.
+- Keep expected output as JSON when possible so tests can diff structured facts.
+- Avoid timestamps, random IDs, host-specific paths, or real credentials.
+- Use a fixture `README.md` for any non-obvious scenario.
+
+## Migration path
+
+1. Keep current unit tests unchanged.
+2. Add the fixture harness and a first realistic fixture, likely `trivial_repo_only_profile`, then add `heavily_overridden_engineering` for the multi-source write-back concern.
+3. Move repeated in-test filesystem construction from tack/writeback tests into integration fixtures when it improves readability.
+4. Add fixtures for regression cases before changing tack or state-persistence behavior.
+5. Update the root fixture catalog whenever fixtures are added, retired, or repurposed.

--- a/tests/fixtures/integration/README.md
+++ b/tests/fixtures/integration/README.md
@@ -1,0 +1,37 @@
+# Integration Fixtures
+
+Integration fixtures are complete synthetic Bridl filesystem trees. Tests copy a fixture to a temporary directory before running so the fixture source remains immutable.
+
+## Required fixture shape
+
+Each fixture set under this directory MUST include:
+
+```text
+<fixture>/
+  README.md
+  home/
+  project/
+```
+
+A fixture MAY also include:
+
+```text
+<fixture>/
+  cache/
+  native/
+  expected/
+    tack-summary.json
+    warnings.json
+    durable-files-after.json
+    pi/
+    claude/
+```
+
+## Authoring rules
+
+- The fixture root `README.md` explains the user/project setup, selected profile or profiles, expected state ownership, and mutation/write-back behavior under test.
+- `home/` is the synthetic user home directory passed to Bridl.
+- `project/` is the synthetic project directory passed to Bridl.
+- Test code owns active mutation behavior. Fixture files provide static inputs and optional expected outputs.
+- Adapter-specific expected outputs should be nested by adapter, for example `expected/pi/` or `expected/claude/`.
+- Fixture names should describe the user/project situation rather than the adapter whenever possible.

--- a/tests/fixtures/integration/trivial_repo_only_profile/README.md
+++ b/tests/fixtures/integration/trivial_repo_only_profile/README.md
@@ -1,0 +1,22 @@
+# `trivial_repo_only_profile`
+
+This fixture models the ordinary case where a repository contributes one checked-in profile and the user has a normal personal `default` profile.
+
+## Setup
+
+- `home/.bridl/settings.yml` defines the user default profile as `default`.
+- `home/.bridl/profiles/default/profile.yml` contributes personal defaults such as `USER_DEFAULT` environment values.
+- `project/.bridl/settings.yml` declares the profile sources needed for this synthetic test tree: the user profile source and the repo profile source.
+- `project/.bridl/profiles/repo-review/profile.yml` defines the selected repository profile.
+
+The test selects `repo-review` explicitly, so Bridl should resolve the user's `default` profile as the implicit lower-precedence profile and then layer `repo-review` above it.
+
+## Expected behavior
+
+The selected profile should contain both user-default and repo-specific controls, with repo values winning shared keys.
+
+This fixture intentionally does not provide any `cli_specific/<adapter>/` state files. Adapter-declared persistent state should therefore use each adapter's native fallback or configured cache behavior rather than writing state into the repo profile.
+
+## Mutation/write-back behavior
+
+Tests may mutate generated tack files and unknown user-write paths from the fake launcher. Generated tack mutations must not rewrite source settings or profile YAML. Unknown writes should be handled by the selected adapter's `unknown` state policy.

--- a/tests/fixtures/integration/trivial_repo_only_profile/expected/pi/tack-summary.json
+++ b/tests/fixtures/integration/trivial_repo_only_profile/expected/pi/tack-summary.json
@@ -1,0 +1,30 @@
+{
+  "profileId": "repo-review",
+  "agentId": "pi",
+  "launchCommand": "pi",
+  "launchArgs": ["--model", "repo-review-model", "--repo-flag"],
+  "launchEnv": {
+    "PI_CODING_AGENT_DIR": "<tack>",
+    "REPO_PROFILE": "enabled",
+    "SHARED_LAYER": "repo-review",
+    "USER_DEFAULT": "enabled"
+  },
+  "generatedProfile": {
+    "id": "repo-review",
+    "label": "Repository Review",
+    "controls": {
+      "model": "repo-review-model",
+      "environment": {
+        "REPO_PROFILE": "enabled",
+        "SHARED_LAYER": "repo-review",
+        "USER_DEFAULT": "enabled"
+      },
+      "args": ["--repo-flag"]
+    }
+  },
+  "stateTargets": {
+    "auth.json": "<home>/.pi/agent/auth.json",
+    "settings.json": "<home>/.pi/agent/settings.json",
+    "utilities": "<home>/.bridl/cache/utilities"
+  }
+}

--- a/tests/fixtures/integration/trivial_repo_only_profile/expected/pi/warnings.json
+++ b/tests/fixtures/integration/trivial_repo_only_profile/expected/pi/warnings.json
@@ -1,0 +1,1 @@
+["pi wrote undeclared tack state 'unexpected.txt' and it was not persisted."]

--- a/tests/fixtures/integration/trivial_repo_only_profile/home/.bridl/profiles/default/profile.yml
+++ b/tests/fixtures/integration/trivial_repo_only_profile/home/.bridl/profiles/default/profile.yml
@@ -1,0 +1,7 @@
+id: default
+label: Personal Default
+controls:
+  model: user-default-model
+  environment:
+    USER_DEFAULT: 'enabled'
+    SHARED_LAYER: user-default

--- a/tests/fixtures/integration/trivial_repo_only_profile/home/.bridl/settings.yml
+++ b/tests/fixtures/integration/trivial_repo_only_profile/home/.bridl/settings.yml
@@ -1,0 +1,5 @@
+default_profile: default
+default_agent: pi
+cache_directory: ./cache
+profile_sources:
+  - path: ./profiles

--- a/tests/fixtures/integration/trivial_repo_only_profile/project/.bridl/profiles/repo-review/profile.yml
+++ b/tests/fixtures/integration/trivial_repo_only_profile/project/.bridl/profiles/repo-review/profile.yml
@@ -1,0 +1,9 @@
+id: repo-review
+label: Repository Review
+controls:
+  model: repo-review-model
+  environment:
+    REPO_PROFILE: 'enabled'
+    SHARED_LAYER: repo-review
+  args:
+    - --repo-flag

--- a/tests/fixtures/integration/trivial_repo_only_profile/project/.bridl/settings.yml
+++ b/tests/fixtures/integration/trivial_repo_only_profile/project/.bridl/settings.yml
@@ -1,0 +1,3 @@
+profile_sources:
+  - path: ../../home/.bridl/profiles
+  - path: ./profiles

--- a/tests/integration/fixtureHarness.ts
+++ b/tests/integration/fixtureHarness.ts
@@ -13,6 +13,7 @@ export interface IntegrationFixture {
   readonly root: string;
   readonly home: string;
   readonly project: string;
+  readonly cache: string;
   readonly expected: string;
 }
 
@@ -37,6 +38,7 @@ export const copyFixtureToTemp = (name: string): IntegrationFixture => {
     root,
     home: join(root, 'home'),
     project: join(root, 'project'),
+    cache: join(root, 'cache'),
     expected: join(root, 'expected'),
   };
 };
@@ -102,5 +104,6 @@ export const tokenizeFixturePath = (fixture: IntegrationFixture, path: string, t
   return path
     .replaceAll(fixture.home, '<home>')
     .replaceAll(fixture.project, '<project>')
+    .replaceAll(fixture.cache, '<cache>')
     .replaceAll(fixture.root, '<fixture>');
 };

--- a/tests/integration/fixtureHarness.ts
+++ b/tests/integration/fixtureHarness.ts
@@ -1,0 +1,106 @@
+// Provides helpers for copying and asserting integration fixture trees.
+import { cpSync, mkdtempSync, rmSync, readFileSync, readlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { AgentLaunchPlan } from '../../src/agents/AgentAdapter.js';
+import { executeRunCommand } from '../../src/cli/commands/RunCommand.js';
+import type { AgentProcessLauncher, RunCommandInput, RunCommandResult } from '../../src/cli/commands/RunCommand.js';
+
+export interface IntegrationFixture {
+  readonly name: string;
+  readonly root: string;
+  readonly home: string;
+  readonly project: string;
+  readonly expected: string;
+}
+
+export interface RunFixtureOptions extends Omit<Partial<RunCommandInput>, 'homeDirectory' | 'projectDirectory'> {
+  readonly launcher: AgentProcessLauncher;
+  readonly warnings?: string[];
+}
+
+const temporaryRoots: string[] = [];
+
+const fixturesRoot = fileURLToPath(new URL('../fixtures/integration/', import.meta.url));
+
+export const copyFixtureToTemp = (name: string): IntegrationFixture => {
+  const temporaryRoot = mkdtempSync(join(tmpdir(), `bridl-fixture-${name}-`));
+  temporaryRoots.push(temporaryRoot);
+  const root = join(temporaryRoot, name);
+
+  cpSync(join(fixturesRoot, name), root, { recursive: true });
+
+  return {
+    name,
+    root,
+    home: join(root, 'home'),
+    project: join(root, 'project'),
+    expected: join(root, 'expected'),
+  };
+};
+
+export const cleanupIntegrationFixtures = (): void => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+};
+
+export const runFixture = async (
+  fixture: IntegrationFixture,
+  options: RunFixtureOptions,
+): Promise<RunCommandResult> => {
+  const warnings = options.warnings ?? [];
+
+  return executeRunCommand(
+    {
+      homeDirectory: fixture.home,
+      projectDirectory: fixture.project,
+      profileId: options.profileId,
+      agentId: options.agentId,
+      hardTack: options.hardTack,
+      passThroughArgs: options.passThroughArgs,
+    },
+    {
+      launcher: options.launcher,
+      writeError: (message) => warnings.push(message),
+    },
+  );
+};
+
+export const readExpectedJson = <T>(fixture: IntegrationFixture, relativePath: string): T =>
+  JSON.parse(readFileSync(join(fixture.expected, relativePath), 'utf8')) as T;
+
+export const readFixtureText = (fixture: IntegrationFixture, relativePath: string): string =>
+  readFileSync(join(fixture.root, relativePath), 'utf8');
+
+export const tackRootFromLaunchPlan = (plan: AgentLaunchPlan): string => {
+  const tackRoot = plan.env.PI_CODING_AGENT_DIR ?? plan.env.CLAUDE_CONFIG_DIR;
+
+  if (tackRoot === undefined) {
+    throw new Error('Launch plan did not include a known adapter config directory environment variable.');
+  }
+
+  return tackRoot;
+};
+
+export const summarizePiTack = (fixture: IntegrationFixture, tackRoot: string): unknown => ({
+  generatedProfile: JSON.parse(readFileSync(join(tackRoot, 'bridl', 'profile.json'), 'utf8')) as unknown,
+  stateTargets: {
+    'auth.json': tokenizeFixturePath(fixture, readlinkSync(join(tackRoot, 'auth.json')), tackRoot),
+    'settings.json': tokenizeFixturePath(fixture, readlinkSync(join(tackRoot, 'settings.json')), tackRoot),
+    utilities: tokenizeFixturePath(fixture, readlinkSync(join(tackRoot, 'utilities')), tackRoot),
+  },
+});
+
+export const tokenizeFixturePath = (fixture: IntegrationFixture, path: string, tackRoot?: string): string => {
+  if (tackRoot !== undefined && path === tackRoot) {
+    return '<tack>';
+  }
+
+  return path
+    .replaceAll(fixture.home, '<home>')
+    .replaceAll(fixture.project, '<project>')
+    .replaceAll(fixture.root, '<fixture>');
+};

--- a/tests/integration/tack-generation.test.ts
+++ b/tests/integration/tack-generation.test.ts
@@ -1,0 +1,69 @@
+// Tests fixture-backed integration behavior for tack generation and state ownership.
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  cleanupIntegrationFixtures,
+  copyFixtureToTemp,
+  readExpectedJson,
+  readFixtureText,
+  runFixture,
+  summarizePiTack,
+  tackRootFromLaunchPlan,
+  tokenizeFixturePath,
+} from './fixtureHarness.js';
+
+afterEach(() => {
+  cleanupIntegrationFixtures();
+});
+
+describe('integration fixture tack generation', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.3, BRIDL-REQ-005.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('runs a repo-only selected profile over the user default and uses native fallback state', async () => {
+    const fixture = copyFixtureToTemp('trivial_repo_only_profile');
+    const warnings: string[] = [];
+    let tackSummary: unknown;
+
+    const result = await runFixture(fixture, {
+      profileId: 'repo-review',
+      agentId: 'pi',
+      warnings,
+      launcher: {
+        launch(plan) {
+          const tackRoot = tackRootFromLaunchPlan(plan);
+          tackSummary = {
+            profileId: 'repo-review',
+            agentId: 'pi',
+            launchCommand: plan.command,
+            launchArgs: plan.args,
+            launchEnv: {
+              PI_CODING_AGENT_DIR: tokenizeFixturePath(fixture, plan.env.PI_CODING_AGENT_DIR, tackRoot),
+              REPO_PROFILE: plan.env.REPO_PROFILE,
+              SHARED_LAYER: plan.env.SHARED_LAYER,
+              USER_DEFAULT: plan.env.USER_DEFAULT,
+            },
+            ...(summarizePiTack(fixture, tackRoot) as Record<string, unknown>),
+          };
+
+          writeFileSync(join(tackRoot, 'bridl', 'profile.json'), '{"mutated":true}\n');
+          writeFileSync(join(tackRoot, 'settings.json'), '{"fallback":"updated"}\n');
+          writeFileSync(join(tackRoot, 'unexpected.txt'), 'unknown write\n');
+
+          return Promise.resolve(0);
+        },
+      },
+    });
+
+    expect(tackSummary).toEqual(readExpectedJson(fixture, 'pi/tack-summary.json'));
+    expect(result.profileId).toBe('repo-review');
+    expect(result.agentId).toBe('pi');
+    expect(result.warnings).toEqual(readExpectedJson(fixture, 'pi/warnings.json'));
+    expect(warnings).toEqual(result.warnings);
+    expect(readFileSync(join(fixture.home, '.pi', 'agent', 'settings.json'), 'utf8')).toBe('{"fallback":"updated"}\n');
+    expect(readFixtureText(fixture, 'home/.bridl/profiles/default/profile.yml')).toContain('USER_DEFAULT');
+    expect(readFixtureText(fixture, 'project/.bridl/profiles/repo-review/profile.yml')).toContain('REPO_PROFILE');
+  });
+});


### PR DESCRIPTION
## Summary
- add fixture-backed integration test harness and docs
- implement the first realistic fixture: trivial_repo_only_profile
- add DeepSchema/DeepReview coverage for fixture structure and README/catalog freshness

## Validation
- npm run check-ci