### PR TITLE
Add remote baseline local selection integration fixture

### DIFF
--- a/tests/fixtures/integration/INTEGRATION_TEST_FIXTURES.md
+++ b/tests/fixtures/integration/INTEGRATION_TEST_FIXTURES.md
@@ -182,7 +182,7 @@ Write-back focus: replacement should be diagnosed as not persisted, and the orig
 | `profile-missing-inheritance`          | Existing | none                | 1            | missing          | none           | none            | diagnostics      |
 | `trivial_repo_only_profile`            | Existing | user + repo         | 1            | implicit default | pi             | native fallback | generated files  |
 | `heavily_overridden_engineering`       | Proposed | remote + 3          | 5            | 1-2              | all            | highest profile | source ownership |
-| `remote_baseline_local_selection`      | Proposed | remote + 3          | 1-2          | implicit default | all            | mixed           | source ownership |
+| `remote_baseline_local_selection`      | Existing | remote + 3          | 1-2          | implicit default | all            | mixed           | source ownership |
 | `language_stack_with_personal_default` | Existing | user + repo         | 1            | 2-3              | all            | native fallback | inherited output |
 | `local_sandbox_overrides`              | Proposed | user + repo + local | 1-2          | 1                | all            | temporary       | local overrides  |
 | `strict_ci_profile`                    | Proposed | repo                | 1            | 0-1              | all            | temporary       | errors           |

--- a/tests/fixtures/integration/remote_baseline_local_selection/README.md
+++ b/tests/fixtures/integration/remote_baseline_local_selection/README.md
@@ -1,0 +1,17 @@
+# remote_baseline_local_selection
+
+This fixture models a repository that has already synced a remote Bridl baseline into the user cache, then lets local settings choose the active profile while staying offline.
+
+## Setup
+
+- `home/.bridl/settings.yml` points at the cached `acme/bridl-baseline` remote settings source.
+- `home/.bridl/cache/repos/.../settings/bridl.yml` represents the pre-seeded remote settings file that would normally be populated by `bridl sync`.
+- `home/.bridl/cache/repos/.../profiles/` contains the matching pre-seeded remote profile source.
+- `project/.bridl/settings.yml` is the checked-in project configuration.
+- `project/.bridl/local/settings.yml` is developer-local configuration. It selects `local-selection` and repeats the resolved profile source list so the run does not require network access or mutation of checked-in project settings.
+
+## Write-back behavior
+
+The selected local profile owns `cli_specific/pi/settings.json`, so writes through the pi tack `settings.json` symlink should persist only to `project/.bridl/local/profiles/local-selection/cli_specific/pi/settings.json`. Generated tack files such as `bridl/profile.json` are transforms and should not write back to any profile source. Undeclared tack mutations should be reported as warnings and not persisted.
+
+Expected tack summaries intentionally include `REMOTE_*`, `USER_*`, `PROJECT_*`, and `LOCAL_*` values so a failing test makes the winning input layer obvious.

