### PR TITLE
feat(profiles): compose append system prompts

### DIFF
--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -400,6 +400,7 @@ Rules:
 - Pi profiles may provide `cli_specific/pi/.mcp.json`; Outfitter merges contributing profile fragments into the composite profile with unique array entries by identity and last writer wins for duplicate identities.
 - Pi profiles may provide DeepWork jobs under `cli_specific/pi/deepwork/jobs/`; Outfitter appends contributing job folders to `DEEPWORK_ADDITIONAL_JOBS_FOLDERS` when launching Pi so DeepWork can discover those profile-owned workflows.
   Profile-bundled jobs are isolated by default: inherited `DEEPWORK_ADDITIONAL_JOBS_FOLDERS` entries are included only when the profile sets `controls.pi.allow_external_deepwork_jobs: true`.
+- `append_system_prompt` accepts a string or an ordered string array. When multiple resolved profile layers provide it, Outfitter composes the values into repeated agent append-prompt inputs in profile precedence order so shared prompt profiles do not need to use raw CLI `args`.
 - CLI-specific configuration wins over generic controls when both apply to the same generated artifact.
 
 ### Profile Directory Examples

--- a/requirements/OFTR-003-profiles.md
+++ b/requirements/OFTR-003-profiles.md
@@ -49,3 +49,4 @@ Outfitter resolves profile definitions across settings scopes, explicit sources,
 2. YAML object values SHOULD be merged with `defu` or an equivalent controlled deep-merge utility.
 3. Array merge behavior MUST be documented per profile key before that key is treated as stable.
 4. CLI-specific profile content MUST take precedence over generic controls when both generate the same agent-specific artifact.
+5. Outfitter MUST compose `append_system_prompt` values from multiple resolved profile layers into repeated agent append-prompt inputs without requiring profiles to use raw CLI `args` for prompt composition.

--- a/src/agents/AdapterProfileControls.ts
+++ b/src/agents/AdapterProfileControls.ts
@@ -48,8 +48,17 @@ export const mergeAgentSpecificControls = <T extends ProfileControls>(
   } as T;
 };
 
-export const flagValue = (flag: string, value: string | undefined): readonly string[] =>
-  value === undefined ? [] : [flag, value];
+export const flagValue = (flag: string, value: string | readonly string[] | undefined): readonly string[] => {
+  if (value === undefined) {
+    return [];
+  }
+
+  if (typeof value === 'string') {
+    return [flag, value];
+  }
+
+  return repeatFlag(flag, value);
+};
 
 export const repeatFlag = (flag: string, values: readonly string[] | undefined): readonly string[] =>
   values === undefined ? [] : values.flatMap((value) => [flag, value]);

--- a/src/agents/AdapterProfileControls.ts
+++ b/src/agents/AdapterProfileControls.ts
@@ -48,20 +48,19 @@ export const mergeAgentSpecificControls = <T extends ProfileControls>(
   } as T;
 };
 
