### PR TITLE
fix: adapt container entrypoint to bind mount ownership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN npm pkg delete scripts.prepare \
   && npm ci
 
 COPY package.json tsconfig.json tsconfig.build.json ./
+COPY bin/outfitter-docker-entrypoint ./bin/outfitter-docker-entrypoint
 COPY skills ./skills
 COPY src ./src
 
@@ -22,9 +23,11 @@ RUN npm run build \
   && ln -sf /opt/outfitter/node_modules/.bin/pi /usr/local/bin/pi
 
 RUN mkdir -p /home/node/.pi/agent /home/node/repos \
-  && chown -R node:node /home/node/.pi /home/node/repos
+  && chown -R node:node /home/node/.pi /home/node/repos \
+  && install -m 0755 ./bin/outfitter-docker-entrypoint /usr/local/bin/outfitter-docker-entrypoint
 
-USER node
+ENV HOME=/home/node
+USER root
 WORKDIR /home/node/repos
 
-ENTRYPOINT ["outfitter"]
+ENTRYPOINT ["outfitter-docker-entrypoint"]

--- a/bin/outfitter-docker-entrypoint
+++ b/bin/outfitter-docker-entrypoint
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -eu
+
+: "${HOME:=/home/node}"
+export HOME
+
+if [ "$(id -u)" -ne 0 ]; then
+  exec outfitter "$@"
+fi
+
+# Rootful Docker exposes bind mounts with the host UID/GID; rootless Podman often exposes
+# the host user's bind mounts as container root. Pick the mounted workdir owner unless the
+# caller supplied an explicit runtime identity.
+run_uid="${OUTFITTER_CONTAINER_UID:-}"
+run_gid="${OUTFITTER_CONTAINER_GID:-}"
+
+if [ -z "$run_uid" ] || [ -z "$run_gid" ]; then
+  identity_path="${OUTFITTER_CONTAINER_IDENTITY_PATH:-$PWD}"
+
+  if [ ! -e "$identity_path" ]; then
+    identity_path="$HOME"
+  fi
+
+  run_uid="$(stat -c '%u' "$identity_path")"
+  run_gid="$(stat -c '%g' "$identity_path")"
+fi
+
+if [ "$run_uid" = "0" ]; then
+  exec outfitter "$@"
+fi
+
+mkdir -p "$HOME" "$HOME/repos" 2>/dev/null || true
+chown "$run_uid:$run_gid" "$HOME" "$HOME/repos" 2>/dev/null || true
+
+exec setpriv \
+  --reuid="$run_uid" \
+  --regid="$run_gid" \
+  --clear-groups \
+  --inh-caps=-all \
+  --ambient-caps=-all \
+  --no-new-privs \
+  -- \
+  outfitter "$@"

--- a/doc/file_structure.md
+++ b/doc/file_structure.md
@@ -41,7 +41,8 @@ Outfitter is organized around clear TypeScript source boundaries, requirement do
 ├── bin/                               # local executable development helpers
 │   ├── dev-container-setup            # clean container helper for setup smoke tests
 │   ├── dev-setup-source               # local build helper for real setup-source targets
-│   └── dev-tmp-home                   # isolated temporary HOME launch helper
+│   ├── dev-tmp-home                   # isolated temporary HOME launch helper
+│   └── outfitter-docker-entrypoint     # release container entrypoint that adapts to bind-mount ownership
 ├── src/                               # production TypeScript source
 │   ├── cli.ts                         # executable CLI entry point
 │   ├── cli/                           # CLI parser construction and command registration

--- a/requirements/OFTR-009-release-publishing.md
+++ b/requirements/OFTR-009-release-publishing.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Outfitter release publishing prepares package metadata from Conventional Commit release PRs and GitHub release tags, then publishes the `@ai-outfitter/outfitter` npm package through GitHub Actions using npm trusted publishing / OIDC.
+Outfitter release publishing prepares package metadata from Conventional Commit release PRs and GitHub release tags, then publishes the `@ai-outfitter/outfitter` npm package through GitHub Actions using npm trusted publishing / OIDC. It also prepares the release container image so host-mounted Outfitter and Pi state remains writable without leaving root-owned files on conventional Docker hosts.
 
 ## Requirements
 
