### PR TITLE
Add first-run welcome onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ npx --yes @applepi-ai/applepi@latest --help
 
 For source development, see [`CONTRIBUTING.md`](./CONTRIBUTING.md).
 
-ApplePi launches agent CLIs but does not install them. Install the agents you plan to use separately:
+ApplePi launches agent CLIs but does not install them.
+Install the agents you plan to use separately:
 
 - [pi](https://github.com/earendil-works/pi-coding-agent) — follow its installation instructions; the `pi` command must be on your PATH.
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) — only needed if you launch with `--agent claude`.
@@ -70,6 +71,7 @@ applepi run -p support -- --cwd ~/work/customer-issue
 applepi sync
 applepi setup
 applepi setup https://github.com/my_account/applepi_config
+applepi welcome
 applepi profile list
 applepi profile create regulated --scope user
 ```
@@ -79,6 +81,14 @@ Pi runs use `PI_CODING_AGENT_DIR`; Claude Code runs use `CLAUDE_CONFIG_DIR`; bot
 Select the adapter with `applepi run --agent <pi|claude>`, or set `default_agent` in `settings.yml`.
 If neither is set, ApplePi defaults to pi for backward compatibility.
 If `applepi` is run before `applepi setup`, it creates the initial settings and default profile automatically before launching.
+When that first-run setup has an interactive terminal, ApplePi continues into the same welcome onboarding used by `applepi welcome`.
+
+`applepi welcome` explains ApplePi and Pi, asks you to choose an initial built-in role, and recommends a Pi productivity loadout.
+The current built-in role choices are `engineer` and `data_analyst`; ApplePi creates the selected local profile on the fly.
+The recommended loadout includes `ulta-tasklist`, `deepwork`, `pi-subagents`, and `pi-mcp-adapter`; you can accept it, choose individual items, or skip loadout installation.
+If you skip loadout installation, the generated profile has no extensions or skills.
+If Pi does not appear to be logged in after welcome onboarding, ApplePi opens Pi with `/login` automatically; outside welcome onboarding it prints a `/login` reminder instead.
+ApplePi never collects or persists provider API keys itself.
 
 `settings.yml` can point at local profiles, full Git URIs, or GitHub shorthand sources with optional refs and repository subpaths:
 
@@ -132,7 +142,9 @@ When a repository is provided, it clones or updates the repository in ApplePi's 
 - if starter profiles exist, ApplePi copies missing profile files into `~/.applepi/profiles/`;
 - existing user settings and profile files are otherwise left unchanged;
 - after setup, ApplePi runs the same sync behavior used by `applepi sync`;
-- ApplePi then shows a short setup wizard that lists synced profiles and writes the selected default profile to user settings.
+- on initial interactive first-run setup, ApplePi skips the older default-profile prompt and lets welcome onboarding choose the generated local default profile;
+- outside that initial welcome handoff, ApplePi shows a short setup wizard that lists synced profiles and writes the selected default profile to user settings;
+- interactive setup continues into welcome onboarding to record role and loadout choices.
 
 A setup repository can use either root-level ApplePi files:
 
@@ -212,7 +224,8 @@ The exact stable schema is governed by the requirements in `requirements/` and t
 The current recommendation is to build `applepi` around pi's existing native configuration mechanisms:
 
 1. Use a temporary composite profile directory as `PI_CODING_AGENT_DIR` for each run.
-2. Persist intentional pi state through adapter-declared symlinks to profile, native pi, or ApplePi cache files. Native pi fallback is only a durable target for declared state symlinks; it is not an inherited base profile layer.
+2. Persist intentional pi state through adapter-declared symlinks to profile, native pi, or ApplePi cache files.
+   Native pi fallback is only a durable target for declared state symlinks; it is not an inherited base profile layer.
 3. Layer profile-controlled environment variables and pi CLI flags on top.
 4. Use explicit `--extension` / `-e` injection for bootstrap behavior that needs to run inside pi.
 5. Decide per profile whether project-local `.pi` overrides are allowed.

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -550,7 +550,8 @@ $TMPDIR/applepi-<profile-id>-<agent-id>-<random>/
 
 The pi adapter uses this state model for native pi state and for pi-managed utilities: most declared pi state paths, including `tmp/`, symlink to `~/.pi/agent/<path>` by default, while composite profile `utilities/` and `bin/` both symlink to `<cache_directory>/utilities` by default, so temporary composite profile cleanup does not force pi to redownload helper binaries such as `fd` and `rg`.
 
-When profile-controlled Pi extensions would duplicate native Pi `settings.json` package entries, ApplePi generates a reconciled runtime `settings.json` inside the composite profile for that launch. The generated file preserves unrelated settings and package entries, removes duplicate native package entries by normalized resource identity, and keeps the declared `settings.json` state path non-durable with `discard` write handling so runtime edits are not reported as unknown state.
+When profile-controlled Pi extensions would duplicate native Pi `settings.json` package entries, ApplePi generates a reconciled runtime `settings.json` inside the composite profile for that launch.
+The generated file preserves unrelated settings and package entries, removes duplicate native package entries by normalized resource identity, and keeps the declared `settings.json` state path non-durable with `discard` write handling so runtime edits are not reported as unknown state.
 
 During `applepi run`, the ApplePi process remains alive while the child agent CLI runs.
 It owns the composite profile lifecycle.
@@ -655,7 +656,8 @@ ApplePi should prefer native pi mechanisms:
 - generated Pi settings reconciliation in the composite profile where flags/env are not the right mechanism.
 
 If generic ApplePi controls conflict with pi naming or behavior, prefer pi’s terminology and conventions.
-Because ApplePi chooses `PI_CODING_AGENT_DIR` and other startup-sensitive configuration before launching pi, a requested pi control that would require changing startup discovery after pi has already begun cannot be applied by an extension or late runtime hook. The pi adapter reports such unsupported or startup-order-impossible controls through normal adapter warnings, and `--strict` makes those warnings fatal.
+Because ApplePi chooses `PI_CODING_AGENT_DIR` and other startup-sensitive configuration before launching pi, a requested pi control that would require changing startup discovery after pi has already begun cannot be applied by an extension or late runtime hook.
+The pi adapter reports such unsupported or startup-order-impossible controls through normal adapter warnings, and `--strict` makes those warnings fatal.
 
 Claude Code is also supported through the `claude` adapter.
 ApplePi launches `claude` with `CLAUDE_CONFIG_DIR` pointing at the composite profile root, maps supported controls to native flags (`--model`, `--effort`, `--system-prompt`, `--append-system-prompt`, and repeated `--plugin-dir`), and preserves Claude Code state paths such as `settings.json`, `agents/`, `skills/`, `commands/`, `plugins/`, `projects/`, and `debug/` through adapter-declared state persistence.
@@ -697,9 +699,28 @@ Responsibilities:
 - create a default profile when missing;
 - validate all discovered settings files and any starter settings file;
 - run `applepi sync` behavior for URI profile sources before profile selection;
-- show a setup wizard with synced profile choices, preserve display labels where available, validate the selected profile ID, and write the selected default profile to user settings;
+- on initial interactive first-run setup, skip the older setup default-profile prompt and let welcome onboarding choose the generated local default profile;
+- outside that initial welcome handoff, show a setup wizard with synced profile choices, preserve display labels where available, validate the selected profile ID, and write the selected default profile to user settings;
 - create any missing fallback default profile file for the final selected default profile;
+- run welcome onboarding after interactive setup completes;
 - report actionable next steps.
+
+### `applepi welcome`
+
+Responsibilities:
+
+- require an interactive TTY on both stdin and stdout before running welcome prompts;
+- show welcome text that explains ApplePi and Pi before asking onboarding questions;
+- ask whether the user wants to answer setup questions now;
+- ask the user to choose an initial built-in standard role, currently including `engineer` and `data_analyst`;
+- recommend a named Pi productivity loadout containing `git:github.com/applepi-ai/ulta-tasklist`, `git:github.com/applepi-ai/deepwork`, `npm:pi-subagents`, and `npm:pi-mcp-adapter`;
+- allow the user to accept the loadout, choose individual loadout items, or skip loadout installation;
+- create the selected local role profile on the fly, appending only the selected loadout resources and leaving extensions/skills empty when the user selects none;
+- return typed onboarding choices so later work can persist richer profile/loadout metadata behind a schema-validated YAML format if needed.
+
+Before launching Pi after welcome onboarding, `applepi run` checks whether native Pi appears to have login state in `auth.json` or `models.json`.
+If no login state is detected, ApplePi starts Pi with `/login` automatically; outside the welcome flow it prints an informational `/login` notice instead.
+Credential collection stays inside Pi so provider API keys are not collected or persisted by ApplePi.
 
 ### `applepi sync`
 

--- a/doc/file_structure.md
+++ b/doc/file_structure.md
@@ -43,9 +43,12 @@ ApplePi is organized around clear TypeScript source boundaries, requirement docu
 │   │   ├── ApplePiCli.ts
 │   │   └── commands/                  # command objects for non-trivial CLI behavior
 │   │       ├── CommandObject.ts
+│   │       ├── FirstRunWelcomeProfile.ts
+│   │       ├── PiLoginLaunch.ts
 │   │       ├── RunCommand.ts
 │   │       ├── SetupCommand.ts
 │   │       ├── SyncCommand.ts
+│   │       ├── WelcomeCommand.ts
 │   │       └── profile/               # profile command namespace and subcommands
 │   │           ├── Command.ts
 │   │           ├── CreateCommand.ts
@@ -104,7 +107,7 @@ ApplePi is organized around clear TypeScript source boundaries, requirement docu
 │   ├── integration/                   # fixture-backed integration tests and harness helpers
 │   ├── setup.ts                       # Vitest global setup for quiet test-output guards
 │   ├── test-console.ts                # shared console-output guard helpers for tests
-│   └── unit/                          # unit tests grouped by functionality under test
+│   └── unit/                          # unit tests grouped by functionality under test, including welcome and first-run tests
 ├── package-lock.json                  # locked npm dependency graph
 └── package.json                       # npm package metadata and scripts
 ```

--- a/requirements/APPLEPI-REQ-004-sync-and-setup.md
+++ b/requirements/APPLEPI-REQ-004-sync-and-setup.md
@@ -16,10 +16,11 @@ ApplePi provides setup and maintenance commands that create initial configuratio
 6. The `setup` command SHOULD avoid overwriting existing user files unless a future explicit force option authorizes replacement.
 7. When provided a setup source URI, the `setup` command MUST use that source repository's ApplePi `settings.yml` and profiles as the initial user setup starting point.
 8. The interactive `setup` command MUST require interactive TTY streams on both stdin and stdout before prompting.
-9. The interactive `setup` command MUST synchronize remote profile sources before presenting setup profile choices.
-10. The interactive `setup` command MUST present discovered profile IDs as default-profile choices and preserve available display labels in the prompt choices.
-11. The interactive `setup` command MUST validate the selected default profile ID before writing it to `settings.yml`.
-12. After the interactive `setup` command writes the selected default profile, any newly-created fallback default profile file MUST correspond to the final selected default profile.
+9. The interactive `setup` command MUST synchronize remote profile sources before any setup profile choice prompt.
+10. Initial interactive first-run setup MUST NOT ask a separate default-profile choice before welcome onboarding; the welcome role selection determines the generated local default profile.
+11. When the interactive `setup` command presents setup profile choices outside the initial welcome handoff, it MUST present discovered profile IDs as default-profile choices and preserve available display labels in the prompt choices.
+12. When the interactive `setup` command presents setup profile choices outside the initial welcome handoff, it MUST validate the selected default profile ID before writing it to `settings.yml`.
+13. After the interactive `setup` command writes a selected default profile, any newly-created fallback default profile file MUST correspond to the final selected default profile.
 
 ### APPLEPI-REQ-004.2: Sync Command
 