--- a/tests/fixtures/integration/remote_baseline_local_selection/expected/pi/tack-summary.json
+++ b/tests/fixtures/integration/remote_baseline_local_selection/expected/pi/tack-summary.json
@@ -1,0 +1,49 @@
+{
+  "profileId": "local-selection",
+  "agentId": "pi",
+  "launchCommand": "pi",
+  "launchArgs": [
+    "--model",
+    "local-selection-model",
+    "--provider",
+    "remote-provider",
+    "--thinking",
+    "user-default-thinking",
+    "--local-selection",
+    "--project-review",
+    "--remote-baseline",
+    "--user-default"
+  ],
+  "launchEnv": {
+    "PI_CODING_AGENT_DIR": "<tack>",
+    "LOCAL_SELECTION": "enabled",
+    "PROJECT_PROFILE": "enabled",
+    "REMOTE_BASELINE": "enabled",
+    "SHARED_BASELINE": "project",
+    "SHARED_SELECTION": "local",
+    "USER_DEFAULT": "enabled"
+  },
+  "generatedProfile": {
+    "id": "local-selection",
+    "label": "Local Selection",
+    "controls": {
+      "model": "local-selection-model",
+      "provider": "remote-provider",
+      "environment": {
+        "LOCAL_SELECTION": "enabled",
+        "SHARED_SELECTION": "local",
+        "PROJECT_PROFILE": "enabled",
+        "SHARED_BASELINE": "project",
+        "REMOTE_BASELINE": "enabled",
+        "USER_DEFAULT": "enabled"
+      },
+      "args": ["--local-selection", "--project-review", "--remote-baseline", "--user-default"],
+      "thinking": "user-default-thinking"
+    }
+  },
+  "stateTargets": {
+    "auth.json": "<home>/.pi/agent/auth.json",
+    "settings.json": "<project>/.bridl/local/profiles/local-selection/cli_specific/pi/settings.json",
+    "utilities": "<home>/.bridl/cache/repos/Z2l0K2h0dHBzOi8vZ2l0aHViLmNvbS9hY21lL2JyaWRsLWJhc2VsaW5lLmdpdCN2MQ/settings/cache-from-remote-settings/utilities"
+  }
+}

--- a/tests/fixtures/integration/remote_baseline_local_selection/expected/pi/warnings.json
+++ b/tests/fixtures/integration/remote_baseline_local_selection/expected/pi/warnings.json
@@ -1,0 +1,1 @@
+["pi wrote undeclared tack state 'unexpected.txt' and it was not persisted."]

--- a/tests/fixtures/integration/remote_baseline_local_selection/home/.bridl/cache/repos/Z2l0K2h0dHBzOi8vZ2l0aHViLmNvbS9hY21lL2JyaWRsLWJhc2VsaW5lLmdpdCN2MQ/profiles/remote-baseline/profile.yml
+++ b/tests/fixtures/integration/remote_baseline_local_selection/home/.bridl/cache/repos/Z2l0K2h0dHBzOi8vZ2l0aHViLmNvbS9hY21lL2JyaWRsLWJhc2VsaW5lLmdpdCN2MQ/profiles/remote-baseline/profile.yml
@@ -1,0 +1,10 @@
+id: remote-baseline
+label: Remote Baseline
+controls:
+  model: remote-baseline-model
+  provider: remote-provider
+  environment:
+    REMOTE_BASELINE: enabled
+    SHARED_BASELINE: remote
+  args:
+    - --remote-baseline

--- a/tests/fixtures/integration/remote_baseline_local_selection/home/.bridl/cache/repos/Z2l0K2h0dHBzOi8vZ2l0aHViLmNvbS9hY21lL2JyaWRsLWJhc2VsaW5lLmdpdCN2MQ/settings/bridl.yml
+++ b/tests/fixtures/integration/remote_baseline_local_selection/home/.bridl/cache/repos/Z2l0K2h0dHBzOi8vZ2l0aHViLmNvbS9hY21lL2JyaWRsLWJhc2VsaW5lLmdpdCN2MQ/settings/bridl.yml
@@ -1,0 +1,10 @@
+default_agent: pi
+cache_directory: ./cache-from-remote-settings
+profile_sources:
+  - github: acme/bridl-baseline
+    ref: v1
+    path: profiles
+custom_settings:
+  origin:
+    remote: REMOTE_SETTINGS
+    shared: REMOTE_SETTINGS

--- a/tests/fixtures/integration/remote_baseline_local_selection/home/.bridl/profiles/default/profile.yml
+++ b/tests/fixtures/integration/remote_baseline_local_selection/home/.bridl/profiles/default/profile.yml
@@ -1,0 +1,9 @@
+id: default
+label: User Default
+controls:
+  thinking: user-default-thinking
+  environment:
+    USER_DEFAULT: enabled
+    SHARED_SELECTION: user-default
+  args:
+    - --user-default

