### PR TITLE
Add language stack personal default integration fixture

### DIFF
--- a/tests/fixtures/integration/INTEGRATION_TEST_FIXTURES.md
+++ b/tests/fixtures/integration/INTEGRATION_TEST_FIXTURES.md
@@ -183,7 +183,7 @@ Write-back focus: replacement should be diagnosed as not persisted, and the orig
 | `trivial_repo_only_profile`            | Existing | user + repo         | 1            | implicit default | pi             | native fallback | generated files  |
 | `heavily_overridden_engineering`       | Proposed | remote + 3          | 5            | 1-2              | all            | highest profile | source ownership |
 | `remote_baseline_local_selection`      | Proposed | remote + 3          | 1-2          | implicit default | all            | mixed           | source ownership |
-| `language_stack_with_personal_default` | Proposed | user + repo         | 1            | 2-3              | all            | native fallback | inherited output |
+| `language_stack_with_personal_default` | Existing | user + repo         | 1            | 2-3              | all            | native fallback | inherited output |
 | `local_sandbox_overrides`              | Proposed | user + repo + local | 1-2          | 1                | all            | temporary       | local overrides  |
 | `strict_ci_profile`                    | Proposed | repo                | 1            | 0-1              | all            | temporary       | errors           |
 | `profile_owned_cli_state`              | Proposed | user + repo         | 1            | 0-1              | all            | profile state   | symlink writes   |

--- a/tests/fixtures/integration/language_stack_with_personal_default/README.md
+++ b/tests/fixtures/integration/language_stack_with_personal_default/README.md
@@ -1,0 +1,25 @@
+# `language_stack_with_personal_default`
+
+This fixture models a realistic TypeScript repository profile that composes checked-in language and tooling profiles with the user's implicit personal `default` profile.
+
+## Setup
+
+- `home/.bridl/settings.yml` declares the personal `default` profile, the `pi` default agent, and a user cache directory.
+- `home/.bridl/profiles/default/profile.yml` contributes personal environment and session defaults that should sit below all repository profiles.
+- `project/.bridl/settings.yml` exposes both the synthetic user profile source and the checked-in repository profile source.
+- `project/.bridl/profiles/repo-review-base/profile.yml` contains shared review conventions for the repository.
+- `project/.bridl/profiles/language-typescript/profile.yml` inherits the review base and adds TypeScript-specific controls.
+- `project/.bridl/profiles/tooling-node-vitest/profile.yml` inherits the review base and adds Node/Vitest tooling controls.
+- `project/.bridl/profiles/typescript-review/profile.yml` inherits the language and tooling profiles and is selected by the integration test.
+
+## Expected behavior
+
+When the test selects `typescript-review`, Bridl should first include the user's implicit `default` profile, then resolve the repository inheritance stack. Repository controls win overlapping environment keys while preserving lower-precedence personal values that are not overridden.
+
+The resulting pi launch plan should include the selected model, prompt controls, inherited environment variables, and the selected profile's final review argument.
+
+## Mutation/write-back behavior
+
+This fixture intentionally omits `cli_specific/<adapter>/` state files. Adapter-declared state should therefore resolve to native or cache fallback paths, not to parent profiles in the inheritance stack.
+
+Tests may mutate generated tack files, fallback state, and unknown tack paths. Generated tack mutations must not be written back to any inherited repository profile or to the user profile YAML. Unknown writes should follow the adapter's `unknown` state policy.

