### PR TITLE
Support profile-bundled DeepWork jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,9 @@ controls:
 
 The exact stable schema is governed by the requirements in `requirements/` and the JSON Schema files in `src/schemas/`, which are still expected to evolve with implementation.
 
+Pi profiles can also ship DeepWork jobs for that profile under `cli_specific/pi/deepwork/jobs/`.
+When ApplePi launches Pi, it adds contributing profile job folders to `DEEPWORK_ADDITIONAL_JOBS_FOLDERS` so the DeepWork frontend can discover profile-owned workflows without copying them into a project `.deepwork/jobs/` directory. By default, profiles with bundled jobs receive only their profile-bundled jobs; set `controls.pi.allow_external_deepwork_jobs: true` to also include inherited `DEEPWORK_ADDITIONAL_JOBS_FOLDERS` entries.
+
 ## Design direction
 
 The current recommendation is to build `applepi` around pi's existing native configuration mechanisms:

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -398,6 +398,7 @@ Rules:
 - `inherits` is an ordered array of profile names.
 - `cli_specific/<cli-name>/` contains files copied or translated directly into the generated composite profile for that CLI.
 - Pi profiles may provide `cli_specific/pi/.mcp.json`; ApplePi merges contributing profile fragments into the composite profile with unique array entries by identity and last writer wins for duplicate identities.
+- Pi profiles may provide DeepWork jobs under `cli_specific/pi/deepwork/jobs/`; ApplePi appends contributing job folders to `DEEPWORK_ADDITIONAL_JOBS_FOLDERS` when launching Pi so DeepWork can discover those profile-owned workflows. Profile-bundled jobs are isolated by default: inherited `DEEPWORK_ADDITIONAL_JOBS_FOLDERS` entries are included only when the profile sets `controls.pi.allow_external_deepwork_jobs: true`.
 - CLI-specific configuration wins over generic controls when both apply to the same generated artifact.
 
 ### Profile Directory Examples

--- a/src/agents/AgentAdapter.ts
+++ b/src/agents/AgentAdapter.ts
@@ -10,6 +10,10 @@ export interface AgentLaunchPlan {
   readonly env: Readonly<Record<string, string>>;
 }
 
+export interface AgentLaunchContext {
+  readonly profileFolders?: readonly string[];
+}
+
 export interface AgentCompositeProfilePlan {
   readonly compositeProfile: CompositeProfile;
   readonly warnings: readonly string[];
@@ -35,6 +39,7 @@ export interface AgentAdapter {
     compositeProfile: CompositeProfile,
     profile?: Profile,
     passThroughArgs?: readonly string[],
+    context?: AgentLaunchContext,
   ): AgentLaunchPlan;
   getUnsupportedControls(profile: Profile): readonly string[];
 }

--- a/src/agents/pi/PiAdapter.ts
+++ b/src/agents/pi/PiAdapter.ts
@@ -1,8 +1,8 @@
 // Provides the pi adapter for composite profile generation and native pi launch plans.
-import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { delimiter, join } from 'node:path';
 
-import type { AgentAdapter, AgentLaunchPlan, AgentCompositeProfilePlan } from '../AgentAdapter.js';
+import type { AgentAdapter, AgentLaunchPlan, AgentCompositeProfilePlan, AgentLaunchContext } from '../AgentAdapter.js';
 import {
   flagValue,
   genericControlNames,
@@ -19,9 +19,11 @@ import { createCompositeProfileFile } from '../../compositeProfile/CompositeProf
 import type { StatePathDeclaration, CompositeProfileStatePath } from '../../compositeProfile/StatePersistence.js';
 import { createPiMcpConfigFile } from './PiMcpConfig.js';
 
-const piControlNames = new Set(
-  [...genericControlNames].filter((controlName) => controlName !== 'pi' && controlName !== 'claude'),
-);
+const piControlNames = new Set([
+  ...[...genericControlNames].filter((controlName) => controlName !== 'pi' && controlName !== 'claude'),
+  'allowExternalDeepWorkJobs',
+  'allow_external_deepwork_jobs',
+]);
 
 const piStatePathDeclarations = {
   'auth.json': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'error', 'prompt'] },