--- a/requirements/APPLEPI-REQ-010-onboarding-welcome.md
+++ b/requirements/APPLEPI-REQ-010-onboarding-welcome.md
@@ -1,0 +1,37 @@
+# APPLEPI-REQ-010: Onboarding Welcome
+
+## Overview
+
+ApplePi welcome onboarding guides a new user through the minimum choices needed to start productive Pi sessions, including an initial role and a recommended loadout of extensions and skills.
+
+## Requirements
+
+### APPLEPI-REQ-010.1: Welcome Text
+
+1. Welcome text MUST be shown to the user explaining what ApplePi and Pi are.
+
+> Pi is a heavily customizable coding harness. The next few questions will configure ApplePi to best suit your workflow.
+
+### APPLEPI-REQ-010.2: Role Selection
+
+1. The welcome onboarding flow MUST ask the user to choose an initial role for the ApplePi-managed agent session.
+2. Role choices MUST align with ApplePi's built-in standard role catalog, not DeepWork review personas or a remote default profile source.
+3. The role selection prompt MUST include the currently available built-in standard profile roles, including `engineer` and `data_analyst` while those roles remain supported.
+4. The selected role MUST be captured as structured onboarding data so profile creation or profile selection can map it to the matching standard profile ID.
+5. If the selected role cannot be mapped to an available standard profile for the selected agent adapter, ApplePi MUST warn the user and choose a deterministic fallback role rather than silently ignoring the selection.
+
+### APPLEPI-REQ-010.3: Loadout Selection
+
+1. The welcome onboarding flow MUST recommend at least one default loadout for the selected role.
+2. A loadout MUST be represented as a named set of Pi extensions, skills, or package resources that ApplePi can translate into profile controls or profile-managed Pi configuration.
+3. The welcome onboarding flow MUST allow the user to accept the recommended loadout, select individual loadout items, or skip loadout installation.
+4. The default recommended loadout MUST include `git:github.com/applepi-ai/ulta-tasklist`, `git:github.com/applepi-ai/deepwork`, `npm:pi-subagents`, and `npm:pi-mcp-adapter` while those packages remain available.
+5. Loadout installation MUST be captured as structured onboarding data so future profile creation can install the selected extensions, skills, or package resources deterministically.
+6. If a loadout item is unavailable or unsupported by the selected agent adapter, ApplePi MUST warn the user and continue with the remaining selected loadout items unless strict onboarding validation is enabled.
+
+### APPLEPI-REQ-010.4: Pi Login Setup
+
+1. Before launching Pi after the welcome flow, ApplePi MUST detect whether native Pi appears to have no configured login state.
+2. If Pi is not logged in after the welcome flow, ApplePi MUST automatically invoke Pi's `/login` flow when Pi starts.
+3. When ApplePi launches Pi outside the welcome flow and Pi does not appear to be logged in, ApplePi MUST inform the user to run `/login` inside Pi.
+4. Pi login setup MUST NOT ask ApplePi to collect, echo, or persist provider API keys.

--- a/src/cli/ApplePiCli.ts
+++ b/src/cli/ApplePiCli.ts
@@ -6,11 +6,13 @@ import { createProfileCommands } from './commands/profile/Command.js';
 import { createRunCommand } from './commands/RunCommand.js';
 import { createSetupCommand } from './commands/SetupCommand.js';
 import { createSyncCommand } from './commands/SyncCommand.js';
+import { createWelcomeCommand } from './commands/WelcomeCommand.js';
 
 export const createDefaultCommands = (): CommandObject[] => [
   createRunCommand(),
   createSetupCommand(),
   createSyncCommand(),
+  createWelcomeCommand(),
   ...createProfileCommands(),
 ];
 

--- a/src/cli/commands/FirstRunWelcomeProfile.ts
+++ b/src/cli/commands/FirstRunWelcomeProfile.ts
@@ -1,0 +1,81 @@
+// Persists first-run welcome choices as a local profile used before launching Pi.
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { WelcomeCommandResult } from './WelcomeCommand.js';
+
+export interface PersistedFirstRunWelcomeProfile {
+  readonly profileId: string;
+  readonly createdProfile: boolean;
+}
+
+export const persistFirstRunWelcomeProfile = (
+  homeDirectory: string,
+  settingsPath: string,
+  welcomeResult: WelcomeCommandResult | undefined,
+): PersistedFirstRunWelcomeProfile | undefined => {
+  if (welcomeResult === undefined || !welcomeResult.answered || welcomeResult.selectedRole === undefined) {
+    return undefined;
+  }
+
+  const welcomeProfile = createFirstRunWelcomeProfile(welcomeResult, welcomeResult.selectedRole);
+  const profilePath = join(homeDirectory, '.applepi', 'profiles', welcomeProfile.id, 'profile.yml');
+  const createdProfile = !existsSync(profilePath);
+
+  if (createdProfile) {
+    mkdirSync(join(homeDirectory, '.applepi', 'profiles', welcomeProfile.id), { recursive: true });
+    writeFileSync(profilePath, welcomeProfile.content);
+  }
+
+  updateSettingsDefaultProfile(settingsPath, welcomeProfile.id);
+  return { profileId: welcomeProfile.id, createdProfile };
+};
+
+const createFirstRunWelcomeProfile = (
+  welcomeResult: WelcomeCommandResult,
+  selectedRole: NonNullable<WelcomeCommandResult['selectedRole']>,
+): {
+  readonly id: string;
+  readonly content: string;
+} => {
+  const profileId = selectedRole.id;
+  const extensions = welcomeResult.selectedLoadout?.selectedItems.map((item) => item.source) ?? [];
+  const rolePrompt = firstRunWelcomeRolePrompts[selectedRole.id];
+
+  return {
+    id: profileId,
+    content: createFirstRunWelcomeProfileContent(profileId, selectedRole.label, rolePrompt, extensions),
+  };
+};
+
+const firstRunWelcomeRolePrompts = {
+  engineer:
+    'You are operating as an engineering-focused coding agent.\nPrioritize maintainable implementation, clear tests, concise diffs, and verification evidence.\nBefore changing code, inspect the existing project conventions and reuse established patterns.',
+  data_analyst:
+    'You are operating as a data-analysis-focused agent.\nPrioritize careful data inspection, reproducible analysis steps, clear assumptions, and actionable summaries.\nWhen data or methodology is uncertain, call out limitations and validation checks explicitly.',
+} as const;
+
+const createFirstRunWelcomeProfileContent = (
+  profileId: string,
+  roleLabel: string,
+  rolePrompt: string,
+  extensions: readonly string[],
+): string => {
+  const lines = [`id: ${profileId}`, `label: ${roleLabel}`, 'controls:'];
+
+  if (extensions.length > 0) {
+    lines.push('  pi:', '    extensions:', ...extensions.map((extension) => `      - ${extension}`));
+  }
+
+  lines.push('  append_system_prompt: |', ...rolePrompt.split('\n').map((line) => `    ${line}`), '');
+  return lines.join('\n');
+};
+
+const updateSettingsDefaultProfile = (settingsPath: string, profileId: string): void => {
+  const content = readFileSync(settingsPath, 'utf8');
+  const nextContent = /^default_profile:.*$/mu.test(content)
+    ? content.replace(/^default_profile:.*$/gmu, `default_profile: ${profileId}`)
+    : `${content.replace(/\s*$/u, '\n')}default_profile: ${profileId}\n`;
+
+  writeFileSync(settingsPath, nextContent);
+};

--- a/src/cli/commands/PiLoginLaunch.ts
+++ b/src/cli/commands/PiLoginLaunch.ts
@@ -1,0 +1,111 @@
+// Adds first-run Pi login startup behavior without handling credentials in ApplePi.
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import type { AgentLaunchPlan } from '../../agents/AgentAdapter.js';
+import type { SetupCommandResult } from './SetupCommand.js';
+
+export interface PiLoginLaunchPlanInput {
+  readonly adapterId: string;
+  readonly homeDirectory: string;
+  readonly launchPlan: AgentLaunchPlan;
+  readonly setupResult?: SetupCommandResult;
+  readonly writeLine?: (message: string) => void;
+}
+
+const manualLoginMessage =
+  'Pi does not appear to be logged in yet. After Pi starts, run `/login` and choose a subscription such as Codex or provide an API key from another model provider.';
+
+const automaticLoginMessage =
+  'Pi does not appear to be logged in yet. ApplePi will open `/login` automatically after Pi starts.';
+
+const nonInteractivePiLaunchFlags = new Set(['--print', '-p', '--mode', '--export', '--list-models']);
+
+export const preparePiLoginLaunchPlan = (input: PiLoginLaunchPlanInput): AgentLaunchPlan => {
+  if (input.adapterId !== 'pi' || hasConfiguredPiLoginState(input.homeDirectory)) {
+    return input.launchPlan;
+  }
+
+  if (shouldAutoOpenPiLogin(input.setupResult, input.launchPlan.args)) {
+    writePiLoginMessage(input.writeLine, automaticLoginMessage);
+    return addPiLoginPrefillExtension(input.launchPlan);
+  }
+
+  writePiLoginMessage(input.writeLine, manualLoginMessage);
+  return input.launchPlan;
+};
+
+const addPiLoginPrefillExtension = (launchPlan: AgentLaunchPlan): AgentLaunchPlan => {
+  const extensionPath = join(launchPlan.env.PI_CODING_AGENT_DIR, 'applepi', 'prefill-login-extension.js');
+  mkdirSync(dirname(extensionPath), { recursive: true });
+  writeFileSync(extensionPath, piLoginPrefillExtensionContent);
+
+  return { ...launchPlan, args: ['--extension', extensionPath, ...launchPlan.args] };
+};
+
+const piLoginPrefillExtensionContent = `export default function applePiLoginPrefill(pi) {
+  pi.on("session_start", async (_event, ctx) => {
+    ctx.ui.setEditorText("/login");
+    ctx.ui.notify("ApplePi is opening /login so you can choose a provider.", "info");
+    await ctx.ui.custom((tui, _theme, _keybindings, done) => {
+      setTimeout(() => {
+        tui.focusedComponent?.handleInput?.("\\r");
+        done();
+      }, 25);
+
+      return {
+        render: () => [],
+        invalidate: () => undefined,
+      };
+    }, { overlay: true, overlayOptions: { nonCapturing: true, visible: () => false } });
+  });
+}
+`;
+
+const writePiLoginMessage = (writeLine: ((message: string) => void) | undefined, message: string): void => {
+  /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer for login messages. */
+  (writeLine ?? console.log)(message);
+};
+
+const shouldAutoOpenPiLogin = (setupResult: SetupCommandResult | undefined, args: readonly string[]): boolean =>
+  setupResult?.welcomeResult !== undefined && !isNonInteractivePiLaunch(args);
+
+const isNonInteractivePiLaunch = (args: readonly string[]): boolean =>
+  args.some((arg) => nonInteractivePiLaunchFlags.has(arg));
+
+const hasConfiguredPiLoginState = (homeDirectory: string): boolean =>
+  hasConfiguredPiStateFile(homeDirectory, 'auth.json') || hasConfiguredPiStateFile(homeDirectory, 'models.json');
+
+const hasConfiguredPiStateFile = (homeDirectory: string, fileName: string): boolean => {
+  const statePath = join(homeDirectory, '.pi', 'agent', fileName);
+
+  if (!existsSync(statePath)) {
+    return false;
+  }
+
+  try {
+    return hasConfiguredPiStateEntries(JSON.parse(readFileSync(statePath, 'utf8')));
+  } catch {
+    return false;
+  }
+};
+
+const hasConfiguredPiStateEntries = (value: unknown): boolean => {
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+
+  const record = value as Readonly<Record<string, unknown>>;
+  const containerKeys = ['models', 'providers', 'model_providers'];
+  const presentContainers = containerKeys.filter((key) => Object.hasOwn(record, key));
+
+  if (presentContainers.length > 0) {
+    return presentContainers.some((key) => hasConfiguredPiStateEntries(record[key]));
+  }
+
+  return Object.keys(record).length > 0;
+};

