### PR TITLE
fix(onboarding): sequence Pi login before outfitter

### DIFF
--- a/requirements/OFTR-010-onboarding-welcome.md
+++ b/requirements/OFTR-010-onboarding-welcome.md
@@ -2,9 +2,8 @@
 
 ## Overview
 
-Outfitter welcome onboarding gets a new user to a productive Pi session in one question. The
-recommended path installs the founder profile automatically; declining opens `/outfitter` inside Pi
-so the user can configure a profile interactively.
+Outfitter welcome onboarding gets a new user to a productive Pi session in one question.
+The recommended path installs the founder profile automatically; declining opens `/outfitter` inside Pi so the user can configure a profile interactively.
 
 ## Requirements
 
@@ -12,17 +11,17 @@ so the user can configure a profile interactively.
 
 1. Welcome text MUST be shown to the user explaining what Outfitter and Pi are and what the founder profile provides.
 2. Welcome text MUST use Outfitter-branded ASCII/text.
-3. Welcome text MUST reference `/outfitter` as the way to customize the profile after installation.
 
 > Pi is a fully extensible agentic coding harness.
 > The founder profile brings Pi to feature parity with dedicated agentic coding tools.
-> Press Y to install it now. Run /outfitter inside Pi at any time to customize your profile.
+> Press Enter to install it now, or n to skip.
 
 ### OFTR-010.2: Profile Installation
 
 1. The welcome onboarding flow MUST present a single accept/decline prompt for the founder profile.
 2. Accepting (default) MUST install the founder role and the full recommended loadout without further prompts.
-3. The founder role MUST be the default and fallback selection. Outfitter's built-in role catalog also includes `engineer` and `data_analyst`; these are accessible via `/outfitter` after first run.
+3. The founder role MUST be the default and fallback selection.
+   Outfitter's built-in role catalog also includes `engineer` and `data_analyst`; these are accessible via `/outfitter` after first run.
 4. If the accepted role cannot be mapped to an available standard profile, Outfitter MUST warn the user and choose a deterministic fallback role rather than silently ignoring the selection.
 
 ### OFTR-010.3: Loadout
@@ -41,8 +40,11 @@ so the user can configure a profile interactively.
 2. If Pi is not logged in after the welcome flow, Outfitter MUST automatically invoke Pi's `/login` flow when Pi starts.
 3. When Outfitter launches Pi outside the welcome flow and Pi does not appear to be logged in, Outfitter MUST inform the user to run `/login` inside Pi.
 4. Pi login setup MUST NOT ask Outfitter to collect, echo, or persist provider API keys.
+5. If the welcome profile was declined and Pi is not logged in, `/login` MUST run first; after login state exists, Outfitter MUST invoke `/outfitter`.
+6. Pi startup text MUST reference `/outfitter` as the way to customize the profile after installation.
 
 ### OFTR-010.5: Decline Path
 
 1. If the user declines the welcome profile, Outfitter MUST launch Pi with `/outfitter` prefilled and auto-submitted so the user can configure a profile interactively on first session start.
 2. The profile install target MUST always be the user home directory (`~/.outfitter`); no installation scope prompt MUST be shown.
+3. If the user declines the welcome profile during first-run setup, Outfitter MUST NOT persist a default profile or configured profile source before opening `/outfitter`.

--- a/src/agents/pi/PiAdapter.ts
+++ b/src/agents/pi/PiAdapter.ts
@@ -1,7 +1,6 @@
 // Provides the pi adapter for composite profile generation and native pi launch plans.
 import { existsSync, readdirSync, readFileSync, statSync, type Dirent } from 'node:fs';
