### PR TITLE
Add local sandbox overrides integration fixture

### DIFF
--- a/tests/fixtures/integration/INTEGRATION_TEST_FIXTURES.md
+++ b/tests/fixtures/integration/INTEGRATION_TEST_FIXTURES.md
@@ -184,7 +184,7 @@ Write-back focus: replacement should be diagnosed as not persisted, and the orig
 | `heavily_overridden_engineering`       | Proposed | remote + 3          | 5            | 1-2              | all            | highest profile | source ownership |
 | `remote_baseline_local_selection`      | Existing | remote + 3          | 1-2          | implicit default | all            | mixed           | source ownership |
 | `language_stack_with_personal_default` | Existing | user + repo         | 1            | 2-3              | all            | native fallback | inherited output |
-| `local_sandbox_overrides`              | Proposed | user + repo + local | 1-2          | 1                | all            | temporary       | local overrides  |
+| `local_sandbox_overrides`              | Existing | user + repo + local | 1-2          | 1                | all            | temporary       | local overrides  |
 | `strict_ci_profile`                    | Proposed | repo                | 1            | 0-1              | all            | temporary       | errors           |
 | `profile_owned_cli_state`              | Proposed | user + repo         | 1            | 0-1              | all            | profile state   | symlink writes   |
 | `native_fallback_cli_state`            | Proposed | user + repo         | 1            | 0-1              | all            | native fallback | fallback writes  |

--- a/tests/fixtures/integration/local_sandbox_overrides/README.md
+++ b/tests/fixtures/integration/local_sandbox_overrides/README.md
@@ -1,0 +1,25 @@
+# `local_sandbox_overrides`
+
+This fixture models a developer who keeps stable repository profiles checked in, then selects a local-only sandbox without editing those checked-in files.
+
+## Setup
+
+- `home/.bridl/settings.yml` defines normal user defaults and a personal profile source.
+- `project/.bridl/settings.yml` is the checked-in project configuration. It selects `repo-review` and exposes the checked-in project profiles.
+- `project/.bridl/profiles/typescript-base/profile.yml` and `project/.bridl/profiles/repo-review/profile.yml` are stable repository profiles.
+- `project/.bridl/local/settings.yml` is a local override. It selects `local-sandbox` and explicitly lists user, checked-in project, and local profile sources so the local profile can inherit the repository profile stack.
+- `project/.bridl/local/profiles/local-sandbox/profile.yml` adds experimental sandbox controls and state-persistence overrides.
+
+## Expected behavior
+
+Running without an explicit `--profile` should use the project-local `default_profile: local-sandbox`. The resolved profile should include the inherited repository review controls plus local sandbox overrides such as an experimental environment variable, a sandbox prompt, and pi-specific launch flags.
+
+## Mutation/write-back behavior
+
+The local sandbox deliberately makes selected pi state temporary:
+
+- `settings.json: warn` allows settings experiments in the tack, reports them after exit, and does not update native pi settings or checked-in profile files.
+- `cache/` and `sessions/` use `discard`, so fake cache and session writes are thrown away silently with the tack.
+- `unknown: discard` keeps miscellaneous sandbox writes local to the tack without warning.
+
+Tests mutate the generated tack from the fake launcher and then verify that checked-in project profiles and local profile YAML remain unchanged.

--- a/tests/fixtures/integration/local_sandbox_overrides/expected/pi/tack-summary.json
+++ b/tests/fixtures/integration/local_sandbox_overrides/expected/pi/tack-summary.json
@@ -1,0 +1,54 @@
+{
+  "profileId": "local-sandbox",
+  "agentId": "pi",
+  "launchCommand": "pi",
+  "launchArgs": [
+    "--model",
+    "repo-review-model",
+    "--provider",
+    "repo-provider",
+    "--thinking",
+    "high",
+    "--system-prompt",
+    "./prompts/sandbox.md",
+    "--sandbox-mode"
+  ],
+  "launchEnv": {
+    "LOCAL_SANDBOX": "enabled",
+    "PI_CODING_AGENT_DIR": "<tack>",
+    "REPO_REVIEW": "enabled",
+    "REPO_STACK": "typescript",
+    "SHARED_LAYER": "local-sandbox"
+  },
+  "generatedProfile": {
+    "id": "local-sandbox",
+    "label": "Local Sandbox",
+    "controls": {
+      "model": "repo-review-model",
+      "provider": "repo-provider",
+      "environment": {
+        "LOCAL_SANDBOX": "enabled",
+        "REPO_REVIEW": "enabled",
+        "REPO_STACK": "typescript",
+        "SHARED_LAYER": "local-sandbox"
+      },
+      "args": ["--repo-review", "--base-review"],
+      "systemPrompt": "./prompts/sandbox.md",
+      "system_prompt": "./prompts/sandbox.md",
+      "pi": {
+        "thinking": "high",
+        "args": ["--sandbox-mode"]
+      }
+    }
+  },
+  "stateTargets": {
+    "auth.json": "<project>/.bridl/local/profiles/local-sandbox/cli_specific/pi/auth.json",
+    "mcp.json": "<home>/.pi/agent/mcp.json",
+    "utilities": "<project>/.bridl/local/cache/utilities"
+  },
+  "sandboxState": {
+    "cacheExists": true,
+    "sessionsExists": true,
+    "settingsExists": false
+  }
+}