--- a/tests/fixtures/integration/remote_baseline_local_selection/home/.bridl/settings.yml
+++ b/tests/fixtures/integration/remote_baseline_local_selection/home/.bridl/settings.yml
@@ -1,0 +1,9 @@
+default_agent: pi
+remote_settings:
+  - github: acme/bridl-baseline
+    ref: v1
+    path: settings/bridl.yml
+custom_settings:
+  origin:
+    user: USER_SETTINGS
+    shared: USER_SETTINGS

--- a/tests/fixtures/integration/remote_baseline_local_selection/home/.pi/agent/auth.json
+++ b/tests/fixtures/integration/remote_baseline_local_selection/home/.pi/agent/auth.json
@@ -1,1 +1,3 @@
-{ "owner": "native-pi-auth" }
+{
+  "owner": "native-pi-auth"
+}

--- a/tests/fixtures/integration/remote_baseline_local_selection/home/.pi/agent/auth.json
+++ b/tests/fixtures/integration/remote_baseline_local_selection/home/.pi/agent/auth.json
@@ -1,0 +1,1 @@
+{ "owner": "native-pi-auth" }

--- a/tests/fixtures/integration/remote_baseline_local_selection/project/.bridl/local/profiles/local-selection/cli_specific/pi/settings.json
+++ b/tests/fixtures/integration/remote_baseline_local_selection/project/.bridl/local/profiles/local-selection/cli_specific/pi/settings.json
@@ -1,1 +1,4 @@
-{ "owner": "project-local-profile", "source": "LOCAL_SELECTION" }
+{
+  "owner": "project-local-profile",
+  "source": "LOCAL_SELECTION"
+}

--- a/tests/fixtures/integration/remote_baseline_local_selection/project/.bridl/local/profiles/local-selection/cli_specific/pi/settings.json
+++ b/tests/fixtures/integration/remote_baseline_local_selection/project/.bridl/local/profiles/local-selection/cli_specific/pi/settings.json
@@ -1,0 +1,1 @@
+{ "owner": "project-local-profile", "source": "LOCAL_SELECTION" }

--- a/tests/fixtures/integration/remote_baseline_local_selection/project/.bridl/local/profiles/local-selection/profile.yml
+++ b/tests/fixtures/integration/remote_baseline_local_selection/project/.bridl/local/profiles/local-selection/profile.yml
@@ -1,0 +1,14 @@
+id: local-selection
+label: Local Selection
+inherits:
+  - default
+  - project-review
+state_persistence:
+  settings.json: symlink
+controls:
+  model: local-selection-model
+  environment:
+    LOCAL_SELECTION: enabled
+    SHARED_SELECTION: local
+  args:
+    - --local-selection

--- a/tests/fixtures/integration/remote_baseline_local_selection/project/.bridl/local/settings.yml
+++ b/tests/fixtures/integration/remote_baseline_local_selection/project/.bridl/local/settings.yml
@@ -1,0 +1,12 @@
+default_profile: local-selection
+profile_sources:
+  - github: acme/bridl-baseline
+    ref: v1
+    path: profiles
+  - path: ../../../home/.bridl/profiles
+  - path: ../profiles
+  - path: ./profiles
+custom_settings:
+  origin:
+    project_local: LOCAL_SETTINGS
+    shared: LOCAL_SETTINGS

--- a/tests/fixtures/integration/remote_baseline_local_selection/project/.bridl/profiles/project-review/profile.yml
+++ b/tests/fixtures/integration/remote_baseline_local_selection/project/.bridl/profiles/project-review/profile.yml
@@ -1,0 +1,11 @@
+id: project-review
+label: Project Review
+inherits:
+  - remote-baseline
+controls:
+  model: project-review-model
+  environment:
+    PROJECT_PROFILE: enabled
+    SHARED_BASELINE: project
+  args:
+    - --project-review