--- a/tests/fixtures/integration/language_stack_with_personal_default/expected/pi/tack-summary.json
+++ b/tests/fixtures/integration/language_stack_with_personal_default/expected/pi/tack-summary.json
@@ -1,0 +1,64 @@
+{
+  "profileId": "typescript-review",
+  "agentId": "pi",
+  "launchCommand": "pi",
+  "launchArgs": [
+    "--model",
+    "typescript-review-model",
+    "--provider",
+    "local-node",
+    "--prompt-template",
+    "Use npm scripts and Vitest evidence when reviewing changes.",
+    "--system-prompt",
+    "Review for correctness, maintainability, and project conventions.",
+    "--append-system-prompt",
+    "Prefer concise, practical feedback.",
+    "--extension",
+    "tsconfig",
+    "--skill",
+    "strict-typescript",
+    "--review-scope=typescript",
+    "--personal-flag"
+  ],
+  "launchEnv": {
+    "PI_CODING_AGENT_DIR": "<tack>",
+    "EDITOR_STYLE": "noah",
+    "LANGUAGE_STACK": "typescript",
+    "PERSONAL_DEFAULT": "enabled",
+    "REPO_REVIEW_BASE": "enabled",
+    "REVIEW_STACK": "selected-typescript-review",
+    "SELECTED_PROFILE": "typescript-review",
+    "TOOLING_STACK": "node-vitest"
+  },
+  "generatedProfile": {
+    "id": "typescript-review",
+    "label": "TypeScript Review",
+    "controls": {
+      "model": "typescript-review-model",
+      "environment": {
+        "EDITOR_STYLE": "noah",
+        "LANGUAGE_STACK": "typescript",
+        "PERSONAL_DEFAULT": "enabled",
+        "REPO_REVIEW_BASE": "enabled",
+        "REVIEW_STACK": "selected-typescript-review",
+        "SELECTED_PROFILE": "typescript-review",
+        "TOOLING_STACK": "node-vitest"
+      },
+      "append_system_prompt": "Prefer concise, practical feedback.",
+      "args": ["--review-scope=typescript", "--personal-flag"],
+      "system_prompt": "Review for correctness, maintainability, and project conventions.",
+      "extensions": ["tsconfig"],
+      "skills": ["strict-typescript"],
+      "provider": "local-node",
+      "prompt_template": "Use npm scripts and Vitest evidence when reviewing changes.",
+      "appendSystemPrompt": "Prefer concise, practical feedback.",
+      "systemPrompt": "Review for correctness, maintainability, and project conventions.",
+      "promptTemplate": "Use npm scripts and Vitest evidence when reviewing changes."
+    }
+  },
+  "stateTargets": {
+    "auth.json": "<home>/.pi/agent/auth.json",
+    "settings.json": "<home>/.pi/agent/settings.json",
+    "utilities": "<home>/.bridl/cache/utilities"
+  }
+}

--- a/tests/fixtures/integration/language_stack_with_personal_default/expected/pi/warnings.json
+++ b/tests/fixtures/integration/language_stack_with_personal_default/expected/pi/warnings.json
@@ -1,0 +1,1 @@
+["pi wrote undeclared tack state 'scratch.log' and it was not persisted."]

--- a/tests/fixtures/integration/language_stack_with_personal_default/home/.bridl/profiles/default/profile.yml
+++ b/tests/fixtures/integration/language_stack_with_personal_default/home/.bridl/profiles/default/profile.yml
@@ -1,0 +1,11 @@
+id: default
+label: Personal Defaults
+controls:
+  model: personal-fallback-model
+  environment:
+    PERSONAL_DEFAULT: 'enabled'
+    EDITOR_STYLE: noah
+    REVIEW_STACK: personal
+  append_system_prompt: Prefer concise, practical feedback.
+  args:
+    - --personal-flag

--- a/tests/fixtures/integration/language_stack_with_personal_default/home/.bridl/settings.yml
+++ b/tests/fixtures/integration/language_stack_with_personal_default/home/.bridl/settings.yml
@@ -1,0 +1,5 @@
+default_profile: default
+default_agent: pi
+cache_directory: ./cache
+profile_sources:
+  - path: ./profiles

--- a/tests/fixtures/integration/language_stack_with_personal_default/project/.bridl/profiles/language-typescript/profile.yml
+++ b/tests/fixtures/integration/language_stack_with_personal_default/project/.bridl/profiles/language-typescript/profile.yml
@@ -1,0 +1,11 @@
+id: language-typescript
+label: TypeScript Language Standards
+inherits: [repo-review-base]
+controls:
+  environment:
+    LANGUAGE_STACK: typescript
+    REVIEW_STACK: language-typescript
+  extensions:
+    - tsconfig
+  skills:
+    - strict-typescript

