### PR TITLE
feat: add container launch backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,21 @@ If neither is set, Outfitter defaults to pi for backward compatibility.
 If `outfitter` is run before `outfitter setup`, it creates the initial settings and default profile automatically before launching.
 When that first-run setup has an interactive terminal, Outfitter continues into the same welcome onboarding used by `outfitter welcome`.
 
+Profiles can also request a container image and launch backend:
+
+```yaml
+controls:
+  container:
+    image: ghcr.io/ai-outfitter/outfitter-pi:0.6.1
+    backend: docker # host | auto | docker | podman | apple-container
+    pull: missing
+    platform: linux/arm64
+    env_passthrough: [ANTHROPIC_API_KEY]
+    run_args: [--init]
+```
+
+Backend precedence is CLI `--launch-backend`, agent-specific container controls, generic container controls, `settings.default_launch_backend`, then `host` without an image or `auto` with an image. Container images must include the selected agent binary, for example `pi` for Pi profiles. Outfitter identity-mounts required project, composite profile, profile, cache, package, and state paths; it does not mount host home, engine sockets, SSH credentials, cloud credentials, or arbitrary profile-defined mounts by default. Environment passthrough is name-based and only allowed when trusted local settings list the name under `container_policy.env_passthrough`.
+
 `outfitter welcome` explains Outfitter and Pi, asks you to choose an initial built-in role, and recommends a Pi productivity loadout.
 The current built-in role choices are `engineer` and `data_analyst`; Outfitter creates the selected local profile on the fly.
 The recommended loadout includes `ulta-tasklist`, `deepwork`, `pi-subagents`, and `pi-mcp-adapter`; you can accept it, choose individual items, or skip loadout installation.

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -684,6 +684,16 @@ Claude Code is also supported through the `claude` adapter.
 Outfitter launches `claude` with `CLAUDE_CONFIG_DIR` pointing at the composite profile root, maps supported controls to native flags (`--model`, `--effort`, `--system-prompt`, `--append-system-prompt`, and repeated `--plugin-dir`), and preserves Claude Code state paths such as `settings.json`, `agents/`, `skills/`, `commands/`, `plugins/`, `projects/`, and `debug/` through adapter-declared state persistence.
 Claude-specific profile overrides live under `controls.claude` and win over generic controls for Claude runs.
 
+## Launch Backend Boundary
+
+After the adapter creates an inner launch plan, Outfitter resolves a launch backend and renders the final host process plan. The `host` backend launches the adapter plan directly. `docker`, `podman`, and `apple-container` wrap the inner command in the respective CLI's `run` argv, and `auto` resolves deterministically to Docker, then Podman, then Apple `container` on macOS.
+
+Container backends intentionally do not use Docker or Podman APIs. They render shell-free argv arrays and rely on the selected engine's normal `run` behavior. Images must contain the selected agent binary, such as `pi` for Pi profiles.
+
+The v1 container path policy uses conservative identity mounts so existing adapter-owned absolute paths continue to work. Outfitter mounts the project directory, composite profile root, contributing profile folders, package resources, cache directory, and adapter state source parents at the same absolute paths inside the container. It does not implicitly mount the host home directory, `/`, container engine sockets, SSH credentials, cloud credential directories, or arbitrary profile-requested host paths. Future hardening can add mapped materialization that rewrites paths into container-specific roots.
+
+Profiles may request environment variable passthrough by name, but only names allowed by trusted local `container_policy.env_passthrough` settings are passed. Summaries and warnings print variable names only, never values. Mutable image references (`latest` or no tag/digest) produce warnings, and `--strict` makes those warnings fatal.
+
 ## CLI Commands
 
 ### `outfitter run`

--- a/doc/controllable-elements.md
+++ b/doc/controllable-elements.md
@@ -133,26 +133,34 @@ An early-startup customization used to register providers, tools, hooks, or addi
 - Pi name: explicit bootstrap extension via `--extension` / `-e`
 - Claude name: startup hook/plugin mechanism, not mapped by Outfitter yet
 
+### Runtime Image / Launch Backend
+
+The final runtime used to execute the selected agent CLI: native host process, Docker, Podman, or Apple `container`.
+
+- Pi name: backend wrapper around the `pi` launch plan; the image must contain `pi`
+- Claude name: backend wrapper around the `claude` launch plan; the image must contain `claude`
+
 ## Support Matrix
 
-| Controllable Element        | Pi        | Claude    |
-| --------------------------- | --------- | --------- |
-| Agent Config Directory      | Supported | Supported |
-| Session Directory           | Supported | Supported |
-| Extensions                  | Supported | Supported |
-| Skills                      | Supported | Supported |
-| Prompt Templates            | Supported | Supported |
-| System Prompt               | Supported | Supported |
-| Appended System Prompt      | Supported | Supported |
-| Model Selection             | Supported | Supported |
-| Credentials and Environment | Supported | Supported |
-| Tool Availability           | Roadmap   | Roadmap   |
-| Context Files               | Roadmap   | Roadmap   |
-| Theme / UI Presentation     | Roadmap   | Roadmap   |
-| Project Override Policy     | Roadmap   | Roadmap   |
-| Working Directory           | Roadmap   | Roadmap   |
-| Pass-through Arguments      | Supported | Supported |
-| Bootstrap Hook              | Supported | Roadmap   |
+| Controllable Element           | Pi        | Claude    |
+| ------------------------------ | --------- | --------- |
+| Agent Config Directory         | Supported | Supported |
+| Session Directory              | Supported | Supported |
+| Extensions                     | Supported | Supported |
+| Skills                         | Supported | Supported |
+| Prompt Templates               | Supported | Supported |
+| System Prompt                  | Supported | Supported |
+| Appended System Prompt         | Supported | Supported |
+| Model Selection                | Supported | Supported |
+| Credentials and Environment    | Supported | Supported |
+| Tool Availability              | Roadmap   | Roadmap   |
+| Context Files                  | Roadmap   | Roadmap   |
+| Theme / UI Presentation        | Roadmap   | Roadmap   |
+| Project Override Policy        | Roadmap   | Roadmap   |
+| Working Directory              | Roadmap   | Roadmap   |
+| Pass-through Arguments         | Supported | Supported |
+| Bootstrap Hook                 | Supported | Roadmap   |
+| Runtime Image / Launch Backend | Supported | Supported |
 
 ## Day-One Interpretation
 

--- a/doc/file_structure.md
+++ b/doc/file_structure.md
@@ -95,6 +95,16 @@ Outfitter is organized around clear TypeScript source boundaries, requirement do
 │   │   └── claude/                    # Claude Code-specific adapter implementation
 │   │       ├── ClaudeAdapter.ts
 │   │       └── ClaudeCompositeProfileWriter.ts
+│   ├── launchBackends/                # host, Docker, Podman, and Apple container final process renderers
+│   │   ├── LaunchBackend.ts           # launch backend interfaces and process launch plan shape
+│   │   ├── LaunchBackendRegistry.ts   # backend selection, auto detection, and executable preflight
+│   │   ├── ContainerControls.ts       # container control normalization and policy helpers
+│   │   ├── ContainerMountPlanner.ts   # conservative identity bind-mount planning
+│   │   ├── ContainerRenderers.ts      # shared shell-free container argv rendering
+│   │   ├── DockerLaunchBackend.ts
+│   │   ├── PodmanLaunchBackend.ts
+│   │   ├── AppleContainerLaunchBackend.ts
+│   │   └── HostLaunchBackend.ts
 │   ├── schemas/                       # JSON Schema artifacts for persisted formats
 │   │   ├── settings.schema.json
 │   │   ├── profile.schema.json

--- a/doc/integration_test_system.md
+++ b/doc/integration_test_system.md
@@ -212,3 +212,7 @@ When adding or changing a fixture:
 3. Add a Vitest integration test that copies the fixture, runs through command code, and asserts the composite profile/write-back behavior.
 4. Update `tests/fixtures/integration/INTEGRATION_TEST_FIXTURES.md` when the fixture's scenario, status, or purpose changes.
 5. Run `npm run check-ci` before opening or updating the PR.
+
+## Container Backend Fixtures
+
+Container backend tests use mocked launchers and injected executable detection. Normal CI does not require real Docker, Podman, Apple container daemons, or local images. Optional smoke tests may be added behind an explicit environment variable such as `OUTFITTER_CONTAINER_SMOKE=1`.

--- a/doc/state_writeback_strategy.md
+++ b/doc/state_writeback_strategy.md
@@ -340,3 +340,9 @@ Path-keyed state declarations keep the model simple:
 - `state_persistence` says what to do with each path.
 
 This avoids ambiguous writeback behavior and gives users a clear rule: if a CLI write should persist, configure that composite profile path as `symlink` and provide or accept the profile/native file that should receive the mutation.
+
+## Containerized Runs
+
+Container launch backends preserve this writeback model by identity-mounting every state source path parent (or source directory) that an adapter declares for symlink persistence. The composite profile root is also identity-mounted read-write, so the inner agent sees the same absolute paths that the adapter wrote into environment variables and argv.
+
+Profile folders are mounted read-only by default, but a narrower adapter state source mount is read-write when a symlinked state path resolves into profile-owned state. Outfitter does not mount the host home directory wholesale; only required native fallback state paths and cache paths are mounted.

--- a/requirements/OFTR-003-profiles.md
+++ b/requirements/OFTR-003-profiles.md
@@ -52,6 +52,14 @@ Outfitter resolves profile definitions across settings scopes, explicit sources,
 4. CLI-specific profile content MUST take precedence over generic controls when both generate the same agent-specific artifact.
 5. Outfitter MUST compose `append_system_prompt` values from multiple resolved profile layers into repeated agent append-prompt inputs without requiring profiles to use raw CLI `args` for prompt composition.
 
+### OFTR-003.8: Container Controls
+
+1. Generic profile controls MAY include `controls.container` to request a runtime image and launch backend.
+2. Agent-specific controls MAY include `controls.pi.container` and `controls.claude.container` to override generic container controls for that adapter.
+3. Container control object fields MUST be merged deterministically, with higher-precedence scalar values winning.
+4. `env_passthrough` and `run_args` arrays MUST be replaced by the higher-precedence profile layer rather than appended.
+5. `controls.container` MUST be a backend-owned generic control and MUST NOT be reported as unsupported by agent adapters.
+
 ### OFTR-003.7: Template Profiles
 
 1. A profile MAY set top-level `template: true` to indicate it is intended for inheritance by runnable profiles rather than direct launch.

--- a/requirements/OFTR-005-run-and-composite-profile.md
+++ b/requirements/OFTR-005-run-and-composite-profile.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `run` command assembles a temporary agent-specific configuration directory called a composite profile, launches the selected agent CLI, and keeps Outfitter alive to manage the composite profile while the child process runs.
+The `run` command assembles a temporary agent-specific configuration directory called a composite profile, asks the selected agent adapter for an inner launch plan, optionally wraps that plan with a launch backend, launches the final process, and keeps Outfitter alive to manage the composite profile while the child process runs.
 
 ## Requirements
 
@@ -15,6 +15,7 @@ The `run` command assembles a temporary agent-specific configuration directory c
 5. The `run` command MUST use the resolved default profile when no profile option is provided.
 6. The `run` command MUST pass unrecognized arguments through to the selected agent CLI unaltered.
 7. When invoked before user setup has created `~/.outfitter/settings.yml`, the default `run` command MUST execute setup before resolving the profile without printing a separate pre-setup announcement.
