### PR TITLE
docs(contributing): document release workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,6 @@
 ## Architecture essentials
 
 - Outfitter is a TypeScript CLI for assembling and launching reproducible agent-CLI profiles; `pi` is the first and primary supported target.
-- Treat any `outfitter` spelling in docs, prompts, examples, or generated text as the typo `outfitter`.
 - Use generic profile controls at the product boundary, then translate them through agent adapters into CLI-specific files, flags, and environment variables.
 - Prefer pi terminology, behavior, and native mechanisms whenever generic Outfitter controls conflict with pi conventions.
 - Persist user-editable config as YAML and validate every persisted YAML format with JSON Schema at read boundaries.
@@ -12,22 +11,10 @@
 - Warn to stderr when an adapter cannot support a requested control; `--strict` must make unsupported controls or composite profile assembly warnings fatal.
 - Implement non-trivial CLI behavior as command objects with explicit dependencies and typed inputs/outputs, not parser callback logic.
 - A composite profile is the temporary runtime configuration directory assembled for one profile and agent CLI run; Outfitter owns the composite profile lifecycle while the child agent runs.
-- Pi is the only day-one adapter.
-  Claude is roadmap-only unless requirements change.
-
-## Project checks
-
-- Run `npm run check` for local verification.
-  It runs Snapper on Markdown files, writes Prettier formatting, runs ESLint with auto-fixing enabled, then runs the coverage test suite.
-- Run `npm run check-ci` for CI-equivalent verification.
-  It checks Prettier formatting, then runs the same lint and coverage checks without modifying files.
-- `npm run coverage` enforces the configured Vitest coverage thresholds.
-- Coverage includes all `src/**/*.ts` files, so new source files need tests even if they are only scaffolding.
-
-## Notes
-
-- Prefer `npm run check` before handing work back if auto-fixable lint issues may exist.
-- Use `npm run check-ci` when you need a non-mutating validation pass, such as in CI or before reviewing the final diff.
-- Use `bin/dev-setup-source <setup-source>` when you intentionally want real org/project setup behavior from the caller's current directory while still running this checkout's local build. This helper preserves the caller's real `HOME` and cwd, so it can initialize or update the target folder's `.outfitter` state with a remote profile source such as `https://github.com/ai-outfitter/link`. Do not use it for isolated first-run smoke tests; use `bin/dev-tmp-home` for that.
-- When adding files or changing directory layout, first check `doc/file_structure.md` for current structure and update the relevant documentation afterward.
+- Pi is the only day-one adapter. Claude is roadmap-only unless requirements change.
+- When adding files or changing directory layout, first check `doc/file_structure.md` for the current structure and update the relevant documentation afterward.
 - When adding tests that validate formal requirements, include the required two-line traceability comment immediately before the relevant `it(...)` or `describe(...)` block.
+
+## Contributor workflow
+
+@CONTRIBUTING.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,3 +124,22 @@ npm run check-ci
 
 Both commands run the coverage suite.
 Coverage thresholds are intentionally set to 100% for statements, branches, functions, and lines.
+Coverage includes all `src/**/*.ts` files, so new source files need tests even if they are only scaffolding.
+
+## Commit and release workflow
+
+Use Conventional Commits for every commit and PR title that will be squash-merged.
+Valid types are `feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `ci`, `perf`, and `build`.
+Each commit should represent one logical change.
+
+Release automation is split across two workflows:
+
+1. `.github/workflows/release-please.yml` runs on pushes to `main`.
+   It uses `googleapis/release-please-action` to open or update a release PR when releasable Conventional Commits are present.
+2. Merge the release-please PR to publish the GitHub release and tag.
+3. `.github/workflows/release.yml` runs when that GitHub release is published.
+   It publishes the npm package with trusted publishing and then publishes matching GHCR image tags.
+
+`feat` commits normally create a minor release, and `fix` or `perf` commits normally create a patch release.
+Maintenance-only commits such as `chore`, `docs`, `test`, `ci`, `refactor`, and `build` may appear in the changelog context but do not necessarily create a release by themselves.
+If a change must produce a release, use a releasable Conventional Commit type that accurately describes the user-facing impact.


### PR DESCRIPTION
## Summary
- move agent-aware project context into CONTRIBUTING.md
- point AGENTS.md at CONTRIBUTING.md
- document Conventional Commit expectations and the release-please/release publish workflow

## Verification
- npx prettier --write CONTRIBUTING.md AGENTS.md
- npm run check-ci