### PR TITLE
Quiet Vitest output

### DIFF
--- a/doc/file_structure.md
+++ b/doc/file_structure.md
@@ -87,6 +87,8 @@ ApplePi is organized around clear TypeScript source boundaries, requirement docu
 │   │   ├── integration/               # fixture-backed integration scenarios, catalog, and local .deepreview
 │   │   └── scenarios/                 # compact profile-resolution scenarios and expected outputs
 │   ├── integration/                   # fixture-backed integration tests and harness helpers
+│   ├── setup.ts                       # Vitest global setup for quiet test-output guards
+│   ├── test-console.ts                # shared console-output guard helpers for tests
 │   └── unit/                          # unit tests grouped by functionality under test
 ├── package-lock.json                  # locked npm dependency graph
 └── package.json                       # npm package metadata and scripts

--- a/tests/integration/fixtureHarness.ts
+++ b/tests/integration/fixtureHarness.ts
@@ -67,6 +67,7 @@ export const runFixture = async (
     {
       launcher: options.launcher,
       writeError: (message) => warnings.push(message),
+      writeLine: () => undefined,
     },
   );
 };

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,10 @@
+// Installs global Vitest safeguards that keep successful test runs quiet.
+import { afterEach } from 'vitest';
+
+import { installTestConsoleGuard, resetAllowedTestConsoleOutput } from './test-console.js';
+
+installTestConsoleGuard();
+
+afterEach(() => {
+  resetAllowedTestConsoleOutput();
+});

--- a/tests/test-console.ts
+++ b/tests/test-console.ts
@@ -1,0 +1,73 @@
+// Provides a Vitest console guard so accidental test output fails instead of cluttering CI logs.
+export type TestConsoleMethod = 'debug' | 'error' | 'info' | 'log' | 'warn';
+
+export interface TestConsoleMessage {
+  readonly method: TestConsoleMethod;
+  readonly text: string;
+  readonly args: readonly unknown[];
+}
+
+export type TestConsolePredicate = (message: TestConsoleMessage) => boolean;
+
+const guardedMethods: readonly TestConsoleMethod[] = ['debug', 'error', 'info', 'log', 'warn'];
+const originalConsoleMethods = new Map<TestConsoleMethod, (...args: unknown[]) => void>();
+let allowedPredicates: TestConsolePredicate[] = [];
+let installed = false;
+
+export const installTestConsoleGuard = (): void => {
+  if (installed) {
+    return;
+  }
+
+  for (const method of guardedMethods) {
+    originalConsoleMethods.set(method, console[method].bind(console));
+    console[method] = ((...args: unknown[]) => {
+      const message = { method, text: formatConsoleArguments(args), args };
+
+      if (allowedPredicates.some((predicate) => predicate(message))) {
+        return;
+      }
+
+      throw new Error(`Unexpected console.${method} output during test: ${message.text}`);
+    }) as Console[typeof method];
+  }
+
+  installed = true;
+};
+
+export const allowTestConsoleOutput = (predicate: TestConsolePredicate): void => {
+  allowedPredicates.push(predicate);
+};
+
+export const resetAllowedTestConsoleOutput = (): void => {
+  allowedPredicates = [];
+};
+
+export const uninstallTestConsoleGuard = (): void => {
+  if (!installed) {
+    return;
+  }
+
+  for (const [method, originalMethod] of originalConsoleMethods) {
+    console[method] = originalMethod as Console[typeof method];
+  }
+
+  originalConsoleMethods.clear();
+  resetAllowedTestConsoleOutput();
+  installed = false;
+};
+
+const formatConsoleArguments = (args: readonly unknown[]): string =>
+  args.map((argument) => formatConsoleArgument(argument)).join(' ');
+
+const formatConsoleArgument = (argument: unknown): string => {
+  if (typeof argument === 'string') {
+    return argument;
+  }
+
+  if (argument instanceof Error) {
+    return argument.stack ?? argument.message;
+  }
+
+  return JSON.stringify(argument);
+};

--- a/tests/test-console.ts
+++ b/tests/test-console.ts
@@ -69,5 +69,21 @@ const formatConsoleArgument = (argument: unknown): string => {
     return argument.stack ?? argument.message;
   }
 
-  return JSON.stringify(argument);
+  return stringifyBestEffort(argument);
+};
+
+const stringifyBestEffort = (argument: unknown): string => {
+  try {
+    return JSON.stringify(argument) ?? stringifyWithStringConstructor(argument);
+  } catch {
+    return stringifyWithStringConstructor(argument);
+  }
+};
+
+const stringifyWithStringConstructor = (argument: unknown): string => {
+  try {
+    return String(argument);
+  } catch {
+    return '<unformattable console argument>';
+  }
 };