--- a/tests/fixtures/integration/local_sandbox_overrides/expected/pi/warnings.json
+++ b/tests/fixtures/integration/local_sandbox_overrides/expected/pi/warnings.json
@@ -1,0 +1,1 @@
+["pi wrote 'settings.json' with state_persistence 'warn' and it was not persisted."]

--- a/tests/fixtures/integration/local_sandbox_overrides/home/.bridl/profiles/developer-default/profile.yml
+++ b/tests/fixtures/integration/local_sandbox_overrides/home/.bridl/profiles/developer-default/profile.yml
@@ -1,0 +1,5 @@
+id: developer-default
+label: Developer Defaults
+controls:
+  environment:
+    DEVELOPER_DEFAULT: 'enabled'

--- a/tests/fixtures/integration/local_sandbox_overrides/home/.bridl/settings.yml
+++ b/tests/fixtures/integration/local_sandbox_overrides/home/.bridl/settings.yml
@@ -1,0 +1,5 @@
+default_profile: developer-default
+default_agent: pi
+cache_directory: ./cache
+profile_sources:
+  - path: ./profiles

--- a/tests/fixtures/integration/local_sandbox_overrides/home/.pi/agent/settings.json
+++ b/tests/fixtures/integration/local_sandbox_overrides/home/.pi/agent/settings.json
@@ -1,0 +1,1 @@
+{ "theme": "stable" }

--- a/tests/fixtures/integration/local_sandbox_overrides/project/.bridl/local/profiles/local-sandbox/cli_specific/pi/auth.json
+++ b/tests/fixtures/integration/local_sandbox_overrides/project/.bridl/local/profiles/local-sandbox/cli_specific/pi/auth.json
@@ -1,0 +1,1 @@
+{ "token": "local-sandbox-token" }

--- a/tests/fixtures/integration/local_sandbox_overrides/project/.bridl/local/profiles/local-sandbox/profile.yml
+++ b/tests/fixtures/integration/local_sandbox_overrides/project/.bridl/local/profiles/local-sandbox/profile.yml
@@ -1,0 +1,18 @@
+id: local-sandbox
+label: Local Sandbox
+inherits:
+  - repo-review
+controls:
+  system_prompt: ./prompts/sandbox.md
+  environment:
+    LOCAL_SANDBOX: 'enabled'
+    SHARED_LAYER: local-sandbox
+  pi:
+    thinking: high
+    args:
+      - --sandbox-mode
+state_persistence:
+  settings.json: warn
+  cache/: discard
+  sessions/: discard
+  unknown: discard

--- a/tests/fixtures/integration/local_sandbox_overrides/project/.bridl/local/profiles/local-sandbox/prompts/sandbox.md
+++ b/tests/fixtures/integration/local_sandbox_overrides/project/.bridl/local/profiles/local-sandbox/prompts/sandbox.md
@@ -1,0 +1,1 @@
+You are running in a developer-local sandbox. Prefer safe experiments and do not change checked-in Bridl profiles.

--- a/tests/fixtures/integration/local_sandbox_overrides/project/.bridl/local/settings.yml
+++ b/tests/fixtures/integration/local_sandbox_overrides/project/.bridl/local/settings.yml
@@ -1,0 +1,6 @@
+default_profile: local-sandbox
+cache_directory: ./cache
+profile_sources:
+  - path: ../../../home/.bridl/profiles
+  - path: ../profiles
+  - path: ./profiles

--- a/tests/fixtures/integration/local_sandbox_overrides/project/.bridl/profiles/repo-review/profile.yml
+++ b/tests/fixtures/integration/local_sandbox_overrides/project/.bridl/profiles/repo-review/profile.yml
@@ -1,0 +1,11 @@
+id: repo-review
+label: Repository Review
+inherits:
+  - typescript-base
+controls:
+  model: repo-review-model
+  environment:
+    REPO_REVIEW: 'enabled'
+    SHARED_LAYER: repo-review
+  args:
+    - --repo-review

--- a/tests/fixtures/integration/local_sandbox_overrides/project/.bridl/profiles/typescript-base/profile.yml
+++ b/tests/fixtures/integration/local_sandbox_overrides/project/.bridl/profiles/typescript-base/profile.yml
@@ -1,0 +1,10 @@
+id: typescript-base
+label: TypeScript Base
+controls:
+  model: repo-base-model
+  provider: repo-provider
+  environment:
+    REPO_STACK: typescript
+    SHARED_LAYER: repo-base
+  args:
+    - --base-review

