### PR TITLE
Add strict CI integration fixture

### DIFF
--- a/tests/fixtures/integration/INTEGRATION_TEST_FIXTURES.md
+++ b/tests/fixtures/integration/INTEGRATION_TEST_FIXTURES.md
@@ -117,7 +117,7 @@ Location: `tests/fixtures/integration/strict_ci_profile/`
 
 This fixture should model a locked CI profile. It should use strict `state_persistence` values such as `unknown: error`, important settings/config paths as `error`, and caches/sessions as `discard`.
 
-Use it to test reproducibility enforcement, post-run diagnostics, and `--hard-tack` behavior.
+Use it to test reproducibility enforcement and post-run diagnostics for strict state persistence.
 
 Write-back focus: the fake launcher should attempt both declared and unknown writes. Tests should assert failure or warnings without durable persistence for non-persistent paths.
 
@@ -188,7 +188,7 @@ Write-back focus: replacement should be diagnosed as not persisted, and the orig
 | `remote_baseline_local_selection` | Existing | remote + 3 | 1-2 | implicit default | all | mixed | source ownership |
 | `language_stack_with_personal_default` | Existing | user + repo | 1 | 2-3 | all | native fallback | inherited output |
 | `local_sandbox_overrides` | Existing | user + repo + local | 1-2 | 1 | all | temporary | local overrides |
-| `strict_ci_profile` | Proposed | repo | 1 | 0-1 | all | temporary | errors |
+| `strict_ci_profile` | Existing | repo | 1 | 0-1 | all | temporary | errors |
 | `profile_owned_cli_state` | Proposed | user + repo | 1 | 0-1 | all | profile state | symlink writes |
 | `native_fallback_cli_state` | Existing | user + repo | 1 | 0-1 | all | native fallback | fallback writes |
 | `cache_backed_tooling_state` | Existing | user + repo | 1 | 0 | adapter subset | cache | cache writes |
@@ -207,7 +207,7 @@ Write-back focus: replacement should be diagnosed as not persisted, and the orig
 | `remote_baseline_local_selection` | Proposed | remote + 3 | 1-2 | implicit default | all | mixed | source ownership |
 | `language_stack_with_personal_default` | Proposed | user + repo | 1 | 2-3 | all | native fallback | inherited output |
 | `local_sandbox_overrides` | Proposed | user + repo + local | 1-2 | 1 | all | temporary | local overrides |
-| `strict_ci_profile` | Proposed | repo | 1 | 0-1 | all | temporary | errors |
+| `strict_ci_profile` | Existing | repo | 1 | 0-1 | all | temporary | errors |
 | `profile_owned_cli_state` | Proposed | user + repo | 1 | 0-1 | all | profile state | symlink writes |
 | `native_fallback_cli_state` | Proposed | user + repo | 1 | 0-1 | all | native fallback | fallback writes |
 | `cache_backed_tooling_state` | Added | user + repo | 1 | implicit default | pi subset | cache | cache writes |

--- a/tests/fixtures/integration/strict_ci_profile/README.md
+++ b/tests/fixtures/integration/strict_ci_profile/README.md
@@ -1,0 +1,23 @@
+# strict_ci_profile
+
+This fixture models a locked CI job that must fail rather than silently keep agent CLI state outside declared reproducible inputs.
+
+## Setup
+
+- `home/` is a minimal synthetic CI user home with Bridl configured for the pi adapter and a disposable cache directory.
+- `project/` is the repository checkout. Its `.bridl/settings.yml` selects the checked-in `ci-strict` profile and uses only repository profile sources.
+- `project/.bridl/profiles/ci-strict/profile.yml` defines deterministic launch controls and strict state persistence:
+  - `settings.json` and `mcp.json` are `error` so writes to important configuration are diagnosed after the agent exits.
+  - `cache/` and `sessions/` are `discard` so transient runtime data is ignored and does not persist durably.
+  - `unknown` is `error` so any undeclared tack write fails the run.
+
+## Write-back behavior under test
+
+The Vitest integration tests copy this fixture to a temporary directory, run the pi adapter through `tests/integration/fixtureHarness.ts`, and use fake launchers that mutate the tack.
+
+Expected behavior:
+
+- Writes to `settings.json` or `mcp.json` fail with a post-run diagnostic and do not update `home/.pi/agent/`.
+- Writes under discarded cache/session directories do not produce diagnostics and do not persist to native or profile-owned state.
+- Writes to undeclared paths fail with an unknown-state diagnostic.
+- Generated Bridl tack files may be mutated by the fake launcher, but fixture YAML remains unchanged because generated files are not written back to profile sources.