@@ -33,3 +33,10 @@ Outfitter release publishing prepares package metadata from Conventional Commit 
 4. The Release Please workflow MUST derive version bumps from Conventional Commits.
 5. The Release Please workflow MUST update npm package metadata and changelog through a release PR before publishing.
 6. The Release Please workflow MUST use GitHub repository write auth capable of triggering release PR CI and the release-published npm workflow, not the default `GITHUB_TOKEN`.
+
+### OFTR-009.4: Container Image Runtime
+
+1. The release container entrypoint MUST run Outfitter with `HOME=/home/node` unless the caller supplies another home directory.
+2. When the container starts as a non-root user, the entrypoint MUST execute Outfitter directly without changing the caller-selected identity.
+3. When the container starts as root and the working directory is owned by a non-root UID/GID, the entrypoint MUST drop to that UID/GID before executing Outfitter so rootful Docker bind mounts do not receive root-owned files.
+4. When the container starts as root and the working directory is owned by UID `0`, the entrypoint MUST execute Outfitter as root so rootless Podman bind mounts, which expose the host user as container root by default, remain writable.

--- a/tests/unit/container-entrypoint.test.ts
+++ b/tests/unit/container-entrypoint.test.ts
@@ -1,0 +1,182 @@
+// Tests the release container entrypoint's runtime identity selection.
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join, resolve } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const temporaryRoots: string[] = [];
+const entrypointPath = resolve('bin/outfitter-docker-entrypoint');
+
+interface EntrypointRunResult {
+  readonly outfitterLog: string;
+  readonly setprivLog: string;
+}
+
+interface EntrypointRunOptions {
+  readonly omitHome?: boolean;
+}
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-entrypoint-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const writeExecutable = (path: string, content: string): void => {
+  writeFileSync(path, content, { mode: 0o755 });
+};
+
+const readOptionalFile = (path: string): string => (existsSync(path) ? readFileSync(path, 'utf8') : '');
+
+const prepareStubCommands = (root: string): string => {
+  const binDirectory = join(root, 'bin');
+  mkdirSync(binDirectory, { recursive: true });
+  writeExecutable(
+    join(binDirectory, 'id'),
+    [
+      '#!/bin/sh',
+      'if [ "${1:-}" = "-u" ]; then',
+      '  printf "%s\\n" "${FAKE_ID_U:-1000}"',
+      'else',
+      '  printf "uid=%s\\n" "${FAKE_ID_U:-1000}"',
+      'fi',
+      '',
+    ].join('\n'),
+  );
+  writeExecutable(
+    join(binDirectory, 'stat'),
+    [
+      '#!/bin/sh',
+      'if [ "${1:-}" = "-c" ] && [ "${2:-}" = "%u" ]; then',
+      '  printf "%s\\n" "${FAKE_STAT_U:-1000}"',
+      '  exit 0',
+      'fi',
+      'if [ "${1:-}" = "-c" ] && [ "${2:-}" = "%g" ]; then',
+      '  printf "%s\\n" "${FAKE_STAT_G:-1000}"',
+      '  exit 0',
+      'fi',
+      'printf "unexpected stat invocation: %s\\n" "$*" >&2',
+      'exit 64',
+      '',
+    ].join('\n'),
+  );
+  writeExecutable(
+    join(binDirectory, 'setpriv'),
+    [
+      '#!/bin/sh',
+      'printf "%s\\n" "$*" >> "$SETPRIV_LOG"',
+      'while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do',
+      '  shift',
+      'done',
+      'if [ "$#" -eq 0 ]; then',
+      '  exit 65',
+      'fi',
+      'shift',
+      'exec "$@"',
+      '',
+    ].join('\n'),
+  );
+  writeExecutable(
+    join(binDirectory, 'outfitter'),
+    [
+      '#!/bin/sh',
+      'printf "args=%s\\n" "$*" >> "$OUTFITTER_LOG"',
+      'printf "home=%s\\n" "$HOME" >> "$OUTFITTER_LOG"',
+      '',
+    ].join('\n'),
+  );
+
+  return binDirectory;
+};
+
+const runEntrypoint = (
+  root: string,
+  env: NodeJS.ProcessEnv,
+  options: EntrypointRunOptions = {},
+): EntrypointRunResult => {
+  const homeDirectory = join(root, 'home');
+  const workDirectory = join(root, 'work');
+  const outfitterLog = join(root, 'outfitter.log');
+  const setprivLog = join(root, 'setpriv.log');
+  const binDirectory = prepareStubCommands(root);
+  mkdirSync(homeDirectory, { recursive: true });
+  mkdirSync(workDirectory, { recursive: true });
+  const childEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    PATH: `${binDirectory}${delimiter}${process.env.PATH ?? ''}`,
+    OUTFITTER_LOG: outfitterLog,
+    SETPRIV_LOG: setprivLog,
+    ...env,
+  };
+
+  if (options.omitHome === true) {
+    delete childEnv.HOME;
+  } else {
+    childEnv.HOME = homeDirectory;
+  }
+
+  execFileSync(entrypointPath, ['--profile', 'founder'], {
+    cwd: workDirectory,
+    env: childEnv,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  return {
+    outfitterLog: readOptionalFile(outfitterLog),
+    setprivLog: readOptionalFile(setprivLog),
+  };
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-009.4).
+// YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+describe('container entrypoint', () => {
+  it('defaults HOME to /home/node when the caller does not supply one', () => {
+    const root = createTemporaryRoot();
+
+    const result = runEntrypoint(root, { FAKE_ID_U: '1000' }, { omitHome: true });
+
+    expect(result.outfitterLog).toContain('args=--profile founder');
+    expect(result.outfitterLog).toContain('home=/home/node');
+    expect(result.setprivLog).toBe('');
+  });
+
+  it('executes Outfitter directly when the caller already selected a non-root user', () => {
+    const root = createTemporaryRoot();
+
+    const result = runEntrypoint(root, { FAKE_ID_U: '1000' });
+
+    expect(result.outfitterLog).toContain('args=--profile founder');
+    expect(result.outfitterLog).toContain(`home=${join(root, 'home')}`);
+    expect(result.setprivLog).toBe('');
+  });
+
+  it('drops from root to the working-directory owner when that owner is non-root', () => {
+    const root = createTemporaryRoot();
+
+    const result = runEntrypoint(root, { FAKE_ID_U: '0', FAKE_STAT_U: '1234', FAKE_STAT_G: '5678' });
+
+    expect(result.outfitterLog).toContain('args=--profile founder');
+    expect(result.setprivLog).toContain('--reuid=1234');
+    expect(result.setprivLog).toContain('--regid=5678');
+    expect(result.setprivLog).toContain('--clear-groups');
+    expect(result.setprivLog).toContain('--no-new-privs');
+    expect(result.setprivLog).toContain('-- outfitter --profile founder');
+  });
+
+  it('keeps root when root owns the working directory', () => {
+    const root = createTemporaryRoot();
+
+    const result = runEntrypoint(root, { FAKE_ID_U: '0', FAKE_STAT_U: '0', FAKE_STAT_G: '0' });
+
+    expect(result.outfitterLog).toContain('args=--profile founder');
+    expect(result.setprivLog).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

- add a container entrypoint that adapts runtime identity to bind-mount ownership
- keep rootless Podman mounts writable while dropping privileges for rootful Docker mounts
- document and test the new container runtime requirement

## Validation

- `npm test -- tests/unit/container-entrypoint.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `docker build -t ghcr.io/ai-outfitter/outfitter:latest .`
- local container smoke test confirmed bind-mounted `.pi/agent/sessions` is writable under Podman-backed Docker
- DeepWork reviews passed for requirements traceability, docs consistency, TypeScript review, and DeepSchema compliance
