### PR TITLE
Update default profile source

### DIFF
--- a/src/cli/commands/SetupCommand.ts
+++ b/src/cli/commands/SetupCommand.ts
@@ -59,7 +59,7 @@ export interface SetupProfileChoice {
   readonly label?: string;
 }
 
-const defaultProfileSourceRepository = 'Unsupervisedcom/applepi-default-profiles';
+const defaultProfileSourceRepository = 'applepi-ai/default-profiles';
 
 interface StarterLayout {
   readonly cachePath: string;

--- a/tests/unit/run-command.test.ts
+++ b/tests/unit/run-command.test.ts
@@ -186,7 +186,7 @@ describe('run command', () => {
       '`applepi setup` has not been run yet - running now',
       '→ resolving profile engineer',
       `✓ profile layer engineer  ${join(homeDirectory, '.applepi', 'profiles', 'engineer')}`,
-      '✓ profile layer engineer  github:Unsupervisedcom/applepi-default-profiles@main/profiles',
+      '✓ profile layer engineer  github:applepi-ai/default-profiles@main/profiles',
       '✓ merged controls',
       `✓ prepared composite profile  ${result.compositeProfileDirectory}`,
       '↳ launching pi …',

--- a/tests/unit/setup-command.test.ts
+++ b/tests/unit/setup-command.test.ts
@@ -65,7 +65,7 @@ describe('setup command', () => {
         'default_profile: engineer',
         'profile_sources:',
         '  - path: ./profiles',
-        '  - github: Unsupervisedcom/applepi-default-profiles',
+        '  - github: applepi-ai/default-profiles',
         '    ref: main',
         '    path: profiles',
         '',


### PR DESCRIPTION
## Summary
- point setup's built-in default profile source at applepi-ai/default-profiles
- update unit test expectations for the new source

## Tests
- npx vitest --run tests/unit/setup-command.test.ts tests/unit/run-command.test.ts