### PR TITLE
Declare pi tmp state path

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The exact stable schema is governed by the requirements in `requirements/` and t
 The current recommendation is to build `applepi` around pi's existing native configuration mechanisms:
 
 1. Use a temporary composite profile directory as `PI_CODING_AGENT_DIR` for each run.
-2. Persist intentional pi state through adapter-declared symlinks to profile, native pi, or ApplePi cache files.
+2. Persist intentional pi state through adapter-declared symlinks to profile, native pi, or ApplePi cache files. Native pi fallback is only a durable target for declared state symlinks; it is not an inherited base profile layer.
 3. Layer profile-controlled environment variables and pi CLI flags on top.
 4. Use explicit `--extension` / `-e` injection for bootstrap behavior that needs to run inside pi.
 5. Decide per profile whether project-local `.pi` overrides are allowed.

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -447,6 +447,9 @@ controls:
       - --no-themes
 ```
 
+If no resolved profile folder provides `cli_specific/<adapter>/<state-path>` for an adapter-declared symlink path, ApplePi falls back directly to the native CLI state location for that path, such as `~/.pi/agent/settings.json` or `~/.claude/settings.json`.
+That native fallback is not a hidden base profile: it does not participate in `inherits`, cannot contribute profile controls, and only supplies durable symlink targets for declared CLI state.
+
 A checked-in project profile set can add project-specific prompts and pi resources:
 
 ```text