--- a/tests/fixtures/integration/language_stack_with_personal_default/project/.bridl/profiles/repo-review-base/profile.yml
+++ b/tests/fixtures/integration/language_stack_with_personal_default/project/.bridl/profiles/repo-review-base/profile.yml
@@ -1,0 +1,8 @@
+id: repo-review-base
+label: Repository Review Base
+controls:
+  model: repo-review-model
+  environment:
+    REPO_REVIEW_BASE: 'enabled'
+    REVIEW_STACK: repo-base
+  system_prompt: Review for correctness, maintainability, and project conventions.

--- a/tests/fixtures/integration/language_stack_with_personal_default/project/.bridl/profiles/tooling-node-vitest/profile.yml
+++ b/tests/fixtures/integration/language_stack_with_personal_default/project/.bridl/profiles/tooling-node-vitest/profile.yml
@@ -1,0 +1,9 @@
+id: tooling-node-vitest
+label: Node and Vitest Tooling
+inherits: [repo-review-base]
+controls:
+  provider: local-node
+  environment:
+    TOOLING_STACK: node-vitest
+    REVIEW_STACK: tooling-node-vitest
+  prompt_template: Use npm scripts and Vitest evidence when reviewing changes.

--- a/tests/fixtures/integration/language_stack_with_personal_default/project/.bridl/profiles/typescript-review/profile.yml
+++ b/tests/fixtures/integration/language_stack_with_personal_default/project/.bridl/profiles/typescript-review/profile.yml
@@ -1,0 +1,10 @@
+id: typescript-review
+label: TypeScript Review
+inherits: [language-typescript, tooling-node-vitest]
+controls:
+  model: typescript-review-model
+  environment:
+    SELECTED_PROFILE: typescript-review
+    REVIEW_STACK: selected-typescript-review
+  args:
+    - --review-scope=typescript

--- a/tests/fixtures/integration/language_stack_with_personal_default/project/.bridl/settings.yml
+++ b/tests/fixtures/integration/language_stack_with_personal_default/project/.bridl/settings.yml
@@ -1,0 +1,3 @@
+profile_sources:
+  - path: ../../home/.bridl/profiles
+  - path: ./profiles

