### PR TITLE
Add native fallback CLI state fixture

### DIFF
--- a/tests/fixtures/integration/INTEGRATION_TEST_FIXTURES.md
+++ b/tests/fixtures/integration/INTEGRATION_TEST_FIXTURES.md
@@ -187,7 +187,7 @@ Write-back focus: replacement should be diagnosed as not persisted, and the orig
 | `local_sandbox_overrides`              | Existing | user + repo + local | 1-2          | 1                | all            | temporary       | local overrides  |
 | `strict_ci_profile`                    | Proposed | repo                | 1            | 0-1              | all            | temporary       | errors           |
 | `profile_owned_cli_state`              | Proposed | user + repo         | 1            | 0-1              | all            | profile state   | symlink writes   |
-| `native_fallback_cli_state`            | Proposed | user + repo         | 1            | 0-1              | all            | native fallback | fallback writes  |
+| `native_fallback_cli_state`            | Existing | user + repo         | 1            | 0-1              | all            | native fallback | fallback writes  |
 | `cache_backed_tooling_state`           | Proposed | user + repo         | 1            | 0                | adapter subset | cache           | cache writes     |
 | `adapter_specific_overrides`           | Proposed | user + repo         | 1            | 0-1              | all            | mixed           | adapter controls |
 | `state_path_replaced_by_agent`         | Existing | user + repo         | 1            | 0                | all            | profile/native  | symlink replaced |

--- a/tests/fixtures/integration/native_fallback_cli_state/README.md
+++ b/tests/fixtures/integration/native_fallback_cli_state/README.md
@@ -1,0 +1,22 @@
+# `native_fallback_cli_state`
+
+This fixture models a normal user and repository profile selection where neither profile supplies adapter-native state under `cli_specific/pi/`.
+
+## Setup
+
+- `home/.bridl/settings.yml` sets `default` as the user's implicit profile and keeps Bridl's cache under the synthetic home tree.
+- `home/.bridl/profiles/default/profile.yml` contributes personal default controls.
+- `project/.bridl/settings.yml` exposes the user and project profile sources.
+- `project/.bridl/profiles/fallback-review/profile.yml` is the selected project profile and contributes run-specific controls.
+
+There are intentionally no `cli_specific/` directories in any profile. This forces the pi adapter to use native fallback locations for pi-owned state instead of treating profile folders as state owners.
+
+## Expected behavior
+
+Bridl should assemble a pi tack whose declared state paths are symlinks to pi's native user state under `home/.pi/agent/`, except for pi utility/bin state, which is owned by Bridl's cache under `home/.bridl/cache/utilities`.
+
+If those native fallback files or directories do not already exist, tack materialization should create them before launching pi. The selected profile still resolves generic controls from the user default and project profile, with the project profile winning shared keys.
+
+## Mutation/write-back behavior
+
+Writes through declared symlinked state paths are owned by the native fallback locations and should persist there after the fake pi process exits. Generated Bridl tack files, such as `bridl/profile.json`, are temporary and must not rewrite source profile YAML. Undeclared pi writes in the tack should follow the adapter's `unknown` state policy and emit a warning without being persisted to a profile.

--- a/tests/fixtures/integration/native_fallback_cli_state/expected/pi/tack-summary.json
+++ b/tests/fixtures/integration/native_fallback_cli_state/expected/pi/tack-summary.json
@@ -1,0 +1,38 @@
+{
+  "profileId": "fallback-review",
+  "agentId": "pi",
+  "launchCommand": "pi",
+  "launchArgs": ["--model", "fallback-review-model", "--provider", "openai", "--native-fallback-fixture"],
+  "launchEnv": {
+    "PI_CODING_AGENT_DIR": "<tack>",
+    "FALLBACK_LAYER": "project",
+    "PROJECT_NATIVE_FALLBACK": "enabled",
+    "USER_NATIVE_DEFAULT": "enabled"
+  },
+  "generatedProfile": {
+    "id": "fallback-review",
+    "label": "Native Fallback Review",
+    "controls": {
+      "model": "fallback-review-model",
+      "provider": "openai",
+      "environment": {
+        "FALLBACK_LAYER": "project",
+        "PROJECT_NATIVE_FALLBACK": "enabled",
+        "USER_NATIVE_DEFAULT": "enabled"
+      },
+      "args": ["--native-fallback-fixture"]
+    }
+  },
+  "stateTargets": {
+    "auth.json": "<home>/.pi/agent/auth.json",
+    "settings.json": "<home>/.pi/agent/settings.json",
+    "mcp.json": "<home>/.pi/agent/mcp.json",
+    "plugins": "<home>/.pi/agent/plugins",
+    "cache": "<home>/.pi/agent/cache",
+    "sessions": "<home>/.pi/agent/sessions",
+    "npm": "<home>/.pi/agent/npm",
+    "git": "<home>/.pi/agent/git",
+    "utilities": "<home>/.bridl/cache/utilities",
+    "bin": "<home>/.bridl/cache/utilities"
+  }
+}

