### PR TITLE
Add adapter-specific overrides integration fixture

### DIFF
--- a/tests/fixtures/integration/INTEGRATION_TEST_FIXTURES.md
+++ b/tests/fixtures/integration/INTEGRATION_TEST_FIXTURES.md
@@ -192,7 +192,7 @@ Write-back focus: replacement should be diagnosed as not persisted, and the orig
 | `profile_owned_cli_state` | Proposed | user + repo | 1 | 0-1 | all | profile state | symlink writes |
 | `native_fallback_cli_state` | Existing | user + repo | 1 | 0-1 | all | native fallback | fallback writes |
 | `cache_backed_tooling_state` | Existing | user + repo | 1 | 0 | adapter subset | cache | cache writes |
-| `adapter_specific_overrides` | Proposed | user + repo | 1 | 0-1 | all | mixed | adapter controls |
+| `adapter_specific_overrides` | Existing | user + repo | 1 | 0-1 | all | mixed | adapter controls |
 | `state_path_replaced_by_agent` | Existing | user + repo | 1 | 0 | all | profile/native | symlink replaced |
 =======
 | Fixture | Status | Settings layers | Same-id defs | Inherit depth | Adapters | State owner | Mutation focus |
@@ -211,7 +211,7 @@ Write-back focus: replacement should be diagnosed as not persisted, and the orig
 | `profile_owned_cli_state` | Proposed | user + repo | 1 | 0-1 | all | profile state | symlink writes |
 | `native_fallback_cli_state` | Proposed | user + repo | 1 | 0-1 | all | native fallback | fallback writes |
 | `cache_backed_tooling_state` | Added | user + repo | 1 | implicit default | pi subset | cache | cache writes |
-| `adapter_specific_overrides` | Proposed | user + repo | 1 | 0-1 | all | mixed | adapter controls |
+| `adapter_specific_overrides` | Existing | user + repo | 1 | 0-1 | all | mixed | adapter controls |
 | `state_path_replaced_by_agent` | Proposed | user + repo | 1 | 0 | all | profile/native | symlink replaced |
 
 > > > > > > > 1ec01b1 (Add cache-backed tooling integration fixture):INTEGRATION_TEST_FIXTURES.md

--- a/tests/fixtures/integration/adapter_specific_overrides/README.md
+++ b/tests/fixtures/integration/adapter_specific_overrides/README.md
@@ -1,0 +1,21 @@
+# `adapter_specific_overrides`
+
+This fixture models one repository-selected profile that combines portable Bridl controls with adapter-specific overrides for both pi and Claude Code.
+
+## Setup
+
+- `home/.bridl/settings.yml` defines the user's `default` profile and uses pi as the user default agent.
+- `home/.bridl/profiles/default/profile.yml` contributes personal environment defaults below the selected repository profile.
+- `project/.bridl/settings.yml` declares both the synthetic user profile source and the repository profile source.
+- `project/.bridl/profiles/adapter-review/profile.yml` defines generic controls plus `controls.pi` and `controls.claude` overrides.
+- `project/.bridl/profiles/adapter-review/cli_specific/pi/settings.json` and `cli_specific/claude/settings.json` are profile-owned state files for their respective adapters.
+
+## Expected behavior
+
+Running the same selected profile as pi should launch `pi` with generic controls overlaid by `controls.pi`: pi-specific model, thinking, provider, prompt template, skills, args, and environment should win over shared generic values. Running it as Claude Code should launch `claude` with generic controls overlaid by `controls.claude`: Claude-specific model, thinking, system prompts, args, plugin directories, and environment should win over shared generic values.
+
+Both adapters should still receive the user's implicit default environment below the repository profile. Each adapter should select only its own `cli_specific/<adapter>/settings.json` as the declared state target.
+
+## Mutation/write-back behavior
+
+Integration tests mutate generated tack content, the adapter-owned `settings.json`, and an undeclared tack file from a fake launcher. Mutating generated `bridl/profile.json` must not rewrite any source profile YAML. Mutating an adapter `settings.json` must write through only to that adapter's profile-owned state file. Undeclared tack writes should produce the adapter's unknown-state warning and should not be persisted outside the temporary tack.

