### PR TITLE
feat(profiles): support template profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,12 +210,15 @@ id: engineering-default
 label: Engineering Default
 inherits:
   - base-typescript
+  - shared-prose
 
 controls:
   model: anthropic/claude-sonnet-4
   environment:
     TEAM_MODE: engineering
 ```
+
+Set `template: true` on profiles such as `shared-prose` that should only be inherited by runnable profiles, not selected directly with `outfitter run`.
 
 The exact stable schema is governed by the requirements in `requirements/` and the JSON Schema files in `src/schemas/`, which are still expected to evolve with implementation.
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -372,6 +372,7 @@ Example `profile.yml`:
 ```yaml
 id: engineering
 label: Engineering
+template: false
 inherits:
   - base-typescript
 
@@ -396,6 +397,7 @@ Rules:
 
 - Every `profile.yml` MUST validate against `profile.schema.json`.
 - `inherits` is an ordered array of profile names.
+- `template: true` marks a profile as inheritance-only: it may contribute controls to runnable profiles through `inherits`, but `outfitter run --profile <id>` and `default_profile: <id>` launches reject it directly.
 - `cli_specific/<cli-name>/` contains files copied or translated directly into the generated composite profile for that CLI.
 - Pi profiles may provide `cli_specific/pi/.mcp.json`; Outfitter merges contributing profile fragments into the composite profile with unique array entries by identity and last writer wins for duplicate identities.
 - Pi profiles may provide DeepWork jobs under `cli_specific/pi/deepwork/jobs/`; Outfitter appends contributing job folders to `DEEPWORK_ADDITIONAL_JOBS_FOLDERS` when launching Pi so DeepWork can discover those profile-owned workflows.
@@ -437,11 +439,22 @@ controls:
 ```
 
 ```yaml
+# ~/.outfitter/profiles/shared-prose/profile.yml
+id: shared-prose
+label: Shared Prose
+template: true
+
+controls:
+  append_system_prompt: ./prompts/prose.md
+```
+
+```yaml
 # ~/.outfitter/profiles/personal-engineering/profile.yml
 id: personal-engineering
 label: Personal Engineering
 inherits:
   - base-typescript
+  - shared-prose
 
 controls:
   append_system_prompt: ./prompts/system.md
@@ -746,6 +759,8 @@ Responsibilities:
 
 - read and validate settings;
 - load configured local and cached remote profile sources;
+- hide template profiles by default because they are inheritance-only;
+- include template profiles when `--all` is requested and mark them as templates in output;
 - report unique profile IDs deterministically;
 - use the highest-precedence loaded definition when duplicate profile IDs exist.
 

--- a/requirements/OFTR-003-profiles.md
+++ b/requirements/OFTR-003-profiles.md
@@ -50,3 +50,10 @@ Outfitter resolves profile definitions across settings scopes, explicit sources,
 3. Array merge behavior MUST be documented per profile key before that key is treated as stable.
 4. CLI-specific profile content MUST take precedence over generic controls when both generate the same agent-specific artifact.
 5. Outfitter MUST compose `append_system_prompt` values from multiple resolved profile layers into repeated agent append-prompt inputs without requiring profiles to use raw CLI `args` for prompt composition.
+
+### OFTR-003.7: Template Profiles
+
+1. A profile MAY set top-level `template: true` to indicate it is intended for inheritance by runnable profiles rather than direct launch.
+2. Outfitter MUST allow template profiles to contribute controls through `inherits` without marking the inheriting profile as a template.
+3. Outfitter MUST reject direct launches of template profiles, including launches selected through `default_profile`.
+4. `outfitter profile list` SHOULD hide template profiles by default and MUST expose them when the user explicitly requests all profiles.

--- a/src/cli/commands/RunCommand.ts
+++ b/src/cli/commands/RunCommand.ts
@@ -400,6 +400,12 @@ const loadResolvedProfile = (input: RunCommandInput): ResolvedRunProfile => {
     throw new Error(`Cannot resolve profile '${profileId}': ${resolution.issues.map(formatProfileIssue).join('; ')}`);
   }
 