--- a/tests/fixtures/integration/strict_ci_profile/expected/pi/diagnostics.json
+++ b/tests/fixtures/integration/strict_ci_profile/expected/pi/diagnostics.json
@@ -1,0 +1,4 @@
+{
+  "declaredSettingsError": "pi wrote 'settings.json' with state_persistence 'error' and it was not persisted.",
+  "unknownWriteError": "pi wrote undeclared tack state 'undeclared-state.json' and it was not persisted."
+}

--- a/tests/fixtures/integration/strict_ci_profile/expected/pi/launch-summary.json
+++ b/tests/fixtures/integration/strict_ci_profile/expected/pi/launch-summary.json
@@ -1,0 +1,30 @@
+{
+  "profileId": "ci-strict",
+  "agentId": "pi",
+  "launchCommand": "pi",
+  "launchArgs": ["--model", "ci-review-model", "--provider", "ci-provider", "--ci", "--no-interactive"],
+  "launchEnv": {
+    "PI_CODING_AGENT_DIR": "<tack>",
+    "BRIDL_FIXTURE": "strict_ci_profile",
+    "CI_PROFILE": "locked"
+  },
+  "generatedProfile": {
+    "id": "ci-strict",
+    "label": "Strict CI Profile",
+    "controls": {
+      "model": "ci-review-model",
+      "provider": "ci-provider",
+      "environment": {
+        "BRIDL_FIXTURE": "strict_ci_profile",
+        "CI_PROFILE": "locked"
+      },
+      "args": ["--ci", "--no-interactive"]
+    }
+  },
+  "strictStateFiles": {
+    "settings.json": "absent-before-launch",
+    "mcp.json": "absent-before-launch",
+    "cache/": "directory",
+    "sessions/": "directory"
+  }
+}

--- a/tests/fixtures/integration/strict_ci_profile/home/.bridl/settings.yml
+++ b/tests/fixtures/integration/strict_ci_profile/home/.bridl/settings.yml
@@ -1,0 +1,2 @@
+default_agent: pi
+cache_directory: ./cache

--- a/tests/fixtures/integration/strict_ci_profile/project/.bridl/profiles/ci-strict/profile.yml
+++ b/tests/fixtures/integration/strict_ci_profile/project/.bridl/profiles/ci-strict/profile.yml
@@ -1,0 +1,17 @@
+id: ci-strict
+label: Strict CI Profile
+state_persistence:
+  settings.json: error
+  mcp.json: error
+  cache/: discard
+  sessions/: discard
+  unknown: error
+controls:
+  model: ci-review-model
+  provider: ci-provider
+  environment:
+    BRIDL_FIXTURE: strict_ci_profile
+    CI_PROFILE: locked
+  args:
+    - --ci
+    - --no-interactive

--- a/tests/fixtures/integration/strict_ci_profile/project/.bridl/settings.yml
+++ b/tests/fixtures/integration/strict_ci_profile/project/.bridl/settings.yml
@@ -1,0 +1,3 @@
+default_profile: ci-strict
+profile_sources:
+  - path: ./profiles

