### PR TITLE
Clean integration fixture catalog status

### DIFF
--- a/tests/fixtures/integration/INTEGRATION_TEST_FIXTURES.md
+++ b/tests/fixtures/integration/INTEGRATION_TEST_FIXTURES.md
@@ -3,7 +3,7 @@
 This catalog has two groups:
 
 1. Existing small profile-resolution fixtures already under `tests/fixtures/scenarios/`.
-2. Proposed full-directory integration fixtures for tack generation and state persistence under `tests/fixtures/integration/`.
+2. Full-directory integration fixtures for tack generation and state persistence under `tests/fixtures/integration/`, including implemented and planned scenarios.
 
 Integration fixture names should usually describe the user/project situation, not the agent CLI. The same fixture should be usable from pi, Claude Code, and future adapter tests when possible. Adapter-specific expectations can live under `expected/pi/`, `expected/claude/`, or be asserted directly by adapter-specific test cases.
 
@@ -180,7 +180,7 @@ Write-back focus: replacement should be diagnosed as not persisted, and the orig
 | `profile-multiple-inheritance`         | Existing | none                | 1            | 2 parents        | none           | none            | none             |
 | `profile-cycle`                        | Existing | none                | 1            | cycle            | none           | none            | diagnostics      |
 | `profile-missing-inheritance`          | Existing | none                | 1            | missing          | none           | none            | diagnostics      |
-| `trivial_repo_only_profile`            | Existing | user + repo         | 1            | implicit default | all            | native fallback | generated files  |
+| `trivial_repo_only_profile`            | Existing | user + repo         | 1            | implicit default | pi             | native fallback | generated files  |
 | `heavily_overridden_engineering`       | Proposed | remote + 3          | 5            | 1-2              | all            | highest profile | source ownership |
 | `remote_baseline_local_selection`      | Proposed | remote + 3          | 1-2          | implicit default | all            | mixed           | source ownership |
 | `language_stack_with_personal_default` | Proposed | user + repo         | 1            | 2-3              | all            | native fallback | inherited output |


### PR DESCRIPTION
## Summary
- describe integration fixture catalog as containing implemented and planned scenarios
- mark the initial pi-only smoke fixture adapter coverage accurately

## Validation
- npm run check-ci