--- a/tests/fixtures/integration/adapter_specific_overrides/expected/claude/tack-summary.json
+++ b/tests/fixtures/integration/adapter_specific_overrides/expected/claude/tack-summary.json
@@ -1,0 +1,85 @@
+{
+  "profileId": "adapter-review",
+  "agentId": "claude",
+  "launchCommand": "claude",
+  "launchArgs": [
+    "--model",
+    "claude-specialized-model",
+    "--effort",
+    "deep",
+    "--system-prompt",
+    "Use the Claude-specific repository review policy.",
+    "--append-system-prompt",
+    "Include Claude-only diagnostics.",
+    "--plugin-dir",
+    "./tools/claude-plugin",
+    "--claude-flag"
+  ],
+  "launchEnv": {
+    "CLAUDE_CONFIG_DIR": "<tack>",
+    "ADAPTER_ENV": "claude",
+    "CLAUDE_ONLY": "enabled",
+    "GENERIC_ENV": "enabled",
+    "SHARED_LAYER": "adapter-review",
+    "USER_DEFAULT": "enabled"
+  },
+  "generatedProfile": {
+    "id": "adapter-review",
+    "label": "Adapter-Specific Review",
+    "controls": {
+      "model": "generic-model",
+      "thinking": "balanced",
+      "environment": {
+        "ADAPTER_ENV": "generic",
+        "GENERIC_ENV": "enabled",
+        "SHARED_LAYER": "adapter-review",
+        "USER_DEFAULT": "enabled"
+      },
+      "args": ["--generic-flag"],
+      "extensions": ["./tools/generic-extension"],
+      "system_prompt": "Use the shared repository review policy.",
+      "append_system_prompt": "Include the shared checklist.",
+      "pi": {
+        "model": "pi-specialized-model",
+        "provider": "openai-compatible",
+        "thinking": "high",
+        "session_directory": "pi-review-sessions",
+        "prompt_template": "./prompts/pi-review.md",
+        "system_prompt": "Use the pi-specific repository review policy.",
+        "append_system_prompt": "Include pi-only diagnostics.",
+        "environment": {
+          "ADAPTER_ENV": "pi",
+          "PI_ONLY": "enabled"
+        },
+        "args": ["--pi-flag"],
+        "extensions": ["./tools/pi-extension"],
+        "skills": ["repo-review"],
+        "sessionDirectory": "pi-review-sessions",
+        "promptTemplate": "./prompts/pi-review.md",
+        "systemPrompt": "Use the pi-specific repository review policy.",
+        "appendSystemPrompt": "Include pi-only diagnostics."
+      },
+      "claude": {
+        "model": "claude-specialized-model",
+        "thinking": "deep",
+        "system_prompt": "Use the Claude-specific repository review policy.",
+        "append_system_prompt": "Include Claude-only diagnostics.",
+        "environment": {
+          "ADAPTER_ENV": "claude",
+          "CLAUDE_ONLY": "enabled"
+        },
+        "args": ["--claude-flag"],
+        "extensions": ["./tools/claude-plugin"],
+        "systemPrompt": "Use the Claude-specific repository review policy.",
+        "appendSystemPrompt": "Include Claude-only diagnostics."
+      },
+      "systemPrompt": "Use the shared repository review policy.",
+      "appendSystemPrompt": "Include the shared checklist."
+    }
+  },
+  "stateTargets": {
+    "settings.json": "<project>/.bridl/profiles/adapter-review/cli_specific/claude/settings.json",
+    "agents": "<home>/.claude/agents",
+    "projects": "<home>/.claude/projects"
+  }
+}

--- a/tests/fixtures/integration/adapter_specific_overrides/expected/claude/warnings.json
+++ b/tests/fixtures/integration/adapter_specific_overrides/expected/claude/warnings.json
@@ -1,0 +1,1 @@
+["claude wrote undeclared tack state 'unexpected-claude.txt' and it was not persisted."]