-export const flagValue = (flag: string, value: string | readonly string[] | undefined): readonly string[] => {
+export const flagValue = (flag: string, value: string | undefined): readonly string[] =>
+  value === undefined ? [] : [flag, value];
+
+export const repeatFlag = (flag: string, values: readonly string[] | undefined): readonly string[] =>
+  values === undefined ? [] : values.flatMap((value) => [flag, value]);
+
+export const repeatFlagValue = (flag: string, value: string | readonly string[] | undefined): readonly string[] => {
   if (value === undefined) {
     return [];
   }
 
-  if (typeof value === 'string') {
-    return [flag, value];
-  }
-
-  return repeatFlag(flag, value);
+  return typeof value === 'string' ? [flag, value] : repeatFlag(flag, value);
 };
-
-export const repeatFlag = (flag: string, values: readonly string[] | undefined): readonly string[] =>
-  values === undefined ? [] : values.flatMap((value) => [flag, value]);
 
 export const findUnsupportedControlNames = (
   controls: Readonly<Record<string, unknown>>,

--- a/src/agents/claude/ClaudeAdapter.ts
+++ b/src/agents/claude/ClaudeAdapter.ts
@@ -7,6 +7,7 @@ import {
   flagValue,
   mergeAgentSpecificControls,
   repeatFlag,
+  repeatFlagValue,
   supportedControlNames,
 } from '../AdapterProfileControls.js';
 import { createDeclaredStatePaths, findProfileStateSource } from '../AdapterStatePaths.js';
@@ -162,7 +163,7 @@ const createClaudeArgs = (controls: ClaudeProfileControls): readonly string[] =>
   ...flagValue('--model', controls.model),
   ...flagValue('--effort', controls.thinking),
   ...flagValue('--system-prompt', controls.systemPrompt),
-  ...flagValue('--append-system-prompt', controls.appendSystemPrompt),
+  ...repeatFlagValue('--append-system-prompt', controls.appendSystemPrompt),
   ...repeatFlag('--plugin-dir', controls.extensions),
   ...(controls.args ?? []),
 ];

--- a/src/agents/pi/PiAdapter.ts
+++ b/src/agents/pi/PiAdapter.ts
@@ -8,6 +8,7 @@ import {
   genericControlNames,
   mergeAgentSpecificControls,
   repeatFlag,
+  repeatFlagValue,
   supportedControlNames,
 } from '../AdapterProfileControls.js';
 import { createDeclaredStatePaths, findProfileStateSource } from '../AdapterStatePaths.js';
@@ -338,7 +339,7 @@ const createPiArgs = (controls: PiProfileControls): readonly string[] => [
   ...flagValue('--session-dir', controls.sessionDirectory),
   ...flagValue('--prompt-template', controls.promptTemplate),
   ...flagValue('--system-prompt', controls.systemPrompt),
-  ...flagValue('--append-system-prompt', controls.appendSystemPrompt),
+  ...repeatFlagValue('--append-system-prompt', controls.appendSystemPrompt),
   ...repeatFlag('--extension', controls.extensions),
   ...repeatFlag('--skill', controls.skills),
   ...(controls.args ?? []),

--- a/src/merge/ArrayMergePolicy.ts
+++ b/src/merge/ArrayMergePolicy.ts
@@ -1,12 +1,17 @@
 // Defines reusable array merge policies for deterministic settings/profile composition.
 export type ArrayMergeKey<T> = (item: T) => string;
 
-export type ArrayMergePolicy<T = unknown> =
+export type StringArrayMergePolicy =
   | 'replace'
   | 'append'
   | 'prepend'
   | 'appendUnique'
   | 'prependUnique'
+  | 'appendList'
+  | 'prependList';
+
+export type ArrayMergePolicy<T = unknown> =
+  | StringArrayMergePolicy
   | {
       readonly mode: 'uniqueBy';
       readonly key: ArrayMergeKey<T>;
@@ -21,29 +26,37 @@ export const mergeArrayByPolicy = <T>(
 ): readonly T[] => {
   const lower = lowerPrecedence ?? [];
 
-  if (policy === 'replace') {
-    return [...higherPrecedence];
-  }
-
-  if (policy === 'append') {
-    return [...lower, ...higherPrecedence];
-  }
-
-  if (policy === 'prepend') {
-    return [...higherPrecedence, ...lower];
-  }
-
-  if (policy === 'appendUnique') {
-    return uniqueBy([...lower, ...higherPrecedence], defaultArrayMergeKey, 'first');
-  }
-
-  if (policy === 'prependUnique') {
-    return uniqueBy([...higherPrecedence, ...lower], defaultArrayMergeKey, 'first');
+  if (typeof policy === 'string') {
+    return mergeArrayByStringPolicy(lower, higherPrecedence, policy);
   }
 
   const ordered = policy.order === 'append' ? [...lower, ...higherPrecedence] : [...higherPrecedence, ...lower];
 
   return uniqueBy(ordered, policy.key, policy.winner);
+};
+
+const mergeArrayByStringPolicy = <T>(
+  lower: readonly T[],
+  higher: readonly T[],
+  policy: StringArrayMergePolicy,
+): readonly T[] => {
+  if (policy === 'replace') {
+    return [...higher];
+  }
+
+  if (policy === 'append' || policy === 'appendList') {
+    return [...lower, ...higher];
+  }
+
+  if (policy === 'prepend' || policy === 'prependList') {
+    return [...higher, ...lower];
+  }
+
+  if (policy === 'appendUnique') {
+    return uniqueBy([...lower, ...higher], defaultArrayMergeKey, 'first');
+  }
+
+  return uniqueBy([...higher, ...lower], defaultArrayMergeKey, 'first');
 };
 
 const uniqueBy = <T>(items: readonly T[], key: ArrayMergeKey<T>, winner: 'first' | 'last'): readonly T[] => {

--- a/src/merge/SettingsValueMerger.ts
+++ b/src/merge/SettingsValueMerger.ts
@@ -81,7 +81,7 @@ const mergeListMemberValue = (
 
   return mergeArrayByPolicy(
     coerceMergeableList(lowerPrecedence),
-    coerceMergeableList(higherPrecedence),
+    coerceDefinedMergeableList(higherPrecedence),
     arrayPolicy === 'appendList' ? 'append' : 'prepend',
   );
 };
@@ -124,5 +124,8 @@ const coerceMergeableList = (value: MergeableValue | undefined): readonly Mergea
     return undefined;
   }
 
-  return isMergeableArray(value) ? value : [value];
+  return coerceDefinedMergeableList(value);
 };
+
+const coerceDefinedMergeableList = (value: MergeableValue): readonly MergeableValue[] =>
+  isMergeableArray(value) ? value : [value];

--- a/src/merge/SettingsValueMerger.ts
+++ b/src/merge/SettingsValueMerger.ts
@@ -50,12 +50,17 @@ const mergeMemberValue = (
   path: MergePath,
   options: MergeValueOptions,
 ): MergeableValue => {
-  if (Array.isArray(higherPrecedence)) {
-    return mergeArrayByPolicy(
-      isMergeableArray(lowerPrecedence) ? lowerPrecedence : undefined,
-      higherPrecedence,
-      options.arrayPolicyForPath?.(path) ?? 'replace',
-    );
+  const arrayPolicy = options.arrayPolicyForPath?.(path);
+  const listMergedValue = mergeListMemberValue(lowerPrecedence, higherPrecedence, arrayPolicy);
+
+  if (listMergedValue !== undefined) {
+    return listMergedValue;
+  }
+
+  const arrayMergedValue = mergeArrayMemberValue(lowerPrecedence, higherPrecedence, arrayPolicy);
+
+  if (arrayMergedValue !== undefined) {
+    return arrayMergedValue;
   }
 
   if (isPlainMergeableObject(lowerPrecedence) && isPlainMergeableObject(higherPrecedence)) {
@@ -63,6 +68,38 @@ const mergeMemberValue = (
   }
 
   return cloneMergeableValue(higherPrecedence);
+};
+
+const mergeListMemberValue = (
+  lowerPrecedence: MergeableValue | undefined,
+  higherPrecedence: MergeableValue,
+  arrayPolicy: ArrayMergePolicy<MergeableValue> | undefined,
+): MergeableValue | undefined => {
+  if (arrayPolicy !== 'appendList' && arrayPolicy !== 'prependList') {
+    return undefined;
+  }
+
+  return mergeArrayByPolicy(
+    coerceMergeableList(lowerPrecedence),
+    coerceMergeableList(higherPrecedence) ?? [],
+    arrayPolicy === 'appendList' ? 'append' : 'prepend',
+  );
+};
+
+const mergeArrayMemberValue = (
+  lowerPrecedence: MergeableValue | undefined,
+  higherPrecedence: MergeableValue,
+  arrayPolicy: ArrayMergePolicy<MergeableValue> | undefined,
+): MergeableValue | undefined => {
+  if (!Array.isArray(higherPrecedence)) {
+    return undefined;
+  }
+
+  return mergeArrayByPolicy(
+    isMergeableArray(lowerPrecedence) ? lowerPrecedence : undefined,
+    higherPrecedence,
+    arrayPolicy ?? 'replace',
+  );
 };
 
 const cloneMergeableValue = (value: MergeableValue): MergeableValue => {
@@ -81,3 +118,11 @@ const isPlainMergeableObject = (value: unknown): value is MergeableObject =>
   value !== null && typeof value === 'object' && !Array.isArray(value);
 
 const isMergeableArray = (value: unknown): value is readonly MergeableValue[] => Array.isArray(value);
+
+const coerceMergeableList = (value: MergeableValue | undefined): readonly MergeableValue[] | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return isMergeableArray(value) ? value : [value];
+};

--- a/src/merge/SettingsValueMerger.ts
+++ b/src/merge/SettingsValueMerger.ts
@@ -81,7 +81,7 @@ const mergeListMemberValue = (
 
   return mergeArrayByPolicy(
     coerceMergeableList(lowerPrecedence),
-    coerceMergeableList(higherPrecedence) ?? [],
+    coerceMergeableList(higherPrecedence),
     arrayPolicy === 'appendList' ? 'append' : 'prepend',
   );
 };

--- a/src/profiles/Profile.ts
+++ b/src/profiles/Profile.ts
@@ -2,6 +2,7 @@
 import type { StatePersistenceStrategy } from '../compositeProfile/StatePersistence.js';
 
 export type StatePersistenceOverrides = Readonly<Record<string, StatePersistenceStrategy>>;
+export type AppendSystemPromptControl = string | readonly string[];
 
 interface BaseProfileControls {
   readonly [controlName: string]: unknown;
@@ -15,7 +16,7 @@ interface BaseProfileControls {
   readonly skills?: readonly string[];
   readonly promptTemplate?: string;
   readonly systemPrompt?: string;
-  readonly appendSystemPrompt?: string;
+  readonly appendSystemPrompt?: AppendSystemPromptControl;
 }
 
 export type AgentSpecificProfileControls = BaseProfileControls;

--- a/src/profiles/ProfileLoader.ts
+++ b/src/profiles/ProfileLoader.ts
@@ -167,6 +167,14 @@ const readOptionalStringArray = (value: unknown): readonly string[] | undefined 
   return undefined;
 };
 
+const readOptionalStringOrStringArray = (value: unknown): string | readonly string[] | undefined => {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  return readOptionalStringArray(value);
+};
+
 const readControls = (value: unknown): ProfileControls => {
   const controls = readObject(value);
 
@@ -186,7 +194,7 @@ const readControls = (value: unknown): ProfileControls => {
     skills: readOptionalStringArray(controls.skills),
     promptTemplate: readOptionalString(controls.prompt_template),
     systemPrompt: readOptionalString(controls.system_prompt),
-    appendSystemPrompt: readOptionalString(controls.append_system_prompt),
+    appendSystemPrompt: readOptionalStringOrStringArray(controls.append_system_prompt),
     pi: readAgentSpecificControls(controls.pi),
     claude: readAgentSpecificControls(controls.claude),
   });
@@ -211,7 +219,7 @@ const readAgentSpecificControls = (value: unknown): AgentSpecificProfileControls
     skills: readOptionalStringArray(controls.skills),
     promptTemplate: readOptionalString(controls.prompt_template),
     systemPrompt: readOptionalString(controls.system_prompt),
-    appendSystemPrompt: readOptionalString(controls.append_system_prompt),
+    appendSystemPrompt: readOptionalStringOrStringArray(controls.append_system_prompt),
   });
 };
 

--- a/src/profiles/ProfileMerger.ts
+++ b/src/profiles/ProfileMerger.ts
@@ -47,6 +47,10 @@ const profileArrayPolicy = (path: MergePath): ArrayMergePolicy | undefined => {
     return 'prepend';
   }
 
+  if (isAppendSystemPromptPath(pathKey)) {
+    return 'prependList';
+  }
+
   if (['controls.extensions', 'controls.pi.extensions', 'controls.claude.extensions'].includes(pathKey)) {
     return {
       mode: 'uniqueBy',
@@ -67,6 +71,16 @@ const profileArrayPolicy = (path: MergePath): ArrayMergePolicy | undefined => {
 
   return undefined;
 };
+
+const isAppendSystemPromptPath = (pathKey: string): boolean =>
+  [
+    'controls.appendSystemPrompt',
+    'controls.append_system_prompt',
+    'controls.pi.appendSystemPrompt',
+    'controls.pi.append_system_prompt',
+    'controls.claude.appendSystemPrompt',
+    'controls.claude.append_system_prompt',
+  ].includes(pathKey);
 
 export const resolveProfile = (input: ProfileResolutionInput): ProfileResolutionResult => {
   const definitions = createProfileDefinitions(input.profiles);

--- a/src/schemas/profile.schema.json
+++ b/src/schemas/profile.schema.json
@@ -43,7 +43,7 @@
         },
         "prompt_template": { "type": "string" },
         "system_prompt": { "type": "string" },
-        "append_system_prompt": { "type": "string" },
+        "append_system_prompt": { "$ref": "#/$defs/appendSystemPrompt" },
         "environment": {
           "type": "object",
           "additionalProperties": { "type": "string" }
@@ -69,7 +69,7 @@
             },
             "prompt_template": { "type": "string" },
             "system_prompt": { "type": "string" },
-            "append_system_prompt": { "type": "string" },
+            "append_system_prompt": { "$ref": "#/$defs/appendSystemPrompt" },
             "allow_external_deepwork_jobs": { "type": "boolean" },
             "environment": {
               "type": "object",
@@ -99,7 +99,7 @@
             },
             "prompt_template": { "type": "string" },
             "system_prompt": { "type": "string" },
-            "append_system_prompt": { "type": "string" },
+            "append_system_prompt": { "$ref": "#/$defs/appendSystemPrompt" },
             "environment": {
               "type": "object",
               "additionalProperties": { "type": "string" }
@@ -111,5 +111,16 @@
       "additionalProperties": true
     }
   },
-  "additionalProperties": true
+  "additionalProperties": true,
+  "$defs": {
+    "appendSystemPrompt": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      ]
+    }
+  }
 }

