### PR TITLE
Add heavily overridden engineering integration fixture

### DIFF
--- a/tests/fixtures/integration/INTEGRATION_TEST_FIXTURES.md
+++ b/tests/fixtures/integration/INTEGRATION_TEST_FIXTURES.md
@@ -184,7 +184,7 @@ Write-back focus: replacement should be diagnosed as not persisted, and the orig
 | `profile-cycle` | Existing | none | 1 | cycle | none | none | diagnostics |
 | `profile-missing-inheritance` | Existing | none | 1 | missing | none | none | diagnostics |
 | `trivial_repo_only_profile` | Existing | user + repo | 1 | implicit default | pi | native fallback | generated files |
-| `heavily_overridden_engineering` | Proposed | remote + 3 | 5 | 1-2 | all | highest profile | source ownership |
+| `heavily_overridden_engineering` | Existing | remote + 3 | 5 | 1-2 | all | highest profile | source ownership |
 | `remote_baseline_local_selection` | Existing | remote + 3 | 1-2 | implicit default | all | mixed | source ownership |
 | `language_stack_with_personal_default` | Existing | user + repo | 1 | 2-3 | all | native fallback | inherited output |
 | `local_sandbox_overrides` | Existing | user + repo + local | 1-2 | 1 | all | temporary | local overrides |
@@ -203,7 +203,7 @@ Write-back focus: replacement should be diagnosed as not persisted, and the orig
 | `profile-cycle` | Existing | none | 1 | cycle | none | none | diagnostics |
 | `profile-missing-inheritance` | Existing | none | 1 | missing | none | none | diagnostics |
 | `trivial_repo_only_profile` | Proposed | user + repo | 1 | implicit default | all | native fallback | generated files |
-| `heavily_overridden_engineering` | Proposed | remote + 3 | 5 | 1-2 | all | highest profile | source ownership |
+| `heavily_overridden_engineering` | Existing | remote + 3 | 5 | 1-2 | all | highest profile | source ownership |
 | `remote_baseline_local_selection` | Proposed | remote + 3 | 1-2 | implicit default | all | mixed | source ownership |
 | `language_stack_with_personal_default` | Proposed | user + repo | 1 | 2-3 | all | native fallback | inherited output |
 | `local_sandbox_overrides` | Proposed | user + repo + local | 1-2 | 1 | all | temporary | local overrides |

--- a/tests/fixtures/integration/heavily_overridden_engineering/README.md
+++ b/tests/fixtures/integration/heavily_overridden_engineering/README.md
@@ -1,0 +1,19 @@
+# heavily_overridden_engineering
+
+This fixture models a real engineering profile that is intentionally defined in many places at once. It is agent-neutral at the directory level, while individual profiles may include adapter-specific controls and `cli_specific/` state for adapters that support them.
+
+The selected profile id is `engineering`. Profile source order is arranged from lowest to highest precedence:
+
+1. a pre-seeded cached GitHub/team source in `home/.bridl/cache/repos/`;
+2. a repo-declared supplemental team source at `project/.bridl/team-profiles/`;
+3. the user's profile source at `home/.bridl/profiles/`;
+4. the checked-in repository source at `project/.bridl/profiles/`;
+5. project-local overrides at `project/.bridl/local/profiles/`.
+
+Each layer contributes obvious environment values such as `REMOTE_ONLY`, `USER_ONLY`, `REPO_ONLY`, `LOCAL_ONLY`, and `SHARED` so a failed assertion points directly at the wrong winning layer. The project-local `engineering` layer also inherits `team-baseline`, while the user `default` profile is included implicitly below the selected profile.
+
+## Write-back behavior
+
+The project-local `engineering` profile owns `cli_specific/pi/settings.json`, which is the highest-precedence profile-owned Pi state file for that declared state path. Writes through the generated tack's `settings.json` symlink should update only that project-local file.
+
+Generated Bridl files such as `bridl/profile.json` are transform outputs and are not written back to any source profile. Undeclared files created in the tack should produce warnings and should not be persisted to any fixture source layer.