--- a/tests/fixtures/integration/adapter_specific_overrides/expected/pi/tack-summary.json
+++ b/tests/fixtures/integration/adapter_specific_overrides/expected/pi/tack-summary.json
@@ -1,0 +1,93 @@
+{
+  "profileId": "adapter-review",
+  "agentId": "pi",
+  "launchCommand": "pi",
+  "launchArgs": [
+    "--model",
+    "pi-specialized-model",
+    "--provider",
+    "openai-compatible",
+    "--thinking",
+    "high",
+    "--session-dir",
+    "pi-review-sessions",
+    "--prompt-template",
+    "./prompts/pi-review.md",
+    "--system-prompt",
+    "Use the pi-specific repository review policy.",
+    "--append-system-prompt",
+    "Include pi-only diagnostics.",
+    "--extension",
+    "./tools/pi-extension",
+    "--skill",
+    "repo-review",
+    "--pi-flag"
+  ],
+  "launchEnv": {
+    "PI_CODING_AGENT_DIR": "<tack>",
+    "ADAPTER_ENV": "pi",
+    "GENERIC_ENV": "enabled",
+    "PI_ONLY": "enabled",
+    "SHARED_LAYER": "adapter-review",
+    "USER_DEFAULT": "enabled"
+  },
+  "generatedProfile": {
+    "id": "adapter-review",
+    "label": "Adapter-Specific Review",
+    "controls": {
+      "model": "generic-model",
+      "thinking": "balanced",
+      "environment": {
+        "ADAPTER_ENV": "generic",
+        "GENERIC_ENV": "enabled",
+        "SHARED_LAYER": "adapter-review",
+        "USER_DEFAULT": "enabled"
+      },
+      "args": ["--generic-flag"],
+      "extensions": ["./tools/generic-extension"],
+      "system_prompt": "Use the shared repository review policy.",
+      "append_system_prompt": "Include the shared checklist.",
+      "pi": {
+        "model": "pi-specialized-model",
+        "provider": "openai-compatible",
+        "thinking": "high",
+        "session_directory": "pi-review-sessions",
+        "prompt_template": "./prompts/pi-review.md",
+        "system_prompt": "Use the pi-specific repository review policy.",
+        "append_system_prompt": "Include pi-only diagnostics.",
+        "environment": {
+          "ADAPTER_ENV": "pi",
+          "PI_ONLY": "enabled"
+        },
+        "args": ["--pi-flag"],
+        "extensions": ["./tools/pi-extension"],
+        "skills": ["repo-review"],
+        "sessionDirectory": "pi-review-sessions",
+        "promptTemplate": "./prompts/pi-review.md",
+        "systemPrompt": "Use the pi-specific repository review policy.",
+        "appendSystemPrompt": "Include pi-only diagnostics."
+      },
+      "claude": {
+        "model": "claude-specialized-model",
+        "thinking": "deep",
+        "system_prompt": "Use the Claude-specific repository review policy.",
+        "append_system_prompt": "Include Claude-only diagnostics.",
+        "environment": {
+          "ADAPTER_ENV": "claude",
+          "CLAUDE_ONLY": "enabled"
+        },
+        "args": ["--claude-flag"],
+        "extensions": ["./tools/claude-plugin"],
+        "systemPrompt": "Use the Claude-specific repository review policy.",
+        "appendSystemPrompt": "Include Claude-only diagnostics."
+      },
+      "systemPrompt": "Use the shared repository review policy.",
+      "appendSystemPrompt": "Include the shared checklist."
+    }
+  },
+  "stateTargets": {
+    "auth.json": "<home>/.pi/agent/auth.json",
+    "settings.json": "<project>/.bridl/profiles/adapter-review/cli_specific/pi/settings.json",
+    "utilities": "<home>/.bridl/cache/utilities"
+  }
+}

