### PR TITLE
fix(release): avoid Docker Hub base image timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,10 @@ jobs:
           context: .
           file: Dockerfile
           push: true
+          build-args: |
+            NODE_BASE_IMAGE=public.ecr.aws/docker/library/node:22.19.0-bookworm
+          cache-from: type=gha,scope=release-container
+          cache-to: type=gha,mode=max,scope=release-container
           tags: |
             ${{ steps.container.outputs.image }}:${{ steps.container.outputs.version }}
             ${{ steps.container.outputs.image }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:22.19.0-bookworm
+ARG NODE_BASE_IMAGE=node:22.19.0-bookworm
+FROM ${NODE_BASE_IMAGE}
 
 ENV PATH="/opt/outfitter/node_modules/.bin:${PATH}"
 


### PR DESCRIPTION
## Summary
- make the Docker base image configurable with a  build arg
- use Docker's public ECR mirror for the release container base image to avoid Docker Hub metadata timeouts
- enable GitHub Actions build cache for release container layers

## Context
The release container publish failed resolving  from  with an i/o timeout. The release workflow now resolves the same official Node image tag through  instead.

## Validation
- {
    "schemaVersion": 2,
    "mediaType": "application/vnd.oci.image.index.v1+json",
    "manifests": [
        {
            "mediaType": "application/vnd.oci.image.manifest.v1+json",
            "size": 2493,
            "digest": "sha256:f2bf1588ef7e8dd183d9e4cb4330a0d952204b7348ead42afb1aab11f9c4911b",
            "platform": {
                "architecture": "amd64",
                "os": "linux"
            },
            "annotations": {
                "com.docker.official-images.bashbrew.arch": "amd64",
                "org.opencontainers.image.base.digest": "sha256:39735a70c147237a7dedc0c940653da47f92fc16982afeff5168c4a40134b9a5",
                "org.opencontainers.image.base.name": "buildpack-deps:bookworm",
                "org.opencontainers.image.created": "2025-09-08T22:38:55Z",
                "org.opencontainers.image.revision": "8a6ee0d86da85db74f5bcf99c9dc6ef87203592f",
                "org.opencontainers.image.source": "https://github.com/nodejs/docker-node.git#8a6ee0d86da85db74f5bcf99c9dc6ef87203592f:22/bookworm",
                "org.opencontainers.image.url": "https://hub.docker.com/_/node",
                "org.opencontainers.image.version": "22"
            }
        },
        {
            "mediaType": "application/vnd.oci.image.manifest.v1+json",
            "size": 842,
            "digest": "sha256:eac7fe5541d6c474ccf5bb7f9a53c40570786140794cb7fc306e184299f514e2",
            "platform": {
                "architecture": "unknown",
                "os": "unknown"
            },
            "annotations": {
                "com.docker.official-images.bashbrew.arch": "amd64",
                "vnd.docker.reference.digest": "sha256:f2bf1588ef7e8dd183d9e4cb4330a0d952204b7348ead42afb1aab11f9c4911b",
                "vnd.docker.reference.type": "attestation-manifest"
            }
        },
        {
            "mediaType": "application/vnd.oci.image.manifest.v1+json",
            "size": 2495,
            "digest": "sha256:7c625d94126ecb3de2dabcc6d53b591b3ddf9003a9e34257cfe142d8d4c10aa4",
            "platform": {
                "architecture": "arm",
                "os": "linux",
                "variant": "v7"
            },
            "annotations": {
                "com.docker.official-images.bashbrew.arch": "arm32v7",
                "org.opencontainers.image.base.digest": "sha256:0d5f5a6564580ad24a9db7a41f07f58059dab1a0c41519092e81ee4a137412de",
                "org.opencontainers.image.base.name": "buildpack-deps:bookworm",
                "org.opencontainers.image.created": "2025-09-09T10:55:00Z",
                "org.opencontainers.image.revision": "8a6ee0d86da85db74f5bcf99c9dc6ef87203592f",
                "org.opencontainers.image.source": "https://github.com/nodejs/docker-node.git#8a6ee0d86da85db74f5bcf99c9dc6ef87203592f:22/bookworm",
                "org.opencontainers.image.url": "https://hub.docker.com/_/node",
                "org.opencontainers.image.version": "22"
            }
        },
        {
            "mediaType": "application/vnd.oci.image.manifest.v1+json",
            "size": 842,
            "digest": "sha256:1ccaf3bd0d62c150111ac69bfb4faa41b98250efaac682a6fdfb297ae88ad684",
            "platform": {
                "architecture": "unknown",
                "os": "unknown"
            },
            "annotations": {
                "com.docker.official-images.bashbrew.arch": "arm32v7",
                "vnd.docker.reference.digest": "sha256:7c625d94126ecb3de2dabcc6d53b591b3ddf9003a9e34257cfe142d8d4c10aa4",
                "vnd.docker.reference.type": "attestation-manifest"
            }
        },
        {
            "mediaType": "application/vnd.oci.image.manifest.v1+json",
            "size": 2495,
            "digest": "sha256:05a1b8b0be25d20b50775cd644d2f9da5fdd68be4dcfa32a55c5dbd1954efb01",
            "platform": {
                "architecture": "arm64",
                "os": "linux",
                "variant": "v8"
            },
            "annotations": {
                "com.docker.official-images.bashbrew.arch": "arm64v8",
                "org.opencontainers.image.base.digest": "sha256:091068b28937ea5c9df732bb25dcb2c36aaba31eea27692f9ffdae5530066eef",
                "org.opencontainers.image.base.name": "buildpack-deps:bookworm",
                "org.opencontainers.image.created": "2025-09-09T03:15:28Z",
                "org.opencontainers.image.revision": "8a6ee0d86da85db74f5bcf99c9dc6ef87203592f",
                "org.opencontainers.image.source": "https://github.com/nodejs/docker-node.git#8a6ee0d86da85db74f5bcf99c9dc6ef87203592f:22/bookworm",
                "org.opencontainers.image.url": "https://hub.docker.com/_/node",
                "org.opencontainers.image.version": "22"
            }
        },
        {
            "mediaType": "application/vnd.oci.image.manifest.v1+json",
            "size": 842,
            "digest": "sha256:2e84eb418239eb08f8767f2213beb75a3d9a1163f8db05419e681c736ef4dd83",
            "platform": {
                "architecture": "unknown",
                "os": "unknown"
            },
            "annotations": {
                "com.docker.official-images.bashbrew.arch": "arm64v8",
                "vnd.docker.reference.digest": "sha256:05a1b8b0be25d20b50775cd644d2f9da5fdd68be4dcfa32a55c5dbd1954efb01",
                "vnd.docker.reference.type": "attestation-manifest"
            }
        },
        {
            "mediaType": "application/vnd.oci.image.manifest.v1+json",
            "size": 2495,
            "digest": "sha256:701c8d4d9583965b029d50be0cfa9b57cb0633ec54810867fb65dc1e69d27983",
            "platform": {
                "architecture": "ppc64le",
                "os": "linux"
            },
            "annotations": {
                "com.docker.official-images.bashbrew.arch": "ppc64le",
                "org.opencontainers.image.base.digest": "sha256:240ab18eb0329fddd70677037943353aee5bb0b4de5e4ae82d654fea029dea80",
                "org.opencontainers.image.base.name": "buildpack-deps:bookworm",
                "org.opencontainers.image.created": "2025-09-10T03:15:02Z",
                "org.opencontainers.image.revision": "8a6ee0d86da85db74f5bcf99c9dc6ef87203592f",
                "org.opencontainers.image.source": "https://github.com/nodejs/docker-node.git#8a6ee0d86da85db74f5bcf99c9dc6ef87203592f:22/bookworm",
                "org.opencontainers.image.url": "https://hub.docker.com/_/node",
                "org.opencontainers.image.version": "22"
            }
        },
        {
            "mediaType": "application/vnd.oci.image.manifest.v1+json",
            "size": 842,
            "digest": "sha256:6f6fea492ab49304b57288bfba3ecfe769a8ab36821ccfdb7652c0556a748e19",
            "platform": {
                "architecture": "unknown",
                "os": "unknown"
            },
            "annotations": {
                "com.docker.official-images.bashbrew.arch": "ppc64le",
                "vnd.docker.reference.digest": "sha256:701c8d4d9583965b029d50be0cfa9b57cb0633ec54810867fb65dc1e69d27983",
                "vnd.docker.reference.type": "attestation-manifest"
            }
        },
        {
            "mediaType": "application/vnd.oci.image.manifest.v1+json",
            "size": 2493,
            "digest": "sha256:7e2818d38ab00b2bc10dedf1e65d85e0a59ccb84a1873012d36600f0c7fb6071",
            "platform": {
                "architecture": "s390x",
                "os": "linux"
            },
            "annotations": {
                "com.docker.official-images.bashbrew.arch": "s390x",
                "org.opencontainers.image.base.digest": "sha256:6f51f3352815090e26cb9c2bb729479db5f13c8b3ea21a43530136264a33ac9c",
                "org.opencontainers.image.base.name": "buildpack-deps:bookworm",
                "org.opencontainers.image.created": "2025-09-10T03:24:23Z",
                "org.opencontainers.image.revision": "8a6ee0d86da85db74f5bcf99c9dc6ef87203592f",
                "org.opencontainers.image.source": "https://github.com/nodejs/docker-node.git#8a6ee0d86da85db74f5bcf99c9dc6ef87203592f:22/bookworm",
                "org.opencontainers.image.url": "https://hub.docker.com/_/node",
                "org.opencontainers.image.version": "22"
            }
        },
        {
            "mediaType": "application/vnd.oci.image.manifest.v1+json",
            "size": 842,
            "digest": "sha256:1913930fa3c6abdcff0f766daae30327d35f83341330f2dc4c737d0f90d8cd51",
            "platform": {
                "architecture": "unknown",
                "os": "unknown"
            },
            "annotations": {
                "com.docker.official-images.bashbrew.arch": "s390x",
                "vnd.docker.reference.digest": "sha256:7e2818d38ab00b2bc10dedf1e65d85e0a59ccb84a1873012d36600f0c7fb6071",
                "vnd.docker.reference.type": "attestation-manifest"
            }
        }
    ]
} returned a manifest list with 10 entries
- 
> @ai-outfitter/outfitter@0.6.0 check-ci
> prettier --check . && npm run lint && npm run coverage && npm run docs:ci

Checking formatting...
All matched files use Prettier code style!

> @ai-outfitter/outfitter@0.6.0 lint
> eslint .


> @ai-outfitter/outfitter@0.6.0 coverage
> vitest --run --coverage


 RUN  v4.1.7 /home/ncrmro/repos/unsupervised/outfitter
      Coverage enabled with v8

················································································································································································

 Test Files  38 passed (38)
      Tests  176 passed (176)
   Start at  20:28:59
   Duration  1.95s (transform 2.97s, setup 997ms, import 10.29s, tests 3.78s, environment 5ms)

 % Coverage report from v8

=============================== Coverage summary ===============================
Statements   : 99.79% ( 1927/1931 )
Branches     : 99.61% ( 1030/1034 )
Functions    : 100% ( 496/496 )
Lines        : 99.78% ( 1823/1827 )
================================================================================

> @ai-outfitter/outfitter@0.6.0 docs:ci
> npm --prefix doc_site ci && npm run docs:lint && npm run docs:build


added 505 packages, and audited 506 packages in 8s

215 packages are looking for funding
  run `npm fund` for details

3 moderate severity vulnerabilities

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.

> @ai-outfitter/outfitter@0.6.0 docs:lint
> eslint doc_site --config doc_site/eslint.config.js


> @ai-outfitter/outfitter@0.6.0 docs:build
> npm --prefix doc_site run build


> outfitter-doc-site@0.1.0 build
> next build

▲ Next.js 16.2.6 (Turbopack)
- Experiments (use with caution):
  · optimizePackageImports

  Creating an optimized production build ...
✓ Compiled successfully in 5.6s
  Running TypeScript ...
  Finished TypeScript in 1369ms ...
  Collecting page data using 5 workers ...
  Generating static pages using 5 workers (0/4) ...
  Generating static pages using 5 workers (1/4) 
  Generating static pages using 5 workers (2/4) 
  Generating static pages using 5 workers (3/4) 
✓ Generating static pages using 5 workers (4/4) in 371ms
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
└ ○ /state-persistence


○  (Static)  prerendered as static content