--- a/tests/fixtures/integration/heavily_overridden_engineering/expected/pi/tack-summary.json
+++ b/tests/fixtures/integration/heavily_overridden_engineering/expected/pi/tack-summary.json
@@ -1,0 +1,83 @@
+{
+  "profileId": "engineering",
+  "agentId": "pi",
+  "launchCommand": "pi",
+  "launchArgs": [
+    "--model",
+    "local-pi-model",
+    "--provider",
+    "team-provider",
+    "--thinking",
+    "high",
+    "--prompt-template",
+    "Review {{project.name}} with repository standards",
+    "--system-prompt",
+    "Supplemental engineering guardrails",
+    "--append-system-prompt",
+    "Personal review preferences",
+    "--extension",
+    "personal-lint",
+    "--skill",
+    "code-review",
+    "--pi-local-flag"
+  ],
+  "launchEnv": {
+    "PI_CODING_AGENT_DIR": "<tack>",
+    "BASE_SHARED": "team-baseline",
+    "DEFAULT_SHARED": "user-default",
+    "LOCAL_ONLY": "enabled",
+    "PI_ONLY": "enabled",
+    "REMOTE_ONLY": "enabled",
+    "REPO_ONLY": "enabled",
+    "SHARED": "local",
+    "SOURCE_ORDER": "local",
+    "SUPPLEMENTAL_ONLY": "enabled",
+    "TEAM_BASELINE": "enabled",
+    "USER_DEFAULT": "enabled",
+    "USER_ONLY": "enabled"
+  },
+  "generatedProfile": {
+    "id": "engineering",
+    "label": "Local Engineering Override",
+    "controls": {
+      "environment": {
+        "USER_DEFAULT": "enabled",
+        "DEFAULT_SHARED": "user-default",
+        "SHARED": "local",
+        "BASE_SHARED": "team-baseline",
+        "TEAM_BASELINE": "enabled",
+        "REMOTE_ONLY": "enabled",
+        "SOURCE_ORDER": "local",
+        "SUPPLEMENTAL_ONLY": "enabled",
+        "USER_ONLY": "enabled",
+        "REPO_ONLY": "enabled",
+        "LOCAL_ONLY": "enabled"
+      },
+      "appendSystemPrompt": "Personal review preferences",
+      "append_system_prompt": "Personal review preferences",
+      "provider": "team-provider",
+      "skills": ["code-review"],
+      "model": "local-model",
+      "args": ["--local-flag", "--remote-flag"],
+      "systemPrompt": "Supplemental engineering guardrails",
+      "system_prompt": "Supplemental engineering guardrails",
+      "extensions": ["personal-lint"],
+      "promptTemplate": "Review {{project.name}} with repository standards",
+      "prompt_template": "Review {{project.name}} with repository standards",
+      "thinking": "high",
+      "pi": {
+        "model": "local-pi-model",
+        "environment": {
+          "PI_ONLY": "enabled",
+          "PI_SHARED": "local-pi"
+        },
+        "args": ["--pi-local-flag"]
+      }
+    }
+  },
+  "stateTargets": {
+    "auth.json": "<home>/.pi/agent/auth.json",
+    "settings.json": "<project>/.bridl/local/profiles/engineering/cli_specific/pi/settings.json",
+    "utilities": "<home>/.bridl/cache/utilities"
+  }
+}

--- a/tests/fixtures/integration/heavily_overridden_engineering/expected/pi/warnings.json
+++ b/tests/fixtures/integration/heavily_overridden_engineering/expected/pi/warnings.json
@@ -1,0 +1,1 @@
+["pi wrote undeclared tack state 'unexpected-local.txt' and it was not persisted."]

