### PR TITLE
fix(release): declare npm provenance repository

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,14 @@
       "name": "@ai-outfitter/outfitter",
       "version": "0.6.0",
       "license": "BUSL-1.1",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/ai-outfitter/outfitter.git"
+      },
+      "bugs": {
+        "url": "https://github.com/ai-outfitter/outfitter/issues"
+      },
+      "homepage": "https://github.com/ai-outfitter/outfitter#readme",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.78.1",
         "ajv": "^8.20.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
   "version": "0.6.0",
   "description": "Profile-oriented wrapper for launching pi, Claude Code, and future agent CLIs with reproducible configuration.",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ai-outfitter/outfitter.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ai-outfitter/outfitter/issues"
+  },
+  "homepage": "https://github.com/ai-outfitter/outfitter#readme",
   "bin": {
     "outfitter": "dist/cli.js"
   },

--- a/requirements/OFTR-009-release-publishing.md
+++ b/requirements/OFTR-009-release-publishing.md
@@ -13,7 +13,8 @@ Outfitter release publishing prepares package metadata from Conventional Commit 
 3. The release metadata synchronization script MUST reject invalid Semantic Versioning values before mutating package metadata.
 4. The release metadata synchronization script MUST update the root `package.json` version, root `package-lock.json` version, and `package-lock.json` root package entry version to the same normalized release version.
 5. The release metadata synchronization script MUST verify that the root package metadata it prepares belongs to the `@ai-outfitter/outfitter` npm package.
-6. The release metadata synchronization script MUST fail with an actionable error when required package-lock root package metadata is missing.
+6. The release metadata synchronization script MUST verify that `package.json` and the package-lock root metadata declare `repository.url` as `https://github.com/ai-outfitter/outfitter.git` so npm provenance validation can match the publishing repository.
+7. The release metadata synchronization script MUST fail with an actionable error when required package-lock root package metadata is missing.
 
 ### OFTR-009.2: Npm Release Workflow
 

--- a/scripts/sync-release-version.mjs
+++ b/scripts/sync-release-version.mjs
@@ -23,6 +23,7 @@ const packageJson = await readJson(packageJsonPath);
 const lockfile = await readJson(packageLockPath);
 
 assertPackageName(packageJson);
+assertRepositoryUrl(packageJson);
 assertPackageName(lockfile);
 
 if (lockfile.packages?.[''] === undefined) {
@@ -30,6 +31,7 @@ if (lockfile.packages?.[''] === undefined) {
 }
 
 assertPackageName(lockfile.packages['']);
+assertRepositoryUrl(lockfile.packages['']);
 
 packageJson.version = version;
 lockfile.version = version;
@@ -67,6 +69,16 @@ function isSemanticVersion(version) {
 function assertPackageName(packageJson) {
   if (packageJson.name !== '@ai-outfitter/outfitter') {
     throw new Error(`Expected package name '@ai-outfitter/outfitter' but found '${packageJson.name}'.`);
+  }
+}
+
+function assertRepositoryUrl(packageJson) {
+  const repositoryUrl = packageJson.repository?.url;
+
+  if (repositoryUrl !== 'https://github.com/ai-outfitter/outfitter.git') {
+    throw new Error(
+      `Expected repository.url 'https://github.com/ai-outfitter/outfitter.git' but found '${repositoryUrl ?? ''}'.`,
+    );
   }
 }
 

--- a/tests/unit/release-version-script.test.ts
+++ b/tests/unit/release-version-script.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 const temporaryRoots: string[] = [];
 const scriptPath = resolve('scripts/sync-release-version.mjs');
+const repository = { type: 'git', url: 'https://github.com/ai-outfitter/outfitter.git' } as const;
 
 const createTemporaryPackageRoot = (
   packageName = '@ai-outfitter/outfitter',
@@ -15,13 +16,13 @@ const createTemporaryPackageRoot = (
 ): string => {
   const root = mkdtempSync(join(tmpdir(), 'outfitter-release-version-'));
   temporaryRoots.push(root);
-  writeJson(join(root, 'package.json'), { name: packageName, version: '0.1.0' });
+  writeJson(join(root, 'package.json'), { name: packageName, version: '0.1.0', repository });
   writeJson(join(root, 'package-lock.json'), {
     name: lockfilePackageName,
     version: '0.1.0',
     lockfileVersion: 3,
     packages: {
-      '': { name: lockfilePackageName, version: '0.1.0' },
+      '': { name: lockfilePackageName, version: '0.1.0', repository },
     },
   });
   return root;
@@ -85,6 +86,17 @@ describe('release version synchronization script', () => {
     const invalidVersionRoot = createTemporaryPackageRoot();
     const packageMismatchRoot = createTemporaryPackageRoot('not-outfitter');
     const lockfileMismatchRoot = createTemporaryPackageRoot('@ai-outfitter/outfitter', 'not-outfitter');
+    const packageRepositoryMismatchRoot = createTemporaryPackageRoot();
+    const packageRepositoryMismatch = readJson(join(packageRepositoryMismatchRoot, 'package.json'));
+    packageRepositoryMismatch.repository = { type: 'git', url: '' };
+    writeJson(join(packageRepositoryMismatchRoot, 'package.json'), packageRepositoryMismatch);
+    const lockfileRepositoryMismatchRoot = createTemporaryPackageRoot();
+    const lockfileRepositoryMismatch = readJson(join(lockfileRepositoryMismatchRoot, 'package-lock.json'));
+    const lockfileRepositoryMismatchRootPackage = (
+      lockfileRepositoryMismatch.packages as Record<string, Record<string, unknown>>
+    )[''];
+    lockfileRepositoryMismatchRootPackage.repository = { type: 'git', url: '' };
+    writeJson(join(lockfileRepositoryMismatchRoot, 'package-lock.json'), lockfileRepositoryMismatch);
     const missingLockfileRootPackageRoot = createTemporaryPackageRoot();
     const missingRootPackageLockfile = readJson(join(missingLockfileRootPackageRoot, 'package-lock.json'));
     delete (missingRootPackageLockfile.packages as Record<string, unknown>)[''];
@@ -106,6 +118,12 @@ describe('release version synchronization script', () => {
     expect(() => runScript(invalidVersionRoot, '1.2.3-a..b')).toThrow('Invalid Outfitter release version: 1.2.3-a..b');
     expect(() => runScript(packageMismatchRoot, '1.2.3')).toThrow("Expected package name '@ai-outfitter/outfitter'");
     expect(() => runScript(lockfileMismatchRoot, '1.2.3')).toThrow("Expected package name '@ai-outfitter/outfitter'");
+    expect(() => runScript(packageRepositoryMismatchRoot, '1.2.3')).toThrow(
+      "Expected repository.url 'https://github.com/ai-outfitter/outfitter.git'",
+    );
+    expect(() => runScript(lockfileRepositoryMismatchRoot, '1.2.3')).toThrow(
+      "Expected repository.url 'https://github.com/ai-outfitter/outfitter.git'",
+    );
     expect(readFileSync(join(lockfileMismatchRoot, 'package.json'), 'utf8')).toBe(originalLockfileMismatchPackageJson);
     expect(readFileSync(join(lockfileMismatchRoot, 'package-lock.json'), 'utf8')).toBe(
       originalLockfileMismatchPackageLockJson,


### PR DESCRIPTION
## Summary
- add canonical GitHub repository, bugs, and homepage metadata to package.json and package-lock root metadata
- make the release metadata sync script fail before publish if package metadata cannot satisfy npm provenance repository validation
- cover repository metadata validation in the release script test and release publishing requirement

## Validation
- npm run check-ci