+  const selectedProfile = resolution.profileStack.find((profile) => profile.id === profileId) as Profile;
+
+  if (selectedProfile.template === true) {
+    throw new Error(`Profile '${profileId}' is a template profile and must be inherited by a runnable profile.`);
+  }
+
   return {
     profile: resolution.profile,
     profileLayers: findContributingLoadedProfiles(resolution.profileStack, loadedProfiles.profiles),

--- a/src/cli/commands/profile/ListCommand.ts
+++ b/src/cli/commands/profile/ListCommand.ts
@@ -20,11 +20,13 @@ export interface ListedProfile {
   readonly id: string;
   readonly label?: string;
   readonly profilePath: string;
+  readonly template: boolean;
 }
 
 export interface ListProfilesInput {
   readonly homeDirectory: string;
   readonly projectDirectory: string;
+  readonly includeTemplates?: boolean;
 }
 
 export interface ListProfilesResult {
@@ -45,16 +47,20 @@ export const createProfileListCommand = (dependencies: ProfileCommandDependencie
 };
 
 const createProfileListCommander = (dependencies: ProfileCommandDependencies): Command =>
-  new Command('list').description('List available Outfitter profiles.').action(() => {
-    const result = executeListProfilesCommand({
-      /* v8 ignore next -- default process home is exercised by the direct CLI entrypoint, not unit tests. */
-      homeDirectory: dependencies.homeDirectory ?? homedir(),
-      /* v8 ignore next -- default process cwd is exercised by the direct CLI entrypoint, not unit tests. */
-      projectDirectory: dependencies.projectDirectory ?? process.cwd(),
-    });
+  new Command('list')
+    .description('List available Outfitter profiles.')
+    .option('--all', 'Include template profiles that are intended only for inheritance.')
+    .action((options: { all?: boolean }) => {
+      const result = executeListProfilesCommand({
+        /* v8 ignore next -- default process home is exercised by the direct CLI entrypoint, not unit tests. */
+        homeDirectory: dependencies.homeDirectory ?? homedir(),
+        /* v8 ignore next -- default process cwd is exercised by the direct CLI entrypoint, not unit tests. */
+        projectDirectory: dependencies.projectDirectory ?? process.cwd(),
+        includeTemplates: options.all,
+      });
 
-    emitMessages(result.messages, dependencies.writeLine);
-  });
+      emitMessages(result.messages, dependencies.writeLine);
+    });
 
 export const executeListProfilesCommand = (input: ListProfilesInput): ListProfilesResult => {
   const loadedSettings = loadSettingsWithCachedRemoteSettings(input);
@@ -73,11 +79,13 @@ export const executeListProfilesCommand = (input: ListProfilesInput): ListProfil
     );
   }
 
-  const profiles = listHighestPrecedenceProfiles(profileLoadResult.profiles);
+  const profiles = listHighestPrecedenceProfiles(profileLoadResult.profiles).filter(
+    (profile) => input.includeTemplates === true || !profile.template,
+  );
 
   return {
     profiles,
-    messages: profiles.length === 0 ? ['No profiles found.'] : profiles.map((profile) => profile.id),
+    messages: profiles.length === 0 ? ['No profiles found.'] : profiles.map(formatListedProfile),
   };
 };
 
@@ -132,11 +140,15 @@ const listHighestPrecedenceProfiles = (loadedProfiles: readonly LoadedProfile[])
       id: loadedProfile.profile.id,
       label: loadedProfile.profile.label,
       profilePath: loadedProfile.profilePath,
+      template: loadedProfile.profile.template === true,
     });
   }
 
   return [...profilesById.values()].sort((left, right) => left.id.localeCompare(right.id));
 };
