### PR TITLE
Preserve Pi trust state in composite profiles

### DIFF
--- a/doc/state_writeback_strategy.md
+++ b/doc/state_writeback_strategy.md
@@ -101,6 +101,14 @@ state_paths:
     default_strategy: symlink
     allowed_strategies: [symlink, warn, error, prompt]
 
+  models.json:
+    default_strategy: symlink
+    allowed_strategies: [symlink, warn, error, prompt]
+
+  trust.json:
+    default_strategy: symlink
+    allowed_strategies: [symlink, warn, error, prompt]
+
   plugins/:
     default_strategy: symlink
     allowed_strategies: [symlink, discard, warn, error, prompt]

--- a/src/agents/pi/PiAdapter.ts
+++ b/src/agents/pi/PiAdapter.ts
@@ -31,6 +31,7 @@ const piStatePathDeclarations = {
   'settings.json': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'warn', 'error', 'prompt'] },
   'mcp.json': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'warn', 'error', 'prompt'] },
   'models.json': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'warn', 'error', 'prompt'] },
+  'trust.json': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'warn', 'error', 'prompt'] },
   'plugins/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error', 'prompt'] },
   'cache/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error'] },
   'sessions/': { defaultStrategy: 'symlink', allowedStrategies: ['symlink', 'discard', 'warn', 'error'] },

--- a/tests/unit/pi-adapter.test.ts
+++ b/tests/unit/pi-adapter.test.ts
@@ -161,27 +161,30 @@ describe('pi adapter', () => {
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.3).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('makes native pi models config available inside the composite profile', () => {
-    const { homeDirectory } = createPiSettingsTestHome();
-    const adapter = createPiAdapter();
-    const compositeProfilePlan = adapter.createCompositeProfile(
-      { id: 'engineering', inherits: [], controls: {} },
-      {
-        rootDirectory: '/tmp/outfitter-engineering-pi-models',
-        profilePaths: ['/profiles/engineering/profile.yml'],
-        homeDirectory,
-      },
-    );
+  it.each(['models.json', 'trust.json'])(
+    'makes native pi %s available inside the composite profile',
+    (relativePath) => {
+      const { homeDirectory } = createPiSettingsTestHome();
+      const adapter = createPiAdapter();
+      const compositeProfilePlan = adapter.createCompositeProfile(
+        { id: 'engineering', inherits: [], controls: {} },
+        {
+          rootDirectory: `/tmp/outfitter-engineering-pi-${relativePath}`,
+          profilePaths: ['/profiles/engineering/profile.yml'],
+          homeDirectory,
+        },
+      );
 
-    expect(
-      compositeProfilePlan.compositeProfile.statePaths.find((statePath) => statePath.relativePath === 'models.json'),
-    ).toEqual({
-      relativePath: 'models.json',
-      strategy: 'symlink',
-      directory: false,
-      sourcePath: join(homeDirectory, '.pi', 'agent', 'models.json'),
-    });
-  });
+      expect(
+        compositeProfilePlan.compositeProfile.statePaths.find((statePath) => statePath.relativePath === relativePath),
+      ).toEqual({
+        relativePath,
+        strategy: 'symlink',
+        directory: false,
+        sourcePath: join(homeDirectory, '.pi', 'agent', relativePath),
+      });
+    },
+  );
 
   it('initializes missing native mcp and models configs as valid empty JSON documents', () => {
     const { homeDirectory } = createPiSettingsTestHome();


### PR DESCRIPTION
## Summary
- symlink Pi `trust.json` into generated composite profiles
- document `trust.json` as a Pi state path
- add unit coverage for the trust state path

## Validation
- `npm -C outfitter test -- tests/unit/pi-adapter.test.ts`