@@ -79,14 +81,17 @@ export const createPiAdapter = (): AgentAdapter => ({
     compositeProfile: CompositeProfile,
     profile?: Profile,
     passThroughArgs: readonly string[] = [],
+    context: AgentLaunchContext = {},
   ): AgentLaunchPlan {
     const controls = mergePiControls(profile?.controls ?? {});
+    const deepWorkJobsFolders = createDeepWorkAdditionalJobsFolders(controls, context.profileFolders ?? []);
 
     return {
       command: 'pi',
       args: [...createPiArgs(controls), ...passThroughArgs],
       env: {
         ...controls.environment,
+        ...(deepWorkJobsFolders === undefined ? {} : { DEEPWORK_ADDITIONAL_JOBS_FOLDERS: deepWorkJobsFolders }),
         PI_CODING_AGENT_DIR: compositeProfile.rootDirectory,
       },
     };
@@ -234,6 +239,56 @@ const resolvePiStateSourcePath = (
     normalizedRelativePath,
   );
 };
+
+const deepWorkAdditionalJobsFoldersEnv = 'DEEPWORK_ADDITIONAL_JOBS_FOLDERS';
+
+const createDeepWorkAdditionalJobsFolders = (
+  controls: PiProfileControls,
+  profileFolders: readonly string[],
+): string | undefined => {
+  const profileJobFolders = [
+    ...new Set(profileFolders.map(deepWorkJobsFolderForProfile).filter(isExistingDeepWorkJobsFolder)),
+  ];
+
+  if (profileJobFolders.length === 0) {
+    return undefined;
+  }
+
+  const existingValue = allowExternalDeepWorkJobs(controls)
+    ? (controls.environment?.[deepWorkAdditionalJobsFoldersEnv] ?? process.env[deepWorkAdditionalJobsFoldersEnv])
+    : undefined;
+  return [...splitPathList(existingValue), ...profileJobFolders].join(delimiter);
+};
+
+const allowExternalDeepWorkJobs = (controls: PiProfileControls): boolean =>
+  controls.allowExternalDeepWorkJobs === true || controls.allow_external_deepwork_jobs === true;
+
+const deepWorkJobsFolderForProfile = (profileFolder: string): string =>
+  join(profileFolder, 'cli_specific', 'pi', 'deepwork', 'jobs');
+
+const isExistingDeepWorkJobsFolder = (folderPath: string): boolean => {
+  try {
+    return readdirSync(folderPath, { withFileTypes: true }).some(isDeepWorkJobEntry(folderPath));
+  } catch {
+    return false;
+  }
+};
+
+const isDeepWorkJobEntry =
+  (folderPath: string) =>
+  (entry: { readonly name: string; isDirectory(): boolean }): boolean =>
+    entry.isDirectory() && isFile(join(folderPath, entry.name, 'job.yml'));
+
+const isFile = (path: string): boolean => {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+};
+
+const splitPathList = (value: string | undefined): readonly string[] =>
+  value === undefined || value === '' ? [] : value.split(delimiter).filter((entry) => entry !== '');
 
 const mergePiControls = (controls: ProfileControls): PiProfileControls =>
   mergeAgentSpecificControls<PiProfileControls>(controls, 'pi');

--- a/src/cli/commands/RunCommand.ts
+++ b/src/cli/commands/RunCommand.ts
@@ -102,6 +102,7 @@ export const executeRunCommand = async (
       compositeProfilePlan.compositeProfile,
       resolvedProfile.profile,
       input.passThroughArgs ?? [],
+      { profileFolders: resolvedProfile.profileFolders },
     ),
     setupResult,
     writeLine: dependencies.writeLine,

--- a/src/schemas/profile.schema.json
+++ b/src/schemas/profile.schema.json
@@ -70,6 +70,7 @@
             "prompt_template": { "type": "string" },
             "system_prompt": { "type": "string" },
             "append_system_prompt": { "type": "string" },
+            "allow_external_deepwork_jobs": { "type": "boolean" },
             "environment": {
               "type": "object",
               "additionalProperties": { "type": "string" }

--- a/tests/unit/pi-adapter-deepwork-jobs.test.ts
+++ b/tests/unit/pi-adapter-deepwork-jobs.test.ts
@@ -1,0 +1,127 @@
+// Tests Pi adapter profile-bundled DeepWork job exposure.
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createPiAdapter } from '../../src/agents/pi/PiAdapter.js';
+
+const temporaryPiAdapterTestRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of temporaryPiAdapterTestRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('pi adapter DeepWork jobs', () => {
+  it('adds only selected profile-bundled DeepWork jobs to the pi launch environment by default', () => {
+    const root = mkdtempSync(join(tmpdir(), 'applepi-pi-deepwork-jobs-'));
+    temporaryPiAdapterTestRoots.push(root);
+    const baseProfileFolder = join(root, 'base');
+    const selectedProfileFolder = join(root, 'selected');
+    const unrelatedProfileFolder = join(root, 'unrelated');
+    const invalidProfileFolder = join(root, 'invalid');
+    const missingProfileFolder = join(root, 'missing');
+    const baseJobsFolder = join(baseProfileFolder, 'cli_specific', 'pi', 'deepwork', 'jobs');
+    const selectedJobsFolder = join(selectedProfileFolder, 'cli_specific', 'pi', 'deepwork', 'jobs');
+    const unrelatedJobsFolder = join(unrelatedProfileFolder, 'cli_specific', 'pi', 'deepwork', 'jobs');
+    const invalidJobsFolder = join(invalidProfileFolder, 'cli_specific', 'pi', 'deepwork', 'jobs');
+
+    mkdirSync(join(baseJobsFolder, 'metric_audit'), { recursive: true });
+    mkdirSync(join(selectedJobsFolder, 'insight_brief'), { recursive: true });
+    mkdirSync(join(unrelatedJobsFolder, 'should_not_load'), { recursive: true });
+    mkdirSync(join(invalidJobsFolder, 'empty_job'), { recursive: true });
+    writeFileSync(join(baseJobsFolder, 'metric_audit', 'job.yml'), 'name: metric_audit\nsummary: Metric audit\n');
+    writeFileSync(
+      join(selectedJobsFolder, 'insight_brief', 'job.yml'),
+      'name: insight_brief\nsummary: Insight brief\n',
+    );
+    writeFileSync(join(unrelatedJobsFolder, 'should_not_load', 'job.yml'), 'name: should_not_load\nsummary: No\n');
+    writeFileSync(join(invalidJobsFolder, 'README.md'), 'not a job\n');
+
+    const adapter = createPiAdapter();
+    const launchPlan = adapter.createLaunchPlan(
+      { rootDirectory: join(root, 'composite'), files: [], statePaths: [] },
+      {
+        id: 'selected',
+        inherits: ['base'],
+        controls: {
+          environment: {
+            DEEPWORK_ADDITIONAL_JOBS_FOLDERS: '/existing/jobs',
+          },
+        },
+      },
+      [],
+      { profileFolders: [baseProfileFolder, selectedProfileFolder, invalidProfileFolder, missingProfileFolder] },
+    );
+
+    expect(launchPlan.env.DEEPWORK_ADDITIONAL_JOBS_FOLDERS).toBe([baseJobsFolder, selectedJobsFolder].join(delimiter));
+    expect(launchPlan.env.DEEPWORK_ADDITIONAL_JOBS_FOLDERS).not.toContain(unrelatedJobsFolder);
+    expect(launchPlan.env.DEEPWORK_ADDITIONAL_JOBS_FOLDERS).not.toContain(invalidJobsFolder);
+  });
+
+  it('uses external DeepWork job folders only when the profile allows them', () => {
+    const root = mkdtempSync(join(tmpdir(), 'applepi-pi-deepwork-process-env-'));
+    temporaryPiAdapterTestRoots.push(root);
+    const profileFolder = join(root, 'selected');
+    const jobsFolder = join(profileFolder, 'cli_specific', 'pi', 'deepwork', 'jobs');
+    const previousJobsFolders = process.env.DEEPWORK_ADDITIONAL_JOBS_FOLDERS;
+
+    try {
+      delete process.env.DEEPWORK_ADDITIONAL_JOBS_FOLDERS;
+      mkdirSync(join(jobsFolder, 'insight_brief'), { recursive: true });
+      writeFileSync(join(jobsFolder, 'insight_brief', 'job.yml'), 'name: insight_brief\nsummary: Insight brief\n');
+
+      const adapter = createPiAdapter();
+      const withoutExistingValue = adapter.createLaunchPlan(
+        { rootDirectory: join(root, 'composite'), files: [], statePaths: [] },
+        { id: 'selected', inherits: [], controls: {} },
+        [],
+        { profileFolders: [profileFolder] },
+      );
+      process.env.DEEPWORK_ADDITIONAL_JOBS_FOLDERS = '/process/jobs';
+      const withProcessValueDisallowed = adapter.createLaunchPlan(
+        { rootDirectory: join(root, 'composite'), files: [], statePaths: [] },
+        { id: 'selected', inherits: [], controls: {} },
+        [],
+        { profileFolders: [profileFolder] },
+      );
+      const withProcessValueAllowed = adapter.createLaunchPlan(
+        { rootDirectory: join(root, 'composite'), files: [], statePaths: [] },
+        { id: 'selected', inherits: [], controls: { pi: { allow_external_deepwork_jobs: true } } },
+        [],
+        { profileFolders: [profileFolder] },
+      );
+      const withProfileValueAllowed = adapter.createLaunchPlan(
+        { rootDirectory: join(root, 'composite'), files: [], statePaths: [] },
+        {
+          id: 'selected',
+          inherits: [],
+          controls: {
+            environment: { DEEPWORK_ADDITIONAL_JOBS_FOLDERS: '/profile/jobs' },
+            pi: { allowExternalDeepWorkJobs: true },
+          },
+        },
+        [],
+        { profileFolders: [profileFolder] },
+      );
+
+      expect(withoutExistingValue.env.DEEPWORK_ADDITIONAL_JOBS_FOLDERS).toBe(jobsFolder);
+      expect(withProcessValueDisallowed.env.DEEPWORK_ADDITIONAL_JOBS_FOLDERS).toBe(jobsFolder);
+      expect(withProcessValueAllowed.env.DEEPWORK_ADDITIONAL_JOBS_FOLDERS).toBe(
+        ['/process/jobs', jobsFolder].join(delimiter),
+      );
+      expect(withProfileValueAllowed.env.DEEPWORK_ADDITIONAL_JOBS_FOLDERS).toBe(
+        ['/profile/jobs', jobsFolder].join(delimiter),
+      );
+    } finally {
+      if (previousJobsFolders === undefined) {
+        delete process.env.DEEPWORK_ADDITIONAL_JOBS_FOLDERS;
+      } else {
+        process.env.DEEPWORK_ADDITIONAL_JOBS_FOLDERS = previousJobsFolders;
+      }
+    }
+  });
+});

--- a/tests/unit/run-command-deepwork-jobs.test.ts
+++ b/tests/unit/run-command-deepwork-jobs.test.ts
@@ -1,0 +1,87 @@
+// Tests profile-bundled DeepWork job exposure during run command launches.
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { executeRunCommand } from '../../src/cli/commands/RunCommand.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'applepi-run-deepwork-jobs-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const writeSettings = (homeDirectory: string, content: string): void => {
+  mkdirSync(join(homeDirectory, '.applepi'), { recursive: true });
+  writeFileSync(join(homeDirectory, '.applepi', 'settings.yml'), content);
+};
+
+const writeProfile = (root: string, id: string, content: string): string => {
+  const profileDirectory = join(root, id);
+  mkdirSync(profileDirectory, { recursive: true });
+  const profilePath = join(profileDirectory, 'profile.yml');
+  writeFileSync(profilePath, content);
+  return profileDirectory;
+};
+
+const writeDeepWorkJob = (profileDirectory: string, jobName: string): string => {
+  const jobsFolder = join(profileDirectory, 'cli_specific', 'pi', 'deepwork', 'jobs');
+  mkdirSync(join(jobsFolder, jobName), { recursive: true });
+  writeFileSync(join(jobsFolder, jobName, 'job.yml'), `name: ${jobName}\nsummary: ${jobName}\n`);
+  return jobsFolder;
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('run command DeepWork job exposure', () => {
+  it('exposes selected profile-bundled DeepWork jobs when launching pi', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const profilesDirectory = join(homeDirectory, '.applepi', 'profiles');
+    const baseProfileDirectory = writeProfile(profilesDirectory, 'base', 'id: base\ncontrols: {}\n');
+    const selectedProfileDirectory = writeProfile(
+      profilesDirectory,
+      'default',
+      [
+        'id: default',
+        'inherits: [base]',
+        'controls:',
+        '  environment:',
+        '    DEEPWORK_ADDITIONAL_JOBS_FOLDERS: /existing/jobs',
+        '',
+      ].join('\n'),
+    );
+    const unrelatedProfileDirectory = writeProfile(profilesDirectory, 'unrelated', 'id: unrelated\ncontrols: {}\n');
+    writeSettings(homeDirectory, 'default_profile: default\nprofile_sources:\n  - path: ./profiles\n');
+
+    const baseJobsFolder = writeDeepWorkJob(baseProfileDirectory, 'metric_audit');
+    const selectedJobsFolder = writeDeepWorkJob(selectedProfileDirectory, 'insight_brief');
+    const unrelatedJobsFolder = writeDeepWorkJob(unrelatedProfileDirectory, 'should_not_load');
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+        writeLine: () => undefined,
+      },
+    );
+
+    expect(result.launchPlan.env.DEEPWORK_ADDITIONAL_JOBS_FOLDERS).toBe(
+      [baseJobsFolder, selectedJobsFolder].join(delimiter),
+    );
+    expect(result.launchPlan.env.DEEPWORK_ADDITIONAL_JOBS_FOLDERS).not.toContain(unrelatedJobsFolder);
+  });
+});


### PR DESCRIPTION
## Summary
- Add Pi launch context so ApplePi can pass contributing profile folders into adapter launch planning.
- Detect `cli_specific/pi/deepwork/jobs` in selected/inherited Pi profiles and expose those folders through `DEEPWORK_ADDITIONAL_JOBS_FOLDERS`.
- Isolate profile-bundled DeepWork jobs by default: existing/global/project `DEEPWORK_ADDITIONAL_JOBS_FOLDERS` entries are excluded unless `controls.pi.allow_external_deepwork_jobs` is explicitly `true`.
- Add profile schema support and unit coverage for bundled job discovery, default isolation, and external-job opt-in.

## Validation
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npx vitest --run tests/unit/pi-adapter.test.ts tests/unit/run-command.test.ts tests/unit/run-command-deepwork-jobs.test.ts`
- Manual smoke check via `/tmp/test-analyst-profile-pr.sh` confirmed the `data_analyst` profile exposes only its bundled analyst DeepWork jobs by default.
- GitHub check is passing.

## Linked PRs
- Enables default analyst profile delivery: https://github.com/ncrmro/applepi-default-profiles/pull/1