@@ -543,7 +546,7 @@ Composite profiles are generated under the system temp directory so they can be 
 $TMPDIR/applepi-<profile-id>-<agent-id>-<random>/
 ```
 
-The pi adapter uses this state model for native pi state and for pi-managed utilities: composite profile `utilities/` and `bin/` both symlink to `<cache_directory>/utilities` by default, so temporary composite profile cleanup does not force pi to redownload helper binaries such as `fd` and `rg`.
+The pi adapter uses this state model for native pi state and for pi-managed utilities: most declared pi state paths, including `tmp/`, symlink to `~/.pi/agent/<path>` by default, while composite profile `utilities/` and `bin/` both symlink to `<cache_directory>/utilities` by default, so temporary composite profile cleanup does not force pi to redownload helper binaries such as `fd` and `rg`.
 
 During `applepi run`, the ApplePi process remains alive while the child agent CLI runs.
 It owns the composite profile lifecycle.

--- a/doc/state_writeback_strategy.md
+++ b/doc/state_writeback_strategy.md
@@ -68,6 +68,7 @@ ApplePi default profile
 
 Native CLI state is not represented as an extra profile layer.
 For `symlink` paths without a profile-provided source, the selected adapter resolves a native fallback location directly, such as `~/.pi/agent/...` for most Pi state paths, `~/.claude/...` for most Claude Code state paths, or `<cache_directory>/utilities` for Pi `utilities/` and `bin/`.
+This native fallback is not a base profile: it does not participate in profile inheritance or merge precedence, and it cannot contribute controls or profile YAML.
 Claude Code `projects/` is additionally controlled by `controls.session_directory` or `controls.claude.session_directory` when set.
 
 ## Path-keyed adapter declarations
@@ -109,6 +110,10 @@ state_paths:
     allowed_strategies: [symlink, discard, warn, error]
 
   git/:
+    default_strategy: symlink
+    allowed_strategies: [symlink, discard, warn, error]
+
+  tmp/:
     default_strategy: symlink
     allowed_strategies: [symlink, discard, warn, error]
 

--- a/doc/state_writeback_strategy.md
+++ b/doc/state_writeback_strategy.md
@@ -115,7 +115,7 @@ state_paths:
 
   tmp/:
     default_strategy: symlink
-    allowed_strategies: [symlink, discard, warn, error]
+    allowed_strategies: [symlink, discard]
 
   utilities/:
     default_strategy: symlink

--- a/doc_site/app/page.mdx
+++ b/doc_site/app/page.mdx
@@ -104,7 +104,9 @@ theme:
       <h2>Dotfiles, team standards, and repo overrides — resolved into one composite profile</h2>
       <div className="applepi-section-copy">
         ApplePi combines the relevant layers deterministically, warns when a requested control is unsupported, and
-        prepares a clean runtime composite profile before launch.
+        prepares a clean runtime composite profile before launch. If no profile owns a declared CLI state path, ApplePi
+        symlinks that path to the native CLI fallback, such as <code>~/.pi/agent/settings.json</code>; that fallback is
+        durable state, not a hidden base profile layer.
       </div>
     </div>
     <div className="applepi-layers">
@@ -135,6 +137,7 @@ theme:
           <h3>Native pi launch</h3>
           <p>
             The pi adapter translates supported controls into the runtime composite profile and native pi launch inputs.
+            Missing profile-owned state symlinks fall back directly to native pi files, not inherited profile controls.
           </p>
         </div>
       </div>

--- a/doc_site/app/state-persistence/page.mdx
+++ b/doc_site/app/state-persistence/page.mdx
@@ -13,7 +13,7 @@ ApplePi makes those writes explicit with `state_persistence` rules. Each selecte
 
 1. ApplePi resolves the profile and its `state_persistence` overrides.
 2. The selected adapter fills in defaults for every declared state path.
-3. Durable paths are connected to a profile-managed file/directory or to a native fallback location.
+3. Durable paths are connected to a profile-managed file/directory or to a native fallback location. The native fallback is only a symlink target, not a base profile layer.
 4. The agent runs inside the composite profile and reads/writes those paths normally.
 5. After the agent exits, ApplePi checks non-durable and unknown writes.
 6. Temporary composite profile contents are deleted; durable symlink targets remain.
@@ -100,7 +100,7 @@ Update scenario: pi writes session transcripts and cache entries while investiga
 
 ## Pi defaults and special paths
 
-Pi is ApplePi's day-one adapter. Most symlinked pi state paths resolve to profile files under `cli_specific/pi/` when present, or to the native pi agent directory as a fallback.
+Pi is ApplePi's day-one adapter. Most symlinked pi state paths, including `tmp/`, resolve to profile files under `cli_specific/pi/` when present, or to the native pi agent directory as a fallback.
 
 Pi `utilities/` and `bin/` are special cache-backed paths. Both resolve to `<cache_directory>/utilities` so helper binaries such as `fd` and `rg` are reused across temporary composite profiles without becoming profile-editable state.
 

--- a/src/agents/pi/PiAdapter.ts
+++ b/src/agents/pi/PiAdapter.ts
@@ -33,6 +33,9 @@ const piStatePathDeclarations = {
   // Pi clones git-sourced packages here for user-scoped `pi install git:...` entries.
   // Persisting it prevents every ApplePi run from re-cloning or using stale temporary checkouts.
   'git/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error'] },
+  // Pi expands git-sourced extensions and other temporary runtime artifacts here.
+  // Persisting it avoids noisy unknown-write diagnostics and lets pi reuse the native tmp tree.
+  'tmp/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error'] },
   'utilities/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error'] },
   'bin/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error'] },
   unknown: { defaultStrategy: 'warn', allowedStrategies: ['discard', 'warn', 'error', 'prompt'] },

--- a/src/agents/pi/PiAdapter.ts
+++ b/src/agents/pi/PiAdapter.ts
@@ -35,7 +35,7 @@ const piStatePathDeclarations = {
   'git/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error'] },
   // Pi expands git-sourced extensions and other temporary runtime artifacts here.
   // Persisting it avoids noisy unknown-write diagnostics and lets pi reuse the native tmp tree.
-  'tmp/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error'] },
+  'tmp/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard'] },
   'utilities/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error'] },
   'bin/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error'] },
   unknown: { defaultStrategy: 'warn', allowedStrategies: ['discard', 'warn', 'error', 'prompt'] },

--- a/tests/fixtures/integration/native_fallback_cli_state/README.md
+++ b/tests/fixtures/integration/native_fallback_cli_state/README.md
@@ -14,7 +14,7 @@ This forces the pi adapter to use native fallback locations for pi-owned state i
 
 ## Expected behavior
 
-ApplePi should assemble a pi composite profile whose declared state paths are symlinks to pi's native user state under `home/.pi/agent/`, except for pi utility/bin state, which is owned by ApplePi's cache under `home/.applepi/cache/utilities`.
+ApplePi should assemble a pi composite profile whose declared state paths are symlinks to pi's native user state under `home/.pi/agent/`, including pi runtime `tmp/` state, except for pi utility/bin state, which is owned by ApplePi's cache under `home/.applepi/cache/utilities`.
 
 If those native fallback files or directories do not already exist, composite profile materialization should create them before launching pi.
 The selected profile still resolves generic controls from the user default and project profile, with the project profile winning shared keys.

--- a/tests/fixtures/integration/native_fallback_cli_state/expected/pi/composite-profile-summary.json
+++ b/tests/fixtures/integration/native_fallback_cli_state/expected/pi/composite-profile-summary.json
@@ -32,6 +32,7 @@
     "sessions": "<home>/.pi/agent/sessions",
     "npm": "<home>/.pi/agent/npm",
     "git": "<home>/.pi/agent/git",
+    "tmp": "<home>/.pi/agent/tmp",
     "utilities": "<home>/.applepi/cache/utilities",
     "bin": "<home>/.applepi/cache/utilities"
   }

--- a/tests/integration/composite-profile-generation.test.ts
+++ b/tests/integration/composite-profile-generation.test.ts
@@ -380,6 +380,7 @@ describe('integration fixture composite profile generation', () => {
                 'sessions',
                 'npm',
                 'git',
+                'tmp',
                 'utilities',
                 'bin',
               ].map((relativePath) => [
@@ -401,6 +402,11 @@ describe('integration fixture composite profile generation', () => {
           writeFileSync(join(compositeProfileRoot, 'sessions', 'session.json'), '{"id":"fixture-session"}\n');
           writeFileSync(join(compositeProfileRoot, 'npm', 'package.json'), '{"name":"fixture-package"}\n');
           writeFileSync(join(compositeProfileRoot, 'git', 'checkout.json'), '{"repo":"fixture-repo"}\n');
+          mkdirSync(join(compositeProfileRoot, 'tmp', 'extensions'), { recursive: true });
+          writeFileSync(
+            join(compositeProfileRoot, 'tmp', 'extensions', 'checkout.json'),
+            '{"repo":"fixture-extension"}\n',
+          );
           writeFileSync(join(compositeProfileRoot, 'utilities', 'tool.txt'), 'utility cache\n');
           writeFileSync(join(compositeProfileRoot, 'bin', 'pi-helper'), 'helper cache\n');
           writeFileSync(join(compositeProfileRoot, 'applepi', 'profile.json'), '{"mutated":true}\n');
@@ -435,6 +441,9 @@ describe('integration fixture composite profile generation', () => {
     );
     expect(readFileSync(join(fixture.home, '.pi', 'agent', 'git', 'checkout.json'), 'utf8')).toBe(
       '{"repo":"fixture-repo"}\n',
+    );
+    expect(readFileSync(join(fixture.home, '.pi', 'agent', 'tmp', 'extensions', 'checkout.json'), 'utf8')).toBe(
+      '{"repo":"fixture-extension"}\n',
     );
     expect(readFileSync(join(fixture.home, '.applepi', 'cache', 'utilities', 'tool.txt'), 'utf8')).toBe(
       'utility cache\n',

--- a/tests/unit/state-persistence.test.ts
+++ b/tests/unit/state-persistence.test.ts
@@ -163,7 +163,7 @@ describe('state persistence', () => {
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-005.6).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('persists pi package install directories across temporary composite profile directories', () => {
+  it('persists pi package install and temporary runtime directories across composite profiles', () => {
     const root = createTemporaryRoot();
     const homeDirectory = join(root, 'home');
     const compositeProfile = createPiAdapter().createCompositeProfile(
@@ -182,11 +182,15 @@ describe('state persistence', () => {
     expect(compositeProfile.statePaths.find((statePath) => statePath.relativePath === 'git/')?.sourcePath).toBe(
       join(homeDirectory, '.pi', 'agent', 'git'),
     );
+    expect(compositeProfile.statePaths.find((statePath) => statePath.relativePath === 'tmp/')?.sourcePath).toBe(
+      join(homeDirectory, '.pi', 'agent', 'tmp'),
+    );
 
     writeCompositeProfile(compositeProfile);
 
     expect(readlinkSync(join(compositeProfile.rootDirectory, 'npm'))).toBe(join(homeDirectory, '.pi', 'agent', 'npm'));
     expect(readlinkSync(join(compositeProfile.rootDirectory, 'git'))).toBe(join(homeDirectory, '.pi', 'agent', 'git'));
+    expect(readlinkSync(join(compositeProfile.rootDirectory, 'tmp'))).toBe(join(homeDirectory, '.pi', 'agent', 'tmp'));
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-005.6).


### PR DESCRIPTION
## Summary
- document that native CLI fallback is a durable state symlink target, not a hidden/base profile layer
- declare pi `tmp/` as a supported symlinked state path resolving to native pi state by default
- update unit/integration coverage and public docs for pi `tmp/` fallback behavior

## Validation
- `npm run check-ci`