--- a/tests/fixtures/integration/native_fallback_cli_state/expected/pi/warnings.json
+++ b/tests/fixtures/integration/native_fallback_cli_state/expected/pi/warnings.json
@@ -1,0 +1,4 @@
+[
+  "pi wrote undeclared tack state 'scratch' and it was not persisted.",
+  "pi wrote undeclared tack state 'scratch/native-note.txt' and it was not persisted."
+]

--- a/tests/fixtures/integration/native_fallback_cli_state/home/.bridl/profiles/default/profile.yml
+++ b/tests/fixtures/integration/native_fallback_cli_state/home/.bridl/profiles/default/profile.yml
@@ -1,0 +1,7 @@
+id: default
+label: Native Fallback User Defaults
+controls:
+  model: user-native-model
+  environment:
+    USER_NATIVE_DEFAULT: 'enabled'
+    FALLBACK_LAYER: user

--- a/tests/fixtures/integration/native_fallback_cli_state/home/.bridl/settings.yml
+++ b/tests/fixtures/integration/native_fallback_cli_state/home/.bridl/settings.yml
@@ -1,0 +1,5 @@
+default_profile: default
+default_agent: pi
+cache_directory: ./cache
+profile_sources:
+  - path: ./profiles

--- a/tests/fixtures/integration/native_fallback_cli_state/project/.bridl/profiles/fallback-review/profile.yml
+++ b/tests/fixtures/integration/native_fallback_cli_state/project/.bridl/profiles/fallback-review/profile.yml
@@ -1,0 +1,10 @@
+id: fallback-review
+label: Native Fallback Review
+controls:
+  model: fallback-review-model
+  provider: openai
+  environment:
+    PROJECT_NATIVE_FALLBACK: 'enabled'
+    FALLBACK_LAYER: project
+  args:
+    - --native-fallback-fixture

--- a/tests/fixtures/integration/native_fallback_cli_state/project/.bridl/settings.yml
+++ b/tests/fixtures/integration/native_fallback_cli_state/project/.bridl/settings.yml
@@ -1,0 +1,3 @@
+profile_sources:
+  - path: ../../home/.bridl/profiles
+  - path: ./profiles