--- a/tests/integration/tack-generation.test.ts
+++ b/tests/integration/tack-generation.test.ts
@@ -73,6 +73,15 @@ describe('integration fixture tack generation', () => {
     const fixture = copyFixtureToTemp('language_stack_with_personal_default');
     const warnings: string[] = [];
     let tackSummary: unknown;
+    const inheritedProfilePaths = [
+      'home/.bridl/profiles/default/profile.yml',
+      'project/.bridl/profiles/repo-review-base/profile.yml',
+      'project/.bridl/profiles/language-typescript/profile.yml',
+      'project/.bridl/profiles/tooling-node-vitest/profile.yml',
+    ] as const;
+    const originalInheritedProfiles = new Map(
+      inheritedProfilePaths.map((profilePath) => [profilePath, readFixtureText(fixture, profilePath)]),
+    );
 
     const result = await runFixture(fixture, {
       profileId: 'typescript-review',
@@ -116,15 +125,8 @@ describe('integration fixture tack generation', () => {
     expect(readFileSync(join(fixture.home, '.pi', 'agent', 'settings.json'), 'utf8')).toBe(
       '{"language-stack":"updated"}\n',
     );
-    expect(readFixtureText(fixture, 'home/.bridl/profiles/default/profile.yml')).toContain('PERSONAL_DEFAULT');
-    expect(readFixtureText(fixture, 'project/.bridl/profiles/repo-review-base/profile.yml')).toContain(
-      'REPO_REVIEW_BASE',
-    );
-    expect(readFixtureText(fixture, 'project/.bridl/profiles/language-typescript/profile.yml')).toContain(
-      'LANGUAGE_STACK',
-    );
-    expect(readFixtureText(fixture, 'project/.bridl/profiles/tooling-node-vitest/profile.yml')).toContain(
-      'TOOLING_STACK',
-    );
+    for (const [profilePath, originalProfileYaml] of originalInheritedProfiles) {
+      expect(readFixtureText(fixture, profilePath)).toBe(originalProfileYaml);
+    }
   });
 });

--- a/tests/integration/tack-generation.test.ts
+++ b/tests/integration/tack-generation.test.ts
@@ -66,4 +66,65 @@ describe('integration fixture tack generation', () => {
     expect(readFixtureText(fixture, 'home/.bridl/profiles/default/profile.yml')).toContain('USER_DEFAULT');
     expect(readFixtureText(fixture, 'project/.bridl/profiles/repo-review/profile.yml')).toContain('REPO_PROFILE');
   });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-003.2, BRIDL-REQ-005.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('runs a realistic TypeScript profile stack over the user default without writing back inherited profiles', async () => {
+    const fixture = copyFixtureToTemp('language_stack_with_personal_default');
+    const warnings: string[] = [];
+    let tackSummary: unknown;
+
+    const result = await runFixture(fixture, {
+      profileId: 'typescript-review',
+      agentId: 'pi',
+      warnings,
+      launcher: {
+        launch(plan) {
+          const tackRoot = tackRootFromLaunchPlan(plan);
+          tackSummary = {
+            profileId: 'typescript-review',
+            agentId: 'pi',
+            launchCommand: plan.command,
+            launchArgs: plan.args,
+            launchEnv: {
+              PI_CODING_AGENT_DIR: tokenizeFixturePath(fixture, plan.env.PI_CODING_AGENT_DIR, tackRoot),
+              EDITOR_STYLE: plan.env.EDITOR_STYLE,
+              LANGUAGE_STACK: plan.env.LANGUAGE_STACK,
+              PERSONAL_DEFAULT: plan.env.PERSONAL_DEFAULT,
+              REPO_REVIEW_BASE: plan.env.REPO_REVIEW_BASE,
+              REVIEW_STACK: plan.env.REVIEW_STACK,
+              SELECTED_PROFILE: plan.env.SELECTED_PROFILE,
+              TOOLING_STACK: plan.env.TOOLING_STACK,
+            },
+            ...(summarizePiTack(fixture, tackRoot) as Record<string, unknown>),
+          };
+
+          writeFileSync(join(tackRoot, 'bridl', 'profile.json'), '{"mutated":true}\n');
+          writeFileSync(join(tackRoot, 'settings.json'), '{"language-stack":"updated"}\n');
+          writeFileSync(join(tackRoot, 'scratch.log'), 'scratch output\n');
+
+          return Promise.resolve(0);
+        },
+      },
+    });
+
+    expect(tackSummary).toEqual(readExpectedJson(fixture, 'pi/tack-summary.json'));
+    expect(result.profileId).toBe('typescript-review');
+    expect(result.agentId).toBe('pi');
+    expect(result.warnings).toEqual(readExpectedJson(fixture, 'pi/warnings.json'));
+    expect(warnings).toEqual(result.warnings);
+    expect(readFileSync(join(fixture.home, '.pi', 'agent', 'settings.json'), 'utf8')).toBe(
+      '{"language-stack":"updated"}\n',
+    );
+    expect(readFixtureText(fixture, 'home/.bridl/profiles/default/profile.yml')).toContain('PERSONAL_DEFAULT');
+    expect(readFixtureText(fixture, 'project/.bridl/profiles/repo-review-base/profile.yml')).toContain(
+      'REPO_REVIEW_BASE',
+    );
+    expect(readFixtureText(fixture, 'project/.bridl/profiles/language-typescript/profile.yml')).toContain(
+      'LANGUAGE_STACK',
+    );
+    expect(readFixtureText(fixture, 'project/.bridl/profiles/tooling-node-vitest/profile.yml')).toContain(
+      'TOOLING_STACK',
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add the language_stack_with_personal_default integration fixture with user default and repo language/tooling inheritance stack
- document fixture setup and write-back expectations
- add pi integration coverage using the fixture harness and expected tack outputs

## Validation
- npm run check-ci