--- a/tests/fixtures/integration/remote_baseline_local_selection/project/.bridl/settings.yml
+++ b/tests/fixtures/integration/remote_baseline_local_selection/project/.bridl/settings.yml
@@ -1,0 +1,4 @@
+custom_settings:
+  origin:
+    project: PROJECT_SETTINGS
+    shared: PROJECT_SETTINGS

--- a/tests/integration/tack-generation.test.ts
+++ b/tests/integration/tack-generation.test.ts
@@ -129,4 +129,58 @@ describe('integration fixture tack generation', () => {
       expect(readFixtureText(fixture, profilePath)).toBe(originalProfileYaml);
     }
   });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-003.1, BRIDL-REQ-003.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('uses cached remote baseline settings while project-local settings select a local profile offline', async () => {
+    const fixture = copyFixtureToTemp('remote_baseline_local_selection');
+    const warnings: string[] = [];
+    let tackSummary: unknown;
+
+    const result = await runFixture(fixture, {
+      warnings,
+      launcher: {
+        launch(plan) {
+          const tackRoot = tackRootFromLaunchPlan(plan);
+          tackSummary = {
+            profileId: 'local-selection',
+            agentId: 'pi',
+            launchCommand: plan.command,
+            launchArgs: plan.args,
+            launchEnv: {
+              PI_CODING_AGENT_DIR: tokenizeFixturePath(fixture, plan.env.PI_CODING_AGENT_DIR, tackRoot),
+              LOCAL_SELECTION: plan.env.LOCAL_SELECTION,
+              PROJECT_PROFILE: plan.env.PROJECT_PROFILE,
+              REMOTE_BASELINE: plan.env.REMOTE_BASELINE,
+              SHARED_BASELINE: plan.env.SHARED_BASELINE,
+              SHARED_SELECTION: plan.env.SHARED_SELECTION,
+              USER_DEFAULT: plan.env.USER_DEFAULT,
+            },
+            ...(summarizePiTack(fixture, tackRoot) as Record<string, unknown>),
+          };
+
+          writeFileSync(join(tackRoot, 'bridl', 'profile.json'), '{"mutated":true}\n');
+          writeFileSync(join(tackRoot, 'settings.json'), '{"owner":"pi-write","source":"LOCAL_SELECTION"}\n');
+          writeFileSync(join(tackRoot, 'unexpected.txt'), 'unknown write\n');
+
+          return Promise.resolve(0);
+        },
+      },
+    });
+
+    expect(tackSummary).toEqual(readExpectedJson(fixture, 'pi/tack-summary.json'));
+    expect(result.profileId).toBe('local-selection');
+    expect(result.agentId).toBe('pi');
+    expect(result.warnings).toEqual(readExpectedJson(fixture, 'pi/warnings.json'));
+    expect(warnings).toEqual(result.warnings);
+    expect(
+      readFileSync(
+        join(fixture.project, '.bridl', 'local', 'profiles', 'local-selection', 'cli_specific', 'pi', 'settings.json'),
+        'utf8',
+      ),
+    ).toBe('{"owner":"pi-write","source":"LOCAL_SELECTION"}\n');
+    expect(readFixtureText(fixture, 'home/.bridl/settings.yml')).toContain('remote_settings');
+    expect(readFixtureText(fixture, 'project/.bridl/settings.yml')).not.toContain('default_profile');
+    expect(readFixtureText(fixture, 'project/.bridl/local/settings.yml')).toContain('default_profile: local-selection');
+  });
 });


### PR DESCRIPTION
## Summary\n- Add the remote_baseline_local_selection integration fixture with cached remote settings/profile sources, user/project/project-local inputs, and fixture README\n- Add expected pi tack summary/warnings for source precedence and write-back behavior\n- Cover the fixture with a Vitest integration test through fixtureHarness\n\n## Validation\n- npm run check-ci