--- a/tests/fixtures/integration/local_sandbox_overrides/project/.bridl/settings.yml
+++ b/tests/fixtures/integration/local_sandbox_overrides/project/.bridl/settings.yml
@@ -1,0 +1,5 @@
+default_profile: repo-review
+default_agent: pi
+profile_sources:
+  - path: ../../home/.bridl/profiles
+  - path: ./profiles

--- a/tests/integration/tack-generation.test.ts
+++ b/tests/integration/tack-generation.test.ts
@@ -1,5 +1,5 @@
 // Tests fixture-backed integration behavior for tack generation and state ownership.
-import { lstatSync, mkdirSync, readFileSync, readlinkSync, unlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, lstatSync, mkdirSync, readFileSync, readlinkSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
@@ -246,6 +246,70 @@ describe('integration fixture tack generation', () => {
     );
     expect(readFixtureText(fixture, 'project/.bridl/profiles/state-replacement/profile.yml')).toContain(
       'state_persistence',
+    );
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-002.2, BRIDL-REQ-005.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('uses project-local sandbox defaults and keeps sandbox state writes temporary', async () => {
+    const fixture = copyFixtureToTemp('local_sandbox_overrides');
+    const warnings: string[] = [];
+    let tackSummary: unknown;
+
+    const result = await runFixture(fixture, {
+      agentId: 'pi',
+      warnings,
+      launcher: {
+        launch(plan) {
+          const tackRoot = tackRootFromLaunchPlan(plan);
+          tackSummary = {
+            profileId: 'local-sandbox',
+            agentId: 'pi',
+            launchCommand: plan.command,
+            launchArgs: plan.args,
+            launchEnv: {
+              LOCAL_SANDBOX: plan.env.LOCAL_SANDBOX,
+              PI_CODING_AGENT_DIR: tokenizeFixturePath(fixture, plan.env.PI_CODING_AGENT_DIR, tackRoot),
+              REPO_REVIEW: plan.env.REPO_REVIEW,
+              REPO_STACK: plan.env.REPO_STACK,
+              SHARED_LAYER: plan.env.SHARED_LAYER,
+            },
+            generatedProfile: JSON.parse(readFileSync(join(tackRoot, 'bridl', 'profile.json'), 'utf8')) as unknown,
+            stateTargets: {
+              'auth.json': tokenizeFixturePath(fixture, readlinkSync(join(tackRoot, 'auth.json')), tackRoot),
+              'mcp.json': tokenizeFixturePath(fixture, readlinkSync(join(tackRoot, 'mcp.json')), tackRoot),
+              utilities: tokenizeFixturePath(fixture, readlinkSync(join(tackRoot, 'utilities')), tackRoot),
+            },
+            sandboxState: {
+              cacheExists: existsSync(join(tackRoot, 'cache')),
+              sessionsExists: existsSync(join(tackRoot, 'sessions')),
+              settingsExists: existsSync(join(tackRoot, 'settings.json')),
+            },
+          };
+
+          writeFileSync(join(tackRoot, 'bridl', 'profile.json'), '{"mutated":true}\n');
+          writeFileSync(join(tackRoot, 'settings.json'), '{"theme":"sandbox"}\n');
+          mkdirSync(join(tackRoot, 'cache'), { recursive: true });
+          writeFileSync(join(tackRoot, 'cache', 'experiment.json'), '{"cached":true}\n');
+          mkdirSync(join(tackRoot, 'sessions'), { recursive: true });
+          writeFileSync(join(tackRoot, 'sessions', 'scratch.log'), 'sandbox session\n');
+          writeFileSync(join(tackRoot, 'scratch.txt'), 'unknown sandbox write\n');
+
+          return Promise.resolve(0);
+        },
+      },
+    });
+
+    expect(tackSummary).toEqual(readExpectedJson(fixture, 'pi/tack-summary.json'));
+    expect(result.profileId).toBe('local-sandbox');
+    expect(result.agentId).toBe('pi');
+    expect(result.warnings).toEqual(readExpectedJson(fixture, 'pi/warnings.json'));
+    expect(warnings).toEqual(result.warnings);
+    expect(readFileSync(join(fixture.home, '.pi', 'agent', 'settings.json'), 'utf8')).toBe('{ "theme": "stable" }\n');
+    expect(existsSync(join(fixture.project, '.bridl', 'local', 'cache', 'cache', 'experiment.json'))).toBe(false);
+    expect(readFixtureText(fixture, 'project/.bridl/profiles/repo-review/profile.yml')).toContain('--repo-review');
+    expect(readFixtureText(fixture, 'project/.bridl/local/profiles/local-sandbox/profile.yml')).toContain(
+      'settings.json: warn',
     );
   });
 });


### PR DESCRIPTION
## Summary
- add the local_sandbox_overrides integration fixture with user, checked-in project, and project-local profile layers
- cover project-local default profile selection and pi state_persistence overrides in the integration harness
- include adapter-specific expected tack summary and warning outputs

## Validation
- npm run check-ci (passed on retry; first run hit an existing flaky state-live-update timing assertion)