### PR TITLE
Add state path replacement integration fixture

### DIFF
--- a/doc/file_structure.md
+++ b/doc/file_structure.md
@@ -78,8 +78,8 @@ Bridl is organized around clear TypeScript source boundaries, requirement docume
 ├── tests/                             # automated tests
 │   ├── fixtures/                      # reusable test fixtures
 │   │   ├── integration/               # fixture-backed integration scenarios and catalog
-│   │   └── scenarios/                 # realistic .bridl scenarios and expected outputs
-│   ├── integration/                   # integration tests and fixture harness
+│   │   └── scenarios/                 # compact profile-resolution scenarios and expected outputs
+│   ├── integration/                   # fixture-backed integration tests and harness helpers
 │   └── unit/                          # unit tests grouped by functionality under test
 ├── package-lock.json                  # locked npm dependency graph
 └── package.json                       # npm package metadata and scripts
@@ -87,7 +87,10 @@ Bridl is organized around clear TypeScript source boundaries, requirement docume
 
 The exact layout may evolve, but these boundaries should stay recognizable.
 
-## Test Scenario Fixtures
+## Test Fixtures
+
+Integration fixtures should live under `tests/fixtures/integration/` with full `home/`, `project/`, and optional
+`expected/` trees. Fixture-backed integration tests and shared harness helpers should live under `tests/integration/`.
 
 Scenario fixtures should live under `tests/fixtures/scenarios/`, for example:
 

--- a/tests/fixtures/integration/INTEGRATION_TEST_FIXTURES.md
+++ b/tests/fixtures/integration/INTEGRATION_TEST_FIXTURES.md
@@ -190,4 +190,4 @@ Write-back focus: replacement should be diagnosed as not persisted, and the orig
 | `native_fallback_cli_state`            | Proposed | user + repo         | 1            | 0-1              | all            | native fallback | fallback writes  |
 | `cache_backed_tooling_state`           | Proposed | user + repo         | 1            | 0                | adapter subset | cache           | cache writes     |
 | `adapter_specific_overrides`           | Proposed | user + repo         | 1            | 0-1              | all            | mixed           | adapter controls |
-| `state_path_replaced_by_agent`         | Proposed | user + repo         | 1            | 0                | all            | profile/native  | symlink replaced |
+| `state_path_replaced_by_agent`         | Existing | user + repo         | 1            | 0                | all            | profile/native  | symlink replaced |

--- a/tests/fixtures/integration/state_path_replaced_by_agent/README.md
+++ b/tests/fixtures/integration/state_path_replaced_by_agent/README.md
@@ -1,0 +1,19 @@
+# state_path_replaced_by_agent
+
+This fixture models a project profile with persistent pi state owned by the profile folder. The selected
+`state-replacement` profile declares durable symlink-backed state for `settings.json` and `sessions/`, and seeds both
+paths under `project/.bridl/profiles/state-replacement/cli_specific/pi/`.
+
+## Setup
+
+- `home/.bridl/settings.yml` defines the personal `default` profile and pi as the default agent.
+- `project/.bridl/settings.yml` composes the user profile source with the project profile source.
+- `project/.bridl/profiles/state-replacement/profile.yml` selects explicit symlink persistence for `settings.json` and
+  `sessions/`.
+
+## Write-back behavior
+
+A real child CLI should write through the symlinks, which would update the profile-owned files. The integration test's
+fake launcher intentionally does the wrong thing: it unlinks the tack symlinks and replaces them with a regular file and
+a regular directory. Bridl must diagnose those replacements as not persisted, and the original profile-owned source file
+and directory contents must remain unchanged.

--- a/tests/fixtures/integration/state_path_replaced_by_agent/expected/pi/warnings.json
+++ b/tests/fixtures/integration/state_path_replaced_by_agent/expected/pi/warnings.json
@@ -1,0 +1,4 @@
+[
+  "pi replaced symlinked state path 'sessions/' and the change was not persisted.",
+  "pi replaced symlinked state path 'settings.json' and the change was not persisted."
+]

--- a/tests/fixtures/integration/state_path_replaced_by_agent/home/.bridl/profiles/default/profile.yml
+++ b/tests/fixtures/integration/state_path_replaced_by_agent/home/.bridl/profiles/default/profile.yml
@@ -1,0 +1,6 @@
+id: default
+label: Personal Defaults for State Replacement
+controls:
+  environment:
+    USER_DEFAULT: 'enabled'
+    SHARED_STATE_OWNER: user-default

--- a/tests/fixtures/integration/state_path_replaced_by_agent/home/.bridl/settings.yml
+++ b/tests/fixtures/integration/state_path_replaced_by_agent/home/.bridl/settings.yml
@@ -1,0 +1,4 @@
+default_profile: default
+default_agent: pi
+profile_sources:
+  - path: ./profiles

--- a/tests/fixtures/integration/state_path_replaced_by_agent/project/.bridl/profiles/state-replacement/cli_specific/pi/sessions/session.txt
+++ b/tests/fixtures/integration/state_path_replaced_by_agent/project/.bridl/profiles/state-replacement/cli_specific/pi/sessions/session.txt
@@ -1,0 +1,1 @@
+profile-owned session remains unchanged