--- a/tests/fixtures/integration/heavily_overridden_engineering/home/.bridl/cache/repos/Z2l0K2h0dHBzOi8vZ2l0aHViLmNvbS9hY21lL2VuZ2luZWVyaW5nLXByb2ZpbGVzLmdpdCNtYWlu/profiles/engineering/profile.yml
+++ b/tests/fixtures/integration/heavily_overridden_engineering/home/.bridl/cache/repos/Z2l0K2h0dHBzOi8vZ2l0aHViLmNvbS9hY21lL2VuZ2luZWVyaW5nLXByb2ZpbGVzLmdpdCNtYWlu/profiles/engineering/profile.yml
@@ -1,0 +1,10 @@
+id: engineering
+label: Remote Engineering Baseline
+controls:
+  model: remote-model
+  environment:
+    REMOTE_ONLY: 'enabled'
+    SHARED: remote
+    SOURCE_ORDER: remote
+  args:
+    - --remote-flag

--- a/tests/fixtures/integration/heavily_overridden_engineering/home/.bridl/profiles/default/profile.yml
+++ b/tests/fixtures/integration/heavily_overridden_engineering/home/.bridl/profiles/default/profile.yml
@@ -1,0 +1,8 @@
+id: default
+label: Personal Default
+controls:
+  environment:
+    USER_DEFAULT: 'enabled'
+    DEFAULT_SHARED: user-default
+    SHARED: user-default
+  append_system_prompt: Personal review preferences

--- a/tests/fixtures/integration/heavily_overridden_engineering/home/.bridl/profiles/engineering/profile.yml
+++ b/tests/fixtures/integration/heavily_overridden_engineering/home/.bridl/profiles/engineering/profile.yml
@@ -1,0 +1,9 @@
+id: engineering
+label: User Engineering Preferences
+controls:
+  environment:
+    USER_ONLY: 'enabled'
+    SHARED: user
+    SOURCE_ORDER: user
+  extensions:
+    - personal-lint

--- a/tests/fixtures/integration/heavily_overridden_engineering/home/.bridl/settings.yml
+++ b/tests/fixtures/integration/heavily_overridden_engineering/home/.bridl/settings.yml
@@ -1,0 +1,5 @@
+default_profile: default
+default_agent: pi
+cache_directory: ./cache
+profile_sources:
+  - path: ./profiles

--- a/tests/fixtures/integration/heavily_overridden_engineering/home/.pi/agent/auth.json
+++ b/tests/fixtures/integration/heavily_overridden_engineering/home/.pi/agent/auth.json
@@ -1,0 +1,1 @@
+{ "native": "auth" }

--- a/tests/fixtures/integration/heavily_overridden_engineering/home/.pi/agent/settings.json
+++ b/tests/fixtures/integration/heavily_overridden_engineering/home/.pi/agent/settings.json
@@ -1,0 +1,1 @@
+{ "owner": "native-fallback" }

--- a/tests/fixtures/integration/heavily_overridden_engineering/project/.bridl/local/profiles/engineering/cli_specific/pi/settings.json
+++ b/tests/fixtures/integration/heavily_overridden_engineering/project/.bridl/local/profiles/engineering/cli_specific/pi/settings.json
@@ -1,0 +1,1 @@
+{ "owner": "project-local", "version": 1 }

--- a/tests/fixtures/integration/heavily_overridden_engineering/project/.bridl/local/profiles/engineering/profile.yml
+++ b/tests/fixtures/integration/heavily_overridden_engineering/project/.bridl/local/profiles/engineering/profile.yml
@@ -1,0 +1,23 @@
+id: engineering
+label: Local Engineering Override
+inherits:
+  - team-baseline
+state_persistence:
+  settings.json: symlink
+  unknown: warn
+controls:
+  model: local-model
+  thinking: high
+  environment:
+    LOCAL_ONLY: 'enabled'
+    SHARED: local
+    SOURCE_ORDER: local
+  args:
+    - --local-flag
+  pi:
+    model: local-pi-model
+    environment:
+      PI_ONLY: 'enabled'
+      PI_SHARED: local-pi
+    args:
+      - --pi-local-flag