+8. The `run` command MUST accept `--launch-backend` for selecting `host`, `auto`, `docker`, `podman`, or `apple-container`.
 
 ### OFTR-005.2: Composite profile Definition
 

--- a/requirements/OFTR-006-agent-adapters.md
+++ b/requirements/OFTR-006-agent-adapters.md
@@ -14,6 +14,7 @@ Pi is the default and primary supported adapter; Claude Code is also supported t
 3. Each adapter MUST report which controllable elements it supports.
 4. Each adapter MUST return warnings for profile controls it cannot translate.
 5. Outfitter SHOULD keep generic profile resolution independent from adapter-specific file generation.
+6. Adapters MUST produce an inner agent launch plan before any launch backend wraps it into a final host process plan.
 
 ### OFTR-006.2: Supported Adapter Availability
 

--- a/requirements/OFTR-007-controllable-elements.md
+++ b/requirements/OFTR-007-controllable-elements.md
@@ -30,3 +30,4 @@ This vocabulary is documented separately from implementation details so companie
 4. The documentation MUST include System Prompt and Appended System Prompt controllable elements.
 5. The documentation MUST include Model Selection and Credentials and Environment controllable elements.
 6. The documentation MUST include Tool Availability, Context Files, Theme or UI Presentation, Project Override Policy, Working Directory, Pass-through Arguments, and Bootstrap Hook controllable elements.
+7. The documentation MUST include Runtime Image and Launch Backend as a controllable element.

--- a/requirements/OFTR-011-launch-backends.md
+++ b/requirements/OFTR-011-launch-backends.md
@@ -1,0 +1,39 @@
+# OFTR-011: Launch Backends and Containerized Runs
+
+## Overview
+
+Launch backends transform an agent adapter launch plan into the final host process that Outfitter starts. The host backend preserves native execution. Container backends wrap the adapter launch plan in Docker, Podman, or Apple `container` CLI argv without invoking a shell.
+
+## Requirements
+
+### OFTR-011.1: Profile and Settings Contract
+
+1. Profiles MAY define `controls.container` with `image`, `backend`, `pull`, `platform`, `env_passthrough`, and `run_args` fields.
+2. Agent-specific controls MAY override generic container controls at `controls.pi.container` or `controls.claude.container`.
+3. `backend` MUST be one of `host`, `auto`, `docker`, `podman`, or `apple-container`.
+4. `pull` MUST be one of `missing`, `always`, or `never`.
+5. Settings MAY define trusted local `default_launch_backend` and `container_policy.env_passthrough` values.
+6. Remote cached settings MUST NOT be trusted to grant environment passthrough policy.
+
+### OFTR-011.2: Backend Selection
+
+1. Outfitter MUST select the launch backend with precedence: CLI `--launch-backend`, agent-specific profile backend, generic profile backend, trusted local settings `default_launch_backend`, then `host` when no image is configured or `auto` when an image is configured.
+2. `auto` MUST resolve deterministically by checking Docker, then Podman, then Apple `container` on macOS.
+3. Outfitter MUST fail before launch when a selected backend executable is unavailable.
+
+### OFTR-011.3: Launch Wrapping
+
+1. Agent adapters MUST continue to produce the inner agent launch plan.
+2. Container launch backends MUST return the final host process launch plan.
+3. `RunCommandResult.launchPlan` MUST expose the final plan, and `RunCommandResult.innerLaunchPlan` SHOULD expose the adapter plan when wrapping is applied.
+4. Backend renderers MUST produce shell-free argv arrays.
+5. The final process launcher MUST pass the resolved project directory as `cwd`.
+
+### OFTR-011.4: Mount, Environment, and Warning Policy
+
+1. Container backends MUST use conservative identity bind mounts for the project directory, composite profile root, contributing profile folders, package resources, cache directory, and adapter state source paths required by the launch.
+2. Container backends MUST NOT implicitly mount the host home directory, filesystem root, container engine sockets, SSH credentials, or cloud credential directories.
+3. Profiles MAY request environment variable names through `env_passthrough`, but Outfitter MUST pass only names allowed by trusted local `container_policy.env_passthrough`.
+4. Outfitter MUST NOT render secret environment values in argv summaries or warnings.
+5. Outfitter MUST warn for mutable image references using `latest` or no tag/digest, and `--strict` MUST make that warning fatal.
+6. Apple `container` launches MUST warn when a profile requests unsupported portable pull policy behavior.

--- a/src/agents/AdapterProfileControls.ts
+++ b/src/agents/AdapterProfileControls.ts
@@ -18,6 +18,7 @@ export const genericControlNames = new Set([
   'system_prompt',
   'appendSystemPrompt',
   'append_system_prompt',
+  'container',
   'pi',
   'claude',
 ]);
@@ -38,14 +39,18 @@ export const mergeAgentSpecificControls = <T extends ProfileControls>(
 ): T => {
   const agentControls = controls[agentKey];
 
-  return {
+  return definedControls({
     ...controls,
     ...definedControls(agentControls),
     environment: { ...controls.environment, ...agentControls?.environment },
     args: agentControls?.args ?? controls.args,
     extensions: mergeLaunchResourceSources('extension', controls.extensions, agentControls?.extensions),
     skills: mergeLaunchResourceSources('skill', controls.skills, agentControls?.skills),
-  } as T;
+    container:
+      controls.container === undefined && agentControls?.container === undefined
+        ? undefined
+        : { ...controls.container, ...agentControls?.container },
+  }) as T;
 };
 
 export const flagValue = (flag: string, value: string | undefined): readonly string[] =>

