### PR TITLE
Run automatic setup interactively

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Under the hood, `applepi` translates a selected profile into the selected agent 
 Pi runs use `PI_CODING_AGENT_DIR`; Claude Code runs use `CLAUDE_CONFIG_DIR`; both receive supported CLI flags, prompts, model settings, and environment variables.
 Select the adapter with `applepi run --agent <pi|claude>`, or set `default_agent` in `settings.yml`.
 If neither is set, ApplePi defaults to pi for backward compatibility.
-If `applepi` is run before `applepi setup`, it starts the interactive setup wizard, creates the initial settings and default profile, then launches with the selected profile.
+If `applepi` is run in an interactive terminal before `applepi setup`, it starts the setup wizard, creates the initial settings and default profile, then launches with the selected profile. Noninteractive first-run invocations use the default noninteractive setup path instead of prompting.
 
 `settings.yml` can point at local profiles, full Git URIs, or GitHub shorthand sources with optional refs and repository subpaths:
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Under the hood, `applepi` translates a selected profile into the selected agent 
 Pi runs use `PI_CODING_AGENT_DIR`; Claude Code runs use `CLAUDE_CONFIG_DIR`; both receive supported CLI flags, prompts, model settings, and environment variables.
 Select the adapter with `applepi run --agent <pi|claude>`, or set `default_agent` in `settings.yml`.
 If neither is set, ApplePi defaults to pi for backward compatibility.
-If `applepi` is run before `applepi setup`, it creates the initial settings and default profile automatically before launching.
+If `applepi` is run before `applepi setup`, it starts the interactive setup wizard, creates the initial settings and default profile, then launches with the selected profile.
 
 `settings.yml` can point at local profiles, full Git URIs, or GitHub shorthand sources with optional refs and repository subpaths:
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -682,6 +682,7 @@ Requirements:
 - `-p` / `--profile` selects a profile.
 - `--agent <pi|claude>` selects the agent adapter; if omitted, `default_agent` from settings is used, then `pi`.
 - Without a selected profile, the unified settings default profile is used.
+- If user setup has not created `~/.applepi/settings.yml`, the default CLI command runs the interactive setup wizard before resolving the profile.
 - Unknown args are passed through to the inner agent CLI unaltered.
 - `--strict` makes unsupported profile controls or composite profile assembly warnings fatal.
 - The child agent CLI runs with the generated composite profile, env, and argv.

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -682,7 +682,7 @@ Requirements:
 - `-p` / `--profile` selects a profile.
 - `--agent <pi|claude>` selects the agent adapter; if omitted, `default_agent` from settings is used, then `pi`.
 - Without a selected profile, the unified settings default profile is used.
-- If user setup has not created `~/.applepi/settings.yml`, the default CLI command runs the interactive setup wizard before resolving the profile.
+- If user setup has not created `~/.applepi/settings.yml`, the default CLI command runs the interactive setup wizard before resolving the profile when stdin and stdout are TTYs; noninteractive invocations use noninteractive setup.
 - Unknown args are passed through to the inner agent CLI unaltered.
 - `--strict` makes unsupported profile controls or composite profile assembly warnings fatal.
 - The child agent CLI runs with the generated composite profile, env, and argv.