--- a/tests/unit/adapter-helpers.test.ts
+++ b/tests/unit/adapter-helpers.test.ts
@@ -11,6 +11,7 @@ import {
   genericControlNames,
   mergeAgentSpecificControls,
   repeatFlag,
+  repeatFlagValue,
 } from '../../src/agents/AdapterProfileControls.js';
 import {
   createDeclaredStatePaths,
@@ -49,6 +50,13 @@ describe('adapter helper modules', () => {
     expect(flagValue('--model', undefined)).toEqual([]);
     expect(repeatFlag('--skill', ['a', 'b'])).toEqual(['--skill', 'a', '--skill', 'b']);
     expect(repeatFlag('--skill', undefined)).toEqual([]);
+    expect(repeatFlagValue('--append-system-prompt', 'base.md')).toEqual(['--append-system-prompt', 'base.md']);
+    expect(repeatFlagValue('--append-system-prompt', ['base.md', 'vcs.md'])).toEqual([
+      '--append-system-prompt',
+      'base.md',
+      '--append-system-prompt',
+      'vcs.md',
+    ]);
   });
 
   it('finds unsupported controls while normalizing aliases', () => {

--- a/tests/unit/pi-adapter.test.ts
+++ b/tests/unit/pi-adapter.test.ts
@@ -135,6 +135,30 @@ describe('pi adapter', () => {
     }
   });
 
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.6, OFTR-006.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('passes composed append system prompts as repeated pi flags', () => {
+    const adapter = createPiAdapter();
+    const compositeProfilePlan = adapter.createCompositeProfile(
+      { id: 'engineering', inherits: [], controls: {} },
+      { rootDirectory: '/tmp/outfitter-engineering-pi-append-prompts', profilePaths: [] },
+    );
+    const launchPlan = adapter.createLaunchPlan(compositeProfilePlan.compositeProfile, {
+      id: 'engineering',
+      inherits: [],
+      controls: {
+        appendSystemPrompt: ['./prompts/role.md', './prompts/vcs.md'],
+      },
+    });
+
+    expect(launchPlan.args).toEqual([
+      '--append-system-prompt',
+      './prompts/role.md',
+      '--append-system-prompt',
+      './prompts/vcs.md',
+    ]);
+  });
+
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.3).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('makes native pi models config available inside the composite profile', () => {

--- a/tests/unit/profile-control-parsing.test.ts
+++ b/tests/unit/profile-control-parsing.test.ts
@@ -14,14 +14,17 @@ describe('profile control parsing', () => {
         '  args: [--generic]',
         '  extensions: [ext-a]',
         '  skills: [skill-a]',
+        '  append_system_prompt: [prompt-a, prompt-b]',
         '  pi:',
         '    args: [--pi]',
         '    extensions: [ext-pi]',
         '    skills: [skill-pi]',
+        '    append_system_prompt: [prompt-pi-a, prompt-pi-b]',
         '  claude:',
         '    args: [--claude]',
         '    extensions: [plugin-claude]',
         '    skills: [skill-claude]',
+        '    append_system_prompt: [prompt-claude-a, prompt-claude-b]',
         '',
       ].join('\n'),
       'fallback',
@@ -32,12 +35,15 @@ describe('profile control parsing', () => {
       expect(profile.controls.args).toEqual(['--generic']);
       expect(profile.controls.extensions).toEqual(['ext-a']);
       expect(profile.controls.skills).toEqual(['skill-a']);
+      expect(profile.controls.appendSystemPrompt).toEqual(['prompt-a', 'prompt-b']);
       expect(profile.controls.pi?.args).toEqual(['--pi']);
       expect(profile.controls.pi?.extensions).toEqual(['ext-pi']);
       expect(profile.controls.pi?.skills).toEqual(['skill-pi']);
+      expect(profile.controls.pi?.appendSystemPrompt).toEqual(['prompt-pi-a', 'prompt-pi-b']);
       expect(profile.controls.claude?.args).toEqual(['--claude']);
       expect(profile.controls.claude?.extensions).toEqual(['plugin-claude']);
       expect(profile.controls.claude?.skills).toEqual(['skill-claude']);
+      expect(profile.controls.claude?.appendSystemPrompt).toEqual(['prompt-claude-a', 'prompt-claude-b']);
     }
   });
 });

--- a/tests/unit/profile-resolution.test.ts
+++ b/tests/unit/profile-resolution.test.ts
@@ -81,6 +81,8 @@ describe('profile resolution', () => {
     ).toBe('user');
   });
 
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('uses path-specific array merge policies and deduplicates profile launch resources by identity', () => {
     const result = resolveProfile({
       profileId: 'selected',
@@ -93,8 +95,11 @@ describe('profile resolution', () => {
             inherits: [],
             controls: {
               args: ['--default'],
+              appendSystemPrompt: 'default prompt',
+              append_system_prompt: 'default prompt',
               extensions: ['npm:pi-subagents@1', 'git:github.com/ai-outfitter/deepwork#main'],
               skills: ['./skills/review'],
+              pi: { appendSystemPrompt: 'default pi prompt' },
               custom_list: ['default'],
             },
           },
@@ -106,8 +111,11 @@ describe('profile resolution', () => {
             inherits: [],
             controls: {
               args: ['--base'],
+              appendSystemPrompt: 'base prompt',
+              append_system_prompt: 'base prompt',
               extensions: ['npm:base-only', 'npm:pi-subagents@2'],
               skills: ['./skills/base'],
+              pi: { appendSystemPrompt: 'base pi prompt' },
             },
           },
         }),
@@ -118,8 +126,11 @@ describe('profile resolution', () => {
             inherits: ['base'],
             controls: {
               args: ['--selected'],
+              appendSystemPrompt: 'selected prompt',
+              append_system_prompt: 'selected prompt',
               extensions: ['npm:pi-subagents@3'],
               skills: ['./skills/review'],
+              pi: { appendSystemPrompt: 'selected pi prompt' },
               custom_list: ['selected'],
             },
           },
@@ -129,6 +140,13 @@ describe('profile resolution', () => {
 
     expect(result.issues).toEqual([]);
     expect(result.profile?.controls.args).toEqual(['--selected', '--base', '--default']);
+    expect(result.profile?.controls.appendSystemPrompt).toEqual(['selected prompt', 'base prompt', 'default prompt']);
+    expect(result.profile?.controls.append_system_prompt).toEqual(['selected prompt', 'base prompt', 'default prompt']);
+    expect(result.profile?.controls.pi?.appendSystemPrompt).toEqual([
+      'selected pi prompt',
+      'base pi prompt',
+      'default pi prompt',
+    ]);
     expect(result.profile?.controls.extensions).toEqual([
       'npm:pi-subagents@3',
       'npm:base-only',

--- a/tests/unit/settings-value-merger.test.ts
+++ b/tests/unit/settings-value-merger.test.ts
@@ -12,4 +12,33 @@ describe('settings value merger', () => {
       ),
     ).toEqual({ nested: { keep: true, list: ['higher'] }, scalarToArray: ['higher'] });
   });
+
+  it('coerces scalars to arrays for list append and prepend policies', () => {
+    const arrayPolicyForPath = (path: readonly string[]) => {
+      if (path.join('.') === 'appendPrompts') return 'appendList' as const;
+      if (path.join('.') === 'prependPrompts') return 'prependList' as const;
+      return undefined;
+    };
+
+    expect(
+      mergeObjectsWithPolicy(
+        { appendPrompts: ['base'], prependPrompts: 'base' },
+        { appendPrompts: 'selected', prependPrompts: ['selected'] },
+        { arrayPolicyForPath },
+      ),
+    ).toEqual({
+      appendPrompts: ['base', 'selected'],
+      prependPrompts: ['selected', 'base'],
+    });
+  });
+
+  it('coerces undefined lower-precedence list values to empty arrays for list policies', () => {
+    expect(
+      mergeObjectsWithPolicy(
+        { appendPrompts: undefined },
+        { appendPrompts: 'selected' },
+        { arrayPolicyForPath: () => 'appendList' },
+      ),
+    ).toEqual({ appendPrompts: ['selected'] });
+  });
 });


### PR DESCRIPTION
## Summary
- add OFTR-003.6 requirement for composing `append_system_prompt` across resolved profile layers
- allow `append_system_prompt` to be a string or ordered string array in the profile schema/parser
- compose inherited append prompts into repeated agent append-prompt flags instead of requiring raw CLI `args`
- cover parsing, profile resolution, and Pi launch translation with tests

## Validation
- `npm test`
- `npm run typecheck`
- `npm run lint`
- requirements_file DeepSchema verification commands for `requirements/OFTR-003-profiles.md`
- `/tmp` smoke test using built CLI to confirm inherited native `append_system_prompt` values compose