--- a/src/agents/AgentAdapter.ts
+++ b/src/agents/AgentAdapter.ts
@@ -8,6 +8,7 @@ export interface AgentLaunchPlan {
   readonly command: string;
   readonly args: readonly string[];
   readonly env: Readonly<Record<string, string>>;
+  readonly cwd?: string;
 }
 
 export interface AgentLaunchContext {

--- a/src/cli/commands/RunCommand.ts
+++ b/src/cli/commands/RunCommand.ts
@@ -43,6 +43,10 @@ import type { CommandObject } from './CommandObject.js';
 import { preparePiLoginLaunchPlan } from './PiLoginLaunch.js';
 import { executeSetupCommand } from './SetupCommand.js';
 import type { SetupCommandDependencies, SetupCommandResult } from './SetupCommand.js';
+import type { LaunchBackendId } from '../../launchBackends/LaunchBackend.js';
+import type { LaunchBackendResolverDependencies } from '../../launchBackends/LaunchBackendRegistry.js';
+import { isLaunchBackendId } from '../../launchBackends/ContainerControls.js';
+import { createRunLaunchBackendPlan } from './RunLaunchBackend.js';
 
 export interface RunCommandInput {
   readonly homeDirectory: string;
@@ -50,6 +54,7 @@ export interface RunCommandInput {
   readonly profileId?: string;
   readonly agentId?: string;
   readonly strict?: boolean;
+  readonly launchBackend?: LaunchBackendId;
   readonly passThroughArgs?: readonly string[];
 }
 
@@ -57,6 +62,8 @@ export interface RunCommandResult {
   readonly profileId: string;
   readonly agentId: string;
   readonly launchPlan: AgentLaunchPlan;
+  readonly innerLaunchPlan?: AgentLaunchPlan;
+  readonly launchBackendId: Exclude<LaunchBackendId, 'auto'>;
   readonly compositeProfileDirectory: string;
   readonly warnings: readonly string[];
   readonly exitCode: number;
@@ -70,6 +77,9 @@ export interface RunCommandDependencies extends SetupCommandDependencies {
   readonly adapter?: AgentAdapter;
   readonly launcher?: AgentProcessLauncher;
   readonly writeError?: (message: string) => void;
+  readonly launchBackendResolver?: LaunchBackendResolverDependencies;
+  readonly stdinIsTty?: boolean;
+  readonly stdoutIsTty?: boolean;
 }
 
 export const executeRunCommand = async (
@@ -95,7 +105,7 @@ export const executeRunCommand = async (
     compositeProfilePlan.compositeProfile.rootDirectory,
     compositeProfilePlan.compositeProfile.statePaths,
   );
-  const launchPlan = preparePiLoginLaunchPlan({
+  const innerLaunchPlan = preparePiLoginLaunchPlan({
     adapterId: adapter.id,
     homeDirectory: input.homeDirectory,
     launchPlan: adapter.createLaunchPlan(
@@ -107,10 +117,29 @@ export const executeRunCommand = async (
     setupResult,
     writeLine: dependencies.writeLine,
   });
+  const { backendPlan, image } = createRunLaunchBackendPlan({
+    cliLaunchBackend: input.launchBackend,
+    agentId: adapter.id,
+    profile: resolvedProfile.profile,
+    settings: resolvedProfile.settings,
+    compositeProfilePlan,
+    profileFolders: resolvedProfile.profileFolders,
+    projectDirectory: resolvedProfile.projectDirectory,
+    cacheDirectory: resolvedProfile.cacheDirectory,
+    innerLaunchPlan,
+    resolver: dependencies.launchBackendResolver,
+    stdinIsTty: dependencies.stdinIsTty ?? dependencies.input?.isTTY === true,
+    stdoutIsTty: dependencies.stdoutIsTty ?? dependencies.output?.isTTY === true,
+  });
+  const allPreLaunchWarnings = [...warnings, ...backendPlan.warnings];
+
+  failStrictOnWarnings(adapter.id, allPreLaunchWarnings, input.strict);
+  emitWarnings(backendPlan.warnings, dependencies.writeError);
   emitLaunchSummary(
     resolvedProfile,
     adapter.id,
     compositeProfilePlan.compositeProfile.rootDirectory,
+    { backendId: backendPlan.backendId, image },
     dependencies.writeLine,
   );
   const watcher = watchCompositeProfileInputs({
@@ -133,7 +162,7 @@ export const executeRunCommand = async (
     const launcher =
       dependencies.launcher ??
       /* v8 ignore next -- tests inject launchers instead of spawning pi. */ createSpawnLauncher();
-    const exitCode = await launcher.launch(launchPlan);
+    const exitCode = await launcher.launch(backendPlan.launchPlan);
     const stateWriteWarnings = handleCompositeProfileStateWrites(
       adapter.id,
       compositeProfilePlan.compositeProfile.rootDirectory,
@@ -147,9 +176,11 @@ export const executeRunCommand = async (
     return {
       profileId: resolvedProfile.profile.id,
       agentId: adapter.id,
-      launchPlan,
+      launchPlan: backendPlan.launchPlan,
+      innerLaunchPlan,
+      launchBackendId: backendPlan.backendId,
       compositeProfileDirectory: compositeProfilePlan.compositeProfile.rootDirectory,
-      warnings: [...warnings, ...stateWriteWarnings],
+      warnings: [...warnings, ...backendPlan.warnings, ...stateWriteWarnings],
       exitCode,
     };
   } finally {
@@ -165,7 +196,7 @@ export const createRunCommand = (dependencies: RunCommandDependencies = {}): Com
     register(program: Command): void {
       const action = async (
         args: readonly string[],
-        options: { profile?: string; agent?: string; strict?: boolean },
+        options: { profile?: string; agent?: string; strict?: boolean; launchBackend?: string },
       ) => {
         const result = await executeRunCommand(
           {
@@ -174,6 +205,7 @@ export const createRunCommand = (dependencies: RunCommandDependencies = {}): Com
             profileId: options.profile,
             agentId: options.agent,
             strict: options.strict,
+            launchBackend: parseLaunchBackendOption(options.launchBackend),
             passThroughArgs: args,
           },
           dependencies,
@@ -196,12 +228,16 @@ export const createRunCommand = (dependencies: RunCommandDependencies = {}): Com
 
 const configureRunCommander = (
   command: Command,
-  action: (args: readonly string[], options: { profile?: string; agent?: string; strict?: boolean }) => Promise<void>,
+  action: (
+    args: readonly string[],
+    options: { profile?: string; agent?: string; strict?: boolean; launchBackend?: string },
+  ) => Promise<void>,
 ): void => {
   command
     .argument('[args...]')
     .option('-p, --profile <profile>', 'Outfitter profile id to run')
     .option('--agent <agent>', 'agent adapter to launch: pi or claude')
+    .option('--launch-backend <backend>', 'launch backend: host, auto, docker, podman, or apple-container')
     .option('--strict', 'Fail instead of warning when controls cannot be translated')
     .allowUnknownOption(true)
     .allowExcessArguments(true)
@@ -240,6 +276,7 @@ const emitLaunchSummary = (
   resolvedProfile: ResolvedRunProfile,
   adapterId: string,
   compositeProfileRootDirectory: string,
+  backendSummary: { readonly backendId: string; readonly image?: string },
   writeLine: ((message: string) => void) | undefined,
 ): void => {
   const writer = writeLine ?? console.log;
@@ -255,7 +292,24 @@ const emitLaunchSummary = (
 
   writer(`${chalk.green('✓')} merged controls${model === undefined ? '' : `  model=${chalk.yellow(model)}`}`);
   writer(`${chalk.green('✓')} prepared composite profile  ${chalk.dim(compositeProfileRootDirectory)}`);
+  writer(
+    `${chalk.green('✓')} launch backend ${chalk.yellow(backendSummary.backendId)}${
+      backendSummary.image === undefined ? '' : `  image=${chalk.yellow(backendSummary.image)}`
+    }`,
+  );
   writer(`${chalk.blue('↳')} launching ${chalk.cyan(adapterId)} …`);
+};
+
+const parseLaunchBackendOption = (value: string | undefined): LaunchBackendId | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (isLaunchBackendId(value)) {
+    return value;
+  }
+
+  throw new Error(`Invalid launch backend '${value}'. Expected host, auto, docker, podman, or apple-container.`);
 };
 
 const selectSummaryModel = (profile: Profile, adapterId: string): string | undefined => {
@@ -494,6 +548,7 @@ const createSpawnLauncher = (): AgentProcessLauncher => ({
       const child: ChildProcess = spawn(plan.command, plan.args, {
         env: { ...process.env, ...plan.env },
         stdio: 'inherit',
+        cwd: plan.cwd,
       });
 
       child.on('error', reject);

--- a/src/cli/commands/RunLaunchBackend.ts
+++ b/src/cli/commands/RunLaunchBackend.ts
@@ -1,0 +1,51 @@
+// Resolves launch backends for the run command without bloating RunCommand.
+import type { AgentLaunchPlan } from '../../agents/AgentAdapter.js';
+import type { AgentCompositeProfilePlan } from '../../agents/AgentAdapter.js';
+import { selectContainerControls, selectRequestedLaunchBackend } from '../../launchBackends/ContainerControls.js';
+import type { LaunchBackendId, LaunchBackendPlan } from '../../launchBackends/LaunchBackend.js';
+import {
+  createLaunchBackend,
+  type LaunchBackendResolverDependencies,
+} from '../../launchBackends/LaunchBackendRegistry.js';
+import type { Profile } from '../../profiles/Profile.js';
+import type { Settings } from '../../settings/Settings.js';
+
+export interface RunLaunchBackendInput {
+  readonly cliLaunchBackend?: LaunchBackendId;
+  readonly agentId: string;
+  readonly profile: Profile;
+  readonly settings: Settings;
+  readonly compositeProfilePlan: AgentCompositeProfilePlan;
+  readonly profileFolders: readonly string[];
+  readonly projectDirectory: string;
+  readonly cacheDirectory: string;
+  readonly innerLaunchPlan: AgentLaunchPlan;
+  readonly resolver?: LaunchBackendResolverDependencies;
+  readonly stdinIsTty: boolean;
+  readonly stdoutIsTty: boolean;
+}
+
+export const createRunLaunchBackendPlan = (
+  input: RunLaunchBackendInput,
+): { readonly backendPlan: LaunchBackendPlan; readonly image?: string } => {
+  const containerControls = selectContainerControls(input.profile, input.agentId);
+  const requestedBackend = selectRequestedLaunchBackend(input.cliLaunchBackend, containerControls, input.settings);
+  const backend = createLaunchBackend(requestedBackend, input.resolver);
+
+  return {
+    image: containerControls.image,
+    backendPlan: backend.render({
+      innerLaunchPlan: input.innerLaunchPlan,
+      container: containerControls,
+      compositeProfile: input.compositeProfilePlan.compositeProfile,
+      profileFolders: input.profileFolders,
+      projectDirectory: input.projectDirectory,
+      cacheDirectory: input.cacheDirectory,
+      statePaths: input.compositeProfilePlan.compositeProfile.statePaths,
+      /* v8 ignore next -- settings merger supplies the default empty policy during run command execution. */
+      envPassthroughAllowed: input.settings.containerPolicy?.envPassthrough ?? [],
+      stdinIsTty: input.stdinIsTty,
+      stdoutIsTty: input.stdoutIsTty,
+    }),
+  };
+};

--- a/src/launchBackends/AppleContainerLaunchBackend.ts
+++ b/src/launchBackends/AppleContainerLaunchBackend.ts
@@ -1,0 +1,8 @@
+// Apple container CLI launch backend renderer.
+import type { LaunchBackend } from './LaunchBackend.js';
+import { renderAppleContainerBackend } from './ContainerRenderers.js';
+
+export const createAppleContainerLaunchBackend = (): LaunchBackend => ({
+  id: 'apple-container',
+  render: renderAppleContainerBackend,
+});

--- a/src/launchBackends/ContainerControls.ts
+++ b/src/launchBackends/ContainerControls.ts
@@ -1,0 +1,65 @@
+// Normalizes and selects profile-defined container controls for launch backends.
+import type { Profile, ContainerProfileControls } from '../profiles/Profile.js';
+import type { Settings } from '../settings/Settings.js';
+import type { LaunchBackendId } from './LaunchBackend.js';
+
+export const launchBackendIds = ['host', 'auto', 'docker', 'podman', 'apple-container'] as const;
+export const containerPullPolicies = ['missing', 'always', 'never'] as const;
+
+export const isLaunchBackendId = (value: string): value is LaunchBackendId =>
+  (launchBackendIds as readonly string[]).includes(value);
+
+export const mergeContainerControls = (
+  generic: ContainerProfileControls | undefined,
+  agentSpecific: ContainerProfileControls | undefined,
+): ContainerProfileControls | undefined => {
+  const merged = { ...generic, ...agentSpecific };
+
+  return Object.keys(merged).length === 0 ? undefined : merged;
+};
+
+export const selectContainerControls = (profile: Profile, agentId: string): ContainerProfileControls => {
+  const agentContainer = agentId === 'pi' ? profile.controls.pi?.container : profile.controls.claude?.container;
+
+  return (
+    mergeContainerControls(
+      profile.controls.container,
+      agentId === 'pi' || agentId === 'claude' ? agentContainer : undefined,
+    ) ?? {}
+  );
+};
+
+export const selectRequestedLaunchBackend = (
+  cliBackend: LaunchBackendId | undefined,
+  container: ContainerProfileControls,
+  settings: Settings,
+): LaunchBackendId =>
+  cliBackend ?? container.backend ?? settings.defaultLaunchBackend ?? (container.image === undefined ? 'host' : 'auto');
+
+export const mutableImageReferenceWarning = (image: string | undefined): string | undefined => {
+  if (image === undefined) {
+    return undefined;
+  }
+
+  const withoutRegistryPort = image.includes('/') ? image.slice(image.lastIndexOf('/') + 1) : image;
+  const hasDigest = image.includes('@sha256:');
+  const tag = withoutRegistryPort.includes(':')
+    ? withoutRegistryPort.slice(withoutRegistryPort.lastIndexOf(':') + 1)
+    : undefined;
+
+  if (hasDigest || (tag !== undefined && tag !== 'latest')) {
+    return undefined;
+  }
+
+  return `Container image '${image}' is mutable; pin a non-latest tag or digest for reproducible launches.`;
+};
+
+export const envPassthroughForContainer = (
+  requested: readonly string[] | undefined,
+  allowed: readonly string[] | undefined,
+  hostEnv: NodeJS.ProcessEnv = process.env,
+): readonly string[] => {
+  const allowedSet = new Set(allowed ?? []);
+
+  return [...new Set(requested ?? [])].filter((name) => allowedSet.has(name) && hostEnv[name] !== undefined);
+};

--- a/src/launchBackends/ContainerMountPlanner.ts
+++ b/src/launchBackends/ContainerMountPlanner.ts
@@ -1,0 +1,92 @@
+// Computes conservative identity bind mounts needed by containerized launches.
+import { existsSync } from 'node:fs';
+import { dirname, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { LaunchBackendRenderInput } from './LaunchBackend.js';
+
+export interface ContainerMount {
+  readonly source: string;
+  readonly target: string;
+  readonly readonly: boolean;
+}
+
+export interface ContainerMountPlan {
+  readonly mounts: readonly ContainerMount[];
+  readonly warnings: readonly string[];
+}
+
+const packageRootDirectory = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+export const planContainerMounts = (input: LaunchBackendRenderInput): ContainerMountPlan => {
+  const warnings: string[] = [];
+  const mounts = new Map<string, ContainerMount>();
+  const add = (path: string | undefined, readonly: boolean): void => {
+    /* v8 ignore next -- defensive guard for future optional mount inputs; current required inputs are covered. */
+    if (path === undefined || path === '') {
+      return;
+    }
+
+    const source = resolve(path);
+
+    if (isUnsafeDefaultMount(source)) {
+      warnings.push(`Refusing unsafe implicit container mount '${source}'.`);
+      return;
+    }
+
+    if (!existsSync(source)) {
+      warnings.push(`Required container mount source '${source}' does not exist.`);
+      return;
+    }
+
+    const existing = mounts.get(source);
+    mounts.set(source, {
+      source,
+      target: source,
+      readonly: existing === undefined ? readonly : existing.readonly && readonly,
+    });
+  };
+
+  add(input.projectDirectory, false);
+  add(input.compositeProfile.rootDirectory, false);
+  add(input.cacheDirectory, false);
+  add(packageRootDirectory, true);
+
+  for (const profileFolder of input.profileFolders) {
+    add(profileFolder, true);
+  }
+
+  for (const file of input.compositeProfile.files) {
+    for (const sourceInput of file.sourceInputs) {
+      add(dirname(sourceInput), true);
+    }
+  }
+
+  for (const statePath of input.statePaths) {
+    if (statePath.sourcePath !== undefined) {
+      add(statePath.directory ? statePath.sourcePath : dirname(statePath.sourcePath), false);
+    }
+  }
+
+  return { mounts: [...mounts.values()].sort((left, right) => left.target.localeCompare(right.target)), warnings };
+};
+
+const isUnsafeDefaultMount = (path: string): boolean => {
+  if (path === sep || path === process.env.HOME || path.endsWith(`${sep}docker.sock`)) {
+    return true;
+  }
+
+  const homeDirectory = process.env.HOME;
+  const sensitiveDirectories =
+    homeDirectory === undefined
+      ? []
+      : [resolve(homeDirectory, '.ssh'), resolve(homeDirectory, '.aws'), resolve(homeDirectory, '.config', 'gcloud')];
+
+  return sensitiveDirectories.some((directory) => path === directory || isPathInside(path, directory));
+};
+
+const isPathInside = (path: string, parent: string): boolean => {
+  const childRelativePath = relative(parent, path);
+
+  return childRelativePath !== '' && !childRelativePath.startsWith('..') && !childRelativePath.startsWith(sep);
+};

--- a/src/launchBackends/ContainerRenderers.ts
+++ b/src/launchBackends/ContainerRenderers.ts
@@ -1,0 +1,133 @@
+// Shared argv rendering helpers for Docker-compatible and Apple container launches.
+import { envPassthroughForContainer, mutableImageReferenceWarning } from './ContainerControls.js';
+import { planContainerMounts, type ContainerMount } from './ContainerMountPlanner.js';
+import type { LaunchBackendPlan, LaunchBackendRenderInput, ConcreteLaunchBackendId } from './LaunchBackend.js';
+
+export const renderDockerLikeBackend = (
+  id: 'docker' | 'podman',
+  input: LaunchBackendRenderInput,
+): LaunchBackendPlan => {
+  const { image, warnings } = requireContainerImage(id, input);
+  const mounts = planContainerMounts(input);
+  const args = [
+    'run',
+    '--rm',
+    '--interactive',
+    ...(input.stdoutIsTty ? ['--tty'] : []),
+    '--workdir',
+    input.projectDirectory,
+    ...mounts.mounts.flatMap(renderDockerMount),
+    ...renderEnvFlags(input),
+    ...renderDockerPull(input.container.pull),
+    ...renderOptionValue('--platform', input.container.platform),
+    ...(input.container.runArgs ?? input.container.run_args ?? []),
+    image,
+    input.innerLaunchPlan.command,
+    ...input.innerLaunchPlan.args,
+  ];
+
+  return {
+    backendId: id,
+    launchPlan: { command: id, args, env: renderContainerProcessEnv(input), cwd: input.projectDirectory },
+    warnings: [...warnings, ...mounts.warnings],
+  };
+};
+
+export const renderAppleContainerBackend = (input: LaunchBackendRenderInput): LaunchBackendPlan => {
+  const { image, warnings } = requireContainerImage('apple-container', input);
+  const mounts = planContainerMounts(input);
+  const pullWarning =
+    input.container.pull === undefined
+      ? []
+      : [`apple-container launch backend does not support portable pull policy '${input.container.pull}'.`];
+  const args = [
+    'run',
+    '--rm',
+    '--interactive',
+    /* v8 ignore next -- Apple TTY parity is covered by the Docker-compatible renderer tests. */
+    ...(input.stdoutIsTty ? ['--tty'] : []),
+    '--workdir',
+    input.projectDirectory,
+    ...mounts.mounts.flatMap(renderAppleMount),
+    ...renderEnvFlags(input),
+    ...renderOptionValue('--platform', input.container.platform),
+    ...(input.container.runArgs ?? input.container.run_args ?? []),
+    image,
+    input.innerLaunchPlan.command,
+    ...input.innerLaunchPlan.args,
+  ];
+
+  return {
+    backendId: 'apple-container',
+    launchPlan: { command: 'container', args, env: renderContainerProcessEnv(input), cwd: input.projectDirectory },
+    warnings: [...warnings, ...pullWarning, ...mounts.warnings],
+  };
+};
+
+export const renderHostBackend = (input: LaunchBackendRenderInput): LaunchBackendPlan => ({
+  backendId: 'host',
+  launchPlan: input.innerLaunchPlan,
+  warnings:
+    input.container.image === undefined
+      ? []
+      : [`host launch backend ignores configured container image '${input.container.image}'.`],
+});
+
+const requireContainerImage = (
+  backendId: ConcreteLaunchBackendId,
+  input: LaunchBackendRenderInput,
+): { readonly image: string; readonly warnings: readonly string[] } => {
+  if (input.container.image === undefined) {
+    throw new Error(`Launch backend '${backendId}' requires controls.container.image.`);
+  }
+
+  return {
+    image: input.container.image,
+    warnings: [mutableImageReferenceWarning(input.container.image)].filter((warning) => warning !== undefined),
+  };
+};
+
+const renderDockerMount = (mount: ContainerMount): readonly string[] => [
+  '--mount',
+  `type=bind,src=${mount.source},dst=${mount.target}${mount.readonly ? ',readonly' : ''}`,
+];
+
+const renderAppleMount = (mount: ContainerMount): readonly string[] => [
+  '--mount',
+  `source=${mount.source},target=${mount.target}${mount.readonly ? ',readonly' : ''}`,
+];
+
+const renderEnvFlags = (input: LaunchBackendRenderInput): readonly string[] => {
+  const innerEnvNames = Object.keys(input.innerLaunchPlan.env).sort();
+  const passThroughNames = envPassthroughForContainer(
+    input.container.envPassthrough ?? input.container.env_passthrough,
+    input.envPassthroughAllowed,
+  );
+
+  return [...new Set([...innerEnvNames, ...passThroughNames])].flatMap((name) => ['--env', name]);
+};
+
+const renderContainerProcessEnv = (input: LaunchBackendRenderInput): Readonly<Record<string, string>> => {
+  const passThroughNames = envPassthroughForContainer(
+    input.container.envPassthrough ?? input.container.env_passthrough,
+    input.envPassthroughAllowed,
+  );
+  const passThroughEnv = Object.fromEntries(
+    passThroughNames
+      .map((name) => [name, process.env[name]])
+      .filter((entry): entry is [string, string] => entry[1] !== undefined),
+  );
+
+  return { ...passThroughEnv, ...input.innerLaunchPlan.env };
+};
+
+const renderDockerPull = (pull: string | undefined): readonly string[] => {
+  if (pull === undefined || pull === 'missing') {
+    return [];
+  }
+
+  return [`--pull=${pull}`];
+};
+
+const renderOptionValue = (option: string, value: string | undefined): readonly string[] =>
+  value === undefined ? [] : [option, value];

--- a/src/launchBackends/DockerLaunchBackend.ts
+++ b/src/launchBackends/DockerLaunchBackend.ts
@@ -1,0 +1,8 @@
+// Docker launch backend renderer.
+import type { LaunchBackend } from './LaunchBackend.js';
+import { renderDockerLikeBackend } from './ContainerRenderers.js';
+
+export const createDockerLaunchBackend = (): LaunchBackend => ({
+  id: 'docker',
+  render: (input) => renderDockerLikeBackend('docker', input),
+});

--- a/src/launchBackends/HostLaunchBackend.ts
+++ b/src/launchBackends/HostLaunchBackend.ts
@@ -1,0 +1,8 @@
+// Host launch backend that preserves native agent execution.
+import type { LaunchBackend } from './LaunchBackend.js';
+import { renderHostBackend } from './ContainerRenderers.js';
+
+export const createHostLaunchBackend = (): LaunchBackend => ({
+  id: 'host',
+  render: renderHostBackend,
+});

--- a/src/launchBackends/LaunchBackend.ts
+++ b/src/launchBackends/LaunchBackend.ts
@@ -1,0 +1,39 @@
+/* v8 ignore start -- interface-only module. */
+// Defines the generic launch backend boundary used to wrap agent launch plans.
+import type { CompositeProfile } from '../compositeProfile/CompositeProfile.js';
+import type { CompositeProfileStatePath } from '../compositeProfile/StatePersistence.js';
+import type { ContainerProfileControls } from '../profiles/Profile.js';
+
+export type LaunchBackendId = 'host' | 'auto' | 'docker' | 'podman' | 'apple-container';
+export type ConcreteLaunchBackendId = Exclude<LaunchBackendId, 'auto'>;
+
+export interface ProcessLaunchPlan {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly env: Readonly<Record<string, string>>;
+  readonly cwd?: string;
+}
+
+export interface LaunchBackendPlan {
+  readonly backendId: ConcreteLaunchBackendId;
+  readonly launchPlan: ProcessLaunchPlan;
+  readonly warnings: readonly string[];
+}
+
+export interface LaunchBackendRenderInput {
+  readonly innerLaunchPlan: ProcessLaunchPlan;
+  readonly container: ContainerProfileControls;
+  readonly compositeProfile: CompositeProfile;
+  readonly profileFolders: readonly string[];
+  readonly projectDirectory: string;
+  readonly cacheDirectory: string;
+  readonly statePaths: readonly CompositeProfileStatePath[];
+  readonly envPassthroughAllowed: readonly string[];
+  readonly stdinIsTty: boolean;
+  readonly stdoutIsTty: boolean;
+}
+
+export interface LaunchBackend {
+  readonly id: ConcreteLaunchBackendId;
+  render(input: LaunchBackendRenderInput): LaunchBackendPlan;
+}

--- a/src/launchBackends/LaunchBackendRegistry.ts
+++ b/src/launchBackends/LaunchBackendRegistry.ts
@@ -1,0 +1,96 @@
+// Selects launch backends and resolves auto detection with injectable dependencies.
+import { accessSync, constants } from 'node:fs';
+import { delimiter, join } from 'node:path';
+
+import type { LaunchBackend, LaunchBackendId, ConcreteLaunchBackendId } from './LaunchBackend.js';
+import { createAppleContainerLaunchBackend } from './AppleContainerLaunchBackend.js';
+import { createDockerLaunchBackend } from './DockerLaunchBackend.js';
+import { createHostLaunchBackend } from './HostLaunchBackend.js';
+import { createPodmanLaunchBackend } from './PodmanLaunchBackend.js';
+
+export interface LaunchBackendResolverDependencies {
+  readonly commandExists?: (command: string) => boolean;
+  readonly platform?: NodeJS.Platform;
+}
+
+export const createLaunchBackend = (
+  requestedBackend: LaunchBackendId,
+  dependencies: LaunchBackendResolverDependencies = {},
+): LaunchBackend => {
+  const backendId = resolveConcreteBackendId(requestedBackend, dependencies);
+
+  assertBackendExecutable(backendId, dependencies.commandExists ?? defaultCommandExists);
+
+  if (backendId === 'docker') {
+    return createDockerLaunchBackend();
+  }
+
+  if (backendId === 'podman') {
+    return createPodmanLaunchBackend();
+  }
+
+  if (backendId === 'apple-container') {
+    return createAppleContainerLaunchBackend();
+  }
+
+  return createHostLaunchBackend();
+};
+
+export const resolveConcreteBackendId = (
+  requestedBackend: LaunchBackendId,
+  dependencies: LaunchBackendResolverDependencies = {},
+): ConcreteLaunchBackendId => {
+  if (requestedBackend !== 'auto') {
+    return requestedBackend;
+  }
+
+  /* v8 ignore next -- default PATH/platform probing is host-environment behavior; tests inject both. */
+  const commandExists = dependencies.commandExists ?? defaultCommandExists;
+  const platform = dependencies.platform ?? process.platform;
+
+  if (commandExists('docker')) {
+    return 'docker';
+  }
+
+  if (commandExists('podman')) {
+    return 'podman';
+  }
+
+  if (platform === 'darwin' && commandExists('container')) {
+    return 'apple-container';
+  }
+
+  throw new Error(
+    "No container launch backend executable found for 'auto' (tried docker, podman, and Apple container on macOS). Use --launch-backend host or install a backend.",
+  );
+};
+
+const assertBackendExecutable = (
+  backendId: ConcreteLaunchBackendId,
+  commandExists: (command: string) => boolean,
+): void => {
+  if (backendId === 'host') {
+    return;
+  }
+
+  const command = backendId === 'apple-container' ? 'container' : backendId;
+
+  if (!commandExists(command)) {
+    throw new Error(`Launch backend '${backendId}' requires executable '${command}' on PATH.`);
+  }
+};
+
+/* v8 ignore start -- default PATH probing is host-environment behavior; tests inject commandExists. */
+const defaultCommandExists = (command: string): boolean => {
+  const pathEntries = (process.env.PATH ?? '').split(delimiter).filter((entry) => entry !== '');
+
+  return pathEntries.some((entry) => {
+    try {
+      accessSync(join(entry, command), constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+};
+/* v8 ignore stop */

--- a/src/launchBackends/PodmanLaunchBackend.ts
+++ b/src/launchBackends/PodmanLaunchBackend.ts
@@ -1,0 +1,8 @@
+// Podman launch backend renderer.
+import type { LaunchBackend } from './LaunchBackend.js';
+import { renderDockerLikeBackend } from './ContainerRenderers.js';
+
+export const createPodmanLaunchBackend = (): LaunchBackend => ({
+  id: 'podman',
+  render: (input) => renderDockerLikeBackend('podman', input),
+});

--- a/src/profiles/Profile.ts
+++ b/src/profiles/Profile.ts
@@ -3,6 +3,19 @@ import type { StatePersistenceStrategy } from '../compositeProfile/StatePersiste
 
 export type StatePersistenceOverrides = Readonly<Record<string, StatePersistenceStrategy>>;
 export type AppendSystemPromptControl = string | readonly string[];
+export type LaunchBackendControl = 'host' | 'auto' | 'docker' | 'podman' | 'apple-container';
+export type ContainerPullPolicy = 'missing' | 'always' | 'never';
+
+export interface ContainerProfileControls {
+  readonly image?: string;
+  readonly backend?: LaunchBackendControl;
+  readonly pull?: ContainerPullPolicy;
+  readonly platform?: string;
+  readonly envPassthrough?: readonly string[];
+  readonly env_passthrough?: readonly string[];
+  readonly runArgs?: readonly string[];
+  readonly run_args?: readonly string[];
+}
 
 interface BaseProfileControls {
   readonly [controlName: string]: unknown;
@@ -17,6 +30,7 @@ interface BaseProfileControls {
   readonly promptTemplate?: string;
   readonly systemPrompt?: string;
   readonly appendSystemPrompt?: AppendSystemPromptControl;
+  readonly container?: ContainerProfileControls;
 }
 
 export type AgentSpecificProfileControls = BaseProfileControls;

--- a/src/profiles/ProfileLoader.ts
+++ b/src/profiles/ProfileLoader.ts
@@ -5,7 +5,13 @@ import { join } from 'node:path';
 import type { ValidationIssue } from '../validation/SchemaValidator.js';
 import { validateSchema } from '../validation/SchemaValidator.js';
 import { parseYamlDocument } from '../validation/YamlDocument.js';
-import type { AgentSpecificProfileControls, Profile, ProfileControls, StatePersistenceOverrides } from './Profile.js';
+import type {
+  AgentSpecificProfileControls,
+  ContainerProfileControls,
+  Profile,
+  ProfileControls,
+  StatePersistenceOverrides,
+} from './Profile.js';
 import type { ProfileSourceReference } from './ProfileSource.js';
 
 const profileIdPattern = /^[a-z0-9][a-z0-9._-]*[a-z0-9]$|^[a-z0-9]$/u;
@@ -205,6 +211,7 @@ const readControls = (value: unknown): ProfileControls => {
     promptTemplate: readOptionalString(controls.prompt_template),
     systemPrompt: readOptionalString(controls.system_prompt),
     appendSystemPrompt: readOptionalStringOrStringArray(controls.append_system_prompt),
+    container: readContainerControls(controls.container),
     pi: readAgentSpecificControls(controls.pi),
     claude: readAgentSpecificControls(controls.claude),
   });
@@ -230,6 +237,24 @@ const readAgentSpecificControls = (value: unknown): AgentSpecificProfileControls
     promptTemplate: readOptionalString(controls.prompt_template),
     systemPrompt: readOptionalString(controls.system_prompt),
     appendSystemPrompt: readOptionalStringOrStringArray(controls.append_system_prompt),
+    container: readContainerControls(controls.container),
+  });
+};
+
+const readContainerControls = (value: unknown): ContainerProfileControls | undefined => {
+  const controls = readObject(value);
+
+  if (controls === undefined) {
+    return undefined;
+  }
+
+  return omitUndefined({
+    image: readOptionalString(controls.image),
+    backend: readOptionalString(controls.backend) as ContainerProfileControls['backend'],
+    pull: readOptionalString(controls.pull) as ContainerProfileControls['pull'],
+    platform: readOptionalString(controls.platform),
+    envPassthrough: readOptionalStringArray(controls.env_passthrough),
+    runArgs: readOptionalStringArray(controls.run_args),
   });
 };
 

--- a/src/profiles/ProfileMerger.ts
+++ b/src/profiles/ProfileMerger.ts
@@ -55,6 +55,10 @@ const profileArrayPolicy = (path: MergePath): ArrayMergePolicy | undefined => {
     return 'prepend';
   }
 
+  if (isContainerReplaceArrayPath(pathKey)) {
+    return 'replace';
+  }
+
   if (isAppendSystemPromptPath(pathKey)) {
     return 'prependList';
   }
@@ -79,6 +83,22 @@ const profileArrayPolicy = (path: MergePath): ArrayMergePolicy | undefined => {
 
   return undefined;
 };
+
+const isContainerReplaceArrayPath = (pathKey: string): boolean =>
+  [
+    'controls.container.envPassthrough',
+    'controls.container.env_passthrough',
+    'controls.container.runArgs',
+    'controls.container.run_args',
+    'controls.pi.container.envPassthrough',
+    'controls.pi.container.env_passthrough',
+    'controls.pi.container.runArgs',
+    'controls.pi.container.run_args',
+    'controls.claude.container.envPassthrough',
+    'controls.claude.container.env_passthrough',
+    'controls.claude.container.runArgs',
+    'controls.claude.container.run_args',
+  ].includes(pathKey);
 
 const isAppendSystemPromptPath = (pathKey: string): boolean =>
   [

--- a/src/schemas/profile.schema.json
+++ b/src/schemas/profile.schema.json
@@ -46,6 +46,7 @@
         "prompt_template": { "type": "string" },
         "system_prompt": { "type": "string" },
         "append_system_prompt": { "$ref": "#/$defs/appendSystemPrompt" },
+        "container": { "$ref": "#/$defs/containerControls" },
         "environment": {
           "type": "object",
           "additionalProperties": { "type": "string" }
@@ -72,6 +73,7 @@
             "prompt_template": { "type": "string" },
             "system_prompt": { "type": "string" },
             "append_system_prompt": { "$ref": "#/$defs/appendSystemPrompt" },
+            "container": { "$ref": "#/$defs/containerControls" },
             "allow_external_deepwork_jobs": { "type": "boolean" },
             "environment": {
               "type": "object",
@@ -102,6 +104,7 @@
             "prompt_template": { "type": "string" },
             "system_prompt": { "type": "string" },
             "append_system_prompt": { "$ref": "#/$defs/appendSystemPrompt" },
+            "container": { "$ref": "#/$defs/containerControls" },
             "environment": {
               "type": "object",
               "additionalProperties": { "type": "string" }
@@ -115,6 +118,24 @@
   },
   "additionalProperties": true,
   "$defs": {
+    "containerControls": {
+      "type": "object",
+      "properties": {
+        "image": { "type": "string", "minLength": 1 },
+        "backend": { "enum": ["host", "auto", "docker", "podman", "apple-container"] },
+        "pull": { "enum": ["missing", "always", "never"] },
+        "platform": { "type": "string", "minLength": 1 },
+        "env_passthrough": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*$" }
+        },
+        "run_args": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
+    },
     "appendSystemPrompt": {
       "oneOf": [
         { "type": "string" },

--- a/src/schemas/settings.schema.json
+++ b/src/schemas/settings.schema.json
@@ -6,6 +6,7 @@
   "properties": {
     "default_profile": { "type": "string", "minLength": 1 },
     "default_agent": { "enum": ["pi", "claude"] },
+    "default_launch_backend": { "enum": ["host", "auto", "docker", "podman", "apple-container"] },
     "cache_directory": { "type": "string", "minLength": 1 },
     "profile_sources": {
       "type": "array",
@@ -27,6 +28,16 @@
         },
         "additionalProperties": false
       }
+    },
+    "container_policy": {
+      "type": "object",
+      "properties": {
+        "env_passthrough": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*$" }
+        }
+      },
+      "additionalProperties": false
     },
     "custom_settings": {
       "type": "object",

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -11,12 +11,18 @@ export type SettingsValue =
   | { readonly [key: string]: SettingsValue };
 export type CustomSettings = Readonly<Record<string, SettingsValue>>;
 
+export interface ContainerPolicySettings {
+  readonly envPassthrough?: readonly string[];
+}
+
 export interface Settings {
   readonly defaultProfile?: string;
   readonly defaultAgent?: string;
+  readonly defaultLaunchBackend?: 'host' | 'auto' | 'docker' | 'podman' | 'apple-container';
   readonly profileSources?: readonly ProfileSourceReference[];
   readonly remoteSettings?: readonly RemoteSettingsReference[];
   readonly cacheDirectory?: string;
+  readonly containerPolicy?: ContainerPolicySettings;
   readonly customSettings?: CustomSettings;
 }
 

--- a/src/settings/SettingsLoader.ts
+++ b/src/settings/SettingsLoader.ts
@@ -40,9 +40,11 @@ export interface SettingsLoadIssue extends ValidationIssue {
 interface SettingsDocument {
   readonly default_profile?: string;
   readonly default_agent?: string;
+  readonly default_launch_backend?: 'host' | 'auto' | 'docker' | 'podman' | 'apple-container';
   readonly profile_sources?: readonly ProfileSourceDocument[];
   readonly remote_settings?: readonly RemoteSettingsDocument[];
   readonly cache_directory?: string;
+  readonly container_policy?: { readonly env_passthrough?: readonly string[] };
   readonly custom_settings?: CustomSettings;
 }
 
@@ -125,7 +127,7 @@ export const loadSettingsWithCachedRemoteSettings = (
   return {
     files,
     issues,
-    settings: mergeSettingsStack(files.map((file) => file.settings)),
+    settings: mergeSettingsStack(files.map((file) => stripRemoteTrustedSettings(file))),
   };
 };
 
@@ -168,6 +170,18 @@ interface SettingsLocationDiscoveryResult {
   readonly issues: readonly SettingsLoadIssue[];
 }
 
+const stripRemoteTrustedSettings = (file: LoadedSettingsFile): Settings => {
+  if (file.location.scope !== 'remote') {
+    return file.settings;
+  }
+
+  const { defaultLaunchBackend: _defaultLaunchBackend, containerPolicy: _containerPolicy, ...settings } = file.settings;
+  void _defaultLaunchBackend;
+  void _containerPolicy;
+
+  return settings;
+};
+
 const addSettingsFile = (
   location: SettingsLocation,
   files: LoadedSettingsFile[],
@@ -196,12 +210,15 @@ const addSettingsFile = (
 const convertSettingsDocument = (document: SettingsDocument, settingsDirectory: string): Settings => ({
   defaultProfile: document.default_profile,
   defaultAgent: document.default_agent,
+  defaultLaunchBackend: document.default_launch_backend,
   profileSources: document.profile_sources?.map((source) => convertProfileSource(source, settingsDirectory)),
   remoteSettings: document.remote_settings?.map(convertRemoteSettingsSource),
   cacheDirectory:
     document.cache_directory === undefined
       ? undefined
       : resolveConfigDirectory(document.cache_directory, settingsDirectory),
+  containerPolicy:
+    document.container_policy === undefined ? undefined : { envPassthrough: document.container_policy.env_passthrough },
   customSettings: document.custom_settings,
 });
 

--- a/src/settings/SettingsMerger.ts
+++ b/src/settings/SettingsMerger.ts
@@ -3,21 +3,27 @@ import { mergeObjectsWithPolicy } from '../merge/SettingsValueMerger.js';
 import type { CustomSettings, Settings } from './Settings.js';
 import { emptySettings } from './Settings.js';
 
+// Settings precedence is easier to audit as a direct field-by-field merge.
+// eslint-disable-next-line complexity
 export const mergeSettingsStack = (settingsStack: readonly Settings[]): Settings => {
   let defaultProfile: string | undefined;
   let defaultAgent: string | undefined;
+  let defaultLaunchBackend: Settings['defaultLaunchBackend'];
   let profileSources: Settings['profileSources'];
   let remoteSettings: Settings['remoteSettings'];
   let cacheDirectory: string | undefined;
+  let containerPolicy: Settings['containerPolicy'];
   let customSettings: CustomSettings | undefined;
 
   for (const settings of settingsStack) {
     defaultProfile = settings.defaultProfile ?? defaultProfile;
     defaultAgent = settings.defaultAgent ?? defaultAgent;
+    defaultLaunchBackend = settings.defaultLaunchBackend ?? defaultLaunchBackend;
 
     profileSources = settings.profileSources ?? profileSources;
     remoteSettings = settings.remoteSettings ?? remoteSettings;
     cacheDirectory = settings.cacheDirectory ?? cacheDirectory;
+    containerPolicy = settings.containerPolicy ?? containerPolicy;
     customSettings = mergeOptionalCustomSettings(customSettings, settings.customSettings);
   }
 
@@ -25,9 +31,11 @@ export const mergeSettingsStack = (settingsStack: readonly Settings[]): Settings
     ...emptySettings(),
     defaultProfile,
     defaultAgent,
+    defaultLaunchBackend,
     profileSources: profileSources ?? [],
     remoteSettings: remoteSettings ?? [],
     cacheDirectory,
+    containerPolicy: containerPolicy ?? { envPassthrough: [] },
     customSettings: customSettings ?? {},
   };
 };

--- a/tests/unit/launch-backends.test.ts
+++ b/tests/unit/launch-backends.test.ts
@@ -1,0 +1,278 @@
+// Tests container launch backend selection and shell-free argv rendering.
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { createCompositeProfile } from '../../src/compositeProfile/CompositeProfile.js';
+import { createCompositeProfileFile } from '../../src/compositeProfile/CompositeProfileFile.js';
+import {
+  renderAppleContainerBackend,
+  renderDockerLikeBackend,
+  renderHostBackend,
+} from '../../src/launchBackends/ContainerRenderers.js';
+import {
+  envPassthroughForContainer,
+  isLaunchBackendId,
+  mutableImageReferenceWarning,
+  selectContainerControls,
+  selectRequestedLaunchBackend,
+} from '../../src/launchBackends/ContainerControls.js';
+import { planContainerMounts } from '../../src/launchBackends/ContainerMountPlanner.js';
+import { createHostLaunchBackend } from '../../src/launchBackends/HostLaunchBackend.js';
+import { createLaunchBackend, resolveConcreteBackendId } from '../../src/launchBackends/LaunchBackendRegistry.js';
+import type { LaunchBackendRenderInput } from '../../src/launchBackends/LaunchBackend.js';
+
+const createInput = (): LaunchBackendRenderInput => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-container-backend-'));
+  const project = join(root, 'project');
+  const composite = join(root, 'composite');
+  const profile = join(root, 'profiles', 'engineering');
+  const cache = join(root, 'cache');
+  const state = join(root, 'state');
+  const profileFile = join(profile, 'profile.yml');
+
+  for (const directory of [project, composite, profile, cache, state]) {
+    mkdirSync(directory, { recursive: true });
+  }
+  writeFileSync(profileFile, 'id: engineering\n');
+  writeFileSync(join(state, 'settings.json'), '{}\n');
+
+  return {
+    innerLaunchPlan: { command: 'pi', args: ['--model', 'sonnet'], env: { PI_CODING_AGENT_DIR: composite } },
+    container: {
+      image: 'ghcr.io/ai-outfitter/outfitter-pi:0.6.1',
+      backend: 'docker',
+      pull: 'always',
+      platform: 'linux/arm64',
+      envPassthrough: ['ANTHROPIC_API_KEY'],
+      runArgs: ['--init'],
+    },
+    compositeProfile: createCompositeProfile(
+      composite,
+      [
+        createCompositeProfileFile({
+          rootDirectory: composite,
+          relativePath: 'outfitter/profile.json',
+          content: '{}\n',
+          sourceInputs: [profileFile],
+          strategy: 'transform',
+        }),
+      ],
+      [
+        {
+          relativePath: 'settings.json',
+          strategy: 'symlink',
+          sourcePath: join(state, 'settings.json'),
+          directory: false,
+        },
+      ],
+    ),
+    profileFolders: [profile],
+    projectDirectory: project,
+    cacheDirectory: cache,
+    statePaths: [
+      {
+        relativePath: 'settings.json',
+        strategy: 'symlink',
+        sourcePath: join(state, 'settings.json'),
+        directory: false,
+      },
+    ],
+    envPassthroughAllowed: ['ANTHROPIC_API_KEY'],
+    stdinIsTty: true,
+    stdoutIsTty: true,
+  };
+};
+
+describe('launch backend resolver and renderers', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-011.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('resolves auto deterministically and renders Docker argv without a shell', () => {
+    expect(resolveConcreteBackendId('auto', { commandExists: (command) => command === 'podman' })).toBe('podman');
+
+    const originalApiKey = process.env.ANTHROPIC_API_KEY;
+    process.env.ANTHROPIC_API_KEY = 'test-secret';
+    const input = createInput();
+    const plan = renderDockerLikeBackend('docker', input);
+    if (originalApiKey === undefined) {
+      delete process.env.ANTHROPIC_API_KEY;
+    } else {
+      process.env.ANTHROPIC_API_KEY = originalApiKey;
+    }
+
+    expect(plan.launchPlan.command).toBe('docker');
+    expect(plan.launchPlan.cwd).toBe(input.projectDirectory);
+    expect(plan.launchPlan.args).toContain('--pull=always');
+    expect(plan.launchPlan.args).toContain('--platform');
+    expect(plan.launchPlan.args).toContain('linux/arm64');
+    expect(plan.launchPlan.args).toContain('--init');
+    expect(plan.launchPlan.args.slice(-3)).toEqual(
+      ['ghcr.io/ai-outfitter/outfitter-pi:0.6.1', 'pi', '--model', 'sonnet'].slice(-3),
+    );
+    expect(plan.launchPlan.args).toContain(`type=bind,src=${input.projectDirectory},dst=${input.projectDirectory}`);
+    expect(plan.launchPlan.args).toContain('--env');
+    expect(plan.launchPlan.args).toContain('ANTHROPIC_API_KEY');
+    expect(plan.launchPlan.args).not.toContain('test-secret');
+    expect(plan.launchPlan.env).toMatchObject({
+      ANTHROPIC_API_KEY: 'test-secret',
+      PI_CODING_AGENT_DIR: input.compositeProfile.rootDirectory,
+    });
+
+    const podmanPlan = renderDockerLikeBackend('podman', {
+      ...input,
+      container: { ...input.container, backend: 'podman' },
+    });
+    expect(podmanPlan.launchPlan.command).toBe('podman');
+    expect(podmanPlan.launchPlan.args).toContain(
+      `type=bind,src=${input.projectDirectory},dst=${input.projectDirectory}`,
+    );
+    expect(podmanPlan.launchPlan.args.slice(-3)).toEqual(['pi', '--model', 'sonnet']);
+    expect(podmanPlan.launchPlan.args).not.toContain('test-secret');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-011.4).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('plans identity mounts and warns for Apple pull policy gaps and mutable images', () => {
+    const container = { image: 'example/agent:latest', pull: 'always' } satisfies LaunchBackendRenderInput['container'];
+    const input = { ...createInput(), container };
+    const mounts = planContainerMounts(input);
+    const targets = mounts.mounts.map((mount) => mount.target);
+    const missingInput = { ...input, cacheDirectory: join(input.projectDirectory, 'missing-cache') };
+    const unsafeInput = { ...input, cacheDirectory: process.env.HOME ?? '/' };
+    const unsafeDescendantInput = { ...input, cacheDirectory: join(process.env.HOME ?? '/', '.ssh', 'keys') };
+    const writableProfileInput = {
+      ...input,
+      statePaths: [
+        {
+          relativePath: 'settings.json',
+          strategy: 'symlink' as const,
+          sourcePath: join(input.profileFolders[0], 'state.json'),
+          directory: false,
+        },
+      ],
+    };
+    writeFileSync(join(input.profileFolders[0], 'state.json'), '{}\n');
+
+    const stateSource = input.statePaths[0]?.sourcePath;
+    expect(stateSource).toBeDefined();
+    expect(targets).toContain(input.projectDirectory);
+    expect(targets).toContain(input.compositeProfile.rootDirectory);
+    expect(targets).toContain(dirname(stateSource ?? ''));
+    expect(planContainerMounts(missingInput).warnings[0]).toContain('does not exist');
+    expect(planContainerMounts(unsafeInput).warnings[0]).toContain('Refusing unsafe implicit container mount');
+    expect(planContainerMounts(unsafeDescendantInput).warnings[0]).toContain(
+      'Refusing unsafe implicit container mount',
+    );
+    expect(
+      planContainerMounts({ ...input, statePaths: [{ relativePath: 'unknown', strategy: 'warn', directory: false }] })
+        .warnings,
+    ).toEqual([]);
+    expect(
+      planContainerMounts(writableProfileInput).mounts.find((mount) => mount.target === input.profileFolders[0])
+        ?.readonly,
+    ).toBe(false);
+    rmSync(join(input.profileFolders[0], 'state.json'));
+
+    const apple = renderAppleContainerBackend(input);
+    expect(apple.launchPlan.command).toBe('container');
+    expect(apple.warnings).toContain("apple-container launch backend does not support portable pull policy 'always'.");
+    expect(apple.warnings.some((warning) => warning.includes('mutable'))).toBe(true);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-011.2, OFTR-011.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('covers backend factories, host rendering, and validation helper branches', () => {
+    const input = createInput();
+
+    expect(isLaunchBackendId('docker')).toBe(true);
+    expect(isLaunchBackendId('invalid')).toBe(false);
+    expect(mutableImageReferenceWarning('example/agent@sha256:abc')).toBeUndefined();
+    expect(mutableImageReferenceWarning('example/agent:1.0.0')).toBeUndefined();
+    expect(mutableImageReferenceWarning('example/agent')).toContain('mutable');
+    expect(mutableImageReferenceWarning('agent:latest')).toContain('mutable');
+    expect(mutableImageReferenceWarning(undefined)).toBeUndefined();
+    expect(
+      envPassthroughForContainer(['SECRET', 'MISSING', 'SECRET'], ['SECRET', 'OTHER'], { SECRET: 'value' }),
+    ).toEqual(['SECRET']);
+    expect(envPassthroughForContainer(undefined, undefined, {})).toEqual([]);
+
+    const hostBackend = createLaunchBackend('host');
+    expect(hostBackend.id).toBe('host');
+    expect(hostBackend.render(input).launchPlan).toEqual(input.innerLaunchPlan);
+    expect(createHostLaunchBackend().render(input).backendId).toBe('host');
+    expect(createLaunchBackend('docker', { commandExists: (command) => command === 'docker' }).id).toBe('docker');
+    expect(createLaunchBackend('podman', { commandExists: (command) => command === 'podman' }).id).toBe('podman');
+    expect(createLaunchBackend('apple-container', { commandExists: (command) => command === 'container' }).id).toBe(
+      'apple-container',
+    );
+    expect(resolveConcreteBackendId('auto', { commandExists: (command) => command === 'docker' })).toBe('docker');
+    expect(
+      resolveConcreteBackendId('auto', { platform: 'darwin', commandExists: (command) => command === 'container' }),
+    ).toBe('apple-container');
+    expect(() =>
+      resolveConcreteBackendId('auto', { platform: 'linux', commandExists: (command) => command === 'container' }),
+    ).toThrow('No container launch backend');
+    expect(() => createLaunchBackend('docker', { commandExists: () => false })).toThrow("requires executable 'docker'");
+    expect(() => resolveConcreteBackendId('auto', { commandExists: () => false })).toThrow(
+      'No container launch backend',
+    );
+
+    expect(renderHostBackend(input).warnings).toEqual([
+      "host launch backend ignores configured container image 'ghcr.io/ai-outfitter/outfitter-pi:0.6.1'.",
+    ]);
+    expect(renderHostBackend({ ...input, container: {} }).warnings).toEqual([]);
+    expect(() => renderDockerLikeBackend('podman', { ...input, container: {} })).toThrow(
+      "Launch backend 'podman' requires controls.container.image.",
+    );
+    expect(
+      renderAppleContainerBackend({ ...input, stdoutIsTty: false, container: { image: 'example/agent:1.0.0' } })
+        .launchPlan.args,
+    ).not.toContain('--tty');
+    expect(renderAppleContainerBackend({ ...input, container: { image: 'example/agent:1.0.0' } }).warnings).toEqual([]);
+
+    expect(
+      selectRequestedLaunchBackend(
+        'podman',
+        { backend: 'docker', image: 'example:1' },
+        { defaultLaunchBackend: 'host' },
+      ),
+    ).toBe('podman');
+    expect(
+      selectRequestedLaunchBackend(
+        undefined,
+        { backend: 'docker', image: 'example:1' },
+        { defaultLaunchBackend: 'host' },
+      ),
+    ).toBe('docker');
+    expect(selectRequestedLaunchBackend(undefined, { image: 'example:1' }, { defaultLaunchBackend: 'host' })).toBe(
+      'host',
+    );
+    expect(selectRequestedLaunchBackend(undefined, { image: 'example:1' }, {})).toBe('auto');
+    expect(selectRequestedLaunchBackend(undefined, {}, {})).toBe('host');
+
+    expect(selectContainerControls({ id: 'p', inherits: [], controls: {} }, 'unknown')).toEqual({});
+    expect(
+      selectContainerControls({ id: 'p', inherits: [], controls: { container: { image: 'generic' } } }, 'unknown'),
+    ).toEqual({
+      image: 'generic',
+    });
+    expect(
+      selectContainerControls(
+        {
+          id: 'p',
+          inherits: [],
+          controls: { container: { image: 'generic' }, pi: { container: { backend: 'docker' } } },
+        },
+        'pi',
+      ),
+    ).toEqual({ image: 'generic', backend: 'docker' });
+    expect(
+      selectContainerControls(
+        { id: 'p', inherits: [], controls: { claude: { container: { backend: 'podman' } } } },
+        'claude',
+      ),
+    ).toEqual({ backend: 'podman' });
+  });
+});

--- a/tests/unit/profile-container-merge.test.ts
+++ b/tests/unit/profile-container-merge.test.ts
@@ -1,0 +1,50 @@
+// Tests profile container control merge behavior.
+import { describe, expect, it } from 'vitest';
+
+import { resolveProfile } from '../../src/profiles/ProfileMerger.js';
+import { createLocalProfileSource } from '../../src/profiles/ProfileSource.js';
+import type { LoadedProfile } from '../../src/profiles/ProfileLoader.js';
+
+const loadedProfile = (profile: LoadedProfile['profile']): LoadedProfile => ({
+  source: createLocalProfileSource('<profiles>'),
+  folderPath: '<profiles>/profile',
+  profilePath: '<profiles>/profile/profile.yml',
+  profile,
+});
+
+describe('profile container control merging', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-011.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('deep-merges container controls and replaces env/run argument arrays', () => {
+    const result = resolveProfile({
+      profileId: 'selected',
+      profiles: [
+        loadedProfile({
+          id: 'base',
+          inherits: [],
+          controls: {
+            container: { image: 'example/base:1', envPassthrough: ['BASE_ENV'], runArgs: ['--base-run'] },
+            pi: { container: { runArgs: ['--base-pi-run'] } },
+          },
+        }),
+        loadedProfile({
+          id: 'selected',
+          inherits: ['base'],
+          controls: {
+            container: { backend: 'docker', envPassthrough: ['SELECTED_ENV'], runArgs: ['--selected-run'] },
+            pi: { container: { runArgs: ['--selected-pi-run'] } },
+          },
+        }),
+      ],
+    });
+
+    expect(result.issues).toEqual([]);
+    expect(result.profile?.controls.container).toEqual({
+      image: 'example/base:1',
+      backend: 'docker',
+      envPassthrough: ['SELECTED_ENV'],
+      runArgs: ['--selected-run'],
+    });
+    expect(result.profile?.controls.pi?.container).toEqual({ runArgs: ['--selected-pi-run'] });
+  });
+});

--- a/tests/unit/profile-control-parsing.test.ts
+++ b/tests/unit/profile-control-parsing.test.ts
@@ -46,4 +46,70 @@ describe('profile control parsing', () => {
       expect(profile.controls.claude?.appendSystemPrompt).toEqual(['prompt-claude-a', 'prompt-claude-b']);
     }
   });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-011.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('normalizes generic and agent-specific container controls from profile YAML', () => {
+    const profile = parseProfileYaml(
+      [
+        'id: containerized',
+        'controls:',
+        '  container:',
+        '    image: ghcr.io/example/pi:1.2.3',
+        '    backend: docker',
+        '    pull: missing',
+        '    platform: linux/arm64',
+        '    env_passthrough: [ANTHROPIC_API_KEY]',
+        '    run_args: [--init]',
+        '  pi:',
+        '    container:',
+        '      backend: podman',
+        '      run_args: [--userns=keep-id]',
+        '',
+      ].join('\n'),
+      'fallback',
+    );
+
+    expect('message' in profile).toBe(false);
+    if (!('message' in profile)) {
+      expect(profile.controls.container).toEqual({
+        image: 'ghcr.io/example/pi:1.2.3',
+        backend: 'docker',
+        pull: 'missing',
+        platform: 'linux/arm64',
+        envPassthrough: ['ANTHROPIC_API_KEY'],
+        runArgs: ['--init'],
+      });
+      expect(profile.controls.pi?.container).toEqual({ backend: 'podman', runArgs: ['--userns=keep-id'] });
+    }
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-011.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('rejects invalid container control values from profile YAML', () => {
+    expect(parseProfileYaml('id: bad\ncontrols:\n  container:\n    image: ""\n', 'fallback')).toEqual({
+      path: '/controls/container/image',
+      message: 'must NOT have fewer than 1 characters',
+    });
+    expect(parseProfileYaml('id: bad\ncontrols:\n  container:\n    platform: ""\n', 'fallback')).toEqual({
+      path: '/controls/container/platform',
+      message: 'must NOT have fewer than 1 characters',
+    });
+    expect(parseProfileYaml('id: bad\ncontrols:\n  container:\n    backend: invalid\n', 'fallback')).toEqual({
+      path: '/controls/container/backend',
+      message: 'must be equal to one of the allowed values',
+    });
+    expect(parseProfileYaml('id: bad\ncontrols:\n  container:\n    pull: sometimes\n', 'fallback')).toEqual({
+      path: '/controls/container/pull',
+      message: 'must be equal to one of the allowed values',
+    });
+    expect(parseProfileYaml('id: bad\ncontrols:\n  container:\n    env_passthrough: [1]\n', 'fallback')).toEqual({
+      path: '/controls/container/env_passthrough/0',
+      message: 'must be string',
+    });
+    expect(parseProfileYaml('id: bad\ncontrols:\n  container:\n    run_args: nope\n', 'fallback')).toEqual({
+      path: '/controls/container/run_args',
+      message: 'must be array',
+    });
+  });
 });

--- a/tests/unit/run-command-container.test.ts
+++ b/tests/unit/run-command-container.test.ts
@@ -1,0 +1,126 @@
+// Tests run command integration with container launch backends.
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { executeRunCommand } from '../../src/cli/commands/RunCommand.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-run-command-container-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const writeSettings = (homeDirectory: string, content: string): void => {
+  mkdirSync(join(homeDirectory, '.outfitter'), { recursive: true });
+  writeFileSync(join(homeDirectory, '.outfitter', 'settings.yml'), content);
+};
+
+const writeProfile = (root: string, id: string, content: string): void => {
+  const profileDirectory = join(root, id);
+  mkdirSync(profileDirectory, { recursive: true });
+  writeFileSync(join(profileDirectory, 'profile.yml'), content);
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('run command container backend integration', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-011.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('wraps the adapter launch plan with a selected container launch backend', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const profilesDirectory = join(homeDirectory, '.outfitter', 'profiles');
+    mkdirSync(projectDirectory, { recursive: true });
+    writeSettings(
+      homeDirectory,
+      [
+        'default_profile: default',
+        'default_launch_backend: docker',
+        'container_policy:',
+        '  env_passthrough:',
+        '    - ANTHROPIC_API_KEY',
+        'profile_sources:',
+        '  - path: ./profiles',
+        '',
+      ].join('\n'),
+    );
+    writeProfile(
+      profilesDirectory,
+      'default',
+      [
+        'id: default',
+        'controls:',
+        '  container:',
+        '    image: ghcr.io/ai-outfitter/outfitter-pi:0.6.1',
+        '    env_passthrough: [ANTHROPIC_API_KEY]',
+        '  model: test-model',
+        '',
+      ].join('\n'),
+    );
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory, passThroughArgs: ['hello'] },
+      {
+        writeLine: () => undefined,
+        launchBackendResolver: { commandExists: (command) => command === 'docker' },
+        stdoutIsTty: false,
+        launcher: { launch: () => Promise.resolve(0) },
+      },
+    );
+
+    expect(result.launchBackendId).toBe('docker');
+    expect(result.launchPlan.command).toBe('docker');
+    expect(result.innerLaunchPlan?.command).toBe('pi');
+    const imageIndex = result.launchPlan.args.indexOf('ghcr.io/ai-outfitter/outfitter-pi:0.6.1');
+    expect(imageIndex).toBeGreaterThan(-1);
+    expect(result.launchPlan.args.slice(imageIndex, imageIndex + 2)).toEqual([
+      'ghcr.io/ai-outfitter/outfitter-pi:0.6.1',
+      'pi',
+    ]);
+    expect(result.launchPlan.args).toContain('--model');
+    expect(result.launchPlan.args).toContain('test-model');
+    expect(result.launchPlan.args).toContain('hello');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-011.4).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('makes mutable image warnings fatal in strict mode', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const profilesDirectory = join(homeDirectory, '.outfitter', 'profiles');
+    mkdirSync(projectDirectory, { recursive: true });
+    writeSettings(
+      homeDirectory,
+      ['default_profile: default', 'profile_sources:', '  - path: ./profiles', ''].join('\n'),
+    );
+    writeProfile(
+      profilesDirectory,
+      'default',
+      ['id: default', 'controls:', '  container:', '    image: ghcr.io/ai-outfitter/outfitter-pi:latest', ''].join(
+        '\n',
+      ),
+    );
+
+    await expect(
+      executeRunCommand(
+        { homeDirectory, projectDirectory, strict: true },
+        {
+          writeLine: () => undefined,
+          launchBackendResolver: { commandExists: (command) => command === 'docker' },
+          launcher: { launch: () => Promise.resolve(0) },
+        },
+      ),
+    ).rejects.toThrow('mutable');
+  });
+});

--- a/tests/unit/run-command.test.ts
+++ b/tests/unit/run-command.test.ts
@@ -56,6 +56,7 @@ const isRunCommandSummaryMessage = (text: string): boolean => {
     normalizedText.startsWith('✓ profile layer ') ||
     normalizedText.startsWith('✓ merged controls') ||
     normalizedText.startsWith('✓ prepared composite profile ') ||
+    normalizedText.startsWith('✓ launch backend ') ||
     normalizedText.startsWith('↳ launching ')
   );
 };
@@ -71,7 +72,7 @@ afterEach(() => {
 });
 
 describe('run command', () => {
-  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.1, OFTR-005.2, OFTR-005.3, OFTR-005.4, OFTR-005.5).
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.1, OFTR-005.2, OFTR-005.3, OFTR-005.4, OFTR-005.5, OFTR-011.3).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('resolves the default profile, writes and refreshes a temp compositeProfile, warns, and passes through args', async () => {
     const root = createTemporaryRoot();
@@ -144,6 +145,8 @@ describe('run command', () => {
     );
 
     expect(result.profileId).toBe('default');
+    expect(result.launchBackendId).toBe('host');
+    expect(result.launchPlan.command).toBe('pi');
     expect(result.compositeProfileDirectory).toContain('outfitter-default-pi-');
     expect(existsSync(join(result.compositeProfileDirectory, 'outfitter', 'profile.json'))).toBe(true);
     const profileMetadata = readFileSync(join(result.compositeProfileDirectory, 'outfitter', 'profile.json'), 'utf8');
@@ -424,6 +427,7 @@ describe('run command', () => {
     const root = createTemporaryRoot();
     const badSettingsHome = join(root, 'bad-settings-home');
     const projectDirectory = join(root, 'project');
+    mkdirSync(projectDirectory, { recursive: true });
     writeSettings(badSettingsHome, 'profile_sources:\n  - only: [default]\n');
     await expect(executeRunCommand({ homeDirectory: badSettingsHome, projectDirectory })).rejects.toThrow(
       'Cannot run with invalid settings',

--- a/tests/unit/settings-loader.test.ts
+++ b/tests/unit/settings-loader.test.ts
@@ -52,7 +52,7 @@ describe('settings loading', () => {
     ]);
   });
 
-  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.2).
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.2, OFTR-011.1).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('loads discovered settings and merges them with project-local precedence', () => {
     const root = createTemporaryRoot();
@@ -60,11 +60,11 @@ describe('settings loading', () => {
     const projectDirectory = join(root, 'project');
     writeSettings(
       join(homeDirectory, '.outfitter', 'settings.yml'),
-      'default_profile: user-default\ndefault_agent: pi\ncache_directory: ./user-cache\nprofile_sources:\n  - path: ./profiles\n',
+      'default_profile: user-default\ndefault_agent: pi\ndefault_launch_backend: podman\ncache_directory: ./user-cache\ncontainer_policy:\n  env_passthrough: [ANTHROPIC_API_KEY]\nprofile_sources:\n  - path: ./profiles\n',
     );
     writeSettings(
       join(projectDirectory, '.outfitter', 'settings.yml'),
-      'default_profile: project-default\ndefault_agent: claude\ncache_directory: ./project-cache\n',
+      'default_profile: project-default\ndefault_agent: claude\ndefault_launch_backend: docker\ncache_directory: ./project-cache\n',
     );
     writeSettings(
       join(projectDirectory, '.outfitter', 'local', 'settings.yml'),
@@ -77,6 +77,8 @@ describe('settings loading', () => {
     expect(loaded.files.map((file) => file.location.scope)).toEqual(['user', 'project', 'project-local']);
     expect(loaded.settings.defaultProfile).toBe('local-default');
     expect(loaded.settings.defaultAgent).toBe('claude');
+    expect(loaded.settings.defaultLaunchBackend).toBe('docker');
+    expect(loaded.settings.containerPolicy).toEqual({ envPassthrough: ['ANTHROPIC_API_KEY'] });
     expect(loaded.settings.profileSources).toEqual([{ path: join(homeDirectory, '.outfitter', 'profiles') }]);
     expect(loaded.settings.remoteSettings).toEqual([]);
     expect(loaded.settings.cacheDirectory).toBe(join(projectDirectory, '.outfitter', 'local', 'local-cache'));
@@ -193,7 +195,36 @@ describe('settings loading', () => {
     expect(validateSchema('settings', null).issues[0]?.path).toBe('/');
   });
 
-  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.6).
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-011.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('rejects invalid container launch backend settings values', () => {
+    const root = createTemporaryRoot();
+    const backendPath = join(root, 'invalid-backend.yml');
+    const envPath = join(root, 'invalid-env.yml');
+    writeSettings(backendPath, 'default_launch_backend: invalid\n');
+    writeSettings(envPath, 'container_policy:\n  env_passthrough: [1]\n');
+
+    const result = loadSettingsFiles(
+      createSettingsLoadPlan([
+        { scope: 'user', path: backendPath },
+        { scope: 'project', path: envPath },
+      ]),
+    );
+
+    expect(result.files).toEqual([]);
+    expect(result.issues).toContainEqual({
+      filePath: backendPath,
+      path: '/default_launch_backend',
+      message: 'must be equal to one of the allowed values',
+    });
+    expect(result.issues).toContainEqual({
+      filePath: envPath,
+      path: '/container_policy/env_passthrough/0',
+      message: 'must be string',
+    });
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.6, OFTR-011.1).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('loads cached remote settings from repository subpaths with local settings precedence', () => {
     const root = createTemporaryRoot();
@@ -212,13 +243,24 @@ describe('settings loading', () => {
     );
     writeSettings(
       remoteSettingsPath,
-      'default_profile: remote\nprofile_sources:\n  - github: example/outfitter-config\n    path: remote-profiles\n',
+      [
+        'default_profile: remote',
+        'default_launch_backend: docker',
+        'container_policy:',
+        '  env_passthrough: [REMOTE_SECRET]',
+        'profile_sources:',
+        '  - github: example/outfitter-config',
+        '    path: remote-profiles',
+        '',
+      ].join('\n'),
     );
 
     const loaded = loadSettingsWithCachedRemoteSettings({ homeDirectory, projectDirectory });
 
     expect(loaded.issues).toEqual([]);
     expect(loaded.settings.defaultProfile).toBe('local');
+    expect(loaded.settings.defaultLaunchBackend).toBeUndefined();
+    expect(loaded.settings.containerPolicy).toEqual({ envPassthrough: [] });
     expect(loaded.settings.profileSources).toEqual([{ github: 'example/outfitter-config', path: 'remote-profiles' }]);
 
     writeSettings(

--- a/tests/unit/setup-command.test.ts
+++ b/tests/unit/setup-command.test.ts
@@ -663,7 +663,9 @@ describe('setup command', () => {
     expect(readFileSync(join(projectDirectory, '.outfitter', 'profiles', 'shared', 'profile.yml'), 'utf8')).toContain(
       'template: true',
     );
-    expect(readFileSync(join(projectDirectory, '.outfitter', 'prompts', 'plan.md'), 'utf8')).toBe('# Founder planning\n');
+    expect(readFileSync(join(projectDirectory, '.outfitter', 'prompts', 'plan.md'), 'utf8')).toBe(
+      '# Founder planning\n',
+    );
     expect(result.messages.join('\n')).not.toContain("Cannot resolve profile 'founder'");
   });
 

--- a/tests/unit/source-layout.test.ts
+++ b/tests/unit/source-layout.test.ts
@@ -135,7 +135,9 @@ describe('source layout scaffolding', () => {
       remoteSettings: [],
       defaultProfile: 'remote',
       defaultAgent: undefined,
+      defaultLaunchBackend: undefined,
       cacheDirectory: undefined,
+      containerPolicy: { envPassthrough: [] },
       customSettings: {},
     });
     expect(normalizeRemoteSourceUri({ github: 'example/outfitter-config' })).toBe(


### PR DESCRIPTION
## Summary

- Add profile-defined `controls.container` support with agent-specific overrides and trusted local settings for `default_launch_backend` / `container_policy.env_passthrough`.
- Add launch backend layer for host, Docker, Podman, and Apple `container`, including shell-free argv rendering, deterministic `auto` resolution, conservative identity mounts, and strict-mode warning handling.
- Integrate backend wrapping into `outfitter run`, preserving native host launches by default while exposing final and inner launch plans.
- Update requirements, architecture/user docs, and tests for container launch behavior.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run coverage` — 42 files / 195 tests
- `npm run docs:ci`
- `npm run check-ci`

## Notes

- No real Docker/Podman/Apple daemon smoke tests were added; runtime smoke testing remains optional/gated so normal CI stays daemon-independent.
- Implementation was done in `/home/ncrmro/repos/unsupervised/worktrees/outfitter/feat/container-launch-backends`; the dirty original checkout was not edited.