-import { delimiter, dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { delimiter, join } from 'node:path';
 
 import type { AgentAdapter, AgentLaunchPlan, AgentCompositeProfilePlan, AgentLaunchContext } from '../AgentAdapter.js';
 import {
@@ -246,11 +245,8 @@ const resolvePiStateSourcePath = (
 };
 
 const deepWorkAdditionalJobsFoldersEnv = 'DEEPWORK_ADDITIONAL_JOBS_FOLDERS';
-const packageRootDirectory = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
-const builtInOutfitterSkill = join(packageRootDirectory, 'skills', 'outfitter');
-
 const createPiSkillSources = (controls: PiProfileControls, profileFolders: readonly string[]): readonly string[] => [
-  ...new Set([builtInOutfitterSkill, ...(controls.skills ?? []), ...profileFolders.flatMap(skillSourcesForProfile)]),
+  ...new Set([...(controls.skills ?? []), ...profileFolders.flatMap(skillSourcesForProfile)]),
 ];
 
 const skillSourcesForProfile = (profileFolder: string): readonly string[] => [

--- a/src/cli/commands/PiLoginLaunch.ts
+++ b/src/cli/commands/PiLoginLaunch.ts
@@ -1,6 +1,7 @@
 // Adds first-run Pi login startup behavior without handling credentials in Outfitter.
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import type { AgentLaunchPlan } from '../../agents/AgentAdapter.js';
 import type { SetupCommandResult } from './SetupCommand.js';
@@ -23,34 +24,44 @@ const automaticLoginMessage =
   'Pi does not appear to be logged in yet. Outfitter will open `/login` automatically after Pi starts.';
 
 const nonInteractivePiLaunchFlags = new Set(['--print', '-p', '--mode', '--export', '--list-models']);
+const packageRootDirectory = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const builtInOutfitterSkill = join(packageRootDirectory, 'skills', 'outfitter', 'SKILL.md');
 
 export const preparePiLoginLaunchPlan = (input: PiLoginLaunchPlanInput): AgentLaunchPlan => {
   if (input.adapterId !== 'pi') {
     return input.launchPlan;
   }
 
-  // Load the Outfitter runtime extension for every interactive pi session. It brands the
-  // startup header today and is the home for future Outfitter↔pi integration. The header
-  // text is compiled into pi, so a launch-time extension is the only repo-local override.
-  // Non-interactive launches (--print, --export, …) keep pi untouched.
   let launchPlan = input.launchPlan;
-  if (!isNonInteractivePiLaunch(input.launchPlan.args)) {
-    launchPlan = addExtension(launchPlan, 'outfitter-extension.js', piOutfitterExtensionContent);
+  const interactiveLaunch = !isNonInteractivePiLaunch(input.launchPlan.args);
+  const shouldAutoOpenLogin = shouldAutoOpenPiLogin(input.setupResult, input.launchPlan.args);
+  const shouldOpenOutfitter = shouldAutoOpenOutfitterSkill(input.setupResult, input.launchPlan.args);
+  const shouldOpenLogin = !hasConfiguredPiLoginState(input.homeDirectory);
+
+  if (interactiveLaunch) {
+    launchPlan = addExtension(
+      launchPlan,
+      'outfitter-extension.js',
+      createPiOutfitterExtensionContent({
+        outfitterSkillPath: builtInOutfitterSkill,
+        openLogin: shouldAutoOpenLogin,
+        openOutfitterAfterLogin: shouldOpenOutfitter,
+      }),
+    );
   }
 
-  if (!hasConfiguredPiLoginState(input.homeDirectory)) {
-    if (shouldAutoOpenPiLogin(input.setupResult, input.launchPlan.args)) {
+  if (shouldOpenLogin) {
+    if (shouldAutoOpenLogin) {
       writePiLoginMessage(input.writeLine, automaticLoginMessage);
-      return addExtension(launchPlan, 'prefill-login-extension.js', piLoginPrefillExtensionContent);
+      return launchPlan;
     }
 
     writePiLoginMessage(input.writeLine, manualLoginMessage);
     return launchPlan;
   }
 
-  if (shouldAutoOpenOutfitterSkill(input.setupResult, input.launchPlan.args)) {
+  if (shouldOpenOutfitter) {
     writePiLoginMessage(input.writeLine, outfitterSkillMessage);
-    return addExtension(launchPlan, 'prefill-outfitter-extension.js', piOutfitterPrefillExtensionContent);
   }
 
   return launchPlan;
@@ -64,10 +75,57 @@ const addExtension = (launchPlan: AgentLaunchPlan, fileName: string, content: st
   return { ...launchPlan, args: ['--extension', extensionPath, ...launchPlan.args] };
 };
 
-// The general Outfitter pi extension. Currently brands the startup header with an
-// Outfitter + pi line; extend its session_start handler for further integration.
-const piOutfitterExtensionContent = `export default function outfitter(pi) {
-  pi.on("session_start", (_event, ctx) => {
+interface PiOutfitterExtensionOptions {
+  readonly outfitterSkillPath: string;
+  readonly openLogin: boolean;
+  readonly openOutfitterAfterLogin: boolean;
+}
+
+const createPiOutfitterExtensionContent = (
+  options: PiOutfitterExtensionOptions,
+): string => `const outfitterSkillPath = ${JSON.stringify(options.outfitterSkillPath)};
+const openLogin = ${JSON.stringify(options.openLogin)};
+const openOutfitterAfterLogin = ${JSON.stringify(options.openOutfitterAfterLogin)};
+const loginPollIntervalMs = 500;
+const loginPollTimeoutMs = 300000;
+
+const delay = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+const providerIsAvailable = async (ctx) => {
+  const available = await ctx.modelRegistry?.getAvailable?.();
+  return Array.isArray(available) && available.length > 0;
+};
+
+const waitForProvider = async (ctx) => {
+  const deadline = Date.now() + loginPollTimeoutMs;
+  while (Date.now() < deadline) {
+    if (await providerIsAvailable(ctx)) return true;
+    await delay(loginPollIntervalMs);
+  }
+  return false;
+};
+
+const submitCommand = async (ctx, command) => {
+  ctx.ui.setEditorText(command);
+  await ctx.ui.custom((tui, _theme, _keybindings, done) => {
+    setTimeout(() => {
+      tui.focusedComponent?.handleInput?.("\\r");
+      done();
+    }, 25);
+
+    return {
+      render: () => [],
+      invalidate: () => undefined,
+    };
+  }, { overlay: true, overlayOptions: { nonCapturing: true, visible: () => false } });
+};
+
+export default function outfitter(pi) {
+  pi.on("resources_discover", () => ({
+    skillPaths: [outfitterSkillPath],
+  }));
+
+  pi.on("session_start", async (_event, ctx) => {
     if (ctx.mode !== "tui") return;
     ctx.ui.setHeader((_tui, theme) => {
       const lines = [
@@ -78,50 +136,25 @@ const piOutfitterExtensionContent = `export default function outfitter(pi) {
           "dim",
           "Outfitter + Pi can explain its own features and look up its docs. Ask it how to use or extend Pi or outfitter profiles.",
         ),
+        theme.fg("dim", "Run /outfitter inside Pi at any time to customize your profile."),
       ];
       return {
         render: () => lines,
         invalidate: () => undefined,
       };
     });
-  });
-}
-`;
 
-const piOutfitterPrefillExtensionContent = `export default function outfitterSkillPrefill(pi) {
-  pi.on("session_start", async (_event, ctx) => {
-    ctx.ui.setEditorText("/outfitter");
-    ctx.ui.notify("Outfitter is opening /outfitter to help you set up your profile.", "info");
-    await ctx.ui.custom((tui, _theme, _keybindings, done) => {
-      setTimeout(() => {
-        tui.focusedComponent?.handleInput?.("\\r");
-        done();
-      }, 25);
+    if (openLogin && !(await providerIsAvailable(ctx))) {
+      ctx.ui.notify("Outfitter is opening /login so you can choose a provider.", "info");
+      await submitCommand(ctx, "/login");
 
-      return {
-        render: () => [],
-        invalidate: () => undefined,
-      };
-    }, { overlay: true, overlayOptions: { nonCapturing: true, visible: () => false } });
-  });
-}
-`;
+      if (!openOutfitterAfterLogin || !(await waitForProvider(ctx))) return;
+    }
 
-const piLoginPrefillExtensionContent = `export default function outfitterLoginPrefill(pi) {
-  pi.on("session_start", async (_event, ctx) => {
-    ctx.ui.setEditorText("/login");
-    ctx.ui.notify("Outfitter is opening /login so you can choose a provider.", "info");
-    await ctx.ui.custom((tui, _theme, _keybindings, done) => {
-      setTimeout(() => {
-        tui.focusedComponent?.handleInput?.("\\r");
-        done();
-      }, 25);
-
-      return {
-        render: () => [],
-        invalidate: () => undefined,
-      };
-    }, { overlay: true, overlayOptions: { nonCapturing: true, visible: () => false } });
+    if (openOutfitterAfterLogin) {
+      ctx.ui.notify("Outfitter is opening /outfitter to help you set up your profile.", "info");
+      await submitCommand(ctx, "/outfitter");
+    }
   });
 }
 `;

--- a/src/cli/commands/RunCommand.ts
+++ b/src/cli/commands/RunCommand.ts
@@ -77,7 +77,9 @@ export const executeRunCommand = async (
   dependencies: RunCommandDependencies = {},
 ): Promise<RunCommandResult> => {
   const setupResult = await runSetupIfNeeded(input, dependencies);
-  const resolvedProfile = loadResolvedProfile(input);
+  const resolvedProfile = shouldLaunchOutfitterSetupProfile(setupResult, input)
+    ? loadOutfitterSetupProfile(input)
+    : loadResolvedProfile(input);
   const adapter =
     dependencies.adapter ?? createAgentAdapter(selectRunAgentId(input.agentId, resolvedProfile.settings.defaultAgent));
   const compositeProfileRootDirectory = createCompositeProfileRootDirectory(resolvedProfile.profile.id, adapter.id);
@@ -410,6 +412,31 @@ const loadResolvedProfile = (input: RunCommandInput): ResolvedRunProfile => {
     profileLayers: findContributingLoadedProfiles(resolution.profileStack, loadedProfiles.profiles),
     profilePaths: findContributingProfilePaths(resolution.profileStack, loadedProfiles.profiles),
     profileFolders: findContributingProfileFolders(resolution.profileStack, loadedProfiles.profiles),
+    homeDirectory: input.homeDirectory,
+    cacheDirectory: loadedSettings.settings.cacheDirectory ?? join(input.homeDirectory, '.outfitter', 'cache'),
+    projectDirectory: input.projectDirectory,
+    settings: loadedSettings.settings,
+    settingsPaths: loadedSettings.files.map((file) => file.location.path),
+  };
+};
+
+const shouldLaunchOutfitterSetupProfile = (
+  setupResult: SetupCommandResult | undefined,
+  input: RunCommandInput,
+): boolean => setupResult?.welcomeResult?.answered === false && input.profileId === undefined;
+
+const loadOutfitterSetupProfile = (input: RunCommandInput): ResolvedRunProfile => {
+  const loadedSettings = loadSettingsWithCachedRemoteSettings(input);
+
+  if (loadedSettings.issues.length > 0) {
+    throw new Error(`Cannot run with invalid settings: ${loadedSettings.issues.map(formatSettingsIssue).join('; ')}`);
+  }
+
+  return {
+    profile: { id: 'outfitter_setup', label: 'Outfitter setup', inherits: [], controls: {} },
+    profileLayers: [],
+    profilePaths: [],
+    profileFolders: [],
     homeDirectory: input.homeDirectory,
     cacheDirectory: loadedSettings.settings.cacheDirectory ?? join(input.homeDirectory, '.outfitter', 'cache'),
     projectDirectory: input.projectDirectory,

--- a/src/cli/commands/SetupCommand.ts
+++ b/src/cli/commands/SetupCommand.ts
@@ -43,7 +43,7 @@ export interface SetupCommandInput {
 
 export interface SetupCommandResult {
   readonly settingsPath: string;
-  readonly defaultProfilePath: string;
+  readonly defaultProfilePath?: string;
   readonly createdSettings: boolean;
   readonly copiedStarterProfileFiles: number;
   readonly createdDefaultProfile: boolean;
@@ -71,10 +71,6 @@ export type SetupCommandDependencies = SyncCommandDependencies &
       profiles: readonly SetupProfileChoice[],
       currentDefault: string,
     ) => Promise<string>;
-    readonly selectSetupSourceImportTarget?: (
-      choices: readonly SetupSourceImportTargetChoice[],
-      defaultTarget: SetupSourceImportTarget,
-    ) => Promise<SetupSourceImportTarget>;
     readonly selectSetupSourceLaunchAction?: (profileId: string) => Promise<SetupSourcePostImportAction>;
     readonly launchSetupSourceProfile?: (input: SetupSourceLaunchInput) => Promise<void>;
     readonly runWelcome?: (
@@ -90,25 +86,6 @@ export interface SetupProfileChoice {
 }
 
 export type SetupSourceImportTarget = 'home' | 'project';
-
-export interface SetupSourceImportTargetChoice {
-  readonly target: SetupSourceImportTarget;
-  readonly label: string;
-  readonly description: string;
-}
-
-const setupSourceImportTargetChoices: readonly SetupSourceImportTargetChoice[] = [
-  {
-    target: 'home',
-    label: 'User home',
-    description: 'install profiles into ~/.outfitter for all repositories on this machine',
-  },
-  {
-    target: 'project',
-    label: 'Current project',
-    description: 'install profiles into this project .outfitter folder only',
-  },
-];
 
 const builtInSetupProfileChoices: readonly SetupProfileChoice[] = [
   {
@@ -176,7 +153,10 @@ export const executeSetupCommand = async (
     : await selectDefaultProfileIfInteractive(input, settingsPath, defaultProfileId, dependencies, starterLayout);
   const welcomeResult = await runWelcomeAfterInteractiveSetup(input, dependencies);
   const welcomeProfile = persistWelcomeProfileForSetup(input, settingsPath, welcomeResult);
-  const finalDefaultProfile = prepareFinalDefaultProfile(input.homeDirectory, selectedDefaultProfileId, welcomeProfile);
+  const finalDefaultProfile =
+    initialSettingsMissing && welcomeResult?.answered === false
+      ? prepareSkippedWelcomeProfile(settingsPath)
+      : prepareFinalDefaultProfile(input.homeDirectory, selectedDefaultProfileId, welcomeProfile);
 
   return {
     settingsPath,
@@ -197,7 +177,7 @@ export const executeSetupCommand = async (
       createdDefaultProfile: finalDefaultProfile.created,
       syncResult,
       welcomeProfileMessages: welcomeProfile?.messages ?? [],
-      runExampleMessages: input.setupSourceUri === undefined ? [] : [formatRunProfileExample(finalDefaultProfile.id)],
+      runExampleMessages: buildRunExampleMessages(input, finalDefaultProfile.id),
     }),
   };
 };
@@ -304,10 +284,15 @@ const executeInteractiveSetupSourceCommand = async ({
 };
 
 interface FinalDefaultProfile {
-  readonly id: string;
-  readonly path: string;
+  readonly id?: string;
+  readonly path?: string;
   readonly created: boolean;
 }
+
+const prepareSkippedWelcomeProfile = (settingsPath: string): FinalDefaultProfile => {
+  writeFileSync(settingsPath, 'profile_sources: []\n');
+  return { created: false };
+};
 
 const prepareFinalDefaultProfile = (
   homeDirectory: string,
@@ -330,8 +315,8 @@ interface SetupMessageInput {
   readonly profileTargetPath?: string;
   readonly createdSettings: boolean;
   readonly copiedStarterProfileFiles: number;
-  readonly defaultProfileId: string;
-  readonly defaultProfilePath: string;
+  readonly defaultProfileId?: string;
+  readonly defaultProfilePath?: string;
   readonly createdDefaultProfile: boolean;
   readonly syncResult: SyncCommandResult;
   readonly welcomeProfileMessages: readonly string[];
@@ -360,22 +345,27 @@ const buildSetupMessages = (input: SetupMessageInput): readonly string[] => {
     messages.push(`Copied ${input.copiedStarterProfileFiles} starter profile file(s) into ${profileTargetPath}.`);
   }
 
-  if (shouldReportDefaultProfileStatus(input)) {
-    messages.push(
-      input.createdDefaultProfile
-        ? `Created default user profile at ${input.defaultProfilePath}.`
-        : `Default user profile at ${input.defaultProfilePath} already exists; left unchanged.`,
-    );
+  messages.push(...buildDefaultProfileMessages(input));
+
+  if (input.defaultProfileId !== undefined) {
+    messages.push(`Selected default profile '${input.defaultProfileId}'.`);
   }
 
-  messages.push(
-    `Selected default profile '${input.defaultProfileId}'.`,
-    ...input.welcomeProfileMessages,
-    ...input.runExampleMessages,
-    ...input.syncResult.messages,
-  );
+  messages.push(...input.welcomeProfileMessages, ...input.runExampleMessages, ...input.syncResult.messages);
 
   return messages;
+};
+
+const buildDefaultProfileMessages = (input: SetupMessageInput): readonly string[] => {
+  if (!shouldReportDefaultProfileStatus(input)) {
+    return [];
+  }
+
+  return [
+    input.createdDefaultProfile
+      ? `Created default user profile at ${input.defaultProfilePath}.`
+      : `Default user profile at ${input.defaultProfilePath} already exists; left unchanged.`,
+  ];
 };
 
 const shouldReportDefaultProfileStatus = (input: SetupMessageInput): boolean => {
@@ -383,11 +373,22 @@ const shouldReportDefaultProfileStatus = (input: SetupMessageInput): boolean => 
     return true;
   }
 
-  return input.input.setupSourceUri === undefined || input.starterLayout?.profilesPath === undefined;
+  return (
+    input.defaultProfilePath !== undefined &&
+    (input.input.setupSourceUri === undefined || input.starterLayout?.profilesPath === undefined)
+  );
 };
 
 const formatRunProfileExample = (profileId: string): string =>
   `Start the selected default profile either way:\n  outfitter\n  outfitter --profile ${profileId}`;
+
+const buildRunExampleMessages = (input: SetupCommandInput, defaultProfileId: string | undefined): readonly string[] => {
+  if (input.setupSourceUri === undefined || defaultProfileId === undefined) {
+    return [];
+  }
+
+  return [formatRunProfileExample(defaultProfileId)];
+};
 
 const runSetupSourcePostImportAction = async (
   input: SetupCommandInput,
@@ -861,12 +862,12 @@ const runSetupSourceOnboarding = async (
   const promptDefault = sourceDefault ?? currentDefault;
   const profiles = selectSetupPromptProfiles(input, discoveredProfiles, currentDefault, sourceDefault);
 
-  if (dependencies.selectSetupSourceImportTarget === undefined && dependencies.selectDefaultProfile === undefined) {
+  if (dependencies.selectDefaultProfile === undefined) {
     return promptForSetupSourceOnboarding(input, profiles, promptDefault, dependencies);
   }
 
   writeSetupSourceWelcome(input, profiles, resolvePromptOutput(dependencies));
-  const importTarget = await selectSetupSourceImportTarget(dependencies);
+  const importTarget = 'home' as const;
   const selectedProfileId = await selectSetupProfile(profiles, promptDefault, dependencies);
   assertValidSelectedDefaultProfile(selectedProfileId, profiles);
 
@@ -923,26 +924,6 @@ const formatSetupSourceProfileList = (profiles: readonly SetupProfileChoice[]): 
   }
 
   return `: ${profiles.map((profile) => profile.id).join(', ')}`;
-};
-
-const selectSetupSourceImportTarget = async (
-  dependencies: SetupCommandDependencies,
-): Promise<SetupSourceImportTarget> => {
-  /* v8 ignore else -- mixed dependency injection path; the full readline path prompts with one shared readline. */
-  if (dependencies.selectSetupSourceImportTarget !== undefined) {
-    const selectedTarget = await dependencies.selectSetupSourceImportTarget(setupSourceImportTargetChoices, 'home');
-    assertValidSetupSourceImportTarget(selectedTarget);
-    return selectedTarget;
-  }
-
-  return 'home';
-};
-
-const assertValidSetupSourceImportTarget = (target: SetupSourceImportTarget): void => {
-  /* v8 ignore next -- defensive validation for custom dependency injection. */
-  if (setupSourceImportTargetChoices.every((choice) => choice.target !== target)) {
-    throw new Error(`Selected setup-source import target '${target}' is not available.`);
-  }
 };
 
 /* v8 ignore next -- covered by interactive CLI smoke tests; unit tests inject the launch choice. */
@@ -1150,11 +1131,9 @@ const promptForSetupProfileWithReadline = async (
   const candidates = profiles.length > 0 ? profiles : [{ id: currentDefault }];
   output.write(`\n${heading}\n`);
   candidates.forEach((profile, index) => {
-    const label = profile.label === undefined ? '' : ` - ${profile.label}`;
-    output.write(`${index + 1}. ${profile.id}${label}\n`);
-    if (profile.description !== undefined) {
-      output.write(`   ${profile.description}\n`);
-    }
+    const displayName = profile.label ?? profile.id;
+    const description = profile.description === undefined ? '' : ` - ${profile.description}`;
+    output.write(`${index + 1}. ${displayName}${description}\n`);
   });
 
   const currentIndex = Math.max(

--- a/src/cli/commands/WelcomeCommand.ts
+++ b/src/cli/commands/WelcomeCommand.ts
@@ -76,7 +76,7 @@ const welcomeIntroLines = [
   'Outfitter configures Pi with profiles and extensions — turning it into a complete agentic development environment.',
   'The founder profile brings Pi to feature parity with dedicated agentic coding tools:',
   'task tracking, multi-step reviews, browser automation, subagents, interactive shell, and MCP support.',
-  'Press Y to install it now.',
+  'Press Enter to install it now, or n to skip.',
 ] as const;
 
 export const writeWelcomeIntro = (output: Pick<NodeJS.WritableStream, 'write'>): void => {
@@ -197,7 +197,7 @@ export const executeWelcomeCommand = async (
     selectedRole: roleResolution.role,
     selectedLoadout: loadoutResolution.loadout,
     warnings,
-    messages: buildWelcomeMessages(warnings),
+    messages: buildWelcomeMessages(roleResolution.role, warnings),
   };
 };
 
@@ -250,7 +250,9 @@ const promptForWelcomePlan = async (dependencies: WelcomeCommandDependencies): P
 
   try {
     writeWelcomeIntro(output);
-    const answer = (await readline.question('Install the founder profile? [Y/n]: ')).trim().toLowerCase();
+    const answer = (await readline.question('Install the founder profile? [Enter to install, n to skip]: '))
+      .trim()
+      .toLowerCase();
     const answerQuestions = answer === '' || ['y', 'yes'].includes(answer);
 
     if (!answerQuestions) {
@@ -306,8 +308,8 @@ const resolveSelectedLoadout = (
   };
 };
 
-const buildWelcomeMessages = (warnings: readonly string[]): readonly string[] => [
-  'Installed the founder profile. Use /outfitter inside Pi or run `outfitter profile list` to manage profiles.',
+const buildWelcomeMessages = (role: WelcomeRoleChoice, warnings: readonly string[]): readonly string[] => [
+  `Installed the ${role.label} profile. Use /outfitter inside Pi or run \`outfitter profile list\` to manage profiles.`,
   ...warnings.map((warning) => `Warning: ${warning}`),
 ];
 

--- a/tests/fixtures/integration/adapter_specific_overrides/expected/pi/composite-profile-summary.json
+++ b/tests/fixtures/integration/adapter_specific_overrides/expected/pi/composite-profile-summary.json
@@ -24,8 +24,6 @@
     "--extension",
     "./tools/generic-extension",
     "--skill",
-    "<repo>/skills/outfitter",
-    "--skill",
     "repo-review",
     "--pi-flag"
   ],

--- a/tests/fixtures/integration/cache_backed_tooling_state/expected/pi/composite-profile-summary.json
+++ b/tests/fixtures/integration/cache_backed_tooling_state/expected/pi/composite-profile-summary.json
@@ -7,8 +7,6 @@
     "<composite-profile>/outfitter/outfitter-extension.js",
     "--model",
     "cache-tooling-model",
-    "--skill",
-    "<repo>/skills/outfitter",
     "--cache-tooling"
   ],
   "launchEnv": {

--- a/tests/fixtures/integration/heavily_overridden_engineering/expected/pi/composite-profile-summary.json
+++ b/tests/fixtures/integration/heavily_overridden_engineering/expected/pi/composite-profile-summary.json
@@ -18,8 +18,6 @@
     "--extension",
     "personal-lint",
     "--skill",
-    "<repo>/skills/outfitter",
-    "--skill",
     "code-review",
     "--pi-local-flag"
   ],

--- a/tests/fixtures/integration/language_stack_with_personal_default/expected/pi/composite-profile-summary.json
+++ b/tests/fixtures/integration/language_stack_with_personal_default/expected/pi/composite-profile-summary.json
@@ -16,8 +16,6 @@
     "--extension",
     "tsconfig",
     "--skill",
-    "<repo>/skills/outfitter",
-    "--skill",
     "strict-typescript",
     "--review-scope=typescript"
   ],

--- a/tests/fixtures/integration/local_sandbox_overrides/expected/pi/composite-profile-summary.json
+++ b/tests/fixtures/integration/local_sandbox_overrides/expected/pi/composite-profile-summary.json
@@ -13,8 +13,6 @@
     "high",
     "--system-prompt",
     "./prompts/sandbox.md",
-    "--skill",
-    "<repo>/skills/outfitter",
     "--sandbox-mode"
   ],
   "launchEnv": {

--- a/tests/fixtures/integration/native_fallback_cli_state/expected/pi/composite-profile-summary.json
+++ b/tests/fixtures/integration/native_fallback_cli_state/expected/pi/composite-profile-summary.json
@@ -9,8 +9,6 @@
     "fallback-review-model",
     "--provider",
     "openai",
-    "--skill",
-    "<repo>/skills/outfitter",
     "--native-fallback-fixture"
   ],
   "launchEnv": {

--- a/tests/fixtures/integration/profile_owned_cli_state/expected/pi/composite-profile-summary.json
+++ b/tests/fixtures/integration/profile_owned_cli_state/expected/pi/composite-profile-summary.json
@@ -22,8 +22,6 @@
     "--extension",
     "team-extension",
     "--skill",
-    "<repo>/skills/outfitter",
-    "--skill",
     "repo-audit",
     "--pi-owned-state"
   ],

--- a/tests/fixtures/integration/remote_baseline_local_selection/expected/pi/composite-profile-summary.json
+++ b/tests/fixtures/integration/remote_baseline_local_selection/expected/pi/composite-profile-summary.json
@@ -11,8 +11,6 @@
     "remote-provider",
     "--thinking",
     "user-default-thinking",
-    "--skill",
-    "<repo>/skills/outfitter",
     "--local-selection",
     "--project-review",
     "--remote-baseline",

--- a/tests/fixtures/integration/strict_ci_profile/expected/pi/launch-summary.json
+++ b/tests/fixtures/integration/strict_ci_profile/expected/pi/launch-summary.json
@@ -9,8 +9,6 @@
     "ci-review-model",
     "--provider",
     "ci-provider",
-    "--skill",
-    "<repo>/skills/outfitter",
     "--ci",
     "--no-interactive"
   ],

--- a/tests/fixtures/integration/trivial_repo_only_profile/expected/pi/composite-profile-summary.json
+++ b/tests/fixtures/integration/trivial_repo_only_profile/expected/pi/composite-profile-summary.json
@@ -7,8 +7,6 @@
     "<composite-profile>/outfitter/outfitter-extension.js",
     "--model",
     "repo-review-model",
-    "--skill",
-    "<repo>/skills/outfitter",
     "--repo-flag"
   ],
   "launchEnv": {

--- a/tests/unit/first-run-welcome-profile.test.ts
+++ b/tests/unit/first-run-welcome-profile.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import { persistFirstRunWelcomeProfile } from '../../src/cli/commands/FirstRunWelcomeProfile.js';
 import { executeRunCommand } from '../../src/cli/commands/RunCommand.js';
+import { executeListProfilesCommand } from '../../src/cli/commands/profile/ListCommand.js';
 
 const temporaryRoots: string[] = [];
 
@@ -83,7 +84,7 @@ afterEach(() => {
 describe('first-run welcome profile', () => {
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.1).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('leaves first-run welcome opt-out on the generated role profile before launching pi', async () => {
+  it('leaves first-run welcome opt-out with no configured profiles before launching pi', async () => {
     const root = createTemporaryRoot();
     const homeDirectory = join(root, 'home');
     const projectDirectory = join(root, 'project');
@@ -112,14 +113,11 @@ describe('first-run welcome profile', () => {
       },
     );
 
-    expect(result.profileId).toBe('engineer');
+    expect(result.profileId).toBe('outfitter_setup');
     expect(launches).toHaveLength(1);
-    expect(readFileSync(join(homeDirectory, '.outfitter', 'settings.yml'), 'utf8')).toContain(
-      'default_profile: engineer',
-    );
-    expect(readFileSync(join(homeDirectory, '.outfitter', 'profiles', 'engineer', 'profile.yml'), 'utf8')).toBe(
-      'id: engineer\nlabel: Default\ncontrols: {}\n',
-    );
+    expect(readFileSync(join(homeDirectory, '.outfitter', 'settings.yml'), 'utf8')).toBe('profile_sources: []\n');
+    expect(existsSync(join(homeDirectory, '.outfitter', 'profiles', 'engineer', 'profile.yml'))).toBe(false);
+    expect(executeListProfilesCommand({ homeDirectory, projectDirectory }).messages).toEqual(['No profiles found.']);
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.2, OFTR-010.3).
@@ -200,7 +198,7 @@ describe('first-run welcome profile', () => {
 
     expect(result.launchPlan.args[0]).toBe('--extension');
     const loginExtensionContent = readFileSync(result.launchPlan.args[1] ?? '', 'utf8');
-    expect(loginExtensionContent).toContain('setEditorText("/login")');
+    expect(loginExtensionContent).toContain('submitCommand(ctx, "/login")');
     expect(loginExtensionContent).toContain('handleInput?.("\\r")');
     expect(messages).toContain(
       'Pi does not appear to be logged in yet. Outfitter will open `/login` automatically after Pi starts.',

--- a/tests/unit/pi-adapter-profile-resources.test.ts
+++ b/tests/unit/pi-adapter-profile-resources.test.ts
@@ -2,15 +2,12 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { createPiAdapter } from '../../src/agents/pi/PiAdapter.js';
 
 const temporaryRoots: string[] = [];
-const repositoryRoot = fileURLToPath(new URL('../..', import.meta.url));
-const builtInOutfitterSkill = join(repositoryRoot, 'skills', 'outfitter');
 
 afterEach(() => {
   for (const root of temporaryRoots.splice(0)) {
@@ -42,14 +39,7 @@ describe('pi adapter profile resources', () => {
       { profileFolders: [profileFolder] },
     );
 
-    expect(launchPlan.args).toEqual([
-      '--skill',
-      builtInOutfitterSkill,
-      '--skill',
-      'user-skill',
-      '--skill',
-      skillFolder,
-    ]);
+    expect(launchPlan.args).toEqual(['--skill', 'user-skill', '--skill', skillFolder]);
   });
 });
 

--- a/tests/unit/pi-adapter.test.ts
+++ b/tests/unit/pi-adapter.test.ts
@@ -2,7 +2,6 @@
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -11,8 +10,6 @@ import { writeCompositeProfile } from '../../src/compositeProfile/CompositeProfi
 import { parseProfileYaml } from '../../src/profiles/ProfileLoader.js';
 
 const temporaryPiAdapterTestRoots: string[] = [];
-const repositoryRoot = fileURLToPath(new URL('../..', import.meta.url));
-const builtInOutfitterSkill = join(repositoryRoot, 'skills', 'outfitter');
 
 afterEach(() => {
   for (const root of temporaryPiAdapterTestRoots.splice(0)) {
@@ -119,8 +116,6 @@ describe('pi adapter', () => {
       '--extension',
       'ext-a',
       '--skill',
-      builtInOutfitterSkill,
-      '--skill',
       'skill-pi',
       '--skill',
       'skill-a',
@@ -136,8 +131,6 @@ describe('pi adapter', () => {
       expect(adapter.createLaunchPlan(compositeProfilePlan.compositeProfile, genericFallbackProfile).args).toEqual([
         '--model',
         'generic-model',
-        '--skill',
-        builtInOutfitterSkill,
       ]);
     }
   });
@@ -163,8 +156,6 @@ describe('pi adapter', () => {
       './prompts/role.md',
       '--append-system-prompt',
       './prompts/vcs.md',
-      '--skill',
-      builtInOutfitterSkill,
     ]);
   });
 

--- a/tests/unit/pi-login-launch.test.ts
+++ b/tests/unit/pi-login-launch.test.ts
@@ -50,10 +50,15 @@ describe('preparePiLoginLaunchPlan', () => {
     });
 
     const header = readExtension(plan, 'outfitter-extension.js');
+    expect(header).toContain('pi.on("resources_discover"');
+    expect(header).toContain('skillPaths: [outfitterSkillPath]');
+    expect(header).toContain('/skills/outfitter/SKILL.md');
+    expect(header).toContain('const openLogin = false;');
     expect(header).toContain('ctx.ui.setHeader');
     expect(header).toContain(
       'Outfitter + Pi can explain its own features and look up its docs. Ask it how to use or extend Pi or outfitter profiles.',
     );
+    expect(header).toContain('Run /outfitter inside Pi at any time to customize your profile.');
     // Guards against running outside the interactive TUI.
     expect(header).toContain('if (ctx.mode !== "tui") return;');
   });
@@ -95,7 +100,33 @@ describe('preparePiLoginLaunchPlan', () => {
     });
 
     expect(() => readExtension(plan, 'outfitter-extension.js')).not.toThrow();
-    expect(() => readExtension(plan, 'prefill-login-extension.js')).not.toThrow();
+    const extension = readExtension(plan, 'outfitter-extension.js');
+    expect(extension).toContain('const openLogin = true;');
+    expect(extension).toContain('const openOutfitterAfterLogin = false;');
+    expect(extension).toContain('setEditorText(command)');
+    expect(extension).toContain('submitCommand(ctx, "/login")');
+    expect(messages.some((message) => message.includes('/login'))).toBe(true);
+  });
+
+  it('uses one extension to open login before outfitter after a declined welcome', () => {
+    const agentDir = createAgentDir();
+    const messages: string[] = [];
+    const plan = preparePiLoginLaunchPlan({
+      adapterId: 'pi',
+      homeDirectory: agentDir,
+      launchPlan: createLaunchPlan(agentDir),
+      setupResult: { welcomeResult: { answered: false } } as never,
+      writeLine: (message) => messages.push(message),
+    });
+
+    expect(extensionPaths(plan)).toHaveLength(1);
+    const extension = readExtension(plan, 'outfitter-extension.js');
+    expect(extension).toContain('ctx.ui.setHeader');
+    expect(extension).toContain('const openLogin = true;');
+    expect(extension).toContain('const openOutfitterAfterLogin = true;');
+    expect(extension).toContain('submitCommand(ctx, "/login")');
+    expect(extension).toContain('waitForProvider(ctx)');
+    expect(extension).toContain('submitCommand(ctx, "/outfitter")');
     expect(messages.some((message) => message.includes('/login'))).toBe(true);
   });
 });

--- a/tests/unit/run-command.test.ts
+++ b/tests/unit/run-command.test.ts
@@ -2,7 +2,6 @@
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -11,8 +10,6 @@ import { createCompositeProfile } from '../../src/compositeProfile/CompositeProf
 import { allowTestConsoleOutput } from '../test-console.js';
 
 const temporaryRoots: string[] = [];
-const repositoryRoot = fileURLToPath(new URL('../..', import.meta.url));
-const builtInOutfitterSkill = join(repositoryRoot, 'skills', 'outfitter');
 
 const createTemporaryRoot = (): string => {
   const root = mkdtempSync(join(tmpdir(), 'outfitter-run-command-'));
@@ -156,8 +153,6 @@ describe('run command', () => {
       join(result.compositeProfileDirectory, 'outfitter', 'outfitter-extension.js'),
       '--model',
       'test-model',
-      '--skill',
-      builtInOutfitterSkill,
       '--debug',
       'prompt text',
     ]);

--- a/tests/unit/setup-command.test.ts
+++ b/tests/unit/setup-command.test.ts
@@ -332,11 +332,6 @@ describe('setup command', () => {
             }
           },
         },
-        selectSetupSourceImportTarget(choices, defaultTarget) {
-          expect(defaultTarget).toBe('home');
-          expect(choices.map((choice) => choice.target)).toEqual(['home', 'project']);
-          return Promise.resolve('home');
-        },
         selectDefaultProfile(profiles, currentDefault) {
           expect(currentDefault).toBe('engineer');
           expect(profiles.map((profile) => profile.id)).toEqual(['ops', 'project-lead']);
@@ -430,10 +425,8 @@ describe('setup command', () => {
     expect(promptOutput.indexOf('Welcome to Outfitter.')).toBeLessThan(
       promptOutput.indexOf("You're importing Outfitter profiles"),
     );
-    expect(promptOutput).toContain('1. project-lead - Project Lead');
-    expect(promptOutput).toContain('   Planning and delivery setup.');
-    expect(promptOutput).toContain('2. engineer - Engineer');
-    expect(promptOutput).toContain('   General engineering setup.');
+    expect(promptOutput).toContain('1. Project Lead - Planning and delivery setup.');
+    expect(promptOutput).toContain('2. Engineer - General engineering setup.');
     expect(promptOutput).toContain('Default profile [1]:');
     expect(promptOutput).toContain('____        _    __ _ _   _');
     expect(promptOutput).not.toContain('____  _');
@@ -503,7 +496,7 @@ describe('setup command', () => {
       expect(promptOutput).toContain("You're importing Outfitter profiles from https://example.test/link-profiles.");
       expect(promptOutput).not.toContain('Choose where to install these profiles:');
       expect(promptOutput).toContain('Choose the default profile from this setup source:');
-      expect(promptOutput).toContain('1. project-lead - Project Lead');
+      expect(promptOutput).toContain('1. Project Lead');
       expect(promptOutput).toContain('Default profile [1]:');
       expect(result.messages).toContain("Selected default profile 'project-lead'.");
     } finally {
@@ -511,7 +504,7 @@ describe('setup command', () => {
     }
   });
 
-  it('imports setup-source profiles into the project without changing the user default', async () => {
+  it('imports setup-source profiles into the user home without a scope choice', async () => {
     const root = createTemporaryRoot();
     const homeDirectory = join(root, 'home');
     const projectDirectory = join(root, 'project');
@@ -540,11 +533,6 @@ describe('setup command', () => {
             }
           },
         },
-        selectSetupSourceImportTarget(choices, defaultTarget) {
-          expect(defaultTarget).toBe('home');
-          expect(choices.map((choice) => choice.target)).toEqual(['home', 'project']);
-          return Promise.resolve('project');
-        },
         selectDefaultProfile(profiles, currentDefault) {
           expect(currentDefault).toBe('engineer');
           expect(profiles.map((profile) => profile.id)).toEqual(['engineer', 'project-lead']);
@@ -556,23 +544,21 @@ describe('setup command', () => {
       },
     );
 
-    expect(result.settingsPath).toBe(join(projectDirectory, '.outfitter', 'settings.yml'));
+    expect(result.settingsPath).toBe(join(homeDirectory, '.outfitter', 'settings.yml'));
     expect(result.defaultProfilePath).toBe(
-      join(projectDirectory, '.outfitter', 'profiles', 'project-lead', 'profile.yml'),
+      join(homeDirectory, '.outfitter', 'profiles', 'project-lead', 'profile.yml'),
     );
     expect(result.createdDefaultProfile).toBe(false);
     expect(result.messages.join('\n')).not.toContain('Default user profile');
     expect(result.messages.join('\n')).toContain(
       'Start the selected default profile either way:\n  outfitter\n  outfitter --profile project-lead',
     );
-    expect(readFileSync(join(homeDirectory, '.outfitter', 'settings.yml'), 'utf8')).toBe(
-      'default_profile: engineer\nprofile_sources:\n  - path: ./profiles\n',
-    );
-    expect(readFileSync(join(projectDirectory, '.outfitter', 'settings.yml'), 'utf8')).toContain(
+    expect(readFileSync(join(homeDirectory, '.outfitter', 'settings.yml'), 'utf8')).toContain(
       'default_profile: project-lead',
     );
-    expect(readFileSync(join(projectDirectory, '.outfitter', 'settings.yml'), 'utf8')).toContain('path: ./profiles');
-    expect(readFileSync(join(projectDirectory, '.outfitter', 'profiles', 'project-lead', 'profile.yml'), 'utf8')).toBe(
+    expect(readFileSync(join(homeDirectory, '.outfitter', 'settings.yml'), 'utf8')).toContain('path: ./profiles');
+    expect(existsSync(join(projectDirectory, '.outfitter', 'settings.yml'))).toBe(false);
+    expect(readFileSync(join(homeDirectory, '.outfitter', 'profiles', 'project-lead', 'profile.yml'), 'utf8')).toBe(
       'id: project-lead\nlabel: Project Lead\ncontrols: {}\n',
     );
   });
@@ -601,9 +587,6 @@ describe('setup command', () => {
             writeFileSync(join(profileFolder, 'profile.yml'), 'id: project-lead\nlabel: Project Lead\ncontrols: {}\n');
           },
         },
-        selectSetupSourceImportTarget() {
-          return Promise.resolve('project');
-        },
         selectDefaultProfile() {
           return Promise.resolve('project-lead');
         },
@@ -624,7 +607,7 @@ describe('setup command', () => {
     expect(result.messages.join('\n')).not.toContain('outfitter --profile project-lead');
   });
 
-  it('adds a local project profile source when setup-source settings omit profile sources', async () => {
+  it('adds a local profile source when setup-source settings omit profile sources', async () => {
     const root = createTemporaryRoot();
     const homeDirectory = join(root, 'home');
     const projectDirectory = join(root, 'project');
@@ -645,9 +628,6 @@ describe('setup command', () => {
             writeFileSync(join(profileFolder, 'profile.yml'), 'id: project-lead\nlabel: Project Lead\ncontrols: {}\n');
           },
         },
-        selectSetupSourceImportTarget() {
-          return Promise.resolve('project');
-        },
         selectDefaultProfile(profiles, currentDefault) {
           expect(currentDefault).toBe('project-lead');
           expect(profiles.map((profile) => profile.id)).toEqual(['project-lead']);
@@ -656,10 +636,11 @@ describe('setup command', () => {
       },
     );
 
-    const projectSettings = readFileSync(join(projectDirectory, '.outfitter', 'settings.yml'), 'utf8');
-    expect(result.settingsPath).toBe(join(projectDirectory, '.outfitter', 'settings.yml'));
-    expect(projectSettings).toContain('default_profile: project-lead');
-    expect(projectSettings).toContain('path: ./profiles');
+    const homeSettings = readFileSync(join(homeDirectory, '.outfitter', 'settings.yml'), 'utf8');
+    expect(result.settingsPath).toBe(join(homeDirectory, '.outfitter', 'settings.yml'));
+    expect(homeSettings).toContain('default_profile: project-lead');
+    expect(homeSettings).toContain('path: ./profiles');
+    expect(existsSync(join(projectDirectory, '.outfitter', 'settings.yml'))).toBe(false);
   });
 
   it('does not promote a setup source default absent from source profile choices', async () => {
@@ -695,11 +676,6 @@ describe('setup command', () => {
               writeFileSync(join(profileFolder, 'profile.yml'), `id: ${profileId}\nlabel: ${label}\ncontrols: {}\n`);
             }
           },
-        },
-        selectSetupSourceImportTarget(choices, defaultTarget) {
-          expect(defaultTarget).toBe('home');
-          expect(choices.map((choice) => choice.target)).toEqual(['home', 'project']);
-          return Promise.resolve('home');
         },
         selectDefaultProfile(profiles, currentDefault) {
           expect(currentDefault).toBe('engineer');
@@ -975,7 +951,7 @@ describe('setup command', () => {
       },
       warnings: [],
       messages: [
-        'Installed the founder profile. Use /outfitter inside Pi or run `outfitter profile list` to manage profiles.',
+        'Installed the Engineer profile. Use /outfitter inside Pi or run `outfitter profile list` to manage profiles.',
       ],
     });
   });

--- a/tests/unit/source-layout.test.ts
+++ b/tests/unit/source-layout.test.ts
@@ -1,7 +1,5 @@
 // Tests source layout, command registration, schemas, and small boundary helpers.
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import type { AnySchema } from 'ajv';
 import { Ajv2020 } from 'ajv/dist/2020.js';
@@ -43,9 +41,6 @@ import { createValidationResult } from '../../src/validation/SchemaValidator.js'
 
 const readJson = <T>(relativePath: string): T =>
   JSON.parse(readFileSync(new URL(relativePath, import.meta.url), 'utf8')) as T;
-
-const repositoryRoot = fileURLToPath(new URL('../..', import.meta.url));
-const builtInOutfitterSkill = join(repositoryRoot, 'skills', 'outfitter');
 
 describe('source layout scaffolding', () => {
   // THIS TEST VALIDATES COMMAND-AVAILABILITY CLAUSES IN HARD REQUIREMENTS (OFTR-004.1, OFTR-004.2, OFTR-004.3, OFTR-005.1).
@@ -171,7 +166,7 @@ describe('source layout scaffolding', () => {
 
     expect(launchPlan).toEqual({
       command: 'pi',
-      args: ['--skill', builtInOutfitterSkill],
+      args: [],
       env: { PI_CODING_AGENT_DIR: compositeProfileRoot },
     });
     expect(claudeLaunchPlan).toEqual({

--- a/tests/unit/template-profiles.test.ts
+++ b/tests/unit/template-profiles.test.ts
@@ -2,15 +2,12 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { executeRunCommand } from '../../src/cli/commands/RunCommand.js';
 
 const temporaryRoots: string[] = [];
-const repositoryRoot = fileURLToPath(new URL('../..', import.meta.url));
-const builtInOutfitterSkill = join(repositoryRoot, 'skills', 'outfitter');
 
 const createTemporaryRoot = (): string => {
   const root = mkdtempSync(join(tmpdir(), 'outfitter-template-profiles-'));
@@ -98,8 +95,6 @@ describe('template profiles', () => {
       'lead.md',
       '--append-system-prompt',
       'prose.md',
-      '--skill',
-      builtInOutfitterSkill,
     ]);
   });
 });

--- a/tests/unit/welcome-command.test.ts
+++ b/tests/unit/welcome-command.test.ts
@@ -61,7 +61,7 @@ describe('welcome command', () => {
     expect(result.selectedLoadout?.selectedItems.map((item) => item.source)).toEqual(defaultLoadoutSources);
     expect(result.warnings).toEqual([]);
     expect(result.messages).toEqual([
-      'Installed the founder profile. Use /outfitter inside Pi or run `outfitter profile list` to manage profiles.',
+      'Installed the Data Analyst profile. Use /outfitter inside Pi or run `outfitter profile list` to manage profiles.',
     ]);
   });
 
@@ -116,7 +116,7 @@ describe('welcome command', () => {
     await program.parseAsync(['node', 'outfitter', 'welcome']);
 
     expect(messages).toEqual([
-      'Installed the founder profile. Use /outfitter inside Pi or run `outfitter profile list` to manage profiles.',
+      'Installed the Founder profile. Use /outfitter inside Pi or run `outfitter profile list` to manage profiles.',
     ]);
   });
 
@@ -139,7 +139,7 @@ describe('welcome command', () => {
     expect(outputText).toContain('____        _    __ _ _   _');
     expect(outputText).not.toContain('____  _');
     expect(outputText).toContain('Pi is a fully extensible agentic coding harness.');
-    expect(outputText).toContain('Press Y to install it now.');
+    expect(outputText).toContain('Press Enter to install it now, or n to skip.');
     expect(result.answered).toBe(true);
     expect(result.selectedRole?.id).toBe('founder');
     expect(result.selectedLoadout?.selectedItems.map((item) => item.source)).toEqual(defaultLoadoutSources);


### PR DESCRIPTION
## Summary
- make welcome copy and prompt text reflect Enter as the default install action
- use the resolved welcome role label in the install success message
- force setup-source imports into ~/.outfitter by removing the injectable project target path
- consolidate Pi startup behavior into one Outfitter extension
- open /login first when needed, then /outfitter after login state appears for declined onboarding

## Verification
- npm test -- tests/unit/welcome-command.test.ts tests/unit/setup-command.test.ts tests/unit/pi-login-launch.test.ts tests/unit/first-run-welcome-profile.test.ts
- npm run check-ci