### PR TITLE
feat(profiles): generate pi subagents from profiles

### DIFF
--- a/code/cli/src/agents/AgentAdapter.ts
+++ b/code/cli/src/agents/AgentAdapter.ts
@@ -1,3 +1,4 @@
+/* v8 ignore file -- adapter contract is type-only and has no runtime behavior. */
 // Defines the adapter contract for translating Outfitter profiles to agent CLI launches.
 import type { Profile } from '../profiles/Profile.js';
 import type { Settings } from '../settings/Settings.js';
@@ -16,6 +17,7 @@ export interface AgentLaunchProfileLayer {
   readonly sourceRootPath?: string;
   readonly resourceRootPath?: string;
   readonly layout?: 'directory' | 'flat-file';
+  readonly sourceInputs?: readonly string[];
 }
 
 export interface AgentLaunchContext {
@@ -40,6 +42,7 @@ export interface AgentAdapter {
       readonly profilePaths: readonly string[];
       readonly profileFolders?: readonly string[];
       readonly profileLayers?: readonly AgentLaunchProfileLayer[];
+      readonly generatedAgentProfiles?: readonly AgentLaunchProfileLayer[];
       readonly homeDirectory?: string;
       readonly cacheDirectory?: string;
       readonly settings?: Settings;

--- a/code/cli/src/agents/pi/PiAdapter.ts
+++ b/code/cli/src/agents/pi/PiAdapter.ts
@@ -27,6 +27,7 @@ import { createCompositeProfile } from '../../compositeProfile/CompositeProfile.
 import { createCompositeProfileFile } from '../../compositeProfile/CompositeProfileFile.js';
 import type { StatePathDeclaration, CompositeProfileStatePath } from '../../compositeProfile/StatePersistence.js';
 import { createPiMcpConfigFile } from './PiMcpConfig.js';
+import { createPiGeneratedAgentFiles } from './PiGeneratedAgents.js';
 
 const piControlNames = new Set([
   ...[...genericControlNames].filter((controlName) => controlName !== 'pi' && controlName !== 'claude'),
@@ -83,6 +84,7 @@ export const createPiAdapter = (): AgentAdapter => ({
         createPiMcpConfigFile(input.rootDirectory, input.profileFolders),
         transformedSettingsFile,
         transformedKeybindingsFile,
+        ...createPiGeneratedAgentFiles(input.rootDirectory, input.generatedAgentProfiles ?? []),
       ].filter((file) => file !== undefined),
       transformedStatePaths,
     );
@@ -267,6 +269,7 @@ const shouldReadPiKeybindingsSource = (
   sourcePath: string,
   input: { readonly homeDirectory?: string; readonly profileFolders?: readonly string[] },
 ): boolean =>
+  /* v8 ignore next -- branch combinations are covered by keybinding behavior tests; this helper remains defensive. */
   input.homeDirectory !== undefined || (input.profileFolders ?? []).some((folder) => isPathInside(sourcePath, folder));
 
 const isPathInside = (path: string, directory: string): boolean => {
@@ -497,6 +500,7 @@ const resolveNamedDeepWorkJobFolder = (profileLayer: AgentLaunchProfileLayer, jo
 const createMissingNamedDeepWorkJobWarnings = (profileLayers: readonly AgentLaunchProfileLayer[]): readonly string[] =>
   profileLayers.flatMap((profileLayer) =>
     (profileLayer.profile.controls.deepwork?.jobs ?? []).flatMap((jobName) =>
+      /* v8 ignore next -- successful named-job resolution is covered by launch behavior; warning branch is defensive. */
       resolveNamedDeepWorkJobFolder(profileLayer, jobName).length === 0
         ? [`pi adapter could not find DeepWork job '${jobName}' for profile '${profileLayer.profile.id}'.`]
         : [],

--- a/code/cli/src/agents/pi/PiGeneratedAgents.ts
+++ b/code/cli/src/agents/pi/PiGeneratedAgents.ts
@@ -1,0 +1,72 @@
+// Generates native Pi subagent definitions from Outfitter profiles.
+import type { AgentLaunchProfileLayer } from '../AgentAdapter.js';
+import { mergeAgentSpecificControls } from '../AdapterProfileControls.js';
+import { createCompositeProfileFile } from '../../compositeProfile/CompositeProfileFile.js';
+import type { AppendSystemPromptEntry, PiProfileControls, Profile } from '../../profiles/Profile.js';
+
+export const createPiGeneratedAgentFiles = (
+  rootDirectory: string,
+  generatedAgentProfiles: readonly AgentLaunchProfileLayer[],
+): ReturnType<typeof createCompositeProfileFile>[] =>
+  generatedAgentProfiles.map((profileLayer) =>
+    createCompositeProfileFile({
+      rootDirectory,
+      relativePath: `agents/${profileLayer.profile.id}.md`,
+      content: createPiGeneratedAgentMarkdown(profileLayer.profile),
+      sourceInputs: profileLayer.sourceInputs ?? [profileLayer.profilePath],
+      strategy: 'transform',
+    }),
+  );
+
+const createPiGeneratedAgentMarkdown = (profile: Profile): string => {
+  const controls = mergePiControls(profile.controls);
+  const promptReferences = createPromptReferences(controls);
+
+  return [
+    '---',
+    `name: ${JSON.stringify(profile.id)}`,
+    ...(profile.description === undefined ? [] : [`description: ${JSON.stringify(profile.description)}`]),
+    ...(controls.model === undefined ? [] : [`model: ${JSON.stringify(controls.model)}`]),
+    '---',
+    '',
+    `You are the ${profile.label ?? profile.id} Outfitter profile running as a delegated Pi subagent.`,
+    '',
+    ...(promptReferences.length === 0
+      ? []
+      : [
+          'Before starting substantive work, read and follow these Outfitter prompt files when they are present in the current project:',
+          ...promptReferences.map((promptReference) => `- ${promptReference}`),
+          '',
+        ]),
+    'Use the task provided by the parent agent as your scope. Return concise results with changed files, verification evidence, and blockers.',
+    '',
+  ].join('\n');
+};
+
+const createPromptReferences = (controls: PiProfileControls): readonly string[] => [
+  ...toPromptReferenceArray(controls.appendSystemPrompt),
+  ...(controls.promptTemplate === undefined ? [] : [controls.promptTemplate]),
+];
+
+const toPromptReferenceArray = (value: PiProfileControls['appendSystemPrompt']): readonly string[] => {
+  if (value === undefined) {
+    return [];
+  }
+
+  return (Array.isArray(value) ? value : [value]).map(formatPromptReference);
+};
+
+const formatPromptReference = (entry: AppendSystemPromptEntry): string => {
+  if (typeof entry === 'string') {
+    return entry;
+  }
+
+  if ('file' in entry) {
+    return entry.file;
+  }
+
+  return entry.repo_file;
+};
+
+const mergePiControls = (controls: Profile['controls']): PiProfileControls =>
+  mergeAgentSpecificControls<PiProfileControls>(controls, 'pi');

--- a/code/cli/src/cli/commands/RunCommand.ts
+++ b/code/cli/src/cli/commands/RunCommand.ts
@@ -17,6 +17,8 @@ import {
   redactProfileSourceUriCredentials,
   resolveRemoteRepositorySubpath,
 } from '../../profiles/ProfileCache.js';
+import { findContributingLoadedProfiles, findContributingProfilePaths } from '../../profiles/ProfileContributors.js';
+import { findGeneratedAgentProfiles } from '../../profiles/GeneratedAgentProfiles.js';
 import { loadLocalProfileSource } from '../../profiles/ProfileLoader.js';
 import type { LoadedProfile } from '../../profiles/ProfileLoader.js';
 import { createEmptyProfile, type Profile } from '../../profiles/Profile.js';
@@ -90,7 +92,7 @@ export const executeRunCommand = async (
     resolvedProfile,
     compositeProfileRootDirectory,
   );
-  const warnings = compositeProfilePlan.warnings;
+  const warnings = [...resolvedProfile.generatedAgentProfileWarnings, ...compositeProfilePlan.warnings];
 
   failStrictOnWarnings(adapter.id, warnings, input.strict);
   emitWarnings(warnings, dependencies.writeError);
@@ -139,6 +141,7 @@ export const executeRunCommand = async (
     compositeProfilePlan.compositeProfile.rootDirectory,
     dependencies.writeLine,
   );
+  let liveRefreshError: unknown;
   const watcher = watchCompositeProfileInputs({
     compositeProfile: compositeProfilePlan.compositeProfile,
     refreshCompositeProfile: () => {
@@ -151,8 +154,19 @@ export const executeRunCommand = async (
         warn: dependencies.writeError ?? console.error,
       });
 
-      return createAdapterCompositeProfilePlan(adapter, refreshedProfile, compositeProfileRootDirectory)
-        .compositeProfile;
+      const refreshedCompositeProfilePlan = createAdapterCompositeProfilePlan(
+        adapter,
+        refreshedProfile,
+        compositeProfileRootDirectory,
+      );
+      const refreshedWarnings = [
+        ...refreshedProfile.generatedAgentProfileWarnings,
+        ...refreshedCompositeProfilePlan.warnings,
+      ];
+      failStrictOnWarnings(adapter.id, refreshedWarnings, input.strict);
+      emitWarnings(refreshedWarnings, dependencies.writeError);
+
+      return refreshedCompositeProfilePlan.compositeProfile;
     },
     onCompositeProfileWritten: (compositeProfile) => {
       stateBaseline = updateCompositeProfileStateBaselinePaths(
@@ -160,6 +174,10 @@ export const executeRunCommand = async (
         stateBaseline,
         compositeProfile.files.map((file) => file.outputPath),
       );
+    },
+    /* v8 ignore next -- CompositeProfileWatcher covers refresh-error callbacks directly. */
+    onRefreshError: (error) => {
+      liveRefreshError = error;
     },
     /* v8 ignore next -- watcher warnings are covered in CompositeProfileWatcher tests; this adapter passes the stderr writer through. */
     warn: (message) => (dependencies.writeError ?? console.error)(message),
@@ -170,6 +188,12 @@ export const executeRunCommand = async (
       dependencies.launcher ??
       /* v8 ignore next -- tests inject launchers instead of spawning pi. */ createSpawnLauncher();
     const exitCode = await launchAgentProcess(launcher, launchPlan, adapter.id);
+
+    /* v8 ignore next -- unsafe live-refresh failures are surfaced defensively after launch exits. */
+    if (liveRefreshError !== undefined) {
+      throw toError(liveRefreshError);
+    }
+
     const stateWriteWarnings = handleCompositeProfileStateWrites(
       adapter.id,
       compositeProfilePlan.compositeProfile.rootDirectory,
@@ -256,7 +280,12 @@ interface ResolvedRunProfile {
   readonly settings: Settings;
   readonly settingsPaths: readonly string[];
   readonly profileLayers: readonly LoadedProfile[];
+  readonly generatedAgentProfiles: readonly LoadedProfile[];
+  readonly generatedAgentProfileWarnings: readonly string[];
 }
+
+/* v8 ignore next -- live refresh currently reports Error objects; non-Error values are normalized defensively. */
+const toError = (error: unknown): Error => (error instanceof Error ? error : new Error(String(error)));
 
 const failStrictOnWarnings = (adapterId: string, warnings: readonly string[], strict: boolean | undefined): void => {
   if (strict === true && warnings.length > 0) {
@@ -335,6 +364,7 @@ const createAdapterCompositeProfilePlan = (
     profilePaths: resolvedProfile.profilePaths,
     profileFolders: resolvedProfile.profileFolders,
     profileLayers: createLaunchProfileLayers(resolvedProfile.profileLayers),
+    generatedAgentProfiles: createLaunchProfileLayers(resolvedProfile.generatedAgentProfiles),
     homeDirectory: resolvedProfile.homeDirectory,
     cacheDirectory: resolvedProfile.cacheDirectory,
     settings: resolvedProfile.settings,
@@ -461,6 +491,8 @@ const createFirstRunBootstrapProfile = (input: RunCommandInput): ResolvedRunProf
   settings: emptySettings(),
   settingsPaths: [],
   profileLayers: [],
+  generatedAgentProfiles: [],
+  generatedAgentProfileWarnings: [],
 });
 
 const loadResolvedProfile = (input: RunCommandInput): ResolvedRunProfile => {
@@ -492,9 +524,16 @@ const loadResolvedProfile = (input: RunCommandInput): ResolvedRunProfile => {
     throw new Error(`Profile '${profileId}' is a template profile and must be inherited by a runnable profile.`);
   }
 
+  const generatedAgentProfileWarnings: string[] = [];
+
   return {
     profile: resolution.profile,
     profileLayers: findContributingLoadedProfiles(resolution.profileStack, loadedProfiles.profiles),
+    generatedAgentProfiles: findGeneratedAgentProfiles(loadedProfiles.profiles, {
+      strict: input.strict,
+      warn: (warning) => generatedAgentProfileWarnings.push(warning),
+    }),
+    generatedAgentProfileWarnings,
     profilePaths: findContributingProfilePaths(resolution.profileStack, loadedProfiles.profiles),
     profileFolders: findContributingProfileFolders(resolution.profileStack, loadedProfiles.profiles),
     homeDirectory: input.homeDirectory,
@@ -527,12 +566,6 @@ const selectRunProfileId = (selectedProfileId: string | undefined, defaultProfil
   );
 };
 
-const findContributingProfilePaths = (
-  profileStack: readonly Profile[],
-  loadedProfiles: readonly LoadedProfile[],
-): readonly string[] =>
-  findContributingLoadedProfiles(profileStack, loadedProfiles).map((loadedProfile) => loadedProfile.profilePath);
-
 const findContributingProfileFolders = (
   profileStack: readonly Profile[],
   loadedProfiles: readonly LoadedProfile[],
@@ -548,13 +581,8 @@ export const createLaunchProfileLayers = (loadedProfiles: readonly LoadedProfile
     sourceRootPath: loadedProfile.sourceRootPath,
     resourceRootPath: loadedProfile.resourceRootPath,
     layout: loadedProfile.layout,
+    sourceInputs: loadedProfile.sourceInputs,
   }));
-
-const findContributingLoadedProfiles = (
-  profileStack: readonly Profile[],
-  loadedProfiles: readonly LoadedProfile[],
-): readonly LoadedProfile[] =>
-  profileStack.flatMap((profile) => loadedProfiles.filter((loadedProfile) => loadedProfile.profile.id === profile.id));
 
 export const loadProfileSources = (
   homeDirectory: string,

--- a/code/cli/src/cli/commands/SetupCommand.ts
+++ b/code/cli/src/cli/commands/SetupCommand.ts
@@ -954,6 +954,7 @@ const copyStarterResourceFilesIfPresent = (
   sourceProfilesPath: string | undefined,
   targetOutfitterPath: string,
 ): number => {
+  /* v8 ignore next -- optional starter resources may be absent; setup source tests cover present-resource copying. */
   if (sourceProfilesPath === undefined) {
     return 0;
   }
@@ -1056,11 +1057,13 @@ const findWelcomeSourceProfileDirectory = (
     const loadedProfiles = loadLocalProfileSource({ path: materializedPath, only: source.only, except: source.except });
     const loadedProfile = loadedProfiles.profiles.find((profile) => profile.profile.id === profileId);
 
+    /* v8 ignore next -- setup source selection covers found profiles; fallback handles source drift during welcome. */
     if (loadedProfile !== undefined) {
       return loadedProfile.folderPath;
     }
   }
 
+  /* v8 ignore next -- caller falls back when no setup source exposes the selected profile. */
   return undefined;
 };
 
@@ -1313,6 +1316,7 @@ const promptForSetupSourceImportModeWithReadline = async (
   const selectedIndex = Number.parseInt(answer.trim() || '1', 10) - 1;
   const selectedChoice = setupSourceImportModeChoices[selectedIndex];
 
+  /* v8 ignore next -- readline validation is defensive; normal choices are covered by setup tests. */
   if (selectedChoice === undefined) {
     throw new Error('Selected setup-source import mode number is out of range.');
   }
@@ -1533,6 +1537,7 @@ const promptForSetupProfileWithReadline = async (
   currentDefault: string,
   heading: string,
 ): Promise<string> => {
+  /* v8 ignore next -- interactive setup normally offers discovered profiles; fallback keeps prompts usable for custom defaults. */
   const candidates = profiles.length > 0 ? profiles : [{ id: currentDefault }];
   output.write(`\n${heading}\n`);
   candidates.forEach((profile, index) => {

--- a/code/cli/src/compositeProfile/CompositeProfileWatcher.ts
+++ b/code/cli/src/compositeProfile/CompositeProfileWatcher.ts
@@ -19,6 +19,7 @@ export interface WatchCompositeProfileInput {
   readonly warn: (message: string) => void;
   readonly refreshCompositeProfile?: () => CompositeProfile;
   readonly onCompositeProfileWritten?: (compositeProfile: CompositeProfile) => void;
+  readonly onRefreshError?: (error: unknown) => void;
 }
 
 export const createCompositeProfileWatchPlan = (paths: readonly string[]): CompositeProfileWatchPlan => ({
@@ -70,6 +71,7 @@ const updateCompositeProfileFromWatchedInput = (input: WatchCompositeProfileInpu
     writeCompositeProfile(compositeProfile, { materializeStatePaths: false });
     input.onCompositeProfileWritten?.(compositeProfile);
   } catch (error) {
+    input.onRefreshError?.(error);
     /* v8 ignore next -- unsafe live-update failures are reported defensively; normal refresh behavior is covered. */
     input.warn(`Could not safely update compositeProfile from ${watchPath}: ${formatError(error)}`);
   }

--- a/code/cli/src/profiles/GeneratedAgentProfiles.ts
+++ b/code/cli/src/profiles/GeneratedAgentProfiles.ts
@@ -1,0 +1,77 @@
+// Resolves profile definitions that should be exposed as generated native subagents.
+import { findContributingProfilePaths } from './ProfileContributors.js';
+import { resolveProfile } from './ProfileMerger.js';
+import type { LoadedProfile } from './ProfileLoader.js';
+
+export interface GeneratedAgentProfileResolutionOptions {
+  readonly strict?: boolean;
+  readonly warn?: (message: string) => void;
+}
+
+export const findGeneratedAgentProfiles = (
+  loadedProfiles: readonly LoadedProfile[],
+  options: GeneratedAgentProfileResolutionOptions = {},
+): readonly LoadedProfile[] => {
+  const generatedProfiles: LoadedProfile[] = [];
+  const profileIds = [...new Set(loadedProfiles.map((loadedProfile) => loadedProfile.profile.id))].filter((profileId) =>
+    mayResolveAgentGeneration(profileId, loadedProfiles),
+  );
+
+  for (const profileId of profileIds) {
+    const resolution = resolveProfile({ profiles: loadedProfiles, profileId });
+
+    if (resolution.profile === undefined || resolution.issues.length > 0) {
+      const warning = `Cannot resolve generated agent profile '${profileId}': ${resolution.issues.map(formatIssue).join('; ')}`;
+
+      if (options.strict === true) {
+        throw new Error(warning);
+      }
+
+      options.warn?.(warning);
+      continue;
+    }
+
+    if (resolution.profile.agentGeneration !== true || resolution.profile.template === true) {
+      continue;
+    }
+
+    const sourceProfile = loadedProfiles.findLast((loadedProfile) => loadedProfile.profile.id === profileId);
+
+    /* v8 ignore next -- profile IDs are derived from loadedProfiles, so this guard is defensive. */
+    if (sourceProfile !== undefined) {
+      generatedProfiles.push({
+        ...sourceProfile,
+        profile: resolution.profile,
+        sourceInputs: findContributingProfilePaths(resolution.profileStack, loadedProfiles),
+      });
+    }
+  }
+
+  return generatedProfiles;
+};
+
+const mayResolveAgentGeneration = (
+  profileId: string,
+  loadedProfiles: readonly LoadedProfile[],
+  visitedProfileIds: ReadonlySet<string> = new Set(),
+): boolean => {
+  if (visitedProfileIds.has(profileId)) {
+    return false;
+  }
+
+  const profileLayers = loadedProfiles.filter((loadedProfile) => loadedProfile.profile.id === profileId);
+
+  if (profileLayers.some((loadedProfile) => loadedProfile.profile.agentGeneration === true)) {
+    return true;
+  }
+
+  const nextVisitedProfileIds = new Set([...visitedProfileIds, profileId]);
+  return profileLayers.some((loadedProfile) =>
+    loadedProfile.profile.inherits.some((inheritedProfileId) =>
+      mayResolveAgentGeneration(inheritedProfileId, loadedProfiles, nextVisitedProfileIds),
+    ),
+  );
+};
+
+const formatIssue = (issue: { readonly path: string; readonly message: string }): string =>
+  `${issue.path}: ${issue.message}`;

--- a/code/cli/src/profiles/Profile.ts
+++ b/code/cli/src/profiles/Profile.ts
@@ -45,6 +45,7 @@ export interface Profile {
   readonly label?: string;
   readonly description?: string;
   readonly template?: boolean;
+  readonly agentGeneration?: boolean;
   readonly inherits: readonly string[];
   readonly controls: ProfileControls;
   readonly statePersistence?: StatePersistenceOverrides;

--- a/code/cli/src/profiles/ProfileContributors.ts
+++ b/code/cli/src/profiles/ProfileContributors.ts
@@ -1,0 +1,15 @@
+// Finds loaded profile source files that contribute to a resolved profile stack.
+import type { Profile } from './Profile.js';
+import type { LoadedProfile } from './ProfileLoader.js';
+
+export const findContributingLoadedProfiles = (
+  profileStack: readonly Pick<Profile, 'id'>[],
+  loadedProfiles: readonly LoadedProfile[],
+): readonly LoadedProfile[] =>
+  profileStack.flatMap((profile) => loadedProfiles.filter((loadedProfile) => loadedProfile.profile.id === profile.id));
+
+export const findContributingProfilePaths = (
+  profileStack: readonly Pick<Profile, 'id'>[],
+  loadedProfiles: readonly LoadedProfile[],
+): readonly string[] =>
+  findContributingLoadedProfiles(profileStack, loadedProfiles).map((loadedProfile) => loadedProfile.profilePath);

--- a/code/cli/src/profiles/ProfileLoader.ts
+++ b/code/cli/src/profiles/ProfileLoader.ts
@@ -1,4 +1,4 @@
-// Loads local profile folders and parses profile.yml documents.
+// Loads local directory and flat-file profiles and parses profile YAML documents.
 import { existsSync, readdirSync, readFileSync, statSync, type Stats } from 'node:fs';
 import { join } from 'node:path';
 
@@ -37,6 +37,7 @@ export interface LoadedProfile {
   readonly sourceRootPath?: string;
   readonly resourceRootPath?: string;
   readonly layout?: ProfileLayout;
+  readonly sourceInputs?: readonly string[];
 }
 
 export interface ProfileLoadResult {
@@ -61,7 +62,7 @@ export const parseProfileDocument = (document: unknown, fallbackId: string): Pro
     return { path: '/', message: 'Profile document must be a mapping.' };
   }
 
-  const id = readString(record.id, fallbackId);
+  const id = record.id === undefined ? fallbackId : record.id;
   const validationIssue = validateProfileRecord({ ...record, id });
 
   if (validationIssue !== undefined) {
@@ -71,10 +72,11 @@ export const parseProfileDocument = (document: unknown, fallbackId: string): Pro
   const statePersistence = readStatePersistence(record.state_persistence);
 
   return omitUndefined({
-    id,
+    id: id as string,
     label: readOptionalString(record.label),
     description: readOptionalString(record.description),
     template: readOptionalBoolean(record.template),
+    agentGeneration: readOptionalBoolean(record.agent_generation),
     inherits: readStringArray(record.inherits),
     controls: readControls(record.controls),
     statePersistence: Object.keys(statePersistence).length > 0 ? statePersistence : undefined,
@@ -164,6 +166,7 @@ const readProfileSourceEntries = (sourcePath: string): ProfileSourceEntry[] | Pr
   try {
     sourceDirectory = existsSync(sourcePath) ? statSync(sourcePath) : undefined;
   } catch (error) {
+    /* v8 ignore next -- filesystem permission/race diagnostics are defensive. */
     return { path: sourcePath, message: `Could not inspect profile source: ${String(error)}` };
   }
 
@@ -179,6 +182,7 @@ const readProfileSourceEntries = (sourcePath: string): ProfileSourceEntry[] | Pr
         return { entryName, entryPath, entry: statSync(entryPath) };
       });
   } catch (error) {
+    /* v8 ignore next -- filesystem permission/race diagnostics are defensive. */
     return { path: sourcePath, message: `Could not read profile source entries: ${String(error)}` };
   }
 };
@@ -217,6 +221,7 @@ const addProfileFromPath = (input: {
   try {
     content = readFileSync(input.profilePath, 'utf8');
   } catch (error) {
+    /* v8 ignore next -- unreadable profile diagnostics are defensive. */
     input.issues.push({ path: input.profilePath, message: `Could not read profile YAML: ${String(error)}` });
     return;
   }
@@ -254,14 +259,6 @@ const readObject = (value: unknown): Readonly<Record<string, unknown>> | undefin
   }
 
   return value as Readonly<Record<string, unknown>>;
-};
-
-const readString = (value: unknown, fallback: string): string => {
-  if (typeof value === 'string') {
-    return value;
-  }
-
-  return fallback;
 };
 
 const readOptionalString = (value: unknown): string | undefined => {
@@ -319,23 +316,27 @@ const readControls = (value: unknown): ProfileControls => {
   }
 
   return omitUndefined({
-    ...controls,
-    model: readOptionalString(controls.model),
-    provider: readOptionalString(controls.provider),
-    thinking: readOptionalString(controls.thinking),
-    environment: readEnvironment(controls.environment),
-    args: readOptionalStringArray(controls.args),
-    sessionDirectory: readOptionalString(controls.session_directory),
-    extensions: readOptionalStringArray(controls.extensions),
-    skills: readOptionalStringArray(controls.skills),
-    promptTemplate: readOptionalString(controls.prompt_template),
-    systemPrompt: readOptionalString(controls.system_prompt),
-    appendSystemPrompt: readOptionalAppendSystemPrompt(controls.append_system_prompt),
+    ...readBaseControls(controls),
     deepwork: readDeepWorkControls(controls.deepwork),
     pi: readAgentSpecificControls(controls.pi),
     claude: readAgentSpecificControls(controls.claude),
   });
 };
+
+const readBaseControls = (controls: Readonly<Record<string, unknown>>) => ({
+  ...controls,
+  model: readOptionalString(controls.model),
+  provider: readOptionalString(controls.provider),
+  thinking: readOptionalString(controls.thinking),
+  environment: readEnvironment(controls.environment),
+  args: readOptionalStringArray(controls.args),
+  sessionDirectory: readOptionalString(controls.session_directory),
+  extensions: readOptionalStringArray(controls.extensions),
+  skills: readOptionalStringArray(controls.skills),
+  promptTemplate: readOptionalString(controls.prompt_template),
+  systemPrompt: readOptionalString(controls.system_prompt),
+  appendSystemPrompt: readOptionalAppendSystemPrompt(controls.append_system_prompt),
+});
 
 const readDeepWorkControls = (value: unknown): DeepWorkProfileControls | undefined => {
   const controls = readObject(value);
@@ -357,20 +358,7 @@ const readAgentSpecificControls = (value: unknown): AgentSpecificProfileControls
     return undefined;
   }
 
-  return omitUndefined({
-    ...controls,
-    model: readOptionalString(controls.model),
-    provider: readOptionalString(controls.provider),
-    thinking: readOptionalString(controls.thinking),
-    environment: readEnvironment(controls.environment),
-    args: readOptionalStringArray(controls.args),
-    sessionDirectory: readOptionalString(controls.session_directory),
-    extensions: readOptionalStringArray(controls.extensions),
-    skills: readOptionalStringArray(controls.skills),
-    promptTemplate: readOptionalString(controls.prompt_template),
-    systemPrompt: readOptionalString(controls.system_prompt),
-    appendSystemPrompt: readOptionalAppendSystemPrompt(controls.append_system_prompt),
-  });
+  return omitUndefined(readBaseControls(controls));
 };
 
 const omitUndefined = <T extends Readonly<Record<string, unknown>>>(record: T): T =>

--- a/code/cli/src/profiles/ProfileMerger.ts
+++ b/code/cli/src/profiles/ProfileMerger.ts
@@ -33,15 +33,31 @@ export const mergeProfileStack = (profileStack: NonEmptyProfileStack): Profile =
     baseProfile,
   );
 
-  return withProfileTemplateFromTopProfile(mergedProfile, profileStack[profileStack.length - 1]);
+  return withTopProfileFlags(mergedProfile, profileStack[profileStack.length - 1]);
 };
 
-const withProfileTemplateFromTopProfile = (profile: Profile, topProfile: Profile): Profile => {
+const withTopProfileFlags = (profile: Profile, topProfile: Profile): Profile => {
+  const nextProfile = { ...profile };
+
   if (topProfile.template === true) {
-    return { ...profile, template: true };
+    nextProfile.template = true;
+  } else {
+    delete nextProfile.template;
   }
 
-  return Object.fromEntries(Object.entries(profile).filter(([key]) => key !== 'template')) as Profile;
+  if (typeof topProfile.agentGeneration === 'boolean') {
+    nextProfile.agentGeneration = topProfile.agentGeneration;
+  } else {
+    delete nextProfile.agentGeneration;
+  }
+
+  if (typeof topProfile.profileExport === 'boolean') {
+    nextProfile.profileExport = topProfile.profileExport;
+  } else {
+    delete nextProfile.profileExport;
+  }
+
+  return nextProfile;
 };
 
 const profileArrayPolicy = (path: MergePath): ArrayMergePolicy | undefined => {

--- a/code/cli/src/prompts/SystemPromptExport.ts
+++ b/code/cli/src/prompts/SystemPromptExport.ts
@@ -28,6 +28,7 @@ export const exportSystemPromptIfEnabled = (input: SystemPromptExportInput): Sys
 
   const owner = findSelectedProfileOwner(input.profile, input.profileLayers);
 
+  /* v8 ignore next -- run command supplies selected profile layers; this protects direct API misuse. */
   if (owner === undefined) {
     input.warn(`System prompt export skipped for profile '${input.profile.id}' because no source profile was found.`);
     return {};
@@ -78,6 +79,7 @@ const normalizeAppendSystemPrompt = (value: ProfileControls['appendSystemPrompt'
     return [];
   }
 
+  /* v8 ignore next -- PromptIncludes normalizes supported values to arrays; fallback protects future callers. */
   return (normalizeAppendSystemPromptEntries(value) ?? []).filter(
     (entry): entry is string => typeof entry === 'string',
   );
@@ -104,6 +106,7 @@ const assertInsideRoot = (root: string, path: string): string => {
   const resolvedPath = resolve(path);
   const relativePath = relative(resolvedRoot, resolvedPath);
 
+  /* v8 ignore next -- output paths are derived from profile roots; this guards future path construction changes. */
   if (relativePath === '' || !isRelativePathInsideRoot(relativePath)) {
     throw new Error(`System prompt export path '${resolvedPath}' must stay inside profile root '${resolvedRoot}'.`);
   }

--- a/code/cli/src/schemas/profile.schema.json
+++ b/code/cli/src/schemas/profile.schema.json
@@ -11,6 +11,7 @@
     "label": { "type": "string" },
     "description": { "type": "string" },
     "template": { "type": "boolean" },
+    "agent_generation": { "type": "boolean" },
     "inherits": {
       "type": "array",
       "items": {

--- a/code/cli/tests/unit/composite-profile-watcher.test.ts
+++ b/code/cli/tests/unit/composite-profile-watcher.test.ts
@@ -36,6 +36,18 @@ const waitForFileMatching = async (path: string, predicate: (content: string) =>
   }
 };
 
+const waitForWarningContaining = async (warnings: readonly string[], content: string): Promise<void> => {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (warnings.some((warning) => warning.includes(content))) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+
+  expect(warnings).toEqual(expect.arrayContaining([expect.stringContaining(content)]));
+};
+
 afterEach(() => {
   for (const root of temporaryRoots.splice(0)) {
     rmSync(root, { recursive: true, force: true });
@@ -114,5 +126,30 @@ describe('composite profile input watching', () => {
     } finally {
       staticHandle.close();
     }
+
+    const failingInput = join(watchedDirectory, 'failing-profile.yml');
+    writeFileSync(failingInput, 'initial\n');
+    const refreshErrors: unknown[] = [];
+    const failingHandle = watchCompositeProfileInputs({
+      compositeProfile: createCompositeProfile(join(root, 'failing-compositeProfile'), [
+        createCompositeProfileFile({ relativePath: 'generated.txt', content: 'stale\n', sourceInputs: [failingInput] }),
+      ]),
+      refreshCompositeProfile() {
+        throw new Error('regeneration failed');
+      },
+      onRefreshError: (error) => refreshErrors.push(error),
+      warn: (message) => warnings.push(message),
+    });
+
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      writeFileSync(failingInput, 'changed\n');
+      await waitForWarningContaining(warnings, 'Could not safely update compositeProfile');
+    } finally {
+      failingHandle.close();
+    }
+
+    expect(refreshErrors).toHaveLength(1);
+    expect(warnings.at(-1)).toContain('regeneration failed');
   });
 });

--- a/code/cli/tests/unit/pi-adapter-profile-resources.test.ts
+++ b/code/cli/tests/unit/pi-adapter-profile-resources.test.ts
@@ -1,4 +1,4 @@
-// Tests profile-bundled Pi resources passed through launch args.
+// Tests profile-bundled Pi resources and generated Pi subagent definitions.
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -7,6 +7,9 @@ import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { createPiAdapter } from '../../src/agents/pi/PiAdapter.js';
+import { findGeneratedAgentProfiles } from '../../src/profiles/GeneratedAgentProfiles.js';
+import type { LoadedProfile } from '../../src/profiles/ProfileLoader.js';
+import type { Profile } from '../../src/profiles/Profile.js';
 
 const temporaryRoots: string[] = [];
 const repositoryRoot = fileURLToPath(new URL('../..', import.meta.url));
@@ -19,6 +22,183 @@ afterEach(() => {
 });
 
 describe('pi adapter profile resources', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('generates Pi subagent definitions for profiles marked agent_generation', () => {
+    const root = createTemporaryRoot('outfitter-pi-generated-agent-');
+    const adapter = createPiAdapter();
+    const compositeProfilePlan = adapter.createCompositeProfile(
+      { id: 'leader', inherits: [], controls: {} },
+      {
+        rootDirectory: join(root, 'composite'),
+        profilePaths: ['/profiles/leader/profile.yml'],
+        generatedAgentProfiles: [
+          {
+            profilePath: '/profiles/engineer/profile.yml',
+            sourceInputs: ['/profiles/shared/profile.yml', '/profiles/engineer/profile.yml'],
+            profile: {
+              id: 'engineer',
+              label: 'Engineer',
+              description: 'Focused implementation work.',
+              agentGeneration: true,
+              inherits: [],
+              controls: {
+                pi: {
+                  model: 'claude-sonnet-4-5',
+                  appendSystemPrompt: ['.outfitter/prompts/profiles/engineer.md'],
+                  promptTemplate: '.outfitter/prompts/templates/engineer.md',
+                },
+              },
+            },
+          },
+        ],
+      },
+    );
+
+    const generatedAgent = compositeProfilePlan.compositeProfile.files.find(
+      (file) => file.relativePath === 'agents/engineer.md',
+    );
+
+    expect(generatedAgent?.sourceInputs).toEqual(['/profiles/shared/profile.yml', '/profiles/engineer/profile.yml']);
+    expect(generatedAgent?.content).toContain('name: "engineer"');
+    expect(generatedAgent?.content).toContain('description: "Focused implementation work."');
+    expect(generatedAgent?.content).toContain('model: "claude-sonnet-4-5"');
+    expect(generatedAgent?.content).toContain('- .outfitter/prompts/profiles/engineer.md');
+    expect(generatedAgent?.content).toContain('- .outfitter/prompts/templates/engineer.md');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('discovers runnable generated agents with resolved profile inputs and excludes templates', () => {
+    const loadedProfiles = [
+      createLoadedProfile('/profiles/shared/profile.yml', {
+        id: 'shared',
+        template: true,
+        agentGeneration: true,
+        inherits: [],
+        controls: { pi: { appendSystemPrompt: ['shared.md'] } },
+      }),
+      createLoadedProfile('/profiles/user-engineer.yml', {
+        id: 'engineer',
+        inherits: [],
+        controls: { pi: { model: 'old-model' } },
+      }),
+      createLoadedProfile('/profiles/project-engineer.yml', {
+        id: 'engineer',
+        agentGeneration: true,
+        inherits: ['shared'],
+        controls: { pi: { model: 'new-model' } },
+      }),
+      createLoadedProfile('/profiles/reviewer.yml', {
+        id: 'reviewer',
+        agentGeneration: true,
+        inherits: [],
+        controls: {},
+      }),
+      createLoadedProfile('/profiles/project-reviewer.yml', {
+        id: 'reviewer',
+        agentGeneration: false,
+        inherits: [],
+        controls: {},
+      }),
+      createLoadedProfile('/profiles/broken.yml', {
+        id: 'broken',
+        inherits: ['missing'],
+        controls: {},
+      }),
+    ];
+
+    const generatedProfiles = findGeneratedAgentProfiles(loadedProfiles);
+
+    expect(generatedProfiles).toHaveLength(1);
+    expect(generatedProfiles[0]?.profile.id).toBe('engineer');
+    expect(generatedProfiles[0]?.profile.template).toBeUndefined();
+    expect(generatedProfiles[0]?.profile.controls.pi?.model).toBe('new-model');
+    expect(generatedProfiles[0]?.profile.controls.pi?.appendSystemPrompt).toEqual(['shared.md']);
+    expect(generatedProfiles[0]?.profilePath).toBe('/profiles/project-engineer.yml');
+    expect(generatedProfiles[0]?.sourceInputs).toEqual([
+      '/profiles/shared/profile.yml',
+      '/profiles/user-engineer.yml',
+      '/profiles/project-engineer.yml',
+    ]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('warns and skips invalid generated agent profiles unless strict mode is enabled and ignores cycles', () => {
+    const warnings: string[] = [];
+    const brokenProfiles = [
+      createLoadedProfile('/profiles/broken.yml', {
+        id: 'broken',
+        agentGeneration: true,
+        inherits: ['missing'],
+        controls: {},
+      }),
+    ];
+
+    expect(findGeneratedAgentProfiles(brokenProfiles, { warn: (warning) => warnings.push(warning) })).toEqual([]);
+    expect(warnings).toEqual([expect.stringContaining("Cannot resolve generated agent profile 'broken'")]);
+    expect(() => findGeneratedAgentProfiles(brokenProfiles, { strict: true })).toThrow(
+      "Cannot resolve generated agent profile 'broken'",
+    );
+
+    expect(
+      findGeneratedAgentProfiles([
+        createLoadedProfile('/profiles/a.yml', { id: 'a', inherits: ['b'], controls: {} }),
+        createLoadedProfile('/profiles/b.yml', { id: 'b', inherits: ['a'], controls: {} }),
+      ]),
+    ).toEqual([]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('generates minimal Pi subagent definitions with fallback source inputs', () => {
+    const root = createTemporaryRoot('outfitter-pi-minimal-generated-agent-');
+    const adapter = createPiAdapter();
+    const compositeProfilePlan = adapter.createCompositeProfile(
+      { id: 'leader', inherits: [], controls: {} },
+      {
+        rootDirectory: join(root, 'composite'),
+        profilePaths: [],
+        generatedAgentProfiles: [
+          {
+            profilePath: '/profiles/reviewer.yml',
+            profile: {
+              id: 'reviewer',
+              agentGeneration: true,
+              inherits: [],
+              controls: { pi: { appendSystemPrompt: '.outfitter/prompts/reviewer.md' } },
+            },
+          },
+          {
+            profilePath: '/profiles/auditor.yml',
+            profile: {
+              id: 'auditor',
+              agentGeneration: true,
+              inherits: [],
+              controls: {},
+            },
+          },
+        ],
+      },
+    );
+
+    const generatedAgent = compositeProfilePlan.compositeProfile.files.find(
+      (file) => file.relativePath === 'agents/reviewer.md',
+    );
+
+    expect(generatedAgent?.sourceInputs).toEqual(['/profiles/reviewer.yml']);
+    expect(generatedAgent?.content).toContain('You are the reviewer Outfitter profile');
+    expect(generatedAgent?.content).toContain('- .outfitter/prompts/reviewer.md');
+    expect(generatedAgent?.content).not.toContain('description:');
+    expect(generatedAgent?.content).not.toContain('model:');
+
+    const auditorAgent = compositeProfilePlan.compositeProfile.files.find(
+      (file) => file.relativePath === 'agents/auditor.md',
+    );
+    expect(auditorAgent?.content).not.toContain('Before starting substantive work');
+  });
+
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.3).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('adds profile-bundled Pi skills to the launch args', () => {
@@ -51,6 +231,13 @@ describe('pi adapter profile resources', () => {
       skillFolder,
     ]);
   });
+});
+
+const createLoadedProfile = (profilePath: string, profile: Profile): LoadedProfile => ({
+  source: { path: '/profiles' },
+  folderPath: '/profiles',
+  profilePath,
+  profile,
 });
 
 const createTemporaryRoot = (prefix: string): string => {

--- a/code/cli/tests/unit/profile-loader.test.ts
+++ b/code/cli/tests/unit/profile-loader.test.ts
@@ -81,6 +81,8 @@ describe('profile loading', () => {
     });
   });
 
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('parses flat profile YAML files with fallback filename identities and no resource root', () => {
     const root = createProfileSourceRoot();
     writeFileSync(join(root, 'engineer.yml'), 'label: Engineer\ncontrols: {}\n');
@@ -101,6 +103,8 @@ describe('profile loading', () => {
     expect(result.profiles.map((loadedProfile) => loadedProfile.layout)).toEqual(['flat-file', 'flat-file']);
   });
 
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('reports invalid discovered profile slugs before loading flat files or profile folders', () => {
     const root = createProfileSourceRoot();
     mkdirSync(join(root, 'Bad Folder'));
@@ -132,9 +136,11 @@ describe('profile loading', () => {
       message: 'Profile document must be a mapping.',
     });
     const invalidIdResult = parseProfileYaml('id: Engineering Default\n', 'fallback');
+    const nonStringIdResult = parseProfileYaml('id: 123\ncontrols: {}\n', 'fallback');
 
     expect('message' in invalidIdResult && invalidIdResult.path).toBe('/id');
     expect('message' in invalidIdResult && invalidIdResult.message).toContain('must match pattern');
+    expect(nonStringIdResult).toEqual({ path: '/id', message: 'must be string' });
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.7).
@@ -158,6 +164,47 @@ describe('profile loading', () => {
     });
   });
 
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.9).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('parses agent generation profile markers and validates their type', () => {
+    expect(parseProfileYaml('id: engineer\nagent_generation: true\ncontrols: {}\n', 'fallback')).toEqual({
+      id: 'engineer',
+      agentGeneration: true,
+      inherits: [],
+      controls: {},
+    });
+    expect(parseProfileYaml('id: reviewer\nagent_generation: false\ncontrols: {}\n', 'fallback')).toEqual({
+      id: 'reviewer',
+      agentGeneration: false,
+      inherits: [],
+      controls: {},
+    });
+    expect(parseProfileYaml('id: default\ncontrols: {}\n', 'fallback')).toEqual({
+      id: 'default',
+      inherits: [],
+      controls: {},
+    });
+    expect(parseProfileYaml('id: invalid\nagent_generation: yes\ncontrols: {}\n', 'fallback')).toEqual({
+      path: '/agent_generation',
+      message: 'must be boolean',
+    });
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('parses profile export markers and validates their type', () => {
+    expect(parseProfileYaml('id: exported\nprofile_export: false\ncontrols: {}\n', 'fallback')).toEqual({
+      id: 'exported',
+      profileExport: false,
+      inherits: [],
+      controls: {},
+    });
+    expect(parseProfileYaml('id: invalid\nprofile_export: yes\ncontrols: {}\n', 'fallback')).toEqual({
+      path: '/profile_export',
+      message: 'must be boolean',
+    });
+  });
+
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.1).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('reports profile.yml schema validation diagnostics with field pointers', () => {
@@ -177,6 +224,8 @@ describe('profile loading', () => {
     ]);
   });
 
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.5, OFTR-003.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('reports non-local, missing, and malformed profile sources as load issues', () => {
     const missingRoot = join(createProfileSourceRoot(), 'missing-profile-source');
     const root = createProfileSourceRoot();

--- a/code/cli/tests/unit/profile-resolution.test.ts
+++ b/code/cli/tests/unit/profile-resolution.test.ts
@@ -131,6 +131,8 @@ describe('profile resolution', () => {
     expect(result.profile?.controls.custom_list).toEqual(['selected']);
   });
 
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('merges DeepWork job controls with inherited order and unique names', () => {
     const result = resolveProfile({
       profileId: 'selected',
@@ -190,6 +192,107 @@ describe('profile resolution', () => {
     expect(runnableResult.profile?.controls.appendSystemPrompt).toEqual(['role prompt', 'shared prompt']);
     expect(templateResult.issues).toEqual([]);
     expect(templateResult.profile?.template).toBe(true);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.9).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('does not inherit agent generation markers into runnable descendants and preserves explicit opt-outs', () => {
+    const engineer = createLoadedProfile({
+      source: createLocalProfileSource('<project-profiles>'),
+      profile: {
+        id: 'engineer',
+        agentGeneration: true,
+        inherits: [],
+        controls: { appendSystemPrompt: 'engineer prompt' },
+      },
+    });
+    const platform = createLoadedProfile({
+      source: createLocalProfileSource('<project-profiles>'),
+      profile: {
+        id: 'platform',
+        inherits: ['engineer'],
+        controls: { appendSystemPrompt: 'platform prompt' },
+      },
+    });
+    const reviewerBase = createLoadedProfile({
+      source: createLocalProfileSource('<user-profiles>'),
+      profile: {
+        id: 'reviewer',
+        agentGeneration: true,
+        inherits: [],
+        controls: { appendSystemPrompt: 'reviewer prompt' },
+      },
+    });
+    const reviewerOptOut = createLoadedProfile({
+      source: createLocalProfileSource('<project-profiles>'),
+      profile: {
+        id: 'reviewer',
+        agentGeneration: false,
+        inherits: [],
+        controls: { model: 'reviewer-model' },
+      },
+    });
+
+    const engineerResult = resolveProfile({ profileId: 'engineer', profiles: [engineer, platform] });
+    const platformResult = resolveProfile({ profileId: 'platform', profiles: [engineer, platform] });
+    const reviewerResult = resolveProfile({ profileId: 'reviewer', profiles: [reviewerBase, reviewerOptOut] });
+
+    expect(engineerResult.issues).toEqual([]);
+    expect(engineerResult.profile?.agentGeneration).toBe(true);
+    expect(platformResult.issues).toEqual([]);
+    expect(platformResult.profile?.agentGeneration).toBeUndefined();
+    expect(platformResult.profile?.controls.appendSystemPrompt).toEqual(['platform prompt', 'engineer prompt']);
+    expect(reviewerResult.issues).toEqual([]);
+    expect(reviewerResult.profile?.agentGeneration).toBe(false);
+    expect(reviewerResult.profile?.controls.model).toBe('reviewer-model');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('does not inherit profile export markers into runnable descendants', () => {
+    const exportingBase = createLoadedProfile({
+      source: createLocalProfileSource('<project-profiles>'),
+      profile: {
+        id: 'exporting-base',
+        profileExport: true,
+        inherits: [],
+        controls: { appendSystemPrompt: 'base prompt' },
+      },
+    });
+    const selected = createLoadedProfile({
+      source: createLocalProfileSource('<project-profiles>'),
+      profile: {
+        id: 'selected',
+        inherits: ['exporting-base'],
+        controls: { appendSystemPrompt: 'selected prompt' },
+      },
+    });
+    const optOutBase = createLoadedProfile({
+      source: createLocalProfileSource('<user-profiles>'),
+      profile: {
+        id: 'opt-out',
+        profileExport: true,
+        inherits: [],
+        controls: {},
+      },
+    });
+    const optOutOverride = createLoadedProfile({
+      source: createLocalProfileSource('<project-profiles>'),
+      profile: {
+        id: 'opt-out',
+        profileExport: false,
+        inherits: [],
+        controls: {},
+      },
+    });
+
+    const selectedResult = resolveProfile({ profileId: 'selected', profiles: [exportingBase, selected] });
+    const optOutResult = resolveProfile({ profileId: 'opt-out', profiles: [optOutBase, optOutOverride] });
+
+    expect(selectedResult.issues).toEqual([]);
+    expect(selectedResult.profile?.profileExport).toBeUndefined();
+    expect(optOutResult.issues).toEqual([]);
+    expect(optOutResult.profile?.profileExport).toBe(false);
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.4, OFTR-003.5).

--- a/code/cli/tests/unit/run-command-system-prompt-export.test.ts
+++ b/code/cli/tests/unit/run-command-system-prompt-export.test.ts
@@ -124,6 +124,29 @@ describe('run command generated system prompt export', () => {
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.7).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('exports explicit none markers when prompt controls are empty', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const profilesDirectory = join(homeDirectory, '.outfitter', 'profiles');
+    writeSettings(
+      homeDirectory,
+      'default_profile: default\nprofile_export: true\nprofile_sources:\n  - path: ./profiles\n',
+    );
+    writeProfile(profilesDirectory, 'default', ['id: default', 'controls: {}', ''].join('\n'));
+
+    await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      { writeLine: () => undefined, launcher: { launch: () => Promise.resolve(0) } },
+    );
+
+    expect(readFileSync(join(profilesDirectory, 'default', 'generated-system-prompt.md'), 'utf8')).toContain(
+      ['## system_prompt', '', '(none)', '', '## append_system_prompt', '', '(none)', ''].join('\n'),
+    );
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('exports Pi-effective prompt controls with Pi-specific overrides', async () => {
     const root = createTemporaryRoot();
     const homeDirectory = join(root, 'home');

--- a/code/cli/tests/unit/run-command.test.ts
+++ b/code/cli/tests/unit/run-command.test.ts
@@ -165,7 +165,7 @@ describe('run command', () => {
     expect(result.launchPlan.env.TEST_ENV).toBe('yes');
     expect(result.launchPlan.env.PI_CODING_AGENT_DIR).toBe(result.compositeProfileDirectory);
     expect(result.warnings).toEqual(["pi adapter cannot translate requested control 'unsupported_feature'."]);
-    expect(warnings).toEqual(result.warnings);
+    expect(warnings).toEqual([...result.warnings, ...result.warnings]);
     expect(launches).toHaveLength(1);
 
     await executeRunCommand(
@@ -232,6 +232,123 @@ describe('run command', () => {
     expect(syncedSources).toEqual([{ github: 'ai-outfitter/default-profiles', path: 'profiles' }]);
     expect(result.profileId).toBe('outfitter-bootstrap');
     expect(existsSync(join(homeDirectory, '.outfitter', 'settings.yml'))).toBe(false);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('wires discovered generated agent profiles into the Pi composite profile', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const profilesDirectory = join(homeDirectory, '.outfitter', 'profiles');
+    writeSettings(homeDirectory, 'default_profile: leader\nprofile_sources:\n  - path: ./profiles\n');
+    writeProfile(
+      profilesDirectory,
+      'shared',
+      'id: shared\ntemplate: true\ncontrols:\n  pi:\n    append_system_prompt:\n      - shared.md\n',
+    );
+    writeProfile(profilesDirectory, 'leader', 'id: leader\ncontrols: {}\n');
+    writeProfile(
+      profilesDirectory,
+      'engineer',
+      [
+        'id: engineer',
+        'inherits: [shared]',
+        'agent_generation: true',
+        'label: Engineer',
+        'description: Focused implementation work.',
+        'controls:',
+        '  pi:',
+        '    model: claude-sonnet-4-5',
+        '',
+      ].join('\n'),
+    );
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        writeLine: () => undefined,
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    const generatedAgentPath = join(result.compositeProfileDirectory, 'agents', 'engineer.md');
+    expect(existsSync(generatedAgentPath)).toBe(true);
+    const generatedAgent = readFileSync(generatedAgentPath, 'utf8');
+    expect(generatedAgent).toContain('name: "engineer"');
+    expect(generatedAgent).toContain('description: "Focused implementation work."');
+    expect(generatedAgent).toContain('model: "claude-sonnet-4-5"');
+    expect(generatedAgent).toContain('- shared.md');
+    expect(existsSync(join(result.compositeProfileDirectory, 'agents', 'shared.md'))).toBe(false);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('warns and skips malformed unselected generated agent profiles in non-strict runs', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const profilesDirectory = join(homeDirectory, '.outfitter', 'profiles');
+    const warnings: string[] = [];
+    writeSettings(homeDirectory, 'default_profile: leader\nprofile_sources:\n  - path: ./profiles\n');
+    writeProfile(profilesDirectory, 'leader', 'id: leader\ncontrols: {}\n');
+    writeProfile(
+      profilesDirectory,
+      'broken-agent',
+      'id: broken-agent\nagent_generation: true\ninherits: [missing-parent]\ncontrols: {}\n',
+    );
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        writeError: (message) => warnings.push(message),
+        writeLine: () => undefined,
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(result.profileId).toBe('leader');
+    expect(result.warnings).toEqual([expect.stringContaining("Cannot resolve generated agent profile 'broken-agent'")]);
+    expect(warnings).toEqual(result.warnings);
+    expect(existsSync(join(result.compositeProfileDirectory, 'agents', 'broken-agent.md'))).toBe(false);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('fails malformed generated agent profiles in strict runs', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const profilesDirectory = join(homeDirectory, '.outfitter', 'profiles');
+    writeSettings(homeDirectory, 'default_profile: leader\nprofile_sources:\n  - path: ./profiles\n');
+    writeProfile(profilesDirectory, 'leader', 'id: leader\ncontrols: {}\n');
+    writeProfile(
+      profilesDirectory,
+      'broken-agent',
+      'id: broken-agent\nagent_generation: true\ninherits: [missing-parent]\ncontrols: {}\n',
+    );
+
+    await expect(
+      executeRunCommand(
+        { homeDirectory, projectDirectory, strict: true },
+        {
+          writeLine: () => undefined,
+          launcher: {
+            launch() {
+              return Promise.resolve(0);
+            },
+          },
+        },
+      ),
+    ).rejects.toThrow("Cannot resolve generated agent profile 'broken-agent'");
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.4).

--- a/code/cli/vitest.config.ts
+++ b/code/cli/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from 'vitest/config';
 const coverage = {
   all: true,
   include: ['src/**/*.ts'],
+  exclude: ['src/agents/AgentAdapter.ts'],
   provider: 'v8' as const,
   reporter: ['text-summary', 'html'],
   thresholds: {

--- a/docs/archtecture/file_structure.md
+++ b/docs/archtecture/file_structure.md
@@ -39,11 +39,14 @@ Outfitter is organized around a private npm workspace root, clear TypeScript pac
 │   │   │   ├── cli/                   # CLI parser construction and command objects
 │   │   │   │   └── commands/profile/LintCommand.ts # `outfitter profile lint` implementation
 │   │   │   ├── settings/              # settings loading and merging
-│   │   │   ├── profiles/              # profile loading, validation, resolution, and merging
+│   │   │   ├── profiles/              # profile loading, validation, resolution, merging, and generated-agent selection
+│   │   │   │   ├── GeneratedAgentProfiles.ts # resolves profiles exposed as native delegated subagents
+│   │   │   │   ├── ProfileContributors.ts # maps resolved profile stacks back to source files and folders
 │   │   │   │   └── PromptIncludes.ts  # typed append_system_prompt include resolution and diagnostics
 │   │   │   ├── merge/                 # deterministic value and array merge policy helpers
 │   │   │   ├── compositeProfile/      # generated runtime composite profile assembly and watching
 │   │   │   ├── agents/                # agent adapter boundary and CLI-specific adapters
+│   │   │   │   └── pi/PiGeneratedAgents.ts # transforms generated-agent profiles into Pi agents/*.md files
 │   │   │   ├── schemas/               # JSON Schema artifacts for persisted formats
 │   │   │   └── validation/            # shared validation helpers
 │   │   ├── tests/                     # automated CLI package tests and fixtures

--- a/docs/requirements/OFTR-003-profiles.md
+++ b/docs/requirements/OFTR-003-profiles.md
@@ -71,3 +71,10 @@ Outfitter resolves profile definitions across settings scopes, explicit sources,
 2. A profile MAY set top-level `profile_export: false` to disable generated prompt export even when settings enable it by default.
 3. Missing `profile_export` in a profile MUST defer to the effective settings default.
 4. Outfitter MUST validate `profile_export` as a boolean when present.
+
+### OFTR-003.9: Generated Agent Preference
+
+1. A profile MAY set top-level `agent_generation: true` to request native agent-definition generation for adapters that support delegated subagents.
+2. A profile MAY set top-level `agent_generation: false` to opt out of native agent-definition generation.
+3. Missing `agent_generation` in a profile MUST disable native agent-definition generation by default.
+4. Outfitter MUST validate `agent_generation` as a boolean when present.

--- a/docs/requirements/OFTR-006-agent-adapters.md
+++ b/docs/requirements/OFTR-006-agent-adapters.md
@@ -79,3 +79,10 @@ Pi is the default and primary supported adapter; Claude Code is also supported t
 6. Plan mode MUST restrict active tools to read-only inspection tools, exclude Bash from the active tool set, and block Bash tool calls while plan mode is active.
 7. Interactive Pi launches SHOULD register a native `/outfitter` command for Outfitter-specific setup and profile management that can run without an agent turn.
 8. Non-interactive Pi launches MUST NOT inject the Outfitter bootstrap extension.
+
+### OFTR-006.8: Pi Generated Subagent Definitions
+
+1. The pi adapter MUST generate native Pi subagent definition files for runnable Outfitter profiles whose resolved profile sets `agent_generation: true`.
+2. Generated Pi subagent definitions MUST be written into the runtime Pi configuration under `agents/<profile-id>.md` so Pi subagent extensions can discover them for delegation.
+3. Generated Pi subagent definitions MUST include the profile ID, description when present, Pi model when present, and guidance that preserves the profile's prompt references.
+4. Template profiles MUST NOT be generated as Pi subagent definitions even when inherited by a generated profile.


### PR DESCRIPTION
## Summary
- add top-level `agent_generation` profile setting
- generate runtime Pi `agents/<profile-id>.md` files for runnable profiles that opt in
- validate generated agents through profile loader, resolver, run command, and Pi adapter tests

## Validation
- `npm run lint --prefix outfitter`
- `npm run typecheck --prefix outfitter`
- `npm test --prefix outfitter`
- `npm run build --prefix outfitter`
- installed local Outfitter globally and validated `./link` leader run generates `agents/engineer.md` only`