+
+const formatListedProfile = (profile: ListedProfile): string =>
+  profile.template ? `${profile.id} (template)` : profile.id;
 
 const formatSettingsIssue = (issue: {
   readonly filePath: string;

--- a/src/profiles/Profile.ts
+++ b/src/profiles/Profile.ts
@@ -31,6 +31,7 @@ export interface ProfileControls extends BaseProfileControls {
 export interface Profile {
   readonly id: string;
   readonly label?: string;
+  readonly template?: boolean;
   readonly inherits: readonly string[];
   readonly controls: ProfileControls;
   readonly statePersistence?: StatePersistenceOverrides;

--- a/src/profiles/ProfileLoader.ts
+++ b/src/profiles/ProfileLoader.ts
@@ -57,6 +57,7 @@ export const parseProfileDocument = (document: unknown, fallbackId: string): Pro
   return omitUndefined({
     id,
     label: readOptionalString(record.label),
+    template: readOptionalBoolean(record.template),
     inherits: readStringArray(record.inherits),
     controls: readControls(record.controls),
     statePersistence: Object.keys(statePersistence).length > 0 ? statePersistence : undefined,
@@ -145,6 +146,14 @@ const readString = (value: unknown, fallback: string): string => {
 
 const readOptionalString = (value: unknown): string | undefined => {
   if (typeof value === 'string') {
+    return value;
+  }
+
+  return undefined;
+};
+
+const readOptionalBoolean = (value: unknown): boolean | undefined => {
+  if (typeof value === 'boolean') {
     return value;
   }
 

--- a/src/profiles/ProfileMerger.ts
+++ b/src/profiles/ProfileMerger.ts
@@ -28,12 +28,21 @@ export interface ProfileResolutionResult {
 
 export const mergeProfileStack = (profileStack: NonEmptyProfileStack): Profile => {
   const [baseProfile, ...higherPrecedenceProfiles] = profileStack;
-
-  return higherPrecedenceProfiles.reduce<Profile>(
+  const mergedProfile = higherPrecedenceProfiles.reduce<Profile>(
     (mergedProfile, profile) =>
       mergeObjectsWithPolicy(mergedProfile, profile, { arrayPolicyForPath: profileArrayPolicy }),
     baseProfile,
   );
+
+  return withProfileTemplateFromTopProfile(mergedProfile, profileStack[profileStack.length - 1]);
+};
+
+const withProfileTemplateFromTopProfile = (profile: Profile, topProfile: Profile): Profile => {
+  if (topProfile.template === true) {
+    return { ...profile, template: true };
+  }
+
+  return Object.fromEntries(Object.entries(profile).filter(([key]) => key !== 'template')) as Profile;
 };
 
 const profileArrayPolicy = (path: MergePath): ArrayMergePolicy | undefined => {

--- a/src/schemas/profile.schema.json
+++ b/src/schemas/profile.schema.json
@@ -9,6 +9,7 @@
       "pattern": "^[a-z0-9][a-z0-9._-]*[a-z0-9]$|^[a-z0-9]$"
     },
     "label": { "type": "string" },
+    "template": { "type": "boolean" },
     "inherits": {
       "type": "array",
       "items": {

--- a/tests/unit/profile-command.test.ts
+++ b/tests/unit/profile-command.test.ts
@@ -212,15 +212,27 @@ describe('profile command', () => {
     );
     writeProfile(localProfiles, 'engineering', 'id: engineering\nlabel: User Engineering\ncontrols: {}\n');
     writeProfile(localProfiles, 'research');
+    writeProfile(localProfiles, 'shared-prose', 'id: shared-prose\ntemplate: true\ncontrols: {}\n');
     writeProfile(remoteProfiles, 'engineering', 'id: engineering\nlabel: Remote Engineering\ncontrols: {}\n');
     writeProfile(remoteProfiles, 'support');
     writeProfile(uriProfiles, 'plain-uri');
 
     const result = executeListProfilesCommand({ homeDirectory, projectDirectory });
+    const allResult = executeListProfilesCommand({ homeDirectory, projectDirectory, includeTemplates: true });
 
     expect(result.profiles.map((profile) => profile.id)).toEqual(['engineering', 'plain-uri', 'research', 'support']);
     expect(result.profiles.find((profile) => profile.id === 'engineering')?.label).toBe('Remote Engineering');
+    expect(result.profiles.every((profile) => !profile.template)).toBe(true);
     expect(result.messages).toEqual(['engineering', 'plain-uri', 'research', 'support']);
+    expect(allResult.profiles.map((profile) => profile.id)).toEqual([
+      'engineering',
+      'plain-uri',
+      'research',
+      'shared-prose',
+      'support',
+    ]);
+    expect(allResult.profiles.find((profile) => profile.id === 'shared-prose')?.template).toBe(true);
+    expect(allResult.messages).toContain('shared-prose (template)');
 
     const messages: string[] = [];
     const program = new Command();
@@ -231,6 +243,16 @@ describe('profile command', () => {
     });
     await program.parseAsync(['node', 'outfitter', 'profile', 'list']);
     expect(messages).toEqual(['engineering', 'plain-uri', 'research', 'support']);
+
+    const allMessages: string[] = [];
+    const allProgram = new Command();
+    registerProfileCommands(allProgram, {
+      homeDirectory,
+      projectDirectory,
+      writeLine: (message) => allMessages.push(message),
+    });
+    await allProgram.parseAsync(['node', 'outfitter', 'profile', 'list', '--all']);
+    expect(allMessages).toContain('shared-prose (template)');
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.5).

--- a/tests/unit/profile-loader.test.ts
+++ b/tests/unit/profile-loader.test.ts
@@ -92,6 +92,25 @@ describe('profile loading', () => {
     expect('message' in invalidIdResult && invalidIdResult.message).toContain('must match pattern');
   });
 
+  it('parses template profile markers and validates their type', () => {
+    expect(parseProfileYaml('id: shared\ntemplate: true\ncontrols: {}\n', 'fallback')).toEqual({
+      id: 'shared',
+      template: true,
+      inherits: [],
+      controls: {},
+    });
+    expect(parseProfileYaml('id: runnable\ntemplate: false\ncontrols: {}\n', 'fallback')).toEqual({
+      id: 'runnable',
+      template: false,
+      inherits: [],
+      controls: {},
+    });
+    expect(parseProfileYaml('id: invalid\ntemplate: yes\ncontrols: {}\n', 'fallback')).toEqual({
+      path: '/template',
+      message: 'must be boolean',
+    });
+  });
+
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.1).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('reports profile.yml schema validation diagnostics with field pointers', () => {

--- a/tests/unit/profile-resolution.test.ts
+++ b/tests/unit/profile-resolution.test.ts
@@ -156,6 +156,38 @@ describe('profile resolution', () => {
     expect(result.profile?.controls.custom_list).toEqual(['selected']);
   });
 
+  it('keeps template profiles inheritable without marking runnable descendants as templates', () => {
+    const inheritedTemplate = createLoadedProfile({
+      source: createLocalProfileSource('<project-profiles>'),
+      profile: {
+        id: 'shared-prose',
+        template: true,
+        inherits: [],
+        controls: { appendSystemPrompt: 'shared prompt' },
+      },
+    });
+    const selectedRunnable = createLoadedProfile({
+      source: createLocalProfileSource('<project-profiles>'),
+      profile: {
+        id: 'project-lead',
+        inherits: ['shared-prose'],
+        controls: { appendSystemPrompt: 'role prompt' },
+      },
+    });
+
+    const runnableResult = resolveProfile({
+      profileId: 'project-lead',
+      profiles: [inheritedTemplate, selectedRunnable],
+    });
+    const templateResult = resolveProfile({ profileId: 'shared-prose', profiles: [inheritedTemplate] });
+
+    expect(runnableResult.issues).toEqual([]);
+    expect(runnableResult.profile?.template).toBeUndefined();
+    expect(runnableResult.profile?.controls.appendSystemPrompt).toEqual(['role prompt', 'shared prompt']);
+    expect(templateResult.issues).toEqual([]);
+    expect(templateResult.profile?.template).toBe(true);
+  });
+
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.4, OFTR-003.5).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('resolves inherited profiles below explicit profiles and includes the implicit user default without duplicates', () => {

--- a/tests/unit/template-profiles.test.ts
+++ b/tests/unit/template-profiles.test.ts
@@ -1,0 +1,93 @@
+// Tests template profile behavior across loading, listing, resolution, and launch selection.
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { executeRunCommand } from '../../src/cli/commands/RunCommand.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-template-profiles-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const writeSettings = (homeDirectory: string, content: string): void => {
+  mkdirSync(join(homeDirectory, '.outfitter'), { recursive: true });
+  writeFileSync(join(homeDirectory, '.outfitter', 'settings.yml'), content);
+};
+
+const writeProfile = (root: string, id: string, content: string): void => {
+  const profileDirectory = join(root, id);
+  mkdirSync(profileDirectory, { recursive: true });
+  writeFileSync(join(profileDirectory, 'profile.yml'), content);
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('template profiles', () => {
+  it('rejects directly selected template profiles but allows inheriting them', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const profilesDirectory = join(homeDirectory, '.outfitter', 'profiles');
+    writeSettings(homeDirectory, 'default_profile: prose\nprofile_sources:\n  - path: ./profiles\n');
+    writeProfile(
+      profilesDirectory,
+      'prose',
+      'id: prose\ntemplate: true\ncontrols:\n  append_system_prompt: prose.md\n',
+    );
+    writeProfile(
+      profilesDirectory,
+      'project-lead',
+      'id: project-lead\ninherits: [prose]\ncontrols:\n  append_system_prompt: lead.md\n',
+    );
+
+    await expect(
+      executeRunCommand(
+        { homeDirectory, projectDirectory },
+        {
+          launcher: {
+            launch() {
+              return Promise.resolve(0);
+            },
+          },
+        },
+      ),
+    ).rejects.toThrow("Profile 'prose' is a template profile");
+    await expect(
+      executeRunCommand(
+        { homeDirectory, projectDirectory, profileId: 'prose' },
+        {
+          launcher: {
+            launch() {
+              return Promise.resolve(0);
+            },
+          },
+        },
+      ),
+    ).rejects.toThrow("Profile 'prose' is a template profile");
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory, profileId: 'project-lead' },
+      {
+        writeLine: () => undefined,
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(result.profileId).toBe('project-lead');
+    expect(result.launchPlan.args).toEqual(['--append-system-prompt', 'lead.md', '--append-system-prompt', 'prose.md']);
+  });
+});


### PR DESCRIPTION
## Summary

Adds template profiles for inheritance-only profile layers such as shared prose/VCS prompt profiles.

## Behavior

- `profile.yml` accepts top-level `template: true`.
- Template profiles can still be inherited and contribute controls normally.
- Inheriting a template profile does not make the runnable descendant a template.
- Directly launching a template profile, including via `default_profile`, fails with a clear error.
- `outfitter profile list` hides template profiles by default.
- `outfitter profile list --all` includes template profiles and marks them as `(template)`.

## Files changed

- Profile schema/types/loading/resolution: `src/schemas/profile.schema.json`, `src/profiles/*`
- Run/list command behavior: `src/cli/commands/RunCommand.ts`, `src/cli/commands/profile/ListCommand.ts`
- Requirements/docs: `requirements/OFTR-003-profiles.md`, `README.md`, `doc/architecture.md`
- Unit coverage: `tests/unit/*`

## Validation

- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run coverage`
- `npm run check-ci`
- `npm run build`
- `git diff --check`
- `requirements/OFTR-003-profiles.md` DeepSchema verification commands
- Local CLI smoke: default profile list hides templates; `profile list --all` shows `prose (template)`