--- a/tests/fixtures/integration/heavily_overridden_engineering/project/.bridl/local/settings.yml
+++ b/tests/fixtures/integration/heavily_overridden_engineering/project/.bridl/local/settings.yml
@@ -1,0 +1,9 @@
+profile_sources:
+  - github: acme/engineering-profiles
+    ref: main
+    path: profiles
+    only: [engineering]
+  - path: ../team-profiles
+  - path: ../../../home/.bridl/profiles
+  - path: ../profiles
+  - path: ./profiles

--- a/tests/fixtures/integration/heavily_overridden_engineering/project/.bridl/profiles/engineering/profile.yml
+++ b/tests/fixtures/integration/heavily_overridden_engineering/project/.bridl/profiles/engineering/profile.yml
@@ -1,0 +1,8 @@
+id: engineering
+label: Repository Engineering
+controls:
+  environment:
+    REPO_ONLY: 'enabled'
+    SHARED: repo
+    SOURCE_ORDER: repo
+  prompt_template: Review {{project.name}} with repository standards

--- a/tests/fixtures/integration/heavily_overridden_engineering/project/.bridl/settings.yml
+++ b/tests/fixtures/integration/heavily_overridden_engineering/project/.bridl/settings.yml
@@ -1,0 +1,8 @@
+profile_sources:
+  - github: acme/engineering-profiles
+    ref: main
+    path: profiles
+    only: [engineering]
+  - path: ./team-profiles
+  - path: ../../home/.bridl/profiles
+  - path: ./profiles

--- a/tests/fixtures/integration/heavily_overridden_engineering/project/.bridl/team-profiles/engineering/profile.yml
+++ b/tests/fixtures/integration/heavily_overridden_engineering/project/.bridl/team-profiles/engineering/profile.yml
@@ -1,0 +1,8 @@
+id: engineering
+label: Supplemental Engineering
+controls:
+  environment:
+    SUPPLEMENTAL_ONLY: 'enabled'
+    SHARED: supplemental
+    SOURCE_ORDER: supplemental
+  system_prompt: Supplemental engineering guardrails

--- a/tests/fixtures/integration/heavily_overridden_engineering/project/.bridl/team-profiles/team-baseline/profile.yml
+++ b/tests/fixtures/integration/heavily_overridden_engineering/project/.bridl/team-profiles/team-baseline/profile.yml
@@ -1,0 +1,9 @@
+id: team-baseline
+label: Team Baseline
+controls:
+  provider: team-provider
+  environment:
+    TEAM_BASELINE: 'enabled'
+    BASE_SHARED: team-baseline
+  skills:
+    - code-review