--- a/tests/fixtures/integration/adapter_specific_overrides/expected/pi/warnings.json
+++ b/tests/fixtures/integration/adapter_specific_overrides/expected/pi/warnings.json
@@ -1,0 +1,1 @@
+["pi wrote undeclared tack state 'unexpected-pi.txt' and it was not persisted."]

--- a/tests/fixtures/integration/adapter_specific_overrides/home/.bridl/profiles/default/profile.yml
+++ b/tests/fixtures/integration/adapter_specific_overrides/home/.bridl/profiles/default/profile.yml
@@ -1,0 +1,6 @@
+id: default
+label: Personal Adapter Defaults
+controls:
+  environment:
+    USER_DEFAULT: 'enabled'
+    SHARED_LAYER: user-default

--- a/tests/fixtures/integration/adapter_specific_overrides/home/.bridl/settings.yml
+++ b/tests/fixtures/integration/adapter_specific_overrides/home/.bridl/settings.yml
@@ -1,0 +1,5 @@
+default_profile: default
+default_agent: pi
+cache_directory: ./cache
+profile_sources:
+  - path: ./profiles

--- a/tests/fixtures/integration/adapter_specific_overrides/project/.bridl/profiles/adapter-review/cli_specific/claude/settings.json
+++ b/tests/fixtures/integration/adapter_specific_overrides/project/.bridl/profiles/adapter-review/cli_specific/claude/settings.json
@@ -1,0 +1,1 @@
+{ "adapter": "claude", "status": "seeded" }

--- a/tests/fixtures/integration/adapter_specific_overrides/project/.bridl/profiles/adapter-review/cli_specific/pi/settings.json
+++ b/tests/fixtures/integration/adapter_specific_overrides/project/.bridl/profiles/adapter-review/cli_specific/pi/settings.json
@@ -1,0 +1,1 @@
+{ "adapter": "pi", "status": "seeded" }

--- a/tests/fixtures/integration/adapter_specific_overrides/project/.bridl/profiles/adapter-review/profile.yml
+++ b/tests/fixtures/integration/adapter_specific_overrides/project/.bridl/profiles/adapter-review/profile.yml
@@ -1,0 +1,44 @@
+id: adapter-review
+label: Adapter-Specific Review
+controls:
+  model: generic-model
+  thinking: balanced
+  environment:
+    GENERIC_ENV: 'enabled'
+    ADAPTER_ENV: generic
+    SHARED_LAYER: adapter-review
+  args:
+    - --generic-flag
+  extensions:
+    - ./tools/generic-extension
+  system_prompt: Use the shared repository review policy.
+  append_system_prompt: Include the shared checklist.
+  pi:
+    model: pi-specialized-model
+    provider: openai-compatible
+    thinking: high
+    session_directory: pi-review-sessions
+    prompt_template: ./prompts/pi-review.md
+    system_prompt: Use the pi-specific repository review policy.
+    append_system_prompt: Include pi-only diagnostics.
+    environment:
+      ADAPTER_ENV: pi
+      PI_ONLY: 'enabled'
+    args:
+      - --pi-flag
+    extensions:
+      - ./tools/pi-extension
+    skills:
+      - repo-review
+  claude:
+    model: claude-specialized-model
+    thinking: deep
+    system_prompt: Use the Claude-specific repository review policy.
+    append_system_prompt: Include Claude-only diagnostics.
+    environment:
+      ADAPTER_ENV: claude
+      CLAUDE_ONLY: 'enabled'
+    args:
+      - --claude-flag
+    extensions:
+      - ./tools/claude-plugin

--- a/tests/fixtures/integration/adapter_specific_overrides/project/.bridl/settings.yml
+++ b/tests/fixtures/integration/adapter_specific_overrides/project/.bridl/settings.yml
@@ -1,0 +1,3 @@
+profile_sources:
+  - path: ../../home/.bridl/profiles
+  - path: ./profiles