--- a/tests/integration/strict-ci-profile.test.ts
+++ b/tests/integration/strict-ci-profile.test.ts
@@ -1,0 +1,101 @@
+// Tests strict CI integration fixture behavior.
+import { existsSync, lstatSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  cleanupIntegrationFixtures,
+  copyFixtureToTemp,
+  readExpectedJson,
+  readFixtureText,
+  runFixture,
+  tackRootFromLaunchPlan,
+  tokenizeFixturePath,
+} from './fixtureHarness.js';
+
+afterEach(() => {
+  cleanupIntegrationFixtures();
+});
+
+describe('strict CI integration fixture tack generation', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('fails a strict CI profile when declared error-state configuration changes', async () => {
+    const fixture = copyFixtureToTemp('strict_ci_profile');
+    const diagnostics = readExpectedJson<Record<string, string>>(fixture, 'pi/diagnostics.json');
+    let launchSummary: unknown;
+
+    await expect(
+      runFixture(fixture, {
+        agentId: 'pi',
+        launcher: {
+          launch(plan) {
+            const tackRoot = tackRootFromLaunchPlan(plan);
+            const settingsPath = join(tackRoot, 'settings.json');
+            const mcpPath = join(tackRoot, 'mcp.json');
+            const cachePath = join(tackRoot, 'cache');
+            const sessionsPath = join(tackRoot, 'sessions');
+
+            launchSummary = {
+              profileId: 'ci-strict',
+              agentId: 'pi',
+              launchCommand: plan.command,
+              launchArgs: plan.args,
+              launchEnv: {
+                PI_CODING_AGENT_DIR: tokenizeFixturePath(fixture, plan.env.PI_CODING_AGENT_DIR, tackRoot),
+                BRIDL_FIXTURE: plan.env.BRIDL_FIXTURE,
+                CI_PROFILE: plan.env.CI_PROFILE,
+              },
+              generatedProfile: JSON.parse(readFileSync(join(tackRoot, 'bridl', 'profile.json'), 'utf8')) as unknown,
+              strictStateFiles: {
+                'settings.json': existsSync(settingsPath) ? 'present-before-launch' : 'absent-before-launch',
+                'mcp.json': existsSync(mcpPath) ? 'present-before-launch' : 'absent-before-launch',
+                'cache/': lstatSync(cachePath).isDirectory() ? 'directory' : 'unexpected',
+                'sessions/': lstatSync(sessionsPath).isDirectory() ? 'directory' : 'unexpected',
+              },
+            };
+
+            mkdirSync(join(tackRoot, 'cache'), { recursive: true });
+            mkdirSync(join(tackRoot, 'sessions'), { recursive: true });
+            writeFileSync(settingsPath, '{"ci":"mutated"}\n');
+            writeFileSync(join(tackRoot, 'cache', 'index.json'), '{"ephemeral":true}\n');
+            writeFileSync(join(tackRoot, 'sessions', 'run.json'), '{"ephemeral":true}\n');
+
+            return Promise.resolve(0);
+          },
+        },
+      }),
+    ).rejects.toThrow(diagnostics.declaredSettingsError);
+
+    expect(launchSummary).toEqual(readExpectedJson(fixture, 'pi/launch-summary.json'));
+    expect(existsSync(join(fixture.home, '.pi', 'agent', 'settings.json'))).toBe(false);
+    expect(existsSync(join(fixture.home, '.pi', 'agent', 'cache', 'index.json'))).toBe(false);
+    expect(readFixtureText(fixture, 'project/.bridl/profiles/ci-strict/profile.yml')).toContain('unknown: error');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('fails a strict CI profile when undeclared tack state is written', async () => {
+    const fixture = copyFixtureToTemp('strict_ci_profile');
+    const diagnostics = readExpectedJson<Record<string, string>>(fixture, 'pi/diagnostics.json');
+
+    await expect(
+      runFixture(fixture, {
+        agentId: 'pi',
+        launcher: {
+          launch(plan) {
+            const tackRoot = tackRootFromLaunchPlan(plan);
+
+            writeFileSync(join(tackRoot, 'undeclared-state.json'), '{"unexpected":true}\n');
+
+            return Promise.resolve(0);
+          },
+        },
+      }),
+    ).rejects.toThrow(diagnostics.unknownWriteError);
+
+    expect(existsSync(join(fixture.home, '.pi', 'agent', 'undeclared-state.json'))).toBe(false);
+    expect(readFixtureText(fixture, 'project/.bridl/profiles/ci-strict/profile.yml')).toContain('settings.json: error');
+  });
+});


### PR DESCRIPTION
## Summary
- add the strict_ci_profile integration fixture with a locked CI profile and documented write-back expectations
- add pi expected launch/diagnostic outputs
- cover declared error-state writes, discarded transient state, and unknown tack writes via the integration fixture harness

## Validation
- npm run test -- tests/integration/tack-generation.test.ts
- npm run check-ci