--- a/src/cli/commands/RunCommand.ts
+++ b/src/cli/commands/RunCommand.ts
@@ -40,8 +40,9 @@ import type {
 } from '../../compositeProfile/StatePersistence.js';
 import { watchCompositeProfileInputs } from '../../compositeProfile/CompositeProfileWatcher.js';
 import type { CommandObject } from './CommandObject.js';
+import { preparePiLoginLaunchPlan } from './PiLoginLaunch.js';
 import { executeSetupCommand } from './SetupCommand.js';
-import type { SetupCommandDependencies } from './SetupCommand.js';
+import type { SetupCommandDependencies, SetupCommandResult } from './SetupCommand.js';
 
 export interface RunCommandInput {
   readonly homeDirectory: string;
@@ -75,7 +76,7 @@ export const executeRunCommand = async (
   input: RunCommandInput,
   dependencies: RunCommandDependencies = {},
 ): Promise<RunCommandResult> => {
-  await runSetupIfNeeded(input, dependencies);
+  const setupResult = await runSetupIfNeeded(input, dependencies);
   const resolvedProfile = loadResolvedProfile(input);
   const adapter =
     dependencies.adapter ?? createAgentAdapter(selectRunAgentId(input.agentId, resolvedProfile.settings.defaultAgent));
@@ -89,17 +90,22 @@ export const executeRunCommand = async (
 
   failStrictOnWarnings(adapter.id, warnings, input.strict);
   emitWarnings(warnings, dependencies.writeError);
-
   writeCompositeProfile(compositeProfilePlan.compositeProfile);
   let stateBaseline = createCompositeProfileStateBaseline(
     compositeProfilePlan.compositeProfile.rootDirectory,
     compositeProfilePlan.compositeProfile.statePaths,
   );
-  const launchPlan = adapter.createLaunchPlan(
-    compositeProfilePlan.compositeProfile,
-    resolvedProfile.profile,
-    input.passThroughArgs ?? [],
-  );
+  const launchPlan = preparePiLoginLaunchPlan({
+    adapterId: adapter.id,
+    homeDirectory: input.homeDirectory,
+    launchPlan: adapter.createLaunchPlan(
+      compositeProfilePlan.compositeProfile,
+      resolvedProfile.profile,
+      input.passThroughArgs ?? [],
+    ),
+    setupResult,
+    writeLine: dependencies.writeLine,
+  });
   emitLaunchSummary(
     resolvedProfile,
     adapter.id,
@@ -341,16 +347,32 @@ const formatCompositeProfileStateWriteIssue = (adapterId: string, issue: Composi
   return `${adapterId} wrote '${issue.relativePath}' with state_persistence '${issue.strategy}' and it was not persisted.`;
 };
 
-const runSetupIfNeeded = async (input: RunCommandInput, dependencies: RunCommandDependencies): Promise<void> => {
+const runSetupIfNeeded = async (
+  input: RunCommandInput,
+  dependencies: RunCommandDependencies,
+): Promise<SetupCommandResult | undefined> => {
   const settingsPath = join(input.homeDirectory, '.applepi', 'settings.yml');
 
   if (existsSync(settingsPath)) {
-    return;
+    return undefined;
   }
 
   /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
   (dependencies.writeLine ?? console.log)('`applepi setup` has not been run yet - running now');
-  await executeSetupCommand(input, dependencies);
+  return executeSetupCommand(input, { ...dependencies, interactive: shouldRunFirstSetupInteractively(dependencies) });
+};
+
+const shouldRunFirstSetupInteractively = (dependencies: RunCommandDependencies): boolean => {
+  if (dependencies.interactive !== undefined) {
+    return dependencies.interactive;
+  }
+
+  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
+  const inputIsTty = (dependencies.input ?? process.stdin).isTTY === true;
+  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
+  const outputIsTty = (dependencies.output ?? process.stdout).isTTY === true;
+
+  return inputIsTty && outputIsTty;
 };
 
 const loadResolvedProfile = (input: RunCommandInput): ResolvedRunProfile => {

--- a/src/cli/commands/SetupCommand.ts
+++ b/src/cli/commands/SetupCommand.ts
@@ -23,8 +23,11 @@ import {
   loadSettingsWithCachedRemoteSettings,
 } from '../../settings/SettingsLoader.js';
 import type { CommandObject } from './CommandObject.js';
+import { persistFirstRunWelcomeProfile, type PersistedFirstRunWelcomeProfile } from './FirstRunWelcomeProfile.js';
 import type { SyncCommandDependencies, SyncCommandResult } from './SyncCommand.js';
 import { executeSyncCommand } from './SyncCommand.js';
+import { executeWelcomeCommand } from './WelcomeCommand.js';
+import type { WelcomeCommandDependencies, WelcomeCommandResult } from './WelcomeCommand.js';
 
 export interface SetupCommandInput {
   readonly homeDirectory: string;
@@ -39,6 +42,7 @@ export interface SetupCommandResult {
   readonly copiedStarterProfileFiles: number;
   readonly createdDefaultProfile: boolean;
   readonly syncResult: SyncCommandResult;
+  readonly welcomeResult?: WelcomeCommandResult;
   readonly messages: readonly string[];
 }
 
@@ -46,20 +50,28 @@ export interface SetupSourceSynchronizer {
   sync(uri: string, cachePath: string): void;
 }
 
-export type SetupCommandDependencies = SyncCommandDependencies & {
-  readonly setupSourceSynchronizer?: SetupSourceSynchronizer;
-  readonly input?: { readonly isTTY?: boolean } & NodeJS.ReadableStream;
-  readonly output?: { readonly isTTY?: boolean } & NodeJS.WritableStream;
-  readonly interactive?: boolean;
-  readonly selectDefaultProfile?: (profiles: readonly SetupProfileChoice[], currentDefault: string) => Promise<string>;
-};
+export type SetupCommandDependencies = SyncCommandDependencies &
+  WelcomeCommandDependencies & {
+    readonly setupSourceSynchronizer?: SetupSourceSynchronizer;
+    readonly selectDefaultProfile?: (
+      profiles: readonly SetupProfileChoice[],
+      currentDefault: string,
+    ) => Promise<string>;
+    readonly runWelcome?: (
+      input: SetupCommandInput,
+      dependencies: SetupCommandDependencies,
+    ) => Promise<WelcomeCommandResult | undefined>;
+  };
 
 export interface SetupProfileChoice {
   readonly id: string;
   readonly label?: string;
 }
 
-const defaultProfileSourceRepository = 'applepi-ai/default-profiles';
+const builtInSetupProfileChoices: readonly SetupProfileChoice[] = [
+  { id: 'engineer', label: 'Engineer' },
+  { id: 'data_analyst', label: 'Data Analyst' },
+];
 
 interface StarterLayout {
   readonly cachePath: string;
@@ -95,34 +107,52 @@ export const executeSetupCommand = async (
     join(input.homeDirectory, '.applepi', 'profiles'),
   );
   const syncResult = executeSyncCommand(input, dependencies);
-  const selectedDefaultProfileId = await selectDefaultProfileIfInteractive(
-    input,
-    settingsPath,
-    defaultProfileId,
-    dependencies,
-  );
-  const defaultProfilePath = join(input.homeDirectory, '.applepi', 'profiles', selectedDefaultProfileId, 'profile.yml');
-  const createdDefaultProfile = createDefaultProfileIfMissing(defaultProfilePath, selectedDefaultProfileId);
+  const selectedDefaultProfileId = shouldSkipInitialDefaultProfilePrompt(initialSettingsMissing, dependencies)
+    ? defaultProfileId
+    : await selectDefaultProfileIfInteractive(input, settingsPath, defaultProfileId, dependencies);
+  const welcomeResult = await runWelcomeAfterInteractiveSetup(input, dependencies);
+  const welcomeProfile = persistFirstRunWelcomeProfile(input.homeDirectory, settingsPath, welcomeResult);
+  const finalDefaultProfile = prepareFinalDefaultProfile(input.homeDirectory, selectedDefaultProfileId, welcomeProfile);
 
   return {
     settingsPath,
-    defaultProfilePath,
+    defaultProfilePath: finalDefaultProfile.path,
     createdSettings,
     copiedStarterProfileFiles,
-    createdDefaultProfile,
+    createdDefaultProfile: finalDefaultProfile.created,
     syncResult,
+    welcomeResult,
     messages: buildSetupMessages({
       input,
       starterLayout,
       settingsPath,
       createdSettings,
       copiedStarterProfileFiles,
-      defaultProfileId: selectedDefaultProfileId,
-      defaultProfilePath,
-      createdDefaultProfile,
+      defaultProfileId: finalDefaultProfile.id,
+      defaultProfilePath: finalDefaultProfile.path,
+      createdDefaultProfile: finalDefaultProfile.created,
       syncResult,
     }),
   };
+};
+
+interface FinalDefaultProfile {
+  readonly id: string;
+  readonly path: string;
+  readonly created: boolean;
+}
+
+const prepareFinalDefaultProfile = (
+  homeDirectory: string,
+  selectedDefaultProfileId: string,
+  welcomeProfile: PersistedFirstRunWelcomeProfile | undefined,
+): FinalDefaultProfile => {
+  const finalDefaultProfileId = welcomeProfile?.profileId ?? selectedDefaultProfileId;
+  const finalDefaultProfilePath = join(homeDirectory, '.applepi', 'profiles', finalDefaultProfileId, 'profile.yml');
+  const createdDefaultProfile =
+    welcomeProfile?.createdProfile ?? createDefaultProfileIfMissing(finalDefaultProfilePath, finalDefaultProfileId);
+
+  return { id: finalDefaultProfileId, path: finalDefaultProfilePath, created: createdDefaultProfile };
 };
 
 interface SetupMessageInput {
@@ -314,15 +344,7 @@ const assertValidDefaultProfileId = (profileId: string): void => {
 };
 
 const createDefaultSettingsContent = (): string =>
-  [
-    'default_profile: engineer',
-    'profile_sources:',
-    '  - path: ./profiles',
-    `  - github: ${defaultProfileSourceRepository}`,
-    '    ref: main',
-    '    path: profiles',
-    '',
-  ].join('\n');
+  ['default_profile: engineer', 'profile_sources:', '  - path: ./profiles', ''].join('\n');
 
 const createInitialSettingsIfMissing = (settingsPath: string, starterSettingsPath?: string): boolean => {
   if (existsSync(settingsPath)) {
@@ -394,6 +416,21 @@ const createDefaultProfileIfMissing = (profilePath: string, profileId: string): 
   return true;
 };
 
+const runWelcomeAfterInteractiveSetup = async (
+  input: SetupCommandInput,
+  dependencies: SetupCommandDependencies,
+): Promise<WelcomeCommandResult | undefined> => {
+  if (dependencies.interactive !== true) {
+    return undefined;
+  }
+
+  if (dependencies.runWelcome !== undefined) {
+    return dependencies.runWelcome(input, dependencies);
+  }
+
+  return executeWelcomeCommand(input, dependencies);
+};
+
 const requireInteractiveTerminalIfNeeded = (dependencies: SetupCommandDependencies): void => {
   if (dependencies.interactive !== true) {
     return;
@@ -409,6 +446,11 @@ const requireInteractiveTerminalIfNeeded = (dependencies: SetupCommandDependenci
   }
 };
 
+const shouldSkipInitialDefaultProfilePrompt = (
+  initialSettingsMissing: boolean,
+  dependencies: SetupCommandDependencies,
+): boolean => initialSettingsMissing && dependencies.interactive === true;
+
 const selectDefaultProfileIfInteractive = async (
   input: SetupCommandInput,
   settingsPath: string,
@@ -419,7 +461,11 @@ const selectDefaultProfileIfInteractive = async (
     return currentDefault;
   }
 
-  const profiles = discoverSetupProfileChoices(input);
+  const discoveredProfiles = discoverSetupProfileChoices(input);
+  const profiles =
+    discoveredProfiles.length > 0 || builtInSetupProfileChoices.every((profile) => profile.id !== currentDefault)
+      ? discoveredProfiles
+      : builtInSetupProfileChoices;
   const writer = dependencies.writeLine ?? console.log;
   writer('Welcome to ApplePi. ApplePi is the easiest way to run Pi.');
   writer('ApplePi manages full pi configurations for you, so you can use different profiles in different situations.');

--- a/src/cli/commands/WelcomeCommand.ts
+++ b/src/cli/commands/WelcomeCommand.ts
@@ -1,0 +1,354 @@
+// Provides the command object for first-run ApplePi welcome onboarding.
+import { createInterface } from 'node:readline/promises';
+import { homedir } from 'node:os';
+
+import type { Command } from 'commander';
+
+import type { CommandObject } from './CommandObject.js';
+
+export type WelcomeDefaultProfileRoleId = 'engineer' | 'data_analyst';
+export type WelcomeLoadoutItemKind = 'extension' | 'package';
+
+export interface WelcomeCommandInput {
+  readonly homeDirectory: string;
+  readonly projectDirectory: string;
+}
+
+export interface WelcomeRoleChoice {
+  readonly id: WelcomeDefaultProfileRoleId;
+  readonly label: string;
+}
+
+export interface WelcomeLoadoutItem {
+  readonly id: string;
+  readonly label: string;
+  readonly kind: WelcomeLoadoutItemKind;
+  readonly source: string;
+}
+
+export interface WelcomeLoadout {
+  readonly id: string;
+  readonly label: string;
+  readonly items: readonly WelcomeLoadoutItem[];
+}
+
+export interface WelcomeLoadoutSelection {
+  readonly id: string;
+  readonly label: string;
+  readonly selectedItems: readonly WelcomeLoadoutItem[];
+}
+
+export interface WelcomePlan {
+  readonly answerQuestions: boolean;
+  readonly selectedRoleId?: string;
+  readonly loadoutItemIds?: readonly string[];
+}
+
+export interface WelcomeCommandResult {
+  readonly answered: boolean;
+  readonly selectedRole?: WelcomeRoleChoice;
+  readonly selectedLoadout?: WelcomeLoadoutSelection;
+  readonly warnings: readonly string[];
+  readonly messages: readonly string[];
+}
+
+export interface WelcomeCommandDependencies {
+  readonly homeDirectory?: string;
+  readonly projectDirectory?: string;
+  readonly input?: { readonly isTTY?: boolean } & NodeJS.ReadableStream;
+  readonly output?: { readonly isTTY?: boolean } & NodeJS.WritableStream;
+  readonly interactive?: boolean;
+  readonly writeLine?: (message: string) => void;
+  readonly selectWelcomePlan?: (input: WelcomeCommandInput) => Promise<WelcomePlan>;
+}
+
+const welcomeIntroLines = [
+  String.raw`    _                _        ____  _`,
+  String.raw`   / \   _ __  _ __ | | ___  |  _ \(_)`,
+  String.raw`  / _ \ | '_ \| '_ \| |/ _ \ | |_) | |`,
+  String.raw` / ___ \| |_) | |_) | |  __/ |  __/| |`,
+  String.raw`/_/   \_\ .__/| .__/|_|\___| |_|   |_|`,
+  String.raw`        |_|   |_|`,
+  '',
+  'Welcome to ApplePi.',
+  'Pi is a heavily customizable coding harness. The next few questions will configure ApplePi to best suit your workflow.',
+] as const;
+
+const defaultProfileRoleChoices: readonly WelcomeRoleChoice[] = [
+  { id: 'engineer', label: 'Engineer' },
+  { id: 'data_analyst', label: 'Data Analyst' },
+];
+
+const fallbackRoleId: WelcomeDefaultProfileRoleId = 'engineer';
+
+const recommendedPiLoadout: WelcomeLoadout = {
+  id: 'recommended-pi',
+  label: 'Recommended Pi productivity loadout',
+  items: [
+    {
+      id: 'ulta-tasklist',
+      label: 'Ulta Tasklist',
+      kind: 'extension',
+      source: 'git:github.com/applepi-ai/ulta-tasklist',
+    },
+    {
+      id: 'deepwork',
+      label: 'DeepWork',
+      kind: 'extension',
+      source: 'git:github.com/applepi-ai/deepwork',
+    },
+    {
+      id: 'pi-subagents',
+      label: 'Pi Subagents',
+      kind: 'package',
+      source: 'npm:pi-subagents',
+    },
+    {
+      id: 'pi-mcp-adapter',
+      label: 'Pi MCP Adapter',
+      kind: 'package',
+      source: 'npm:pi-mcp-adapter',
+    },
+  ],
+};
+
+export const executeWelcomeCommand = async (
+  input: WelcomeCommandInput,
+  dependencies: WelcomeCommandDependencies = {},
+): Promise<WelcomeCommandResult> => {
+  requireInteractiveTerminalIfNeeded(dependencies);
+  const plan = await selectWelcomePlan(input, dependencies);
+
+  if (!plan.answerQuestions) {
+    return {
+      answered: false,
+      warnings: [],
+      messages: ['Skipped ApplePi welcome questions. Run `applepi welcome` any time to revisit them.'],
+    };
+  }
+
+  const roleResolution = resolveSelectedRole(plan.selectedRoleId);
+  const loadoutResolution = resolveSelectedLoadout(plan.loadoutItemIds);
+  const warnings = [...roleResolution.warnings, ...loadoutResolution.warnings];
+
+  return {
+    answered: true,
+    selectedRole: roleResolution.role,
+    selectedLoadout: loadoutResolution.loadout,
+    warnings,
+    messages: buildWelcomeMessages(roleResolution.role, loadoutResolution.loadout, warnings),
+  };
+};
+
+export const createWelcomeCommand = (dependencies: WelcomeCommandDependencies = {}): CommandObject => {
+  const command: CommandObject = {
+    name: 'welcome',
+    description: 'Run ApplePi welcome onboarding prompts.',
+    register(program: Command): void {
+      program
+        .command(command.name)
+        .description(command.description)
+        .action(async () => {
+          const result = await executeWelcomeCommand(
+            {
+              /* v8 ignore next -- default process home is exercised by the direct CLI entrypoint, not unit tests. */
+              homeDirectory: dependencies.homeDirectory ?? homedir(),
+              /* v8 ignore next -- default process cwd is exercised by the direct CLI entrypoint, not unit tests. */
+              projectDirectory: dependencies.projectDirectory ?? process.cwd(),
+            },
+            { ...dependencies, interactive: true },
+          );
+
+          for (const message of result.messages) {
+            /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
+            (dependencies.writeLine ?? console.log)(message);
+          }
+        });
+    },
+  };
+
+  return command;
+};
+
+const selectWelcomePlan = async (
+  input: WelcomeCommandInput,
+  dependencies: WelcomeCommandDependencies,
+): Promise<WelcomePlan> => {
+  if (dependencies.selectWelcomePlan !== undefined) {
+    return dependencies.selectWelcomePlan(input);
+  }
+
+  return promptForWelcomePlan(dependencies);
+};
+
+const promptForWelcomePlan = async (dependencies: WelcomeCommandDependencies): Promise<WelcomePlan> => {
+  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
+  const output = dependencies.output ?? process.stdout;
+  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
+  const readline = createInterface({ input: dependencies.input ?? process.stdin, output });
+
+  try {
+    output.write(`\n${welcomeIntroLines.join('\n')}\n`);
+    const answerQuestions = await promptForYesNo(
+      readline,
+      'Choose a role and recommended Pi loadout now? [Y/n]: ',
+      true,
+    );
+
+    if (!answerQuestions) {
+      return { answerQuestions: false };
+    }
+
+    const selectedRoleId = await promptForRole(readline, output);
+    const loadoutItemIds = await promptForLoadout(readline, output);
+
+    return { answerQuestions: true, selectedRoleId, loadoutItemIds };
+  } finally {
+    readline.close();
+  }
+};
+
+const promptForYesNo = async (
+  readline: { question(query: string): Promise<string> },
+  query: string,
+  defaultValue: boolean,
+): Promise<boolean> => {
+  const answer = (await readline.question(query)).trim().toLowerCase();
+
+  if (answer === '') {
+    return defaultValue;
+  }
+
+  return ['y', 'yes'].includes(answer);
+};
+
+const promptForRole = async (
+  readline: { question(query: string): Promise<string> },
+  output: NodeJS.WritableStream,
+): Promise<string> => {
+  output.write('\nChoose your initial ApplePi role/profile:\n');
+  defaultProfileRoleChoices.forEach((role, index) => output.write(`${index + 1}. ${role.id} - ${role.label}\n`));
+
+  return defaultProfileRoleChoices[await promptForSelectionIndex(readline, 'Role [1]: ', 0)]?.id ?? fallbackRoleId;
+};
+
+const promptForLoadout = async (
+  readline: { question(query: string): Promise<string> },
+  output: NodeJS.WritableStream,
+): Promise<readonly string[]> => {
+  output.write(`\n${recommendedPiLoadout.label}:\n`);
+  recommendedPiLoadout.items.forEach((item, index) => {
+    output.write(`${index + 1}. ${item.label} (${item.kind}) - ${item.source}\n`);
+  });
+
+  const mode = (await readline.question('Install recommended loadout? [Y=all/c=choose/n=skip]: ')).trim().toLowerCase();
+
+  if (['n', 'no', 'skip'].includes(mode)) {
+    return [];
+  }
+
+  if (!['c', 'choose', 'custom', 's', 'select'].includes(mode)) {
+    return recommendedPiLoadout.items.map((item) => item.id);
+  }
+
+  const answer = (await readline.question('Loadout items [1,2,3,4 or blank for all]: ')).trim();
+
+  if (answer === '') {
+    return recommendedPiLoadout.items.map((item) => item.id);
+  }
+
+  return answer
+    .split(',')
+    .map((part) => Number.parseInt(part.trim(), 10) - 1)
+    .filter((index) => index >= 0 && index < recommendedPiLoadout.items.length)
+    .map((index) => recommendedPiLoadout.items[index].id);
+};
+
+const promptForSelectionIndex = async (
+  readline: { question(query: string): Promise<string> },
+  query: string,
+  defaultIndex: number,
+): Promise<number> => {
+  const answer = (await readline.question(query)).trim();
+
+  if (answer === '') {
+    return defaultIndex;
+  }
+
+  return Math.max(Number.parseInt(answer, 10) - 1, 0);
+};
+
+const resolveSelectedRole = (
+  selectedRoleId: string | undefined,
+): { readonly role: WelcomeRoleChoice; readonly warnings: readonly string[] } => {
+  const roleId = selectedRoleId ?? fallbackRoleId;
+  const selectedRole = defaultProfileRoleChoices.find((role) => role.id === roleId);
+
+  if (selectedRole !== undefined) {
+    return { role: selectedRole, warnings: [] };
+  }
+
+  return {
+    role: defaultProfileRoleChoices.find((role) => role.id === fallbackRoleId)!,
+    warnings: [`Welcome role '${roleId}' is not available; using fallback role '${fallbackRoleId}'.`],
+  };
+};
+
+const resolveSelectedLoadout = (
+  loadoutItemIds: readonly string[] | undefined,
+): { readonly loadout: WelcomeLoadoutSelection; readonly warnings: readonly string[] } => {
+  const selectedItemIds = loadoutItemIds ?? recommendedPiLoadout.items.map((item) => item.id);
+  const availableItems = new Map(recommendedPiLoadout.items.map((item) => [item.id, item]));
+  const selectedItems: WelcomeLoadoutItem[] = [];
+  const warnings: string[] = [];
+
+  for (const itemId of selectedItemIds) {
+    const item = availableItems.get(itemId);
+
+    if (item === undefined) {
+      warnings.push(`Loadout item '${itemId}' is not available for ${recommendedPiLoadout.id}; skipping it.`);
+      continue;
+    }
+
+    if (selectedItems.every((selectedItem) => selectedItem.id !== item.id)) {
+      selectedItems.push(item);
+    }
+  }
+
+  return {
+    loadout: { id: recommendedPiLoadout.id, label: recommendedPiLoadout.label, selectedItems },
+    warnings,
+  };
+};
+
+const buildWelcomeMessages = (
+  selectedRole: WelcomeRoleChoice,
+  selectedLoadout: WelcomeLoadoutSelection,
+  warnings: readonly string[],
+): readonly string[] => {
+  const loadoutMessage =
+    selectedLoadout.selectedItems.length === 0
+      ? `Skipped ${selectedLoadout.label}.`
+      : `Selected ${selectedLoadout.label}: ${selectedLoadout.selectedItems.map((item) => item.source).join(', ')}.`;
+
+  return [
+    `Selected ApplePi role: ${selectedRole.id} (${selectedRole.label}).`,
+    loadoutMessage,
+    ...warnings.map((warning) => `Warning: ${warning}`),
+  ];
+};
+
+const requireInteractiveTerminalIfNeeded = (dependencies: WelcomeCommandDependencies): void => {
+  if (dependencies.interactive !== true) {
+    return;
+  }
+
+  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
+  const inputIsTty = (dependencies.input ?? process.stdin).isTTY === true;
+  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
+  const outputIsTty = (dependencies.output ?? process.stdout).isTTY === true;
+
+  if (!inputIsTty || !outputIsTty) {
+    throw new Error('`applepi welcome` requires an interactive TTY on both stdin and stdout.');
+  }
+};

--- a/src/compositeProfile/StatePersistence.ts
+++ b/src/compositeProfile/StatePersistence.ts
@@ -127,11 +127,13 @@ export const ensureStateSourcePath = (sourcePath: string, directory: boolean): s
       mkdirSync(sourcePath, { recursive: true });
     } else {
       mkdirSync(dirname(sourcePath), { recursive: true });
-      writeFileSync(sourcePath, '');
+      writeFileSync(sourcePath, createInitialStateSourceFileContent(sourcePath));
     }
 
     return sourcePath;
   }
+
+  initializeEmptyJsonStateSourceFile(sourcePath, directory, sourceType);
 
   if (directory && sourceType !== 'directory') {
     throw new Error(`State source path '${sourcePath}' must be a directory.`);
@@ -143,6 +145,37 @@ export const ensureStateSourcePath = (sourcePath: string, directory: boolean): s
 
   return sourcePath;
 };
+
+const initializeEmptyJsonStateSourceFile = (
+  sourcePath: string,
+  directory: boolean,
+  sourceType: 'file' | 'directory',
+): void => {
+  const defaultFileContent = getJsonStateFileDefault(sourcePath);
+
+  if (!directory && sourceType === 'file' && defaultFileContent !== undefined && isEmptyTextFile(sourcePath)) {
+    writeFileSync(sourcePath, defaultFileContent);
+  }
+};
+
+const createInitialStateSourceFileContent = (sourcePath: string): string => getJsonStateFileDefault(sourcePath) ?? '';
+
+const isEmptyTextFile = (sourcePath: string): boolean => readFileSync(sourcePath, 'utf8').trim() === '';
+
+const getJsonStateFileDefault = (sourcePath: string): string | undefined => {
+  if (isStateSourceFileName(sourcePath, 'mcp.json')) {
+    return '{}\n';
+  }
+
+  if (isStateSourceFileName(sourcePath, 'models.json')) {
+    return '{"providers":{}}\n';
+  }
+
+  return undefined;
+};
+
+const isStateSourceFileName = (sourcePath: string, fileName: string): boolean =>
+  sourcePath.endsWith(`${sep}${fileName}`) || sourcePath === fileName;
 
 const getExistingSourceType = (sourcePath: string): 'file' | 'directory' | undefined => {
   try {

--- a/tests/unit/first-run-welcome-profile.test.ts
+++ b/tests/unit/first-run-welcome-profile.test.ts
@@ -1,0 +1,273 @@
+// Tests first-run welcome choices affecting the launched profile.
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { persistFirstRunWelcomeProfile } from '../../src/cli/commands/FirstRunWelcomeProfile.js';
+import { executeRunCommand } from '../../src/cli/commands/RunCommand.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'applepi-first-run-welcome-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('first-run welcome profile', () => {
+  it('leaves first-run welcome opt-out on the generated role profile before launching pi', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const launches: unknown[] = [];
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        interactive: true,
+        input: { isTTY: true } as NodeJS.ReadableStream & { isTTY: true },
+        output: { isTTY: true } as NodeJS.WritableStream & { isTTY: true },
+        writeLine: () => undefined,
+        selectDefaultProfile() {
+          throw new Error('first-run setup should let welcome choose the profile');
+        },
+        selectWelcomePlan() {
+          return Promise.resolve({ answerQuestions: false });
+        },
+        launcher: {
+          launch(plan) {
+            launches.push(plan);
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(result.profileId).toBe('engineer');
+    expect(launches).toHaveLength(1);
+    expect(readFileSync(join(homeDirectory, '.applepi', 'settings.yml'), 'utf8')).toContain(
+      'default_profile: engineer',
+    );
+    expect(readFileSync(join(homeDirectory, '.applepi', 'profiles', 'engineer', 'profile.yml'), 'utf8')).toBe(
+      'id: engineer\nlabel: Default\ncontrols: {}\n',
+    );
+  });
+
+  it('persists first-run welcome role selection with no loadout items before launching pi', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        interactive: true,
+        input: { isTTY: true } as NodeJS.ReadableStream & { isTTY: true },
+        output: { isTTY: true } as NodeJS.WritableStream & { isTTY: true },
+        writeLine: () => undefined,
+        selectDefaultProfile() {
+          return Promise.resolve('engineer');
+        },
+        selectWelcomePlan() {
+          return Promise.resolve({ answerQuestions: true, selectedRoleId: 'engineer', loadoutItemIds: [] });
+        },
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(result.profileId).toBe('engineer');
+    expect(result.launchPlan.args).toContain('--append-system-prompt');
+    expect(readFileSync(join(homeDirectory, '.applepi', 'profiles', 'engineer', 'profile.yml'), 'utf8')).not.toContain(
+      'extensions:',
+    );
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-010.4).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('opens pi login automatically on the first launch after welcome when pi is not logged in', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const messages: string[] = [];
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        interactive: true,
+        input: { isTTY: true } as NodeJS.ReadableStream & { isTTY: true },
+        output: { isTTY: true } as NodeJS.WritableStream & { isTTY: true },
+        writeLine: (message) => messages.push(message),
+        selectDefaultProfile() {
+          return Promise.resolve('engineer');
+        },
+        selectWelcomePlan() {
+          return Promise.resolve({ answerQuestions: false });
+        },
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(result.launchPlan.args[0]).toBe('--extension');
+    const loginExtensionContent = readFileSync(result.launchPlan.args[1] ?? '', 'utf8');
+    expect(loginExtensionContent).toContain('setEditorText("/login")');
+    expect(loginExtensionContent).toContain('handleInput?.("\\r")');
+    expect(messages).toContain(
+      'Pi does not appear to be logged in yet. ApplePi will open `/login` automatically after Pi starts.',
+    );
+    expect(messages.join('\n')).not.toContain('sk-');
+  });
+
+  it('leaves non-interactive pi launches on a manual login notice after welcome', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const messages: string[] = [];
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory, passThroughArgs: ['--print', 'hello'] },
+      {
+        interactive: true,
+        input: { isTTY: true } as NodeJS.ReadableStream & { isTTY: true },
+        output: { isTTY: true } as NodeJS.WritableStream & { isTTY: true },
+        writeLine: (message) => messages.push(message),
+        selectDefaultProfile() {
+          return Promise.resolve('engineer');
+        },
+        selectWelcomePlan() {
+          return Promise.resolve({ answerQuestions: false });
+        },
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(result.launchPlan.args).toEqual(['--print', 'hello']);
+    expect(messages).toContain(
+      'Pi does not appear to be logged in yet. After Pi starts, run `/login` and choose a subscription such as Codex or provide an API key from another model provider.',
+    );
+  });
+
+  it('persists a role-only welcome result without loadout data', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const settingsPath = join(homeDirectory, '.applepi', 'settings.yml');
+    mkdirSync(join(homeDirectory, '.applepi'), { recursive: true });
+    writeFileSync(settingsPath, 'default_profile: engineer\nprofile_sources:\n  - path: ./profiles\n');
+
+    const persisted = persistFirstRunWelcomeProfile(homeDirectory, settingsPath, {
+      answered: true,
+      selectedRole: { id: 'engineer', label: 'Engineer' },
+      warnings: [],
+      messages: [],
+    });
+
+    const profile = readFileSync(join(homeDirectory, '.applepi', 'profiles', 'engineer', 'profile.yml'), 'utf8');
+    expect(persisted).toEqual({ profileId: 'engineer', createdProfile: true });
+    expect(profile).toContain('append_system_prompt: |');
+    expect(profile).not.toContain('extensions:');
+    expect(readFileSync(settingsPath, 'utf8')).toContain('default_profile: engineer');
+  });
+
+  it('does not overwrite an existing role profile when persisting welcome', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const settingsPath = join(homeDirectory, '.applepi', 'settings.yml');
+    const profilePath = join(homeDirectory, '.applepi', 'profiles', 'engineer', 'profile.yml');
+    mkdirSync(join(homeDirectory, '.applepi', 'profiles', 'engineer'), { recursive: true });
+    writeFileSync(settingsPath, 'default_profile: data_analyst\nprofile_sources:\n  - path: ./profiles\n');
+    writeFileSync(profilePath, 'id: engineer\nlabel: Custom Engineer\ncontrols: {}\n');
+
+    const persisted = persistFirstRunWelcomeProfile(homeDirectory, settingsPath, {
+      answered: true,
+      selectedRole: { id: 'engineer', label: 'Engineer' },
+      selectedLoadout: {
+        id: 'recommended',
+        label: 'Recommended',
+        selectedItems: [{ id: 'deepwork', label: 'DeepWork', kind: 'extension', source: 'git:x' }],
+      },
+      warnings: [],
+      messages: [],
+    });
+
+    expect(persisted).toEqual({ profileId: 'engineer', createdProfile: false });
+    expect(readFileSync(profilePath, 'utf8')).toBe('id: engineer\nlabel: Custom Engineer\ncontrols: {}\n');
+    expect(readFileSync(settingsPath, 'utf8')).toContain('default_profile: engineer');
+  });
+
+  it('adds a default profile setting when persisting welcome into sparse settings', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const settingsPath = join(homeDirectory, '.applepi', 'settings.yml');
+    mkdirSync(join(homeDirectory, '.applepi'), { recursive: true });
+    writeFileSync(settingsPath, 'profile_sources:\n  - path: ./profiles\n');
+
+    persistFirstRunWelcomeProfile(homeDirectory, settingsPath, {
+      answered: true,
+      selectedRole: { id: 'data_analyst', label: 'Data Analyst' },
+      warnings: [],
+      messages: [],
+    });
+
+    expect(readFileSync(settingsPath, 'utf8')).toContain('default_profile: data_analyst');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-010.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('persists first-run welcome loadout selection before launching pi', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        interactive: true,
+        input: { isTTY: true } as NodeJS.ReadableStream & { isTTY: true },
+        output: { isTTY: true } as NodeJS.WritableStream & { isTTY: true },
+        writeLine: () => undefined,
+        selectDefaultProfile() {
+          return Promise.resolve('data_analyst');
+        },
+        selectWelcomePlan() {
+          return Promise.resolve({
+            answerQuestions: true,
+            selectedRoleId: 'data_analyst',
+            loadoutItemIds: ['deepwork', 'pi-mcp-adapter'],
+          });
+        },
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(result.profileId).toBe('data_analyst');
+    expect(result.launchPlan.args).toContain('git:github.com/applepi-ai/deepwork');
+    expect(result.launchPlan.args).toContain('npm:pi-mcp-adapter');
+    expect(result.launchPlan.args).not.toContain('git:github.com/nhorton/pi-pr-alerts');
+    expect(readFileSync(join(homeDirectory, '.applepi', 'settings.yml'), 'utf8')).toContain(
+      'default_profile: data_analyst',
+    );
+  });
+});

--- a/tests/unit/pi-adapter.test.ts
+++ b/tests/unit/pi-adapter.test.ts
@@ -1,11 +1,12 @@
 // Tests pi adapter launch translation and composite file behavior.
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { createPiAdapter } from '../../src/agents/pi/PiAdapter.js';
+import { writeCompositeProfile } from '../../src/compositeProfile/CompositeProfileAssembler.js';
 import { parseProfileYaml } from '../../src/profiles/ProfileLoader.js';
 
 const temporaryPiAdapterTestRoots: string[] = [];
@@ -156,6 +157,35 @@ describe('pi adapter', () => {
       directory: false,
       sourcePath: join(homeDirectory, '.pi', 'agent', 'models.json'),
     });
+  });
+
+  it('initializes missing native mcp and models configs as valid empty JSON documents', () => {
+    const { homeDirectory } = createPiSettingsTestHome();
+    const adapter = createPiAdapter();
+
+    const compositeProfilePlan = adapter.createCompositeProfile(
+      { id: 'engineering', inherits: [], controls: {} },
+      {
+        rootDirectory: '/tmp/applepi-engineering-pi-mcp',
+        profilePaths: ['/profiles/engineering/profile.yml'],
+        homeDirectory,
+      },
+    );
+
+    expect(
+      compositeProfilePlan.compositeProfile.statePaths.find((statePath) => statePath.relativePath === 'mcp.json'),
+    ).toMatchObject({ sourcePath: join(homeDirectory, '.pi', 'agent', 'mcp.json') });
+
+    writeCompositeProfile(compositeProfilePlan.compositeProfile);
+
+    expect(readFileSync(join(homeDirectory, '.pi', 'agent', 'mcp.json'), 'utf8')).toBe('{}\n');
+    expect(readFileSync(join(homeDirectory, '.pi', 'agent', 'models.json'), 'utf8')).toBe('{"providers":{}}\n');
+
+    writeFileSync(join(homeDirectory, '.pi', 'agent', 'mcp.json'), '');
+    writeFileSync(join(homeDirectory, '.pi', 'agent', 'models.json'), '');
+    writeCompositeProfile(compositeProfilePlan.compositeProfile);
+    expect(readFileSync(join(homeDirectory, '.pi', 'agent', 'mcp.json'), 'utf8')).toBe('{}\n');
+    expect(readFileSync(join(homeDirectory, '.pi', 'agent', 'models.json'), 'utf8')).toBe('{"providers":{}}\n');
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-006.6).

--- a/tests/unit/profile-command.test.ts
+++ b/tests/unit/profile-command.test.ts
@@ -178,9 +178,12 @@ describe('profile command', () => {
       selectDefaultProfile() {
         return Promise.resolve('engineer');
       },
+      selectWelcomePlan() {
+        return Promise.resolve({ answerQuestions: false });
+      },
     }).register(setupProgram);
     await setupProgram.parseAsync(['node', 'applepi', 'setup']);
-    expect(setupMessages).toContain('Welcome to ApplePi. ApplePi is the easiest way to run Pi.');
+    expect(setupMessages).not.toContain('Welcome to ApplePi. ApplePi is the easiest way to run Pi.');
     expect(setupMessages).toContainEqual(expect.stringContaining('Created user settings'));
   });
 

--- a/tests/unit/run-command.test.ts
+++ b/tests/unit/run-command.test.ts
@@ -204,9 +204,9 @@ describe('run command', () => {
 
     expect(messages).toEqual([
       '`applepi setup` has not been run yet - running now',
+      'Pi does not appear to be logged in yet. After Pi starts, run `/login` and choose a subscription such as Codex or provide an API key from another model provider.',
       '→ resolving profile engineer',
       `✓ profile layer engineer  ${join(homeDirectory, '.applepi', 'profiles', 'engineer')}`,
-      '✓ profile layer engineer  github:applepi-ai/default-profiles@main/profiles',
       '✓ merged controls',
       `✓ prepared composite profile  ${result.compositeProfileDirectory}`,
       '↳ launching pi …',
@@ -214,6 +214,197 @@ describe('run command', () => {
     expect(result.profileId).toBe('engineer');
     expect(existsSync(join(homeDirectory, '.applepi', 'settings.yml'))).toBe(true);
     expect(existsSync(join(homeDirectory, '.applepi', 'profiles', 'engineer', 'profile.yml'))).toBe(true);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-010.4).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('notifies pi users to run login when no native login state is configured', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const messages: string[] = [];
+    writeSettings(homeDirectory, 'default_profile: engineer\nprofile_sources:\n  - path: ./profiles\n');
+    writeProfile(join(homeDirectory, '.applepi', 'profiles'), 'engineer', 'id: engineer\ncontrols: {}\n');
+
+    await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        writeLine: (message) => messages.push(message),
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(messages).toContain(
+      'Pi does not appear to be logged in yet. After Pi starts, run `/login` and choose a subscription such as Codex or provide an API key from another model provider.',
+    );
+    expect(messages.join('\n')).not.toContain('sk-');
+
+    messages.length = 0;
+    mkdirSync(join(homeDirectory, '.pi', 'agent'), { recursive: true });
+    writeFileSync(join(homeDirectory, '.pi', 'agent', 'models.json'), 'not-json\n');
+    await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        writeLine: (message) => messages.push(message),
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+    expect(messages).toContain(
+      'Pi does not appear to be logged in yet. After Pi starts, run `/login` and choose a subscription such as Codex or provide an API key from another model provider.',
+    );
+
+    messages.length = 0;
+    writeFileSync(join(homeDirectory, '.pi', 'agent', 'models.json'), 'null\n');
+    await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        writeLine: (message) => messages.push(message),
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+    expect(messages).toContain(
+      'Pi does not appear to be logged in yet. After Pi starts, run `/login` and choose a subscription such as Codex or provide an API key from another model provider.',
+    );
+
+    messages.length = 0;
+    writeFileSync(join(homeDirectory, '.pi', 'agent', 'auth.json'), 'not-json\n');
+    await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        writeLine: (message) => messages.push(message),
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+    expect(messages).toContain(
+      'Pi does not appear to be logged in yet. After Pi starts, run `/login` and choose a subscription such as Codex or provide an API key from another model provider.',
+    );
+
+    messages.length = 0;
+    writeFileSync(join(homeDirectory, '.pi', 'agent', 'auth.json'), '{"openai":{"type":"oauth"}}\n');
+    await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        writeLine: (message) => messages.push(message),
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+    expect(messages).not.toContain(
+      'Pi does not appear to be logged in yet. After Pi starts, run `/login` and choose a subscription such as Codex or provide an API key from another model provider.',
+    );
+
+    rmSync(join(homeDirectory, '.pi', 'agent', 'auth.json'), { force: true });
+    messages.length = 0;
+    writeFileSync(join(homeDirectory, '.pi', 'agent', 'models.json'), '{"models":["codex"]}\n');
+    await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        writeLine: (message) => messages.push(message),
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(messages).not.toContain(
+      'Pi does not appear to be logged in yet. After Pi starts, run `/login` and choose a subscription such as Codex or provide an API key from another model provider.',
+    );
+
+    messages.length = 0;
+    writeFileSync(join(homeDirectory, '.pi', 'agent', 'models.json'), '{"codex":{}}\n');
+    await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        writeLine: (message) => messages.push(message),
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(messages).not.toContain(
+      'Pi does not appear to be logged in yet. After Pi starts, run `/login` and choose a subscription such as Codex or provide an API key from another model provider.',
+    );
+  });
+
+  it('honors explicit non-interactive first-run setup selection', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        interactive: false,
+        writeLine: () => undefined,
+        synchronizer: {
+          sync(_source, cachePath) {
+            mkdirSync(join(cachePath, 'profiles', 'engineer'), { recursive: true });
+            writeFileSync(join(cachePath, 'profiles', 'engineer', 'profile.yml'), 'id: engineer\ncontrols: {}\n');
+            return 'updated';
+          },
+        },
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(result.profileId).toBe('engineer');
+  });
+
+  it('falls back to non-interactive first-run setup when stdout is not a TTY', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        input: { isTTY: true } as NodeJS.ReadableStream & { isTTY: true },
+        output: { isTTY: false } as NodeJS.WritableStream & { isTTY: false },
+        writeLine: () => undefined,
+        synchronizer: {
+          sync(_source, cachePath) {
+            mkdirSync(join(cachePath, 'profiles', 'engineer'), { recursive: true });
+            writeFileSync(join(cachePath, 'profiles', 'engineer', 'profile.yml'), 'id: engineer\ncontrols: {}\n');
+            return 'updated';
+          },
+        },
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(result.profileId).toBe('engineer');
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-002.3, APPLEPI-REQ-002.4, APPLEPI-REQ-003.1, APPLEPI-REQ-006.1).
@@ -253,7 +444,11 @@ describe('run command', () => {
       'cached',
       'id: cached\ncontrols: {}\n',
     );
-    allowTestConsoleOutput(({ method, text }) => method === 'log' && isRunCommandSummaryMessage(text));
+    allowTestConsoleOutput(
+      ({ method, text }) =>
+        method === 'log' &&
+        (isRunCommandSummaryMessage(text) || text.startsWith('Pi does not appear to be logged in yet.')),
+    );
     const result = await executeRunCommand(
       { homeDirectory: uriHome, projectDirectory, profileId: 'cached' },
       {

--- a/tests/unit/setup-command.test.ts
+++ b/tests/unit/setup-command.test.ts
@@ -62,19 +62,11 @@ describe('setup command', () => {
     expect(firstResult.createdSettings).toBe(true);
     expect(firstResult.createdDefaultProfile).toBe(true);
     expect(readFileSync(settingsPath, 'utf8')).toBe(
-      [
-        'default_profile: engineer',
-        'profile_sources:',
-        '  - path: ./profiles',
-        '  - github: applepi-ai/default-profiles',
-        '    ref: main',
-        '    path: profiles',
-        '',
-      ].join('\n'),
+      ['default_profile: engineer', 'profile_sources:', '  - path: ./profiles', ''].join('\n'),
     );
     expect(readFileSync(defaultProfilePath, 'utf8')).toBe('id: engineer\nlabel: Default\ncontrols: {}\n');
     expect(firstResult.messages).toContain("Selected default profile 'engineer'.");
-    expect(firstResult.syncResult.sources[0]?.message).toBe('2 profiles validated.');
+    expect(firstResult.syncResult.sources).toEqual([]);
 
     writeFileSync(defaultProfilePath, 'id: default\nlabel: Custom\n');
     const secondResult = await executeSetupCommand(
@@ -265,9 +257,11 @@ describe('setup command', () => {
       ),
     ).rejects.toThrow('requires an interactive TTY');
 
+    const unsafeHomeDirectory = join(root, 'unsafe-home');
+    writeSettings(unsafeHomeDirectory, 'default_profile: engineer\nprofile_sources:\n  - path: ./profiles\n');
     await expect(
       executeSetupCommand(
-        { homeDirectory: join(root, 'unsafe-home'), projectDirectory },
+        { homeDirectory: unsafeHomeDirectory, projectDirectory },
         {
           interactive: true,
           input: { isTTY: true } as NodeJS.ReadableStream & { isTTY: true },
@@ -280,9 +274,11 @@ describe('setup command', () => {
         },
       ),
     ).rejects.toThrow('filesystem-safe');
+    const unlistedHomeDirectory = join(root, 'unlisted-home');
+    writeSettings(unlistedHomeDirectory, 'default_profile: engineer\nprofile_sources:\n  - path: ./profiles\n');
     await expect(
       executeSetupCommand(
-        { homeDirectory: join(root, 'unlisted-home'), projectDirectory },
+        { homeDirectory: unlistedHomeDirectory, projectDirectory },
         {
           interactive: true,
           input: { isTTY: true } as NodeJS.ReadableStream & { isTTY: true },
@@ -296,6 +292,7 @@ describe('setup command', () => {
       ),
     ).rejects.toThrow('not one of the available setup profiles');
 
+    writeSettings(homeDirectory, 'default_profile: engineer\nprofile_sources:\n  - path: ./profiles\n');
     const result = await executeSetupCommand(
       { homeDirectory, projectDirectory },
       {
@@ -306,8 +303,11 @@ describe('setup command', () => {
         synchronizer: defaultProfileSynchronizer,
         selectDefaultProfile(profiles, currentDefault) {
           expect(currentDefault).toBe('engineer');
-          expect(profiles.map((profile) => profile.id)).toEqual(['data_analyst', 'engineer']);
+          expect(profiles.map((profile) => profile.id)).toEqual(['engineer', 'data_analyst']);
           return Promise.resolve('data_analyst');
+        },
+        selectWelcomePlan() {
+          return Promise.resolve({ answerQuestions: false });
         },
       },
     );
@@ -324,6 +324,85 @@ describe('setup command', () => {
     );
   });
 
+  it('uses an injected welcome runner after interactive setup completes', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+
+    const result = await executeSetupCommand(
+      { homeDirectory, projectDirectory },
+      {
+        interactive: true,
+        input: { isTTY: true } as NodeJS.ReadableStream & { isTTY: true },
+        output: { isTTY: true } as NodeJS.WritableStream & { isTTY: true },
+        writeLine: () => undefined,
+        synchronizer: defaultProfileSynchronizer,
+        selectDefaultProfile() {
+          return Promise.resolve('engineer');
+        },
+        runWelcome(input) {
+          expect(input.projectDirectory).toBe(projectDirectory);
+          return Promise.resolve({
+            answered: false,
+            warnings: [],
+            messages: ['custom welcome runner'],
+          });
+        },
+      },
+    );
+
+    expect(result.welcomeResult?.messages).toEqual(['custom welcome runner']);
+  });
+
+  it('runs welcome onboarding after interactive setup completes', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+
+    const result = await executeSetupCommand(
+      { homeDirectory, projectDirectory },
+      {
+        interactive: true,
+        input: { isTTY: true } as NodeJS.ReadableStream & { isTTY: true },
+        output: { isTTY: true } as NodeJS.WritableStream & { isTTY: true },
+        writeLine: () => undefined,
+        synchronizer: defaultProfileSynchronizer,
+        selectDefaultProfile() {
+          return Promise.resolve('engineer');
+        },
+        selectWelcomePlan() {
+          return Promise.resolve({
+            answerQuestions: true,
+            selectedRoleId: 'engineer',
+            loadoutItemIds: ['deepwork'],
+          });
+        },
+      },
+    );
+
+    expect(result.welcomeResult).toEqual({
+      answered: true,
+      selectedRole: { id: 'engineer', label: 'Engineer' },
+      selectedLoadout: {
+        id: 'recommended-pi',
+        label: 'Recommended Pi productivity loadout',
+        selectedItems: [
+          {
+            id: 'deepwork',
+            label: 'DeepWork',
+            kind: 'extension',
+            source: 'git:github.com/applepi-ai/deepwork',
+          },
+        ],
+      },
+      warnings: [],
+      messages: [
+        'Selected ApplePi role: engineer (Engineer).',
+        'Selected Recommended Pi productivity loadout: git:github.com/applepi-ai/deepwork.',
+      ],
+    });
+  });
+
   // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-004.1).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('loads wizard choices from legacy URI and repository subpath sources', async () => {
@@ -333,6 +412,7 @@ describe('setup command', () => {
     const legacyUri = 'https://example.test/legacy-profiles.git';
     const repositoryUri = 'https://example.test/repository-profiles.git';
     const duplicateUri = 'https://example.test/duplicate-profiles.git';
+    const githubSource = 'example/github-profiles';
     writeSettings(
       homeDirectory,
       [
@@ -343,6 +423,9 @@ describe('setup command', () => {
         '    ref: main',
         '    path: profiles',
         `  - uri: ${duplicateUri}`,
+        '    ref: main',
+        '    path: profiles',
+        `  - github: ${githubSource}`,
         '    ref: main',
         '    path: profiles',
         '',
@@ -371,19 +454,25 @@ describe('setup command', () => {
                 join(cachePath, 'profiles', 'repository', 'profile.yml'),
                 'id: repository\nlabel: Repository\ncontrols: {}\n',
               );
-            } else {
-              expect(source.uri).toBe(duplicateUri);
+            } else if (source.uri === duplicateUri) {
               expect(cachePath).toBe(createRemoteRepositoryCachePath(homeDirectory, source));
               writeCachedProfile(join(cachePath, 'profiles'), 'repository');
+            } else {
+              expect(source.github).toBe(githubSource);
+              expect(cachePath).toBe(createRemoteRepositoryCachePath(homeDirectory, source));
+              writeCachedProfile(join(cachePath, 'profiles'), 'github');
             }
 
             return 'updated';
           },
         },
         selectDefaultProfile(profiles) {
-          expect(profiles.map((profile) => profile.id)).toEqual(['legacy', 'repository']);
+          expect(profiles.map((profile) => profile.id)).toEqual(['github', 'legacy', 'repository']);
           expect(profiles.find((profile) => profile.id === 'repository')?.label).toBe('Repository');
           return Promise.resolve('repository');
+        },
+        selectWelcomePlan() {
+          return Promise.resolve({ answerQuestions: false });
         },
       },
     );
@@ -416,7 +505,7 @@ describe('setup command', () => {
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-004.1).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('uses the readline setup prompt when no selector dependency is injected', async () => {
+  it('uses the readline setup prompt when no default-profile selector dependency is injected', async () => {
     const root = createTemporaryRoot();
     const homeDirectory = join(root, 'home');
     const projectDirectory = join(root, 'project');
@@ -433,6 +522,9 @@ describe('setup command', () => {
         input,
         output,
         writeLine: (message) => messages.push(message),
+        selectWelcomePlan() {
+          return Promise.resolve({ answerQuestions: false });
+        },
       },
     );
 

--- a/tests/unit/source-layout.test.ts
+++ b/tests/unit/source-layout.test.ts
@@ -16,6 +16,7 @@ import { createProfileCommands } from '../../src/cli/commands/profile/Command.js
 import { createRunCommand } from '../../src/cli/commands/RunCommand.js';
 import { createSetupCommand } from '../../src/cli/commands/SetupCommand.js';
 import { createSyncCommand } from '../../src/cli/commands/SyncCommand.js';
+import { createWelcomeCommand } from '../../src/cli/commands/WelcomeCommand.js';
 import { createEmptyProfile } from '../../src/profiles/Profile.js';
 import { createProfileLoadPlan } from '../../src/profiles/ProfileLoader.js';
 import { mergeProfileStack } from '../../src/profiles/ProfileMerger.js';
@@ -52,12 +53,13 @@ describe('source layout scaffolding', () => {
       'run',
       'setup',
       'sync',
+      'welcome',
       'profile',
       'profile list',
       'profile create',
     ]);
-    expect(program.commands.map((command) => command.name())).toEqual(['run', 'setup', 'sync', 'profile']);
-    expect(program.commands.at(3)?.commands.map((command) => command.name())).toEqual(['list', 'create']);
+    expect(program.commands.map((command) => command.name())).toEqual(['run', 'setup', 'sync', 'welcome', 'profile']);
+    expect(program.commands.at(4)?.commands.map((command) => command.name())).toEqual(['list', 'create']);
     expect(describeCommandObject(createRunCommand())).toEqual({
       name: 'run',
       description: 'Assemble a profile compositeProfile and launch the selected agent CLI.',
@@ -66,12 +68,18 @@ describe('source layout scaffolding', () => {
     const standaloneProgram = new Command();
     createSetupCommand().register(standaloneProgram);
     createSyncCommand().register(standaloneProgram);
+    createWelcomeCommand().register(standaloneProgram);
     for (const command of createProfileCommands()) {
       command.register(standaloneProgram);
     }
 
-    expect(standaloneProgram.commands.map((command) => command.name())).toEqual(['setup', 'sync', 'profile']);
-    expect(standaloneProgram.commands.at(2)?.commands.map((command) => command.name())).toEqual(['list', 'create']);
+    expect(standaloneProgram.commands.map((command) => command.name())).toEqual([
+      'setup',
+      'sync',
+      'welcome',
+      'profile',
+    ]);
+    expect(standaloneProgram.commands.at(3)?.commands.map((command) => command.name())).toEqual(['list', 'create']);
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-002.5).

--- a/tests/unit/welcome-command.test.ts
+++ b/tests/unit/welcome-command.test.ts
@@ -1,0 +1,266 @@
+// Tests welcome command onboarding behavior.
+import { PassThrough } from 'node:stream';
+
+import { Command } from 'commander';
+import { describe, expect, it } from 'vitest';
+
+import { createWelcomeCommand, executeWelcomeCommand } from '../../src/cli/commands/WelcomeCommand.js';
+
+const defaultLoadoutSources = [
+  'git:github.com/applepi-ai/ulta-tasklist',
+  'git:github.com/applepi-ai/deepwork',
+  'npm:pi-subagents',
+  'npm:pi-mcp-adapter',
+];
+
+describe('welcome command', () => {
+  it('returns skipped onboarding without prompting when the selector opts out', async () => {
+    const result = await executeWelcomeCommand(
+      { homeDirectory: '/tmp/home', projectDirectory: '/tmp/project' },
+      {
+        selectWelcomePlan() {
+          return Promise.resolve({ answerQuestions: false });
+        },
+      },
+    );
+
+    expect(result).toEqual({
+      answered: false,
+      warnings: [],
+      messages: ['Skipped ApplePi welcome questions. Run `applepi welcome` any time to revisit them.'],
+    });
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-010.2, APPLEPI-REQ-010.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('returns selected default-profile role and recommended loadout data', async () => {
+    const result = await executeWelcomeCommand(
+      { homeDirectory: '/tmp/home', projectDirectory: '/work/acme/api' },
+      {
+        selectWelcomePlan() {
+          return Promise.resolve({ answerQuestions: true, selectedRoleId: 'data_analyst' });
+        },
+      },
+    );
+
+    expect(result.answered).toBe(true);
+    expect(result.selectedRole).toEqual({ id: 'data_analyst', label: 'Data Analyst' });
+    expect(result.selectedLoadout?.id).toBe('recommended-pi');
+    expect(result.selectedLoadout?.selectedItems.map((item) => item.source)).toEqual(defaultLoadoutSources);
+    expect(result.warnings).toEqual([]);
+    expect(result.messages).toEqual([
+      'Selected ApplePi role: data_analyst (Data Analyst).',
+      `Selected Recommended Pi productivity loadout: ${defaultLoadoutSources.join(', ')}.`,
+    ]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-010.2, APPLEPI-REQ-010.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('falls back for unknown roles and skips unknown loadout items', async () => {
+    const result = await executeWelcomeCommand(
+      { homeDirectory: '/tmp/home', projectDirectory: '/work/acme/api' },
+      {
+        selectWelcomePlan() {
+          return Promise.resolve({
+            answerQuestions: true,
+            selectedRoleId: 'reviewer',
+            loadoutItemIds: ['deepwork', 'deepwork', 'missing-package'],
+          });
+        },
+      },
+    );
+
+    expect(result.selectedRole).toEqual({ id: 'engineer', label: 'Engineer' });
+    expect(result.selectedLoadout?.selectedItems.map((item) => item.source)).toEqual([
+      'git:github.com/applepi-ai/deepwork',
+    ]);
+    expect(result.warnings).toEqual([
+      "Welcome role 'reviewer' is not available; using fallback role 'engineer'.",
+      "Loadout item 'missing-package' is not available for recommended-pi; skipping it.",
+    ]);
+    expect(result.messages).toContain(
+      "Warning: Welcome role 'reviewer' is not available; using fallback role 'engineer'.",
+    );
+  });
+
+  it('runs through the registered welcome command action', async () => {
+    const program = new Command();
+    const messages: string[] = [];
+    createWelcomeCommand({
+      homeDirectory: '/tmp/home',
+      projectDirectory: '/tmp/project',
+      input: { isTTY: true } as NodeJS.ReadableStream & { isTTY: true },
+      output: { isTTY: true } as NodeJS.WritableStream & { isTTY: true },
+      writeLine: (message) => messages.push(message),
+      selectWelcomePlan() {
+        return Promise.resolve({ answerQuestions: true });
+      },
+    }).register(program);
+
+    await program.parseAsync(['node', 'applepi', 'welcome']);
+
+    expect(messages).toEqual([
+      'Selected ApplePi role: engineer (Engineer).',
+      `Selected Recommended Pi productivity loadout: ${defaultLoadoutSources.join(', ')}.`,
+    ]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (APPLEPI-REQ-010.1, APPLEPI-REQ-010.2, APPLEPI-REQ-010.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('supports readline answers for role and selected loadout items while showing welcome text', async () => {
+    const input = Object.assign(new PassThrough(), { isTTY: true });
+    const output = Object.assign(new PassThrough(), { isTTY: true });
+    let outputText = '';
+    output.on('data', (chunk: Buffer | string) => {
+      outputText += chunk.toString();
+    });
+    const answers = ['y', '2', 'c', '2,4'];
+    const writeNextAnswer = (): void => {
+      const answer = answers.shift();
+
+      if (answer === undefined) {
+        input.end();
+        return;
+      }
+
+      input.write(`${answer}\n`);
+      setImmediate(writeNextAnswer);
+    };
+    const resultPromise = executeWelcomeCommand(
+      { homeDirectory: '/tmp/home', projectDirectory: '/work/acme/default' },
+      { interactive: true, input, output },
+    );
+    setImmediate(writeNextAnswer);
+    const result = await resultPromise;
+
+    expect(outputText).toContain('____  _');
+    expect(outputText).toContain('Pi is a heavily customizable coding harness.');
+    expect(outputText).toContain('engineer - Engineer');
+    expect(outputText).toContain('data_analyst - Data Analyst');
+    expect(outputText).toContain('npm:pi-mcp-adapter');
+    expect(result.answered).toBe(true);
+    expect(result.selectedRole?.id).toBe('data_analyst');
+    expect(result.selectedLoadout?.selectedItems.map((item) => item.source)).toEqual([
+      'git:github.com/applepi-ai/deepwork',
+      'npm:pi-mcp-adapter',
+    ]);
+  });
+
+  it('supports readline role fallback and accepting the full loadout', async () => {
+    const input = Object.assign(new PassThrough(), { isTTY: true });
+    const output = Object.assign(new PassThrough(), { isTTY: true });
+    const answers = ['y', '9', ''];
+    const writeNextAnswer = (): void => {
+      const answer = answers.shift();
+
+      if (answer === undefined) {
+        input.end();
+        return;
+      }
+
+      input.write(`${answer}\n`);
+      setImmediate(writeNextAnswer);
+    };
+    const resultPromise = executeWelcomeCommand(
+      { homeDirectory: '/tmp/home', projectDirectory: '/work/acme' },
+      { interactive: true, input, output },
+    );
+    setImmediate(writeNextAnswer);
+    const result = await resultPromise;
+
+    expect(result.selectedRole?.id).toBe('engineer');
+    expect(result.selectedLoadout?.selectedItems.map((item) => item.source)).toEqual(defaultLoadoutSources);
+  });
+
+  it('supports readline custom loadout defaults', async () => {
+    const input = Object.assign(new PassThrough(), { isTTY: true });
+    const output = Object.assign(new PassThrough(), { isTTY: true });
+    const answers = ['y', '', 'c', ''];
+    const writeNextAnswer = (): void => {
+      const answer = answers.shift();
+
+      if (answer === undefined) {
+        input.end();
+        return;
+      }
+
+      input.write(`${answer}\n`);
+      setImmediate(writeNextAnswer);
+    };
+    const resultPromise = executeWelcomeCommand(
+      { homeDirectory: '/tmp/home', projectDirectory: '/work/acme' },
+      { interactive: true, input, output },
+    );
+    setImmediate(writeNextAnswer);
+    const result = await resultPromise;
+
+    expect(result.selectedLoadout?.selectedItems.map((item) => item.source)).toEqual(defaultLoadoutSources);
+  });
+
+  it('supports readline defaults and skipping loadout installation', async () => {
+    const input = Object.assign(new PassThrough(), { isTTY: true });
+    const output = Object.assign(new PassThrough(), { isTTY: true });
+    const answers = ['', '', 'n'];
+    const writeNextAnswer = (): void => {
+      const answer = answers.shift();
+
+      if (answer === undefined) {
+        input.end();
+        return;
+      }
+
+      input.write(`${answer}\n`);
+      setImmediate(writeNextAnswer);
+    };
+    const resultPromise = executeWelcomeCommand(
+      { homeDirectory: '/tmp/home', projectDirectory: '/work/acme' },
+      { interactive: true, input, output },
+    );
+    setImmediate(writeNextAnswer);
+    const result = await resultPromise;
+
+    expect(result.answered).toBe(true);
+    expect(result.selectedRole?.id).toBe('engineer');
+    expect(result.selectedLoadout?.selectedItems).toEqual([]);
+    expect(result.messages).toEqual([
+      'Selected ApplePi role: engineer (Engineer).',
+      'Skipped Recommended Pi productivity loadout.',
+    ]);
+  });
+
+  it('supports readline opt-out answers', async () => {
+    const input = Object.assign(new PassThrough(), { isTTY: true });
+    const output = Object.assign(new PassThrough(), { isTTY: true });
+    const resultPromise = executeWelcomeCommand(
+      { homeDirectory: '/tmp/home', projectDirectory: '/work/acme' },
+      { interactive: true, input, output },
+    );
+    setImmediate(() => input.end('n\n'));
+    const result = await resultPromise;
+
+    expect(result.answered).toBe(false);
+  });
+
+  it('requires TTY streams for interactive welcome prompts', async () => {
+    await expect(
+      executeWelcomeCommand(
+        { homeDirectory: '/tmp/home', projectDirectory: '/tmp/project' },
+        {
+          interactive: true,
+          input: { isTTY: false } as NodeJS.ReadableStream & { isTTY: false },
+          output: { isTTY: true } as NodeJS.WritableStream & { isTTY: true },
+        },
+      ),
+    ).rejects.toThrow('requires an interactive TTY');
+    await expect(
+      executeWelcomeCommand(
+        { homeDirectory: '/tmp/home', projectDirectory: '/tmp/project' },
+        {
+          interactive: true,
+          input: { isTTY: true } as NodeJS.ReadableStream & { isTTY: true },
+          output: { isTTY: false } as NodeJS.WritableStream & { isTTY: false },
+        },
+      ),
+    ).rejects.toThrow('requires an interactive TTY');
+  });
+});


### PR DESCRIPTION
## Summary
- add first-run ApplePi welcome onboarding with built-in engineer/data analyst profiles and selectable Pi loadout
- persist selected role as a local profile and remove the remote default profiles source from setup defaults
- prefill Pi /login after first-run welcome when no Pi login state exists; initialize empty mcp/models state as valid JSON

## Validation
- npm run check-ci
- npm run build