--- a/tests/unit/release-version-script.test.ts
+++ b/tests/unit/release-version-script.test.ts
@@ -35,6 +35,7 @@ const runScript = (root: string, version?: string, env: NodeJS.ProcessEnv = {}):
   execFileSync(process.execPath, [scriptPath, ...(version === undefined ? [] : [version]), `--root=${root}`], {
     encoding: 'utf8',
     env: { ...process.env, APPLEPI_RELEASE_VERSION: undefined, GITHUB_REF_NAME: undefined, ...env },
+    stdio: ['ignore', 'pipe', 'pipe'],
   });
 
 afterEach(() => {

--- a/tests/unit/remote-sources.test.ts
+++ b/tests/unit/remote-sources.test.ts
@@ -178,7 +178,7 @@ describe('remote source settings', () => {
 
     const result = await executeRunCommand(
       { homeDirectory, projectDirectory },
-      { launcher: { launch: () => Promise.resolve(0) } },
+      { launcher: { launch: () => Promise.resolve(0) }, writeLine: () => undefined },
     );
 
     expect(result.profileId).toBe('remote');
@@ -194,7 +194,7 @@ describe('remote source settings', () => {
     );
     const rootProfileResult = await executeRunCommand(
       { homeDirectory: rootProfileHomeDirectory, projectDirectory },
-      { launcher: { launch: () => Promise.resolve(0) } },
+      { launcher: { launch: () => Promise.resolve(0) }, writeLine: () => undefined },
     );
     expect(rootProfileResult.profileId).toBe('remote');
 
@@ -206,7 +206,7 @@ describe('remote source settings', () => {
     await expect(
       executeRunCommand(
         { homeDirectory: escapedProfileHomeDirectory, projectDirectory },
-        { launcher: { launch: () => Promise.resolve(0) } },
+        { launcher: { launch: () => Promise.resolve(0) }, writeLine: () => undefined },
       ),
     ).rejects.toThrow('must stay inside the repository');
 

--- a/tests/unit/run-cache.test.ts
+++ b/tests/unit/run-cache.test.ts
@@ -44,7 +44,7 @@ describe('run command cache persistence', () => {
 
     const result = await executeRunCommand(
       { homeDirectory, projectDirectory },
-      { launcher: { launch: () => Promise.resolve(0) } },
+      { launcher: { launch: () => Promise.resolve(0) }, writeLine: () => undefined },
     );
 
     expect(readlinkSync(join(result.compositeProfileDirectory, 'utilities'))).toBe(
@@ -70,7 +70,7 @@ describe('run command cache persistence', () => {
 
     const result = await executeRunCommand(
       { homeDirectory, projectDirectory },
-      { launcher: { launch: () => Promise.resolve(0) } },
+      { launcher: { launch: () => Promise.resolve(0) }, writeLine: () => undefined },
     );
 
     expect(readlinkSync(join(result.compositeProfileDirectory, 'utilities'))).toBe(join(cacheDirectory, 'utilities'));

--- a/tests/unit/run-command.test.ts
+++ b/tests/unit/run-command.test.ts
@@ -45,12 +45,21 @@ const waitForFileMatching = async (path: string, predicate: (content: string) =>
   }
 };
 
-const isRunCommandSummaryMessage = (text: string): boolean =>
-  text.startsWith('→ resolving profile ') ||
-  text.startsWith('✓ profile layer ') ||
-  text.startsWith('✓ merged controls') ||
-  text.startsWith('✓ prepared composite profile ') ||
-  text.startsWith('↳ launching ');
+const isRunCommandSummaryMessage = (text: string): boolean => {
+  const normalizedText = stripAnsiCodes(text);
+
+  return (
+    normalizedText.startsWith('→ resolving profile ') ||
+    normalizedText.startsWith('✓ profile layer ') ||
+    normalizedText.startsWith('✓ merged controls') ||
+    normalizedText.startsWith('✓ prepared composite profile ') ||
+    normalizedText.startsWith('↳ launching ')
+  );
+};
+
+const ansiEscapePattern = new RegExp(`${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`, 'g');
+
+const stripAnsiCodes = (text: string): string => text.replace(ansiEscapePattern, '');
 
 afterEach(() => {
   for (const root of temporaryRoots.splice(0)) {

--- a/tests/unit/run-command.test.ts
+++ b/tests/unit/run-command.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import { executeRunCommand, resolveChildExitCode } from '../../src/cli/commands/RunCommand.js';
 import { createCompositeProfile } from '../../src/compositeProfile/CompositeProfile.js';
+import { allowTestConsoleOutput } from '../test-console.js';
 
 const temporaryRoots: string[] = [];
 
@@ -43,6 +44,13 @@ const waitForFileMatching = async (path: string, predicate: (content: string) =>
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
 };
+
+const isRunCommandSummaryMessage = (text: string): boolean =>
+  text.startsWith('→ resolving profile ') ||
+  text.startsWith('✓ profile layer ') ||
+  text.startsWith('✓ merged controls') ||
+  text.startsWith('✓ prepared composite profile ') ||
+  text.startsWith('↳ launching ');
 
 afterEach(() => {
   for (const root of temporaryRoots.splice(0)) {
@@ -94,6 +102,7 @@ describe('run command', () => {
       },
       {
         writeError: (message) => warnings.push(message),
+        writeLine: () => undefined,
         launcher: {
           launch(plan) {
             launches.push(plan);
@@ -151,6 +160,8 @@ describe('run command', () => {
             return Promise.resolve(0);
           },
         },
+        writeError: () => undefined,
+        writeLine: () => undefined,
       },
     );
   });
@@ -233,6 +244,7 @@ describe('run command', () => {
       'cached',
       'id: cached\ncontrols: {}\n',
     );
+    allowTestConsoleOutput(({ method, text }) => method === 'log' && isRunCommandSummaryMessage(text));
     const result = await executeRunCommand(
       { homeDirectory: uriHome, projectDirectory, profileId: 'cached' },
       {
@@ -267,6 +279,7 @@ describe('run command', () => {
     const spawnedResult = await executeRunCommand(
       { homeDirectory: spawnedHome, projectDirectory },
       {
+        writeLine: () => undefined,
         adapter: {
           id: 'node',
           supportedControls: [],

--- a/tests/unit/setup-command.test.ts
+++ b/tests/unit/setup-command.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import { executeSetupCommand, updateSettingsDefaultProfile } from '../../src/cli/commands/SetupCommand.js';
 import { createProfileSourceCachePath, createRemoteRepositoryCachePath } from '../../src/profiles/ProfileCache.js';
+import { allowTestConsoleOutput } from '../test-console.js';
 
 const temporaryRoots: string[] = [];
 
@@ -348,6 +349,10 @@ describe('setup command', () => {
       ].join('\n'),
     );
 
+    allowTestConsoleOutput(
+      ({ method, text }) =>
+        method === 'log' && (text.startsWith('Welcome to ApplePi') || text.startsWith('ApplePi manages')),
+    );
     const result = await executeSetupCommand(
       { homeDirectory, projectDirectory },
       {

--- a/tests/unit/state-live-update.test.ts
+++ b/tests/unit/state-live-update.test.ts
@@ -98,6 +98,7 @@ describe('live composite profile update state accounting', () => {
             return [];
           },
         },
+        writeLine: () => undefined,
         launcher: {
           async launch(plan) {
             expect(readFileSync(join(plan.env.MOCK_AGENT_DIR, 'generated.txt'), 'utf8')).toBe('Initial\n');

--- a/tests/unit/state-persistence.test.ts
+++ b/tests/unit/state-persistence.test.ts
@@ -111,6 +111,7 @@ describe('state persistence', () => {
       { homeDirectory, projectDirectory },
       {
         writeError: (message) => warnings.push(message),
+        writeLine: () => undefined,
         launcher: {
           launch(plan) {
             const compositeProfilePiDirectory = plan.env.PI_CODING_AGENT_DIR;
@@ -345,6 +346,8 @@ describe('state persistence', () => {
     const result = await executeRunCommand(
       { homeDirectory, projectDirectory },
       {
+        writeError: () => undefined,
+        writeLine: () => undefined,
         launcher: {
           launch(plan) {
             rmSync(join(plan.env.PI_CODING_AGENT_DIR, 'settings.json'));
@@ -407,6 +410,8 @@ describe('state persistence', () => {
     const result = await executeRunCommand(
       { homeDirectory, projectDirectory },
       {
+        writeError: () => undefined,
+        writeLine: () => undefined,
         adapter: {
           id: 'mock-agent',
           supportedControls: [],
@@ -458,6 +463,7 @@ describe('state persistence', () => {
       executeRunCommand(
         { homeDirectory, projectDirectory },
         {
+          writeLine: () => undefined,
           launcher: {
             launch(plan) {
               writeFileSync(join(plan.env.PI_CODING_AGENT_DIR, 'settings.json'), 'changed\n');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,5 +17,6 @@ const coverage = {
 export default defineConfig({
   test: {
     coverage,
+    setupFiles: ['tests/setup.ts'],
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ const coverage = {
   all: true,
   include: ['src/**/*.ts'],
   provider: 'v8' as const,
-  reporter: ['text', 'html'],
+  reporter: ['text-summary', 'html'],
   thresholds: {
     statements: 100,
     branches: 100,
@@ -17,6 +17,7 @@ const coverage = {
 export default defineConfig({
   test: {
     coverage,
+    reporters: ['dot'],
     setupFiles: ['tests/setup.ts'],
   },
 });


### PR DESCRIPTION
## Summary
- add a Vitest setup file with a console-output guard so accidental console output fails tests
- silence intentional command output in tests by injecting writers or allowing explicit console messages
- capture expected release-script stderr so negative subprocess tests stay quiet
- switch Vitest to the dot reporter and coverage text summary to reduce CI log volume

## Validation
- npm run check-ci
- monitored CI run 27033253593 and confirmed no test stdout/stderr blocks or expected error stack traces are present