--- a/tests/fixtures/integration/state_path_replaced_by_agent/project/.bridl/profiles/state-replacement/cli_specific/pi/settings.json
+++ b/tests/fixtures/integration/state_path_replaced_by_agent/project/.bridl/profiles/state-replacement/cli_specific/pi/settings.json
@@ -1,0 +1,1 @@
+{ "profileOwned": "unchanged", "theme": "dark" }

--- a/tests/fixtures/integration/state_path_replaced_by_agent/project/.bridl/profiles/state-replacement/profile.yml
+++ b/tests/fixtures/integration/state_path_replaced_by_agent/project/.bridl/profiles/state-replacement/profile.yml
@@ -1,0 +1,13 @@
+id: state-replacement
+label: State Path Replacement Regression
+state_persistence:
+  settings.json: symlink
+  sessions/: symlink
+  unknown: warn
+controls:
+  model: state-replacement-model
+  environment:
+    REPLACEMENT_PROFILE: 'enabled'
+    SHARED_STATE_OWNER: project-profile
+  args:
+    - --state-replacement

--- a/tests/fixtures/integration/state_path_replaced_by_agent/project/.bridl/settings.yml
+++ b/tests/fixtures/integration/state_path_replaced_by_agent/project/.bridl/settings.yml
@@ -1,0 +1,3 @@
+profile_sources:
+  - path: ../../home/.bridl/profiles
+  - path: ./profiles

--- a/tests/integration/tack-generation.test.ts
+++ b/tests/integration/tack-generation.test.ts
@@ -1,5 +1,5 @@
 // Tests fixture-backed integration behavior for tack generation and state ownership.
-import { readFileSync, writeFileSync } from 'node:fs';
+import { lstatSync, mkdirSync, readFileSync, readlinkSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
@@ -182,5 +182,70 @@ describe('integration fixture tack generation', () => {
     expect(readFixtureText(fixture, 'home/.bridl/settings.yml')).toContain('remote_settings');
     expect(readFixtureText(fixture, 'project/.bridl/settings.yml')).not.toContain('default_profile');
     expect(readFixtureText(fixture, 'project/.bridl/local/settings.yml')).toContain('default_profile: local-selection');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('diagnoses declared persistent state symlinks replaced by the agent without changing sources', async () => {
+    const fixture = copyFixtureToTemp('state_path_replaced_by_agent');
+    const warnings: string[] = [];
+    const sourceSettingsPath = join(
+      fixture.project,
+      '.bridl',
+      'profiles',
+      'state-replacement',
+      'cli_specific',
+      'pi',
+      'settings.json',
+    );
+    const sourceSessionsPath = join(
+      fixture.project,
+      '.bridl',
+      'profiles',
+      'state-replacement',
+      'cli_specific',
+      'pi',
+      'sessions',
+    );
+
+    const result = await runFixture(fixture, {
+      profileId: 'state-replacement',
+      agentId: 'pi',
+      warnings,
+      launcher: {
+        launch(plan) {
+          const tackRoot = tackRootFromLaunchPlan(plan);
+          const settingsPath = join(tackRoot, 'settings.json');
+          const sessionsPath = join(tackRoot, 'sessions');
+
+          expect(plan.env.REPLACEMENT_PROFILE).toBe('enabled');
+          expect(plan.env.SHARED_STATE_OWNER).toBe('project-profile');
+          expect(lstatSync(settingsPath).isSymbolicLink()).toBe(true);
+          expect(lstatSync(sessionsPath).isSymbolicLink()).toBe(true);
+          expect(readlinkSync(settingsPath)).toBe(sourceSettingsPath);
+          expect(readlinkSync(sessionsPath)).toBe(sourceSessionsPath);
+
+          unlinkSync(settingsPath);
+          writeFileSync(settingsPath, '{"agent":"replaced symlink with file"}\n');
+          unlinkSync(sessionsPath);
+          mkdirSync(sessionsPath);
+          writeFileSync(join(sessionsPath, 'replacement.log'), 'agent replaced symlink with directory\n');
+
+          return Promise.resolve(0);
+        },
+      },
+    });
+
+    expect(result.profileId).toBe('state-replacement');
+    expect(result.agentId).toBe('pi');
+    expect(result.warnings).toEqual(readExpectedJson(fixture, 'pi/warnings.json'));
+    expect(warnings).toEqual(result.warnings);
+    expect(readFileSync(sourceSettingsPath, 'utf8')).toBe('{ "profileOwned": "unchanged", "theme": "dark" }\n');
+    expect(readFileSync(join(sourceSessionsPath, 'session.txt'), 'utf8')).toBe(
+      'profile-owned session remains unchanged\n',
+    );
+    expect(readFixtureText(fixture, 'project/.bridl/profiles/state-replacement/profile.yml')).toContain(
+      'state_persistence',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add the state_path_replaced_by_agent fixture with user/project Bridl config and profile-owned pi state
- add an integration test whose fake launcher replaces persistent state symlinks with a file and directory
- document integration fixture layout in file_structure.md

## Validation
- npm test -- tests/integration/tack-generation.test.ts
- npm run check-ci