@@ -755,7 +755,7 @@ class RunCommand {
   constructor(
     private readonly settingsLoader: SettingsLoader,
     private readonly profileLoader: ProfileLoader,
-    private readonly composite profileAssembler: Composite profileAssembler,
+    private readonly compositeProfileAssembler: CompositeProfileAssembler,
     private readonly processRunner: ProcessRunner,
   ) {}
 

--- a/doc/state_writeback_strategy.md
+++ b/doc/state_writeback_strategy.md
@@ -303,12 +303,12 @@ Persistence happens because the CLI writes through the symlink to an intentional
 
 ### `discard`
 
-Writes are allowed in the composite profile and are thrown away when the composite profile is deleted.
+Writes are allowed in the composite profile but are not copied back to durable profile or native state.
 ApplePi does not emit diagnostics for changed `discard` paths.
 
 ### `warn`
 
-Writes are allowed, discarded, and reported after the child exits.
+Writes are allowed, left non-durable, and reported after the child exits.
 `--strict` makes these warnings fatal.
 
 ### `error`

--- a/doc_site/app/page.mdx
+++ b/doc_site/app/page.mdx
@@ -171,7 +171,7 @@ theme:
       <h2>Select a profile. Launch consistently.</h2>
       <div className="applepi-feature-list">
         <p><strong>Pick the right loadout</strong><br />One flag selects language, role, risk level, or intent.</p>
-        <p><strong>Sync from anywhere</strong><br /><code>applepi sync</code> pulls remote settings and profile sources before a run.</p>
+        <p><strong>Sync from anywhere</strong><br />Run <code>applepi sync</code> to cache remote settings and profile sources for later runs.</p>
         <p><strong>Deterministic every time</strong><br />The same profile resolves to the same composite profile: reviewable and reproducible.</p>
       </div>
     </div>

--- a/doc_site/app/page.mdx
+++ b/doc_site/app/page.mdx
@@ -33,11 +33,11 @@ theme:
       <div className="applepi-terminal applepi-float">
         <div className="applepi-termbar"><i aria-hidden="true" /><i aria-hidden="true" /><i aria-hidden="true" /><span>applepi — run</span></div>
         <pre>{`$ applepi run --profile engineering-default
-→ resolving profile  engineering-default
-  ✓ user source      github:nhorton/agent-profiles@main
-  ✓ repo overlay     .applepi/profiles/engineer
-  ✓ merged controls  model=claude-sonnet-4
-  ✓ prepared composite profile    /tmp/applepi-engineering-default-pi-a91f
+→ resolving profile engineering-default
+✓ profile layer base  github:nhorton/agent-profiles@main
+✓ profile layer engineering-default  .applepi/profiles/engineering-default
+✓ merged controls  model=claude-sonnet-4
+✓ prepared composite profile  /tmp/applepi-engineering-default-pi-a91f
 ↳ launching pi …`}</pre>
       </div>
     </div>

--- a/doc_site/app/state-persistence/page.mdx
+++ b/doc_site/app/state-persistence/page.mdx
@@ -17,17 +17,17 @@ ApplePi makes those writes explicit with `state_persistence` rules. Each selecte
 4. Adapter-generated reconciliation files may replace a declared path for one launch. For example, Pi can receive a transformed `settings.json` that removes native packages already supplied by profile-controlled extensions; writes to that runtime file are discarded.
 5. The agent runs inside the composite profile and reads/writes those paths normally.
 6. After the agent exits, ApplePi checks non-durable and unknown writes.
-7. Temporary composite profile contents are deleted; durable symlink targets remain.
+7. Temporary composite profile contents are not written back to durable state; durable symlink targets keep their writes.
 
 ## Strategies
 
-| Strategy  | Behavior                                                                             |
-| --------- | ------------------------------------------------------------------------------------ |
-| `symlink` | Persist writes by pointing the composite profile path at a durable destination.      |
-| `discard` | Allow writes for this run and throw them away when the composite profile is deleted. |
-| `warn`    | Allow and discard writes, then report them after the agent exits.                    |
-| `error`   | Allow writes during the run, then fail if the path changed.                          |
-| `prompt`  | Reserved for future interactive handling; currently treated like `warn`.             |
+| Strategy  | Behavior                                                                        |
+| --------- | ------------------------------------------------------------------------------- |
+| `symlink` | Persist writes by pointing the composite profile path at a durable destination. |
+| `discard` | Allow writes for this run without copying them back to durable state.           |
+| `warn`    | Allow and discard writes, then report them after the agent exits.               |
+| `error`   | Allow writes during the run, then fail if the path changed.                     |
+| `prompt`  | Reserved for future interactive handling; currently treated like `warn`.        |
 
 Unknown writes outside adapter-declared paths are never silently persisted. They are governed by the adapter's `unknown` policy.
 

--- a/requirements/APPLEPI-REQ-005-run-and-composite-profile.md
+++ b/requirements/APPLEPI-REQ-005-run-and-composite-profile.md
@@ -15,6 +15,7 @@ The `run` command assembles a temporary agent-specific configuration directory c
 5. The `run` command MUST use the resolved default profile when no profile option is provided.
 6. The `run` command MUST pass unrecognized arguments through to the selected agent CLI unaltered.
 7. When invoked before user setup has created `~/.applepi/settings.yml`, the default `run` command MUST print `` `applepi setup` has not been run yet - running now `` and execute setup before resolving the profile.
+8. When the default CLI command auto-runs setup, it MUST use the interactive setup wizard so the user can choose the default profile before the run continues.
 
 ### APPLEPI-REQ-005.2: Composite profile Definition
 

--- a/requirements/APPLEPI-REQ-005-run-and-composite-profile.md
+++ b/requirements/APPLEPI-REQ-005-run-and-composite-profile.md
@@ -15,7 +15,8 @@ The `run` command assembles a temporary agent-specific configuration directory c
 5. The `run` command MUST use the resolved default profile when no profile option is provided.
 6. The `run` command MUST pass unrecognized arguments through to the selected agent CLI unaltered.
 7. When invoked before user setup has created `~/.applepi/settings.yml`, the default `run` command MUST print `` `applepi setup` has not been run yet - running now `` and execute setup before resolving the profile.
-8. When the default CLI command auto-runs setup, it MUST use the interactive setup wizard so the user can choose the default profile before the run continues.
+8. When the default CLI command auto-runs setup with interactive stdin and stdout TTY streams, it MUST use the interactive setup wizard so the user can choose the default profile before the run continues.
+9. When the default CLI command auto-runs setup without interactive TTY streams or with interactive setup disabled by an embedding caller, it MUST use noninteractive setup rather than requiring TTY streams.
 
 ### APPLEPI-REQ-005.2: Composite profile Definition
 

--- a/src/cli/commands/RunCommand.ts
+++ b/src/cli/commands/RunCommand.ts
@@ -10,16 +10,10 @@ import spawn from 'cross-spawn';
 
 import type { AgentAdapter, AgentLaunchPlan } from '../../agents/AgentAdapter.js';
 import { createAgentAdapter, defaultAgentId as registryDefaultAgentId } from '../../agents/AgentRegistry.js';
-import {
-  createProfileSourceCachePath,
-  createRemoteRepositoryCachePath,
-  redactProfileSourceUriCredentials,
-  resolveRemoteRepositorySubpath,
-} from '../../profiles/ProfileCache.js';
-import { loadLocalProfileSource } from '../../profiles/ProfileLoader.js';
+import { redactProfileSourceUriCredentials } from '../../profiles/ProfileCache.js';
+import { loadMaterializedProfileSources } from '../../profiles/ProfileLoader.js';
 import type { LoadedProfile } from '../../profiles/ProfileLoader.js';
 import type { Profile } from '../../profiles/Profile.js';
-import type { ProfileSourceReference } from '../../profiles/ProfileSource.js';
 import { resolveProfile } from '../../profiles/ProfileMerger.js';
 import type { Settings } from '../../settings/Settings.js';
 import { loadSettingsWithCachedRemoteSettings } from '../../settings/SettingsLoader.js';
@@ -154,7 +148,7 @@ export const executeRunCommand = async (
 export const createRunCommand = (dependencies: RunCommandDependencies = {}): CommandObject => {
   const command: CommandObject = {
     name: 'run',
-    description: 'Assemble a profile compositeProfile and launch the selected agent CLI.',
+    description: 'Assemble a composite profile and launch the selected agent CLI.',
     register(program: Command): void {
       const action = async (
         args: readonly string[],
@@ -169,7 +163,7 @@ export const createRunCommand = (dependencies: RunCommandDependencies = {}): Com
             strict: options.strict,
             passThroughArgs: args,
           },
-          { ...dependencies, interactive: true },
+          { ...dependencies, interactive: selectAutoSetupInteractiveMode(dependencies) },
         );
 
         if (result.exitCode !== 0) {
@@ -185,6 +179,19 @@ export const createRunCommand = (dependencies: RunCommandDependencies = {}): Com
   };
 
   return command;
+};
+
+const selectAutoSetupInteractiveMode = (dependencies: RunCommandDependencies): boolean | undefined => {
+  if (dependencies.interactive !== undefined) {
+    return dependencies.interactive;
+  }
+
+  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
+  const input = dependencies.input ?? process.stdin;
+  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
+  const output = dependencies.output ?? process.stdout;
+
+  return input.isTTY === true && output.isTTY === true ? true : undefined;
 };
 
 const configureRunCommander = (
@@ -360,7 +367,7 @@ const loadResolvedProfile = (input: RunCommandInput): ResolvedRunProfile => {
     throw new Error(`Cannot run with invalid settings: ${loadedSettings.issues.map(formatSettingsIssue).join('; ')}`);
   }
 
-  const loadedProfiles = loadProfileSources(input.homeDirectory, loadedSettings.settings.profileSources!);
+  const loadedProfiles = loadMaterializedProfileSources(input.homeDirectory, loadedSettings.settings.profileSources!);
 
   if (loadedProfiles.issues.length > 0) {
     throw new Error(`Cannot run with invalid profiles: ${loadedProfiles.issues.map(formatProfileIssue).join('; ')}`);
@@ -424,42 +431,6 @@ const findContributingLoadedProfiles = (
   loadedProfiles: readonly LoadedProfile[],
 ): readonly LoadedProfile[] =>
   profileStack.flatMap((profile) => loadedProfiles.filter((loadedProfile) => loadedProfile.profile.id === profile.id));
-
-const loadProfileSources = (
-  homeDirectory: string,
-  sources: readonly ProfileSourceReference[],
-): {
-  readonly profiles: readonly LoadedProfile[];
-  readonly issues: readonly { readonly path: string; readonly message: string }[];
-} => {
-  const profiles: LoadedProfile[] = [];
-  const issues: { readonly path: string; readonly message: string }[] = [];
-
-  for (const source of sources) {
-    const materializedSource = materializeSource(homeDirectory, source);
-    const result = loadLocalProfileSource(materializedSource);
-    profiles.push(...result.profiles.map((profile) => ({ ...profile, source })));
-    issues.push(...result.issues);
-  }
-
-  return { profiles, issues };
-};
-
-const materializeSource = (homeDirectory: string, source: ProfileSourceReference): ProfileSourceReference => {
-  if (source.uri === undefined && source.github === undefined) {
-    return source;
-  }
-
-  if (source.uri !== undefined && source.ref === undefined && source.path === undefined) {
-    return { path: createProfileSourceCachePath(homeDirectory, source.uri), only: source.only, except: source.except };
-  }
-
-  return {
-    path: resolveRemoteRepositorySubpath(createRemoteRepositoryCachePath(homeDirectory, source), source.path),
-    only: source.only,
-    except: source.except,
-  };
-};
 
 /* v8 ignore start -- the real child-process launcher is direct runtime behavior; tests inject a launcher. */
 const createSpawnLauncher = (): AgentProcessLauncher => ({

--- a/src/cli/commands/RunCommand.ts
+++ b/src/cli/commands/RunCommand.ts
@@ -85,9 +85,10 @@ export const executeRunCommand = async (
   emitWarnings(warnings, dependencies.writeError);
 
   writeCompositeProfile(compositeProfilePlan.compositeProfile);
+  let statePaths = compositeProfilePlan.compositeProfile.statePaths;
   let stateBaseline = createCompositeProfileStateBaseline(
     compositeProfilePlan.compositeProfile.rootDirectory,
-    compositeProfilePlan.compositeProfile.statePaths,
+    statePaths,
   );
   const launchPlan = adapter.createLaunchPlan(
     compositeProfilePlan.compositeProfile,
@@ -106,6 +107,7 @@ export const executeRunCommand = async (
       createAdapterCompositeProfilePlan(adapter, loadResolvedProfile(input), compositeProfileRootDirectory)
         .compositeProfile,
     onCompositeProfileWritten: (compositeProfile) => {
+      statePaths = compositeProfile.statePaths;
       stateBaseline = updateCompositeProfileStateBaselinePaths(
         compositeProfile.rootDirectory,
         stateBaseline,
@@ -124,7 +126,7 @@ export const executeRunCommand = async (
     const stateWriteWarnings = handleCompositeProfileStateWrites(
       adapter.id,
       compositeProfilePlan.compositeProfile.rootDirectory,
-      compositeProfilePlan.compositeProfile.statePaths,
+      statePaths,
       stateBaseline,
     );
 

--- a/src/cli/commands/RunCommand.ts
+++ b/src/cli/commands/RunCommand.ts
@@ -169,7 +169,7 @@ export const createRunCommand = (dependencies: RunCommandDependencies = {}): Com
             strict: options.strict,
             passThroughArgs: args,
           },
-          dependencies,
+          { ...dependencies, interactive: true },
         );
 
         if (result.exitCode !== 0) {

--- a/src/cli/commands/profile/ListCommand.ts
+++ b/src/cli/commands/profile/ListCommand.ts
@@ -3,14 +3,8 @@ import { homedir } from 'node:os';
 
 import { Command } from 'commander';
 
-import {
-  createProfileSourceCachePath,
-  createRemoteRepositoryCachePath,
-  resolveRemoteRepositorySubpath,
-} from '../../../profiles/ProfileCache.js';
-import { loadLocalProfileSource } from '../../../profiles/ProfileLoader.js';
+import { loadMaterializedProfileSources } from '../../../profiles/ProfileLoader.js';
 import type { LoadedProfile } from '../../../profiles/ProfileLoader.js';
-import type { ProfileSourceReference } from '../../../profiles/ProfileSource.js';
 import { loadSettingsWithCachedRemoteSettings } from '../../../settings/SettingsLoader.js';
 import type { CommandObject } from '../CommandObject.js';
 import type { ProfileCommandDependencies } from './Shared.js';
@@ -65,7 +59,10 @@ export const executeListProfilesCommand = (input: ListProfilesInput): ListProfil
     );
   }
 
-  const profileLoadResult = loadProfileSources(input.homeDirectory, loadedSettings.settings.profileSources!);
+  const profileLoadResult = loadMaterializedProfileSources(
+    input.homeDirectory,
+    loadedSettings.settings.profileSources!,
+  );
 
   if (profileLoadResult.issues.length > 0) {
     throw new Error(
@@ -86,42 +83,6 @@ const emitMessages = (messages: readonly string[], writeLine: ((message: string)
     /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
     (writeLine ?? console.log)(message);
   }
-};
-
-const loadProfileSources = (
-  homeDirectory: string,
-  sources: readonly ProfileSourceReference[],
-): {
-  readonly profiles: readonly LoadedProfile[];
-  readonly issues: readonly { readonly path: string; readonly message: string }[];
-} => {
-  const profiles: LoadedProfile[] = [];
-  const issues: { readonly path: string; readonly message: string }[] = [];
-
-  for (const source of sources) {
-    const materializedSource = materializeSource(homeDirectory, source);
-    const result = loadLocalProfileSource(materializedSource);
-    profiles.push(...result.profiles.map((profile) => ({ ...profile, source })));
-    issues.push(...result.issues);
-  }
-
-  return { profiles, issues };
-};
-
-const materializeSource = (homeDirectory: string, source: ProfileSourceReference): ProfileSourceReference => {
-  if (source.uri === undefined && source.github === undefined) {
-    return source;
-  }
-
-  if (source.uri !== undefined && source.ref === undefined && source.path === undefined) {
-    return { path: createProfileSourceCachePath(homeDirectory, source.uri), only: source.only, except: source.except };
-  }
-
-  return {
-    path: resolveRemoteRepositorySubpath(createRemoteRepositoryCachePath(homeDirectory, source), source.path),
-    only: source.only,
-    except: source.except,
-  };
 };
 
 const listHighestPrecedenceProfiles = (loadedProfiles: readonly LoadedProfile[]): readonly ListedProfile[] => {

--- a/src/profiles/ProfileLoader.ts
+++ b/src/profiles/ProfileLoader.ts
@@ -6,6 +6,11 @@ import type { ValidationIssue } from '../validation/SchemaValidator.js';
 import { validateSchema } from '../validation/SchemaValidator.js';
 import { parseYamlDocument } from '../validation/YamlDocument.js';
 import type { AgentSpecificProfileControls, Profile, ProfileControls, StatePersistenceOverrides } from './Profile.js';
+import {
+  createProfileSourceCachePath,
+  createRemoteRepositoryCachePath,
+  resolveRemoteRepositorySubpath,
+} from './ProfileCache.js';
 import type { ProfileSourceReference } from './ProfileSource.js';
 
 const profileIdPattern = /^[a-z0-9][a-z0-9._-]*[a-z0-9]$|^[a-z0-9]$/u;
@@ -98,6 +103,42 @@ export const loadLocalProfileSource = (source: ProfileSourceReference): ProfileL
   }
 
   return { profiles, issues };
+};
+
+export const loadMaterializedProfileSources = (
+  homeDirectory: string,
+  sources: readonly ProfileSourceReference[],
+): ProfileLoadResult => {
+  const profiles: LoadedProfile[] = [];
+  const issues: ProfileLoadIssue[] = [];
+
+  for (const source of sources) {
+    const materializedSource = materializeProfileSource(homeDirectory, source);
+    const result = loadLocalProfileSource(materializedSource);
+    profiles.push(...result.profiles.map((profile) => ({ ...profile, source })));
+    issues.push(...result.issues);
+  }
+
+  return { profiles, issues };
+};
+
+export const materializeProfileSource = (
+  homeDirectory: string,
+  source: ProfileSourceReference,
+): ProfileSourceReference => {
+  if (source.uri === undefined && source.github === undefined) {
+    return source;
+  }
+
+  if (source.uri !== undefined && source.ref === undefined && source.path === undefined) {
+    return { path: createProfileSourceCachePath(homeDirectory, source.uri), only: source.only, except: source.except };
+  }
+
+  return {
+    path: resolveRemoteRepositorySubpath(createRemoteRepositoryCachePath(homeDirectory, source), source.path),
+    only: source.only,
+    except: source.except,
+  };
 };
 
 const addProfileFromFolder = (

--- a/src/profiles/ProfileLoader.ts
+++ b/src/profiles/ProfileLoader.ts
@@ -1,4 +1,4 @@
-// Loads local profile folders and parses profile.yml documents.
+// Loads profile sources from local folders or remote caches and parses profile.yml documents.
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -216,18 +216,7 @@ const readControls = (value: unknown): ProfileControls => {
   }
 
   return omitUndefined({
-    ...controls,
-    model: readOptionalString(controls.model),
-    provider: readOptionalString(controls.provider),
-    thinking: readOptionalString(controls.thinking),
-    environment: readEnvironment(controls.environment),
-    args: readOptionalStringArray(controls.args),
-    sessionDirectory: readOptionalString(controls.session_directory),
-    extensions: readOptionalStringArray(controls.extensions),
-    skills: readOptionalStringArray(controls.skills),
-    promptTemplate: readOptionalString(controls.prompt_template),
-    systemPrompt: readOptionalString(controls.system_prompt),
-    appendSystemPrompt: readOptionalString(controls.append_system_prompt),
+    ...readBaseProfileControls(controls),
     pi: readAgentSpecificControls(controls.pi),
     claude: readAgentSpecificControls(controls.claude),
   });
@@ -236,11 +225,11 @@ const readControls = (value: unknown): ProfileControls => {
 const readAgentSpecificControls = (value: unknown): AgentSpecificProfileControls | undefined => {
   const controls = readObject(value);
 
-  if (controls === undefined) {
-    return undefined;
-  }
+  return controls === undefined ? undefined : readBaseProfileControls(controls);
+};
 
-  return omitUndefined({
+const readBaseProfileControls = (controls: Readonly<Record<string, unknown>>): AgentSpecificProfileControls =>
+  omitUndefined({
     ...controls,
     model: readOptionalString(controls.model),
     provider: readOptionalString(controls.provider),
@@ -254,7 +243,6 @@ const readAgentSpecificControls = (value: unknown): AgentSpecificProfileControls
     systemPrompt: readOptionalString(controls.system_prompt),
     appendSystemPrompt: readOptionalString(controls.append_system_prompt),
   });
-};
 
 const omitUndefined = <T extends Readonly<Record<string, unknown>>>(record: T): T =>
   Object.fromEntries(Object.entries(record).filter((entry) => entry[1] !== undefined)) as T;

--- a/tests/unit/composite-profile-watcher.test.ts
+++ b/tests/unit/composite-profile-watcher.test.ts
@@ -36,6 +36,16 @@ const waitForFileMatching = async (path: string, predicate: (content: string) =>
   }
 };
 
+const waitForWarningContaining = async (warnings: readonly string[], content: string): Promise<void> => {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (warnings.some((warning) => warning.includes(content))) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+};
+
 afterEach(() => {
   for (const root of temporaryRoots.splice(0)) {
     rmSync(root, { recursive: true, force: true });
@@ -113,6 +123,34 @@ describe('composite profile input watching', () => {
       await waitForFileContent(join(staticOutputRoot, 'generated.txt'), 'static\n');
     } finally {
       staticHandle.close();
+    }
+
+    const unsafeInput = join(watchedDirectory, 'unsafe-profile.yml');
+    const unsafeOutputRoot = join(root, 'unsafe-compositeProfile');
+    writeFileSync(unsafeInput, 'initial\n');
+    const unsafeCompositeProfile = createCompositeProfile(unsafeOutputRoot, [
+      createCompositeProfileFile({ relativePath: 'generated.txt', content: 'safe\n', sourceInputs: [unsafeInput] }),
+    ]);
+    const unsafeHandle = watchCompositeProfileInputs({
+      compositeProfile: unsafeCompositeProfile,
+      refreshCompositeProfile: () =>
+        createCompositeProfile(unsafeOutputRoot, [
+          createCompositeProfileFile({
+            relativePath: '../escape.txt',
+            content: 'unsafe\n',
+            sourceInputs: [unsafeInput],
+          }),
+        ]),
+      warn: (message) => warnings.push(message),
+    });
+
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      writeFileSync(unsafeInput, 'changed\n');
+      await waitForWarningContaining(warnings, 'Could not safely update compositeProfile from');
+      expect(warnings.some((warning) => warning.includes('must stay under compositeProfile root'))).toBe(true);
+    } finally {
+      unsafeHandle.close();
     }
   });
 });

--- a/tests/unit/composite-profile-watcher.test.ts
+++ b/tests/unit/composite-profile-watcher.test.ts
@@ -44,6 +44,8 @@ const waitForWarningContaining = async (warnings: readonly string[], content: st
 
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
+
+  throw new Error(`Timed out waiting for warning containing '${content}'. Warnings: ${warnings.join('; ')}`);
 };
 
 afterEach(() => {

--- a/tests/unit/run-command.test.ts
+++ b/tests/unit/run-command.test.ts
@@ -5,7 +5,8 @@ import { join } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { executeRunCommand, resolveChildExitCode } from '../../src/cli/commands/RunCommand.js';
+import { createApplePiProgram } from '../../src/cli/ApplePiCli.js';
+import { createRunCommand, executeRunCommand, resolveChildExitCode } from '../../src/cli/commands/RunCommand.js';
 import { createCompositeProfile } from '../../src/compositeProfile/CompositeProfile.js';
 import { allowTestConsoleOutput } from '../test-console.js';
 
@@ -214,6 +215,55 @@ describe('run command', () => {
     expect(result.profileId).toBe('engineer');
     expect(existsSync(join(homeDirectory, '.applepi', 'settings.yml'))).toBe(true);
     expect(existsSync(join(homeDirectory, '.applepi', 'profiles', 'engineer', 'profile.yml'))).toBe(true);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-004.1, APPLEPI-REQ-005.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('runs the automatic setup wizard interactively from the default CLI command', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const messages: string[] = [];
+    const selectedProfiles: string[] = [];
+    const program = createApplePiProgram([
+      createRunCommand({
+        homeDirectory,
+        projectDirectory,
+        input: { isTTY: true } as NodeJS.ReadableStream & { isTTY: true },
+        output: { isTTY: true } as NodeJS.WritableStream & { isTTY: true },
+        writeLine: (message) => messages.push(stripAnsiCodes(message)),
+        synchronizer: {
+          sync(_source, cachePath) {
+            mkdirSync(join(cachePath, 'profiles', 'analyst'), { recursive: true });
+            mkdirSync(join(cachePath, 'profiles', 'engineer'), { recursive: true });
+            writeFileSync(join(cachePath, 'profiles', 'analyst', 'profile.yml'), 'id: analyst\ncontrols: {}\n');
+            writeFileSync(join(cachePath, 'profiles', 'engineer', 'profile.yml'), 'id: engineer\ncontrols: {}\n');
+            return 'updated';
+          },
+        },
+        selectDefaultProfile(profiles, currentDefault) {
+          expect(currentDefault).toBe('engineer');
+          expect(profiles.map((profile) => profile.id)).toEqual(['analyst', 'engineer']);
+          selectedProfiles.push('analyst');
+          return Promise.resolve('analyst');
+        },
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      }),
+    ]);
+
+    await program.parseAsync(['node', 'applepi']);
+
+    expect(selectedProfiles).toEqual(['analyst']);
+    expect(readFileSync(join(homeDirectory, '.applepi', 'settings.yml'), 'utf8')).toContain('default_profile: analyst');
+    expect(messages).toContain('Welcome to ApplePi. ApplePi is the easiest way to run Pi.');
+    expect(messages).toContain(
+      'ApplePi manages full pi configurations for you, so you can use different profiles in different situations.',
+    );
+    expect(messages).toContain('→ resolving profile analyst');
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-002.3, APPLEPI-REQ-002.4, APPLEPI-REQ-003.1, APPLEPI-REQ-006.1).

--- a/tests/unit/run-command.test.ts
+++ b/tests/unit/run-command.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+import type { AgentAdapter } from '../../src/agents/AgentAdapter.js';
 import { createApplePiProgram } from '../../src/cli/ApplePiCli.js';
 import { createRunCommand, executeRunCommand, resolveChildExitCode } from '../../src/cli/commands/RunCommand.js';
 import { createCompositeProfile } from '../../src/compositeProfile/CompositeProfile.js';
@@ -71,7 +72,7 @@ afterEach(() => {
 describe('run command', () => {
   // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-005.1, APPLEPI-REQ-005.2, APPLEPI-REQ-005.3, APPLEPI-REQ-005.4, APPLEPI-REQ-005.5).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('resolves the default profile, writes and refreshes a temp compositeProfile, warns, and passes through args', async () => {
+  it('resolves the default profile, writes and refreshes a temp composite profile, warns, and passes through args', async () => {
     const root = createTemporaryRoot();
     const homeDirectory = join(root, 'home');
     const projectDirectory = join(root, 'project');
@@ -176,6 +177,80 @@ describe('run command', () => {
     );
   });
 
+  // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-005.1, APPLEPI-REQ-005.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('parses run command profile, strict, and pass-through options through Commander', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const profilesDirectory = join(homeDirectory, '.applepi', 'profiles');
+    const selectedProfiles: string[] = [];
+    const launchedArgs: string[][] = [];
+    writeSettings(homeDirectory, 'default_profile: default\nprofile_sources:\n  - path: ./profiles\n');
+    writeProfile(profilesDirectory, 'default', 'id: default\ncontrols: {}\n');
+    writeProfile(profilesDirectory, 'selected', 'id: selected\ncontrols: {}\n');
+
+    const adapter: AgentAdapter = {
+      id: 'test-agent',
+      supportedControls: [],
+      createCompositeProfile(profile, compositeProfileInput) {
+        selectedProfiles.push(profile.id);
+        return { compositeProfile: createCompositeProfile(compositeProfileInput.rootDirectory, []), warnings: [] };
+      },
+      createLaunchPlan(_compositeProfile, _profile, passThroughArgs = []) {
+        return { command: 'test-agent', args: [...passThroughArgs], env: {} };
+      },
+      getUnsupportedControls() {
+        return [];
+      },
+    };
+    const program = createApplePiProgram([
+      createRunCommand({
+        homeDirectory,
+        projectDirectory,
+        adapter,
+        writeLine: () => undefined,
+        launcher: {
+          launch(plan) {
+            launchedArgs.push([...plan.args]);
+            return Promise.resolve(0);
+          },
+        },
+      }),
+    ]);
+
+    await program.parseAsync(['node', 'applepi', 'run', '-p', 'selected', '--strict', '--', '--debug', 'prompt text']);
+
+    expect(selectedProfiles).toEqual(['selected']);
+    expect(launchedArgs).toEqual([['--debug', 'prompt text']]);
+
+    const strictProgram = createApplePiProgram([
+      createRunCommand({
+        homeDirectory,
+        projectDirectory,
+        adapter: {
+          ...adapter,
+          createCompositeProfile(_profile, compositeProfileInput) {
+            return {
+              compositeProfile: createCompositeProfile(compositeProfileInput.rootDirectory, []),
+              warnings: ['parser strict warning'],
+            };
+          },
+        },
+        writeLine: () => undefined,
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      }),
+    ]);
+
+    await expect(
+      strictProgram.parseAsync(['node', 'applepi', 'run', '--profile', 'selected', '--strict']),
+    ).rejects.toThrow('Strict failed for test-agent: parser strict warning');
+  });
+
   // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-005.1).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('runs setup automatically before the default run when user setup has not run', async () => {
@@ -264,6 +339,50 @@ describe('run command', () => {
       'ApplePi manages full pi configurations for you, so you can use different profiles in different situations.',
     );
     expect(messages).toContain('→ resolving profile analyst');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-005.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('uses noninteractive automatic setup when the default CLI command has no TTY', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const messages: string[] = [];
+    let launchCount = 0;
+    const program = createApplePiProgram([
+      createRunCommand({
+        homeDirectory,
+        projectDirectory,
+        input: { isTTY: false } as NodeJS.ReadableStream & { isTTY: false },
+        output: { isTTY: false } as NodeJS.WritableStream & { isTTY: false },
+        writeLine: (message) => messages.push(stripAnsiCodes(message)),
+        synchronizer: {
+          sync(_source, cachePath) {
+            mkdirSync(join(cachePath, 'profiles', 'engineer'), { recursive: true });
+            writeFileSync(join(cachePath, 'profiles', 'engineer', 'profile.yml'), 'id: engineer\ncontrols: {}\n');
+            return 'updated';
+          },
+        },
+        selectDefaultProfile() {
+          throw new Error('noninteractive setup must not prompt for a default profile');
+        },
+        launcher: {
+          launch() {
+            launchCount += 1;
+            return Promise.resolve(0);
+          },
+        },
+      }),
+    ]);
+
+    await program.parseAsync(['node', 'applepi']);
+
+    expect(launchCount).toBe(1);
+    expect(readFileSync(join(homeDirectory, '.applepi', 'settings.yml'), 'utf8')).toContain(
+      'default_profile: engineer',
+    );
+    expect(messages).not.toContain('Welcome to ApplePi. ApplePi is the easiest way to run Pi.');
+    expect(messages).toContain('→ resolving profile engineer');
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-002.3, APPLEPI-REQ-002.4, APPLEPI-REQ-003.1, APPLEPI-REQ-006.1).

--- a/tests/unit/source-layout.test.ts
+++ b/tests/unit/source-layout.test.ts
@@ -42,7 +42,7 @@ const readJson = <T>(relativePath: string): T =>
   JSON.parse(readFileSync(new URL(relativePath, import.meta.url), 'utf8')) as T;
 
 describe('source layout scaffolding', () => {
-  // THIS TEST VALIDATES COMMAND-AVAILABILITY CLAUSES IN HARD REQUIREMENTS (APPLEPI-REQ-004.1, APPLEPI-REQ-004.2, APPLEPI-REQ-004.3, APPLEPI-REQ-005.1).
+  // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-004.1, APPLEPI-REQ-004.2, APPLEPI-REQ-004.3, APPLEPI-REQ-005.1).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('exposes focused command objects for the initial CLI commands', () => {
     const commands = createDefaultCommands();
@@ -172,7 +172,7 @@ describe('source layout scaffolding', () => {
     expect(claudePaths.configDirectory).toBe(compositeProfileRoot);
   });
 
-  // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-001.3, APPLEPI-REQ-002.3, APPLEPI-REQ-003.1, APPLEPI-REQ-005.2, APPLEPI-REQ-005.3, APPLEPI-REQ-005.4).
+  // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-001.4, APPLEPI-REQ-002.3, APPLEPI-REQ-003.1, APPLEPI-REQ-005.2, APPLEPI-REQ-005.3, APPLEPI-REQ-005.4).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('defines composite profile, schema, and validation scaffolding boundaries', () => {
     const compositeProfileFile = createCompositeProfileFile('SYSTEM.md', 'hello');

--- a/tests/unit/source-layout.test.ts
+++ b/tests/unit/source-layout.test.ts
@@ -60,7 +60,7 @@ describe('source layout scaffolding', () => {
     expect(program.commands.at(3)?.commands.map((command) => command.name())).toEqual(['list', 'create']);
     expect(describeCommandObject(createRunCommand())).toEqual({
       name: 'run',
-      description: 'Assemble a profile compositeProfile and launch the selected agent CLI.',
+      description: 'Assemble a composite profile and launch the selected agent CLI.',
     });
 
     const standaloneProgram = new Command();

--- a/tests/unit/source-layout.test.ts
+++ b/tests/unit/source-layout.test.ts
@@ -90,6 +90,8 @@ describe('source layout scaffolding', () => {
     expect(validate({ only: ['engineering'] })).toBe(false);
   });
 
+  // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-002.1, APPLEPI-REQ-002.2, APPLEPI-REQ-002.5, APPLEPI-REQ-002.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('defines settings and profile source scaffolding boundaries', () => {
     const localSource = createLocalProfileSource('./profiles');
     const uriSource = createUriProfileSource('git+https://example.test/profiles.git');
@@ -170,7 +172,9 @@ describe('source layout scaffolding', () => {
     expect(claudePaths.configDirectory).toBe(compositeProfileRoot);
   });
 
-  it('defines compositeProfile, schema, and validation scaffolding boundaries', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-001.3, APPLEPI-REQ-002.3, APPLEPI-REQ-003.1, APPLEPI-REQ-005.2, APPLEPI-REQ-005.3, APPLEPI-REQ-005.4).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('defines composite profile, schema, and validation scaffolding boundaries', () => {
     const compositeProfileFile = createCompositeProfileFile('SYSTEM.md', 'hello');
     const compositeProfile = createCompositeProfile('applepi-compositeProfile-root', [compositeProfileFile]);
     const assembledCompositeProfile = assembleCompositeProfile({


### PR DESCRIPTION
## Summary
- make the default → resolving profile engineer
✓ profile layer engineer  /Users/noah/.applepi/profiles/engineer
✓ profile layer engineer  github:applepi-ai/default-profiles@main/profiles
✓ merged controls
✓ prepared composite profile  /var/folders/81/g2d1kf1d46l485w6rljbsc0c0000gn/T/applepi-engineer-pi-yRKD5v
↳ launching pi … auto-setup path invoke the interactive setup wizard
- document that first-run default command setup prompts before continuing
- add regression coverage for Commander default command auto-setup selection

## Validation
- npm test -- tests/unit/run-command.test.ts tests/unit/setup-command.test.ts
- npm run check-ci
- npm run build
- DeepWork review launched: deepwork-review-25f43906-1a79-4d36-8947-3150819b8ca2