--- a/tests/integration/adapter-specific-overrides.test.ts
+++ b/tests/integration/adapter-specific-overrides.test.ts
@@ -1,0 +1,143 @@
+// Tests adapter-specific integration fixture behavior.
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  cleanupIntegrationFixtures,
+  copyFixtureToTemp,
+  readExpectedJson,
+  readFixtureText,
+  runFixture,
+  summarizeClaudeTack,
+  summarizePiTack,
+  tackRootFromLaunchPlan,
+  tokenizeFixturePath,
+} from './fixtureHarness.js';
+
+afterEach(() => {
+  cleanupIntegrationFixtures();
+});
+
+describe('adapter-specific integration fixture tack generation', () => {
+  it('applies pi-specific controls and writes back only pi profile-owned state', async () => {
+    const fixture = copyFixtureToTemp('adapter_specific_overrides');
+    const warnings: string[] = [];
+    let tackSummary: unknown;
+    const originalSourceProfileYaml = readFixtureText(fixture, 'project/.bridl/profiles/adapter-review/profile.yml');
+
+    const result = await runFixture(fixture, {
+      profileId: 'adapter-review',
+      agentId: 'pi',
+      warnings,
+      launcher: {
+        launch(plan) {
+          const tackRoot = tackRootFromLaunchPlan(plan);
+          tackSummary = {
+            profileId: 'adapter-review',
+            agentId: 'pi',
+            launchCommand: plan.command,
+            launchArgs: plan.args,
+            launchEnv: {
+              PI_CODING_AGENT_DIR: tokenizeFixturePath(fixture, plan.env.PI_CODING_AGENT_DIR, tackRoot),
+              ADAPTER_ENV: plan.env.ADAPTER_ENV,
+              GENERIC_ENV: plan.env.GENERIC_ENV,
+              PI_ONLY: plan.env.PI_ONLY,
+              SHARED_LAYER: plan.env.SHARED_LAYER,
+              USER_DEFAULT: plan.env.USER_DEFAULT,
+            },
+            ...(summarizePiTack(fixture, tackRoot) as Record<string, unknown>),
+          };
+
+          writeFileSync(join(tackRoot, 'bridl', 'profile.json'), '{"mutated":true}\n');
+          writeFileSync(join(tackRoot, 'settings.json'), '{"adapter":"pi","status":"updated"}\n');
+          writeFileSync(join(tackRoot, 'unexpected-pi.txt'), 'unknown pi write\n');
+
+          return Promise.resolve(0);
+        },
+      },
+    });
+
+    expect(tackSummary).toEqual(readExpectedJson(fixture, 'pi/tack-summary.json'));
+    expect(result.profileId).toBe('adapter-review');
+    expect(result.agentId).toBe('pi');
+    expect(result.warnings).toEqual(readExpectedJson(fixture, 'pi/warnings.json'));
+    expect(warnings).toEqual(result.warnings);
+    expect(
+      readFileSync(
+        join(fixture.project, '.bridl', 'profiles', 'adapter-review', 'cli_specific', 'pi', 'settings.json'),
+        'utf8',
+      ),
+    ).toBe('{"adapter":"pi","status":"updated"}\n');
+    expect(
+      readFileSync(
+        join(fixture.project, '.bridl', 'profiles', 'adapter-review', 'cli_specific', 'claude', 'settings.json'),
+        'utf8',
+      ),
+    ).toBe('{ "adapter": "claude", "status": "seeded" }\n');
+    expect(readFixtureText(fixture, 'project/.bridl/profiles/adapter-review/profile.yml')).toBe(
+      originalSourceProfileYaml,
+    );
+  });
+
+  it('applies Claude-specific controls and writes back only Claude profile-owned state', async () => {
+    const fixture = copyFixtureToTemp('adapter_specific_overrides');
+    const warnings: string[] = [];
+    let tackSummary: unknown;
+    const originalSourceProfileYaml = readFixtureText(fixture, 'project/.bridl/profiles/adapter-review/profile.yml');
+
+    const result = await runFixture(fixture, {
+      profileId: 'adapter-review',
+      agentId: 'claude',
+      warnings,
+      launcher: {
+        launch(plan) {
+          const tackRoot = tackRootFromLaunchPlan(plan);
+          tackSummary = {
+            profileId: 'adapter-review',
+            agentId: 'claude',
+            launchCommand: plan.command,
+            launchArgs: plan.args,
+            launchEnv: {
+              CLAUDE_CONFIG_DIR: tokenizeFixturePath(fixture, plan.env.CLAUDE_CONFIG_DIR, tackRoot),
+              ADAPTER_ENV: plan.env.ADAPTER_ENV,
+              CLAUDE_ONLY: plan.env.CLAUDE_ONLY,
+              GENERIC_ENV: plan.env.GENERIC_ENV,
+              SHARED_LAYER: plan.env.SHARED_LAYER,
+              USER_DEFAULT: plan.env.USER_DEFAULT,
+            },
+            ...(summarizeClaudeTack(fixture, tackRoot) as Record<string, unknown>),
+          };
+
+          writeFileSync(join(tackRoot, 'bridl', 'profile.json'), '{"mutated":true}\n');
+          writeFileSync(join(tackRoot, 'settings.json'), '{"adapter":"claude","status":"updated"}\n');
+          writeFileSync(join(tackRoot, 'unexpected-claude.txt'), 'unknown claude write\n');
+
+          return Promise.resolve(0);
+        },
+      },
+    });
+
+    expect(tackSummary).toEqual(readExpectedJson(fixture, 'claude/tack-summary.json'));
+    expect(result.profileId).toBe('adapter-review');
+    expect(result.agentId).toBe('claude');
+    expect(result.warnings).toEqual(readExpectedJson(fixture, 'claude/warnings.json'));
+    expect(warnings).toEqual(result.warnings);
+    expect(
+      readFileSync(
+        join(fixture.project, '.bridl', 'profiles', 'adapter-review', 'cli_specific', 'claude', 'settings.json'),
+        'utf8',
+      ),
+    ).toBe('{"adapter":"claude","status":"updated"}\n');
+    expect(
+      readFileSync(
+        join(fixture.project, '.bridl', 'profiles', 'adapter-review', 'cli_specific', 'pi', 'settings.json'),
+        'utf8',
+      ),
+    ).toBe('{ "adapter": "pi", "status": "seeded" }\n');
+    expect(readFixtureText(fixture, 'project/.bridl/profiles/adapter-review/profile.yml')).toBe(
+      originalSourceProfileYaml,
+    );
+  });
+});