--- a/tests/integration/tack-generation.test.ts
+++ b/tests/integration/tack-generation.test.ts
@@ -312,4 +312,103 @@ describe('integration fixture tack generation', () => {
       'settings.json: warn',
     );
   });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (BRIDL-REQ-005.3, BRIDL-REQ-005.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('creates and owns pi native fallback state when profiles provide no cli-specific state', async () => {
+    const fixture = copyFixtureToTemp('native_fallback_cli_state');
+    const warnings: string[] = [];
+    let tackSummary: unknown;
+
+    const result = await runFixture(fixture, {
+      profileId: 'fallback-review',
+      agentId: 'pi',
+      warnings,
+      launcher: {
+        launch(plan) {
+          const tackRoot = tackRootFromLaunchPlan(plan);
+          tackSummary = {
+            profileId: 'fallback-review',
+            agentId: 'pi',
+            launchCommand: plan.command,
+            launchArgs: plan.args,
+            launchEnv: {
+              PI_CODING_AGENT_DIR: tokenizeFixturePath(fixture, plan.env.PI_CODING_AGENT_DIR, tackRoot),
+              FALLBACK_LAYER: plan.env.FALLBACK_LAYER,
+              PROJECT_NATIVE_FALLBACK: plan.env.PROJECT_NATIVE_FALLBACK,
+              USER_NATIVE_DEFAULT: plan.env.USER_NATIVE_DEFAULT,
+            },
+            generatedProfile: JSON.parse(readFileSync(join(tackRoot, 'bridl', 'profile.json'), 'utf8')) as unknown,
+            stateTargets: Object.fromEntries(
+              [
+                'auth.json',
+                'settings.json',
+                'mcp.json',
+                'plugins',
+                'cache',
+                'sessions',
+                'npm',
+                'git',
+                'utilities',
+                'bin',
+              ].map((relativePath) => [
+                relativePath,
+                tokenizeFixturePath(fixture, readlinkSync(join(tackRoot, relativePath)), tackRoot),
+              ]),
+            ),
+          };
+
+          writeFileSync(join(tackRoot, 'auth.json'), '{"token":"native-auth"}\n');
+          writeFileSync(join(tackRoot, 'settings.json'), '{"approval":"on-request"}\n');
+          writeFileSync(join(tackRoot, 'mcp.json'), '{"servers":{}}\n');
+          writeFileSync(join(tackRoot, 'plugins', 'review.json'), '{"enabled":true}\n');
+          writeFileSync(join(tackRoot, 'cache', 'index.json'), '{"cached":true}\n');
+          writeFileSync(join(tackRoot, 'sessions', 'session.json'), '{"id":"fixture-session"}\n');
+          writeFileSync(join(tackRoot, 'npm', 'package.json'), '{"name":"fixture-package"}\n');
+          writeFileSync(join(tackRoot, 'git', 'checkout.json'), '{"repo":"fixture-repo"}\n');
+          writeFileSync(join(tackRoot, 'utilities', 'tool.txt'), 'utility cache\n');
+          writeFileSync(join(tackRoot, 'bin', 'pi-helper'), 'helper cache\n');
+          writeFileSync(join(tackRoot, 'bridl', 'profile.json'), '{"mutated":true}\n');
+          mkdirSync(join(tackRoot, 'scratch'), { recursive: true });
+          writeFileSync(join(tackRoot, 'scratch', 'native-note.txt'), 'undeclared write\n');
+
+          return Promise.resolve(0);
+        },
+      },
+    });
+
+    expect(tackSummary).toEqual(readExpectedJson(fixture, 'pi/tack-summary.json'));
+    expect(result.profileId).toBe('fallback-review');
+    expect(result.agentId).toBe('pi');
+    expect(result.warnings).toEqual(readExpectedJson(fixture, 'pi/warnings.json'));
+    expect(warnings).toEqual(result.warnings);
+    expect(existsSync(join(fixture.project, '.bridl', 'profiles', 'fallback-review', 'cli_specific'))).toBe(false);
+    expect(readFileSync(join(fixture.home, '.pi', 'agent', 'auth.json'), 'utf8')).toBe('{"token":"native-auth"}\n');
+    expect(readFileSync(join(fixture.home, '.pi', 'agent', 'settings.json'), 'utf8')).toBe(
+      '{"approval":"on-request"}\n',
+    );
+    expect(readFileSync(join(fixture.home, '.pi', 'agent', 'mcp.json'), 'utf8')).toBe('{"servers":{}}\n');
+    expect(readFileSync(join(fixture.home, '.pi', 'agent', 'plugins', 'review.json'), 'utf8')).toBe(
+      '{"enabled":true}\n',
+    );
+    expect(readFileSync(join(fixture.home, '.pi', 'agent', 'cache', 'index.json'), 'utf8')).toBe('{"cached":true}\n');
+    expect(readFileSync(join(fixture.home, '.pi', 'agent', 'sessions', 'session.json'), 'utf8')).toBe(
+      '{"id":"fixture-session"}\n',
+    );
+    expect(readFileSync(join(fixture.home, '.pi', 'agent', 'npm', 'package.json'), 'utf8')).toBe(
+      '{"name":"fixture-package"}\n',
+    );
+    expect(readFileSync(join(fixture.home, '.pi', 'agent', 'git', 'checkout.json'), 'utf8')).toBe(
+      '{"repo":"fixture-repo"}\n',
+    );
+    expect(readFileSync(join(fixture.home, '.bridl', 'cache', 'utilities', 'tool.txt'), 'utf8')).toBe(
+      'utility cache\n',
+    );
+    expect(readFileSync(join(fixture.home, '.bridl', 'cache', 'utilities', 'pi-helper'), 'utf8')).toBe(
+      'helper cache\n',
+    );
+    expect(readFixtureText(fixture, 'project/.bridl/profiles/fallback-review/profile.yml')).toContain(
+      'fallback-review-model',
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add the native_fallback_cli_state integration fixture with user/project profiles and expected pi outputs
- cover pi native fallback state materialization, ownership, write-through behavior, and unknown state warnings

## Validation
- npm run check-ci