--- a/tests/integration/heavily-overridden-engineering.test.ts
+++ b/tests/integration/heavily-overridden-engineering.test.ts
@@ -1,0 +1,99 @@
+// Tests heavily overridden fixture behavior.
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  cleanupIntegrationFixtures,
+  copyFixtureToTemp,
+  readExpectedJson,
+  readFixtureText,
+  runFixture,
+  summarizePiTack,
+  tackRootFromLaunchPlan,
+  tokenizeFixturePath,
+} from './fixtureHarness.js';
+
+afterEach(() => {
+  cleanupIntegrationFixtures();
+});
+
+describe('heavily overridden integration fixture tack generation', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-003.3, BRIDL-REQ-003.4, BRIDL-REQ-005.3, BRIDL-REQ-005.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('merges a heavily overridden engineering profile and writes back only highest-precedence owned state', async () => {
+    const fixture = copyFixtureToTemp('heavily_overridden_engineering');
+    const warnings: string[] = [];
+    let tackSummary: unknown;
+    const sourceProfilePaths = [
+      'home/.bridl/cache/repos/Z2l0K2h0dHBzOi8vZ2l0aHViLmNvbS9hY21lL2VuZ2luZWVyaW5nLXByb2ZpbGVzLmdpdCNtYWlu/profiles/engineering/profile.yml',
+      'home/.bridl/profiles/default/profile.yml',
+      'home/.bridl/profiles/engineering/profile.yml',
+      'project/.bridl/local/profiles/engineering/profile.yml',
+      'project/.bridl/profiles/engineering/profile.yml',
+      'project/.bridl/team-profiles/engineering/profile.yml',
+      'project/.bridl/team-profiles/team-baseline/profile.yml',
+    ] as const;
+    const originalSourceProfiles = new Map(
+      sourceProfilePaths.map((profilePath) => [profilePath, readFixtureText(fixture, profilePath)]),
+    );
+
+    const result = await runFixture(fixture, {
+      profileId: 'engineering',
+      agentId: 'pi',
+      warnings,
+      launcher: {
+        launch(plan) {
+          const tackRoot = tackRootFromLaunchPlan(plan);
+          tackSummary = {
+            profileId: 'engineering',
+            agentId: 'pi',
+            launchCommand: plan.command,
+            launchArgs: plan.args,
+            launchEnv: {
+              PI_CODING_AGENT_DIR: tokenizeFixturePath(fixture, plan.env.PI_CODING_AGENT_DIR, tackRoot),
+              BASE_SHARED: plan.env.BASE_SHARED,
+              DEFAULT_SHARED: plan.env.DEFAULT_SHARED,
+              LOCAL_ONLY: plan.env.LOCAL_ONLY,
+              PI_ONLY: plan.env.PI_ONLY,
+              REMOTE_ONLY: plan.env.REMOTE_ONLY,
+              REPO_ONLY: plan.env.REPO_ONLY,
+              SHARED: plan.env.SHARED,
+              SOURCE_ORDER: plan.env.SOURCE_ORDER,
+              SUPPLEMENTAL_ONLY: plan.env.SUPPLEMENTAL_ONLY,
+              TEAM_BASELINE: plan.env.TEAM_BASELINE,
+              USER_DEFAULT: plan.env.USER_DEFAULT,
+              USER_ONLY: plan.env.USER_ONLY,
+            },
+            ...(summarizePiTack(fixture, tackRoot) as Record<string, unknown>),
+          };
+
+          writeFileSync(join(tackRoot, 'bridl', 'profile.json'), '{"mutated":true}\n');
+          writeFileSync(join(tackRoot, 'settings.json'), '{"owner":"project-local","version":2}\n');
+          writeFileSync(join(tackRoot, 'unexpected-local.txt'), 'unknown write\n');
+
+          return Promise.resolve(0);
+        },
+      },
+    });
+
+    expect(tackSummary).toEqual(readExpectedJson(fixture, 'pi/tack-summary.json'));
+    expect(result.profileId).toBe('engineering');
+    expect(result.agentId).toBe('pi');
+    expect(result.warnings).toEqual(readExpectedJson(fixture, 'pi/warnings.json'));
+    expect(warnings).toEqual(result.warnings);
+    expect(
+      readFileSync(
+        join(fixture.project, '.bridl', 'local', 'profiles', 'engineering', 'cli_specific', 'pi', 'settings.json'),
+        'utf8',
+      ),
+    ).toBe('{"owner":"project-local","version":2}\n');
+    expect(readFileSync(join(fixture.home, '.pi', 'agent', 'settings.json'), 'utf8')).toBe(
+      '{ "owner": "native-fallback" }\n',
+    );
+    for (const [profilePath, originalProfileYaml] of originalSourceProfiles) {
+      expect(readFixtureText(fixture, profilePath)).toBe(originalProfileYaml);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add the heavily_overridden_engineering fixture with remote, supplemental, user, repo, and project-local profile layers
- add Pi expected tack outputs and write-back warnings
- add integration coverage for precedence, implicit default/inheritance composition, adapter-specific controls, and highest-precedence profile-owned state writes

## Validation
- npm run check-ci