### PR TITLE
feat(profiles): add prompt-facing descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ An initial profile shape is:
 ```yaml
 id: engineering-default
 label: Engineering Default
+description: General software engineering profile for coding, tests, reviews, and repo navigation.
 inherits:
   - base-typescript
   - shared-prose

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -374,6 +374,7 @@ Example `profile.yml`:
 ```yaml
 id: engineering
 label: Engineering
+description: General software engineering profile for coding, tests, reviews, and repo navigation.
 template: false
 inherits:
   - base-typescript

--- a/requirements/OFTR-003-profiles.md
+++ b/requirements/OFTR-003-profiles.md
@@ -21,6 +21,7 @@ Outfitter resolves profile definitions across settings scopes, explicit sources,
 2. Profile IDs MUST match the regex `^[a-z0-9][a-z0-9._-]*[a-z0-9]$|^[a-z0-9]$`.
 3. Outfitter MUST reject profile IDs that cannot be safely referenced from the CLI.
 4. Outfitter SHOULD support a separate display label if human-readable names need spaces or punctuation.
+5. Profiles MAY include a short `description` for interactive prompts and profile discovery surfaces.
 
 ### OFTR-003.3: Profile Scope Precedence
 

--- a/src/cli/commands/FirstRunWelcomeProfile.ts
+++ b/src/cli/commands/FirstRunWelcomeProfile.ts
@@ -35,7 +35,7 @@ export const persistFirstRunWelcomeProfile = (
   if (createdProfile) {
     if (options.sourceProfileDirectory !== undefined && existsSync(options.sourceProfileDirectory)) {
       cpSync(options.sourceProfileDirectory, profileDirectory, { recursive: true, force: false });
-      updateCopiedProfile(profilePath, welcomeProfile.extensions);
+      updateCopiedProfile(profilePath, welcomeProfile.description, welcomeProfile.extensions);
       excludeDefaultProfileSources(settingsPath, welcomeProfile.id);
       messages.push(
         `Copied the ${welcomeProfile.label} profile locally so your extension choices can be edited at ${profilePath}.`,
@@ -60,6 +60,7 @@ const createFirstRunWelcomeProfile = (
 ): {
   readonly id: string;
   readonly label: string;
+  readonly description: string;
   readonly content: string;
   readonly extensions: readonly string[];
 } => {
@@ -70,7 +71,14 @@ const createFirstRunWelcomeProfile = (
   return {
     id: profileId,
     label: selectedRole.label,
-    content: createFirstRunWelcomeProfileContent(profileId, selectedRole.label, rolePrompt, extensions),
+    description: selectedRole.description,
+    content: createFirstRunWelcomeProfileContent(
+      profileId,
+      selectedRole.label,
+      selectedRole.description,
+      rolePrompt,
+      extensions,
+    ),
     extensions,
   };
 };
@@ -87,10 +95,11 @@ const firstRunWelcomeRolePrompts = {
 const createFirstRunWelcomeProfileContent = (
   profileId: string,
   roleLabel: string,
+  roleDescription: string,
   rolePrompt: string,
   extensions: readonly string[],
 ): string => {
-  const lines = [`id: ${profileId}`, `label: ${roleLabel}`, 'controls:'];
+  const lines = [`id: ${profileId}`, `label: ${roleLabel}`, `description: ${roleDescription}`, 'controls:'];
 
   if (extensions.length > 0) {
     lines.push('  pi:', '    extensions:', ...extensions.map((extension) => `      - ${extension}`));
@@ -100,11 +109,12 @@ const createFirstRunWelcomeProfileContent = (
   return lines.join('\n');
 };
 
-const updateCopiedProfile = (profilePath: string, extensions: readonly string[]): void => {
+const updateCopiedProfile = (profilePath: string, description: string, extensions: readonly string[]): void => {
   const profile = readRecord(parse(readFileSync(profilePath, 'utf8')) as unknown);
   const controls = readRecord(profile.controls);
   const piControls = readRecord(controls.pi);
 
+  profile.description ??= description;
   controls.extensions = [];
   piControls.extensions = [...extensions];
   controls.pi = piControls;

--- a/src/cli/commands/SetupCommand.ts
+++ b/src/cli/commands/SetupCommand.ts
@@ -86,6 +86,7 @@ export type SetupCommandDependencies = SyncCommandDependencies &
 export interface SetupProfileChoice {
   readonly id: string;
   readonly label?: string;
+  readonly description?: string;
 }
 
 export type SetupSourceImportTarget = 'home' | 'project';
@@ -110,8 +111,16 @@ const setupSourceImportTargetChoices: readonly SetupSourceImportTargetChoice[] =
 ];
 
 const builtInSetupProfileChoices: readonly SetupProfileChoice[] = [
-  { id: 'engineer', label: 'Engineer' },
-  { id: 'data_analyst', label: 'Data Analyst' },
+  {
+    id: 'engineer',
+    label: 'Engineer',
+    description: 'Engineering setup for repository navigation, maintainable code changes, tests, and reviews.',
+  },
+  {
+    id: 'data_analyst',
+    label: 'Data Analyst',
+    description: 'Data analysis setup for careful inspection, reproducible methods, assumptions, and summaries.',
+  },
 ];
 
 interface StarterLayout {
@@ -1043,6 +1052,7 @@ const discoverSetupProfileChoicesFromLocalSource = (path: string): readonly Setu
     .map((profile) => ({
       id: profile.profile.id,
       label: profile.profile.label,
+      description: profile.profile.description,
     }))
     .sort((left, right) => left.id.localeCompare(right.id));
 };
@@ -1060,6 +1070,7 @@ const discoverSetupProfileChoicesFromEffectiveSettings = (input: SetupCommandInp
       choices.set(profile.profile.id, {
         id: profile.profile.id,
         label: profile.profile.label ?? existingChoice?.label,
+        description: profile.profile.description ?? existingChoice?.description,
       });
     }
   }
@@ -1141,6 +1152,9 @@ const promptForSetupProfileWithReadline = async (
   candidates.forEach((profile, index) => {
     const label = profile.label === undefined ? '' : ` - ${profile.label}`;
     output.write(`${index + 1}. ${profile.id}${label}\n`);
+    if (profile.description !== undefined) {
+      output.write(`   ${profile.description}\n`);
+    }
   });
 
   const currentIndex = Math.max(

--- a/src/cli/commands/WelcomeCommand.ts
+++ b/src/cli/commands/WelcomeCommand.ts
@@ -17,6 +17,7 @@ export interface WelcomeCommandInput {
 export interface WelcomeRoleChoice {
   readonly id: WelcomeDefaultProfileRoleId;
   readonly label: string;
+  readonly description: string;
 }
 
 export interface WelcomeLoadoutItem {
@@ -83,9 +84,22 @@ export const writeWelcomeIntro = (output: Pick<NodeJS.WritableStream, 'write'>):
 };
 
 const defaultProfileRoleChoices: readonly WelcomeRoleChoice[] = [
-  { id: 'founder', label: 'Founder' },
-  { id: 'engineer', label: 'Engineer' },
-  { id: 'data_analyst', label: 'Data Analyst' },
+  {
+    id: 'founder',
+    label: 'Founder',
+    description:
+      'Founder-operator setup for building, product thinking, research checks, dense prose, and careful delivery.',
+  },
+  {
+    id: 'engineer',
+    label: 'Engineer',
+    description: 'Engineering setup for repository navigation, maintainable code changes, tests, and reviews.',
+  },
+  {
+    id: 'data_analyst',
+    label: 'Data Analyst',
+    description: 'Data analysis setup for careful inspection, reproducible methods, assumptions, and summaries.',
+  },
 ];
 
 const fallbackRoleId: WelcomeDefaultProfileRoleId = 'founder';

--- a/src/profiles/Profile.ts
+++ b/src/profiles/Profile.ts
@@ -31,6 +31,7 @@ export interface ProfileControls extends BaseProfileControls {
 export interface Profile {
   readonly id: string;
   readonly label?: string;
+  readonly description?: string;
   readonly template?: boolean;
   readonly inherits: readonly string[];
   readonly controls: ProfileControls;

--- a/src/profiles/ProfileLoader.ts
+++ b/src/profiles/ProfileLoader.ts
@@ -57,6 +57,7 @@ export const parseProfileDocument = (document: unknown, fallbackId: string): Pro
   return omitUndefined({
     id,
     label: readOptionalString(record.label),
+    description: readOptionalString(record.description),
     template: readOptionalBoolean(record.template),
     inherits: readStringArray(record.inherits),
     controls: readControls(record.controls),

--- a/src/schemas/profile.schema.json
+++ b/src/schemas/profile.schema.json
@@ -9,6 +9,7 @@
       "pattern": "^[a-z0-9][a-z0-9._-]*[a-z0-9]$|^[a-z0-9]$"
     },
     "label": { "type": "string" },
+    "description": { "type": "string" },
     "template": { "type": "boolean" },
     "inherits": {
       "type": "array",

--- a/tests/unit/first-run-welcome-profile.test.ts
+++ b/tests/unit/first-run-welcome-profile.test.ts
@@ -262,13 +262,20 @@ describe('first-run welcome profile', () => {
 
     const persisted = persistFirstRunWelcomeProfile(homeDirectory, settingsPath, {
       answered: true,
-      selectedRole: { id: 'engineer', label: 'Engineer' },
+      selectedRole: {
+        id: 'engineer',
+        label: 'Engineer',
+        description: 'Engineering setup for repository navigation, maintainable code changes, tests, and reviews.',
+      },
       warnings: [],
       messages: [],
     });
 
     const profile = readFileSync(join(homeDirectory, '.outfitter', 'profiles', 'engineer', 'profile.yml'), 'utf8');
     expect(persisted).toEqual({ profileId: 'engineer', createdProfile: true });
+    expect(profile).toContain(
+      'description: Engineering setup for repository navigation, maintainable code changes, tests, and reviews.',
+    );
     expect(profile).toContain('append_system_prompt: |');
     expect(profile).not.toContain('extensions:');
     expect(readFileSync(settingsPath, 'utf8')).toContain('default_profile: engineer');
@@ -285,7 +292,11 @@ describe('first-run welcome profile', () => {
 
     const persisted = persistFirstRunWelcomeProfile(homeDirectory, settingsPath, {
       answered: true,
-      selectedRole: { id: 'engineer', label: 'Engineer' },
+      selectedRole: {
+        id: 'engineer',
+        label: 'Engineer',
+        description: 'Engineering setup for repository navigation, maintainable code changes, tests, and reviews.',
+      },
       selectedLoadout: {
         id: 'recommended',
         label: 'Recommended',
@@ -355,7 +366,11 @@ describe('first-run welcome profile', () => {
       settingsPath,
       {
         answered: true,
-        selectedRole: { id: 'data_analyst', label: 'Data Analyst' },
+        selectedRole: {
+          id: 'data_analyst',
+          label: 'Data Analyst',
+          description: 'Data analysis setup for careful inspection, reproducible methods, assumptions, and summaries.',
+        },
         warnings: [],
         messages: [],
       },
@@ -377,6 +392,12 @@ describe('first-run welcome profile', () => {
     });
     expect(readFileSync(settingsPath, 'utf8')).toContain('profile_sources: []');
     expect(readFileSync(settingsPath, 'utf8')).toContain('default_profile: data_analyst');
+    const copiedProfile = readFileSync(
+      join(homeDirectory, '.outfitter', 'profiles', 'data_analyst', 'profile.yml'),
+      'utf8',
+    );
+    expect(copiedProfile).toContain('description: Data analysis setup for careful inspection');
+    expect(copiedProfile).toContain('assumptions, and summaries.');
   });
 
   it('handles malformed scalar source profiles when copying welcome choices', () => {
@@ -397,7 +418,11 @@ describe('first-run welcome profile', () => {
       settingsPath,
       {
         answered: true,
-        selectedRole: { id: 'data_analyst', label: 'Data Analyst' },
+        selectedRole: {
+          id: 'data_analyst',
+          label: 'Data Analyst',
+          description: 'Data analysis setup for careful inspection, reproducible methods, assumptions, and summaries.',
+        },
         selectedLoadout: {
           id: 'recommended',
           label: 'Recommended',
@@ -464,7 +489,11 @@ describe('first-run welcome profile', () => {
       settingsPath,
       {
         answered: true,
-        selectedRole: { id: 'data_analyst', label: 'Data Analyst' },
+        selectedRole: {
+          id: 'data_analyst',
+          label: 'Data Analyst',
+          description: 'Data analysis setup for careful inspection, reproducible methods, assumptions, and summaries.',
+        },
         selectedLoadout: {
           id: 'recommended',
           label: 'Recommended',
@@ -502,7 +531,11 @@ describe('first-run welcome profile', () => {
 
     persistFirstRunWelcomeProfile(homeDirectory, settingsPath, {
       answered: true,
-      selectedRole: { id: 'data_analyst', label: 'Data Analyst' },
+      selectedRole: {
+        id: 'data_analyst',
+        label: 'Data Analyst',
+        description: 'Data analysis setup for careful inspection, reproducible methods, assumptions, and summaries.',
+      },
       warnings: [],
       messages: [],
     });

--- a/tests/unit/profile-loader.test.ts
+++ b/tests/unit/profile-loader.test.ts
@@ -59,7 +59,7 @@ describe('profile loading', () => {
     writeProfile(
       root,
       'base',
-      'label: Base Profile\ninherits:\n  - shared\ncontrols:\n  environment:\n    MODE: test\n',
+      'label: Base Profile\ndescription: Shared defaults for engineering work.\ninherits:\n  - shared\ncontrols:\n  environment:\n    MODE: test\n',
     );
     writeFileSync(join(root, 'README.md'), 'not a profile folder');
 
@@ -72,6 +72,7 @@ describe('profile loading', () => {
     expect(result.profiles[0]?.profile).toEqual({
       id: 'base',
       label: 'Base Profile',
+      description: 'Shared defaults for engineering work.',
       inherits: ['shared'],
       controls: { environment: { MODE: 'test' } },
     });

--- a/tests/unit/setup-command.test.ts
+++ b/tests/unit/setup-command.test.ts
@@ -399,13 +399,16 @@ describe('setup command', () => {
               'default_profile: project-lead\nprofile_sources:\n  - path: ./profiles\n',
             );
 
-            for (const [profileId, label] of [
-              ['engineer', 'Engineer'],
-              ['project-lead', 'Project Lead'],
+            for (const [profileId, label, description] of [
+              ['engineer', 'Engineer', 'General engineering setup.'],
+              ['project-lead', 'Project Lead', 'Planning and delivery setup.'],
             ] as const) {
               const profileFolder = join(outfitterDirectory, 'profiles', profileId);
               mkdirSync(profileFolder, { recursive: true });
-              writeFileSync(join(profileFolder, 'profile.yml'), `id: ${profileId}\nlabel: ${label}\ncontrols: {}\n`);
+              writeFileSync(
+                join(profileFolder, 'profile.yml'),
+                `id: ${profileId}\nlabel: ${label}\ndescription: ${description}\ncontrols: {}\n`,
+              );
             }
           },
         },
@@ -428,7 +431,9 @@ describe('setup command', () => {
       promptOutput.indexOf("You're importing Outfitter profiles"),
     );
     expect(promptOutput).toContain('1. project-lead - Project Lead');
+    expect(promptOutput).toContain('   Planning and delivery setup.');
     expect(promptOutput).toContain('2. engineer - Engineer');
+    expect(promptOutput).toContain('   General engineering setup.');
     expect(promptOutput).toContain('Default profile [1]:');
     expect(promptOutput).toContain('____        _    __ _ _   _');
     expect(promptOutput).not.toContain('____  _');
@@ -951,7 +956,11 @@ describe('setup command', () => {
 
     expect(result.welcomeResult).toEqual({
       answered: true,
-      selectedRole: { id: 'engineer', label: 'Engineer' },
+      selectedRole: {
+        id: 'engineer',
+        label: 'Engineer',
+        description: 'Engineering setup for repository navigation, maintainable code changes, tests, and reviews.',
+      },
       selectedLoadout: {
         id: 'recommended-pi',
         label: 'Recommended Pi productivity loadout',

--- a/tests/unit/welcome-command.test.ts
+++ b/tests/unit/welcome-command.test.ts
@@ -52,7 +52,11 @@ describe('welcome command', () => {
     );
 
     expect(result.answered).toBe(true);
-    expect(result.selectedRole).toEqual({ id: 'data_analyst', label: 'Data Analyst' });
+    expect(result.selectedRole).toEqual({
+      id: 'data_analyst',
+      label: 'Data Analyst',
+      description: 'Data analysis setup for careful inspection, reproducible methods, assumptions, and summaries.',
+    });
     expect(result.selectedLoadout?.id).toBe('recommended-pi');
     expect(result.selectedLoadout?.selectedItems.map((item) => item.source)).toEqual(defaultLoadoutSources);
     expect(result.warnings).toEqual([]);
@@ -77,7 +81,12 @@ describe('welcome command', () => {
       },
     );
 
-    expect(result.selectedRole).toEqual({ id: 'founder', label: 'Founder' });
+    expect(result.selectedRole).toEqual({
+      id: 'founder',
+      label: 'Founder',
+      description:
+        'Founder-operator setup for building, product thinking, research checks, dense prose, and careful delivery.',
+    });
     expect(result.selectedLoadout?.selectedItems.map((item) => item.source)).toEqual([
       'git:github.com/ai-outfitter/deepwork',
     ]);


### PR DESCRIPTION
## Summary
- add optional profile descriptions to the schema, loader, and profile types
- render profile descriptions in setup profile prompts
- persist descriptions into first-run generated and copied welcome profiles
- document the profile description field

## Verification
- npm test -- tests/unit/profile-loader.test.ts tests/unit/setup-command.test.ts tests/unit/welcome-command.test.ts tests/unit/first-run-welcome-profile.test.ts
- npm run check-ci