--- a/tests/integration/fixtureHarness.ts
+++ b/tests/integration/fixtureHarness.ts
@@ -96,6 +96,15 @@ export const summarizePiTack = (fixture: IntegrationFixture, tackRoot: string): 
   },
 });
 
+export const summarizeClaudeTack = (fixture: IntegrationFixture, tackRoot: string): unknown => ({
+  generatedProfile: JSON.parse(readFileSync(join(tackRoot, 'bridl', 'profile.json'), 'utf8')) as unknown,
+  stateTargets: {
+    'settings.json': tokenizeFixturePath(fixture, readlinkSync(join(tackRoot, 'settings.json')), tackRoot),
+    agents: tokenizeFixturePath(fixture, readlinkSync(join(tackRoot, 'agents')), tackRoot),
+    projects: tokenizeFixturePath(fixture, readlinkSync(join(tackRoot, 'projects')), tackRoot),
+  },
+});
+
 export const tokenizeFixturePath = (fixture: IntegrationFixture, path: string, tackRoot?: string): string => {
   if (tackRoot !== undefined && path === tackRoot) {
     return '<tack>';


### PR DESCRIPTION
## Summary
- add the adapter_specific_overrides integration fixture with generic controls plus controls.pi and controls.claude
- add expected pi and Claude tack summaries/warnings and profile-owned adapter state files
- extend the fixture harness with Claude tack summarization and cover write-back isolation for both adapters

## Validation
- npx vitest --run tests/integration/tack-generation.test.ts --reporter=dot
- npm run check-ci

Note: the first check-ci attempt hit unrelated git-synchronizer test timeouts under coverage; an immediate rerun passed.