### PR TITLE
feat(setup): onboard from shared profiles

### DIFF
--- a/docs/archtecture/README.md
+++ b/docs/archtecture/README.md
@@ -718,7 +718,7 @@ Requirements:
 
 Responsibilities:
 
-- create `~/.outfitter/settings.yml` when missing;
+- create `~/.outfitter/settings.yml` when missing, using `remote_settings` for `github: ai-outfitter/default-profiles`, `ref: main`, and `path: settings.yml` for the built-in first-run source;
 - accept an optional setup source URI, for example `outfitter setup https://github.com/example/outfitter-config`, and clone/update it under `~/.outfitter/cache/repos/<encoded-uri-and-ref>/`;
 
 - when a setup source is provided, use its root `settings.yml` or `.outfitter/settings.yml` and `profiles/` or `.outfitter/profiles/` as the initial non-overwriting setup starting point for the selected import target;
@@ -728,7 +728,8 @@ Responsibilities:
 - require an interactive TTY on both stdin and stdout before running setup prompts;
 - create a default profile when missing;
 - validate all discovered settings files and any starter settings file;
-- run `outfitter sync` behavior for URI profile sources before profile selection;
+- run `outfitter sync` behavior for remote settings and URI profile sources before profile selection;
+- during the initial welcome handoff, load shared-profile choices from the synchronized default-profiles settings source and preserve loaded IDs, labels, and descriptions;
 
 - outside that initial welcome handoff and outside setup-source import onboarding, show a setup wizard with synced profile choices, preserve display labels where available, validate the selected profile ID, and write the selected default profile to user settings;
 - create any missing fallback default profile file for the final selected default profile;
@@ -740,12 +741,11 @@ Responsibilities:
 
 - require an interactive TTY on both stdin and stdout before running welcome prompts;
 - show welcome text that explains Outfitter and Pi before asking onboarding questions;
-- ask a single accept/decline question for the founder profile;
-- install the founder role by default and use it as the deterministic fallback, while keeping `engineer` and `data_analyst` available through `/outfitter` after first run;
-- install the full recommended Pi productivity loadout on acceptance without item-level prompts;
-- keep the recommended loadout aligned to `git:github.com/ai-outfitter/deepwork`, `npm:@juicesharp/rpiv-ask-user-question`, `git:github.com/applepi-ai/ulta-tasklist`, `npm:pi-nolo`, `npm:pi-browser-harness`, `npm:@mjakl/pi-subagent`, `npm:@narumitw/pi-btw`, `npm:pi-must-have-extension`, `npm:pi-interactive-shell`, and `npm:pi-mcp-adapter` while those packages remain available;
-- create the selected local role profile on the fly and warn while continuing if a loadout item is unavailable;
-- return typed onboarding choices so later work can persist richer profile/loadout metadata behind a schema-validated YAML format if needed.
+- ask whether to use shared profiles from `https://github.com/ai-outfitter/default-profiles`;
+- present loaded shared profiles as keyboard-selectable choices using each profile's ID, label, and description when available;
+- choose a deterministic fallback from loaded profiles when an injected or stale selection is unavailable;
+- copy the selected shared profile locally without overwriting user files and without injecting stale hardcoded role prompts into copied remote content;
+- return typed onboarding choices so later work can persist richer profile metadata behind a schema-validated YAML format if needed.
 
 Before launching Pi after welcome onboarding, `outfitter run` checks whether native Pi appears to have login state in `auth.json` or `models.json`.
 If no login state is detected, Outfitter starts interactive Pi welcome launches with `/login` automatically; outside the welcome flow it prints an informational `/login` notice only for interactive launches and leaves non-interactive output streams untouched.

--- a/docs/archtecture/README.md
+++ b/docs/archtecture/README.md
@@ -716,6 +716,8 @@ Requirements:
 
 ### `outfitter setup`
 
+The first-run prompt contract is specified in [`./onboarding.md`](./onboarding.md).
+
 Responsibilities:
 
 - create `~/.outfitter/settings.yml` when missing, using `remote_settings` for `github: ai-outfitter/default-profiles`, `ref: main`, and `path: settings.yml` for the built-in first-run source;
@@ -724,7 +726,8 @@ Responsibilities:
 - when a setup source is provided, use its root `settings.yml` or `.outfitter/settings.yml` and `profiles/` or `.outfitter/profiles/` as the initial non-overwriting setup starting point for the selected import target;
 - keep copy/cache setup-source import as the default behavior; when interactive setup receives a local path whose source contains `.outfitter/`, optionally offer symlink mode for rapid shared-profile development;
 - explain that symlink mode links the selected target `.outfitter` to the local source `.outfitter`, so source edits affect later runs immediately, and refuse to replace a non-empty target `.outfitter` without explicit user action;
-- during interactive setup-source onboarding, show the Outfitter welcome first, explain the source being imported, ask whether to install into user home or the current project, then ask exactly one source-profile/default prompt;
+- when a local Git checkout is imported without symlink mode, prefer stable `remote_settings` and `profile_sources` entries derived from the checkout remote/ref over absolute local paths;
+- during interactive setup-source onboarding, show the Outfitter welcome first, ask whether to use the default catalog, create a profile, or import a different catalog, then ask where to install the configuration with user home as the default target;
 - require an interactive TTY on both stdin and stdout before running setup prompts;
 - create a default profile when missing;
 - validate all discovered settings files and any starter settings file;
@@ -741,8 +744,9 @@ Responsibilities:
 
 - require an interactive TTY on both stdin and stdout before running welcome prompts;
 - show welcome text that explains Outfitter and Pi before asking onboarding questions;
-- make the first prompt a keyboard-selectable choice among loaded shared profiles using each profile's ID, label, and description when available;
-- open `/outfitter` in Pi instead of asking for a profile when no loaded shared profiles are available;
+- make the first prompt a keyboard-selectable setup-path choice: default Outfitter catalog, create a profile, or import a different catalog;
+- after a catalog is selected and loaded, show a keyboard-selectable profile picker using each profile's ID, label, and description when available;
+- open `/outfitter` in Pi when the user chooses profile creation or no loaded catalog profiles are available;
 - choose a deterministic fallback from loaded profiles when an injected or stale selection is unavailable;
 - copy the selected shared profile locally without overwriting user files and without injecting stale hardcoded role prompts into copied remote content;
 - return typed onboarding choices so later work can persist richer profile metadata behind a schema-validated YAML format if needed.

--- a/docs/archtecture/README.md
+++ b/docs/archtecture/README.md
@@ -729,7 +729,7 @@ Responsibilities:
 - create a default profile when missing;
 - validate all discovered settings files and any starter settings file;
 - run `outfitter sync` behavior for remote settings and URI profile sources before profile selection;
-- during the initial welcome handoff, load shared-profile choices from the synchronized default-profiles settings source and preserve loaded IDs, labels, and descriptions;
+- during the initial welcome handoff, load shared-profile choices from the synchronized default-profiles settings source, preserve loaded IDs, labels, and descriptions, and leave welcome unanswered for the `/outfitter` handoff when no shared choices are available;
 
 - outside that initial welcome handoff and outside setup-source import onboarding, show a setup wizard with synced profile choices, preserve display labels where available, validate the selected profile ID, and write the selected default profile to user settings;
 - create any missing fallback default profile file for the final selected default profile;
@@ -741,14 +741,15 @@ Responsibilities:
 
 - require an interactive TTY on both stdin and stdout before running welcome prompts;
 - show welcome text that explains Outfitter and Pi before asking onboarding questions;
-- ask whether to use shared profiles from `https://github.com/ai-outfitter/default-profiles`;
-- present loaded shared profiles as keyboard-selectable choices using each profile's ID, label, and description when available;
+- make the first prompt a keyboard-selectable choice among loaded shared profiles using each profile's ID, label, and description when available;
+- open `/outfitter` in Pi instead of asking for a profile when no loaded shared profiles are available;
 - choose a deterministic fallback from loaded profiles when an injected or stale selection is unavailable;
 - copy the selected shared profile locally without overwriting user files and without injecting stale hardcoded role prompts into copied remote content;
 - return typed onboarding choices so later work can persist richer profile metadata behind a schema-validated YAML format if needed.
 
-Before launching Pi after welcome onboarding, `outfitter run` checks whether native Pi appears to have login state in `auth.json` or `models.json`.
-If no login state is detected, Outfitter starts interactive Pi welcome launches with `/login` automatically; outside the welcome flow it prints an informational `/login` notice only for interactive launches and leaves non-interactive output streams untouched.
+Before launching Pi after accepted welcome onboarding, `outfitter run` checks whether native Pi appears to have login state in `auth.json` or `models.json`.
+If no login state is detected after a profile selection, Outfitter starts interactive Pi welcome launches with `/login` automatically; outside the welcome flow it prints an informational `/login` notice only for interactive launches and leaves non-interactive output streams untouched.
+If no shared profile is selected because none are available, Outfitter opens `/outfitter` instead so the user can configure a profile first.
 Credential collection stays inside Pi so provider API keys are not collected or persisted by Outfitter.
 
 ### `outfitter sync`

--- a/docs/archtecture/file_structure.md
+++ b/docs/archtecture/file_structure.md
@@ -22,6 +22,7 @@ Outfitter is organized around clear TypeScript source boundaries, requirement do
 │   │   ├── controllable-elements.md   # controllable element terminology and support matrix
 │   │   ├── file_structure.md          # repository file structure overview
 │   │   ├── integration_test_system.md # fixture-backed integration test design
+│   │   ├── onboarding.md              # first-run setup prompts and handoff flow
 │   │   └── state_writeback_strategy.md # composite profile state persistence and writeback design
 │   ├── documentation/                 # user-facing Outfitter docs
 │   ├── requirements/                  # formal OUTFITTER requirement documents

--- a/docs/archtecture/onboarding.md
+++ b/docs/archtecture/onboarding.md
@@ -1,0 +1,194 @@
+# First-Run Onboarding Architecture
+
+First-run onboarding chooses how Outfitter should create an initial usable Pi configuration. The first question is the setup path, not the default profile picker. Profile choice happens only after a catalog has been selected and loaded.
+
+```mermaid
+flowchart TD
+  A[First run starts] --> B{Q1: setup path}
+
+  B -->|Default catalog| C[Use ai-outfitter/default-profiles]
+  B -->|Create own profile| D{Q2: install target}
+  B -->|Different catalog| E{Q2: catalog source}
+
+  C --> F{Q2: install target}
+  F -->|Home default| G[Write ~/.outfitter/settings.yml]
+  F -->|Current project| H[Write project .outfitter/settings.yml]
+  G --> I[Sync remote_settings and profile_sources]
+  H --> I
+  I --> J{Catalog profiles found?}
+  J -->|Yes| K{Q3: choose default profile}
+  J -->|No| L[Launch Pi with /outfitter]
+
+  D -->|Home default| L
+  D -->|Current project| L
+
+  E --> M{Local catalog?}
+  M -->|No| N{Q3: install target}
+  M -->|Yes| O{Q3: install target}
+  N --> Q[Write remote_settings and profile_sources]
+  O --> P{Q4: symlink?}
+  P -->|Symlink| Y[Link selected target .outfitter to local catalog]
+  P -->|Reference/import normally| Q
+  Q --> R[Sync/import catalog]
+  Y --> R
+  R --> S{Q5: choose imported profile}
+
+  K --> T[Launch Pi]
+  S --> T
+  L --> U{Pi model/login configured?}
+  T --> U
+  U -->|No and profile selected| V[Open /login]
+  U -->|No and profile creation needed| W[Keep /outfitter first]
+  U -->|Yes| X[Ready]
+```
+
+## Question 1: setup path
+
+This MUST be the first interactive question during first-run setup.
+
+```text
+How would you like to set up Outfitter?
+
+1. Use the default Outfitter profile catalog
+2. Create your own profile
+3. Provide a different catalog to import
+
+Choice [1]:
+```
+
+## Question 2: install target
+
+Outfitter SHOULD install into the user home folder by default so the profile is available in every project. The current-project option is for repository-specific setup.
+
+```text
+Where should Outfitter install this configuration?
+
+1. Home (~/.outfitter) — available in every project
+2. Current project (<project>/.outfitter) — shared with this repository
+
+Install target [1]:
+```
+
+## Default Outfitter catalog path
+
+Choosing the default catalog records the shared catalog through `remote_settings`.
+
+```yaml
+remote_settings:
+  - github: ai-outfitter/default-profiles
+    ref: main
+    path: settings.yml
+```
+
+Outfitter then syncs the catalog and derives profile choices from the loaded profile data. It MUST preserve loaded `id`, `label`, and `description` values. It MUST NOT present a hardcoded role list.
+
+```text
+Choose your default profile from the Outfitter catalog:
+
+1. engineer - Engineer
+   Engineering setup for repository navigation, maintainable code changes, tests, and reviews.
+2. analysis - Analysis
+   Analysis setup for source inspection, data reasoning, and clear synthesis.
+3. data_analyst - Data Analyst
+   Data analysis setup for careful inspection, reproducible methods, assumptions, and summaries.
+
+Default profile [1]:
+```
+
+If the default catalog syncs successfully but no profiles are available, Outfitter MUST skip profile installation and launch Pi with `/outfitter` prefilled.
+
+```text
+No shared default profiles were found.
+Outfitter will open /outfitter inside Pi so you can create or select a profile.
+```
+
+## Create-your-own profile path
+
+Choosing `Create your own profile` skips catalog import and launches Pi with `/outfitter` prefilled. The install target still matters because `/outfitter` should write to the selected home or project `.outfitter` folder.
+
+```text
+Outfitter will open /outfitter inside Pi so you can create a profile.
+```
+
+## Different catalog path
+
+Choosing `Provide a different catalog to import` asks for a GitHub repository, Git URL, or local path.
+
+```text
+Enter an Outfitter catalog GitHub repo, Git URL, or local path.
+
+Examples:
+  github:my_account/outfitter_config
+  https://github.com/my_account/outfitter_config
+  /Users/me/work/outfitter_config
+
+Catalog source:
+```
+
+For a normal GitHub-backed catalog, Outfitter SHOULD write stable catalog references instead of copying absolute local paths.
+
+```yaml
+remote_settings:
+  - github: my_account/outfitter_config
+    ref: main
+    path: settings.yml
+
+profile_sources:
+  - github: my_account/outfitter_config
+    ref: main
+    path: profiles
+```
+
+If the input is a local Git checkout and the user does not choose symlink mode, Outfitter SHOULD derive `github`, `ref`, `settings.yml`, and `profiles` from the checkout's remote and branch when possible. If it cannot derive a stable remote reference, it SHOULD ask for one or fall back to a snapshot import with a clear warning.
+
+## Local catalog symlink mode
+
+If the catalog source is a local folder that contains an `.outfitter/` catalog layout, Outfitter SHOULD offer symlink mode after the install target is known. Symlink mode is for live catalog development only: later edits in the local catalog affect later Outfitter runs immediately.
+
+```text
+Local catalog detected.
+
+How should Outfitter use this catalog?
+
+1. Reference/import it normally
+2. Symlink the target .outfitter to this local catalog for live development
+
+Use symlink only when you are rapidly iterating on a profile catalog.
+Symlink mode makes later edits to the local catalog affect future Outfitter runs immediately.
+
+Mode [1]:
+```
+
+Symlink mode MUST NOT replace a non-empty target `.outfitter` folder without explicit user confirmation.
+
+## Imported catalog profile choice
+
+After an alternate catalog is loaded, the profile picker uses the imported catalog's profile metadata.
+
+```text
+Choose the default profile from this catalog:
+
+1. founder - Founder
+   Founder/operator setup for product, engineering, research, and delivery.
+2. engineer - Engineer
+   Engineering setup for code changes, tests, and reviews.
+
+Default profile [1]:
+```
+
+## Pi model/login check
+
+Before launching Pi, Outfitter checks whether native Pi appears to have model/login state, such as `auth.json` or `models.json`. Outfitter MUST NOT collect credentials itself.
+
+When a profile has been selected and Pi has no configured model/login state, Outfitter opens `/login` inside Pi.
+
+```text
+Pi does not appear to have a configured model login.
+Outfitter will open /login after Pi starts.
+```
+
+When the onboarding path needs profile creation or no catalog profile is available, `/outfitter` takes precedence over `/login` because the user must create or select a profile before login guidance is useful.
+
+```text
+Outfitter will open /outfitter so you can create or select a profile.
+```

--- a/docs/requirements/OFTR-004-sync-and-setup.md
+++ b/docs/requirements/OFTR-004-sync-and-setup.md
@@ -10,37 +10,39 @@ Outfitter provides setup and maintenance commands that create initial configurat
 
 1. Outfitter MUST provide a `setup` command.
 2. The `setup` command MUST create `~/.outfitter/settings.yml` when it does not exist.
-3. The `setup` command MUST create a default user profile when no user default profile exists.
-4. The `setup` command MUST validate discovered settings files.
-5. The `setup` command MUST run sync behavior for URI-based profile sources.
-6. The `setup` command SHOULD avoid overwriting existing user files unless a future explicit force option authorizes replacement.
-7. When provided a setup source URI, the `setup` command MUST use that source repository's Outfitter `settings.yml` and profiles as the initial setup starting point for the selected import target.
-8. When provided a local setup source path, the `setup` command MUST discover profiles and settings from the live local source `.outfitter` rather than from a setup-source cache.
-9. The interactive `setup` command MUST require interactive TTY streams on both stdin and stdout before prompting.
-10. The interactive `setup` command MUST synchronize remote profile sources before any setup profile choice prompt.
-11. Initial interactive first-run setup MUST NOT ask a separate default-profile choice before welcome onboarding; the welcome role selection determines the generated local default profile.
-12. Interactive setup MUST render the shared Outfitter branded ASCII welcome before setup prompts.
-13. When the interactive `setup` command presents setup profile choices outside the initial welcome handoff, it MUST present discovered profile IDs as default-profile choices and preserve available display labels and descriptions in the prompt choices.
-14. Interactive setup profile choices MUST come from loaded profile sources and MUST NOT hardcode profile-repository IDs, labels, or descriptions in setup code.
-15. When the interactive `setup` command presents setup profile choices outside the initial welcome handoff, it MUST validate the selected default profile ID before writing it to `settings.yml`.
-16. After the interactive `setup` command writes a selected default profile, any newly-created fallback default profile file MUST correspond to the final selected default profile.
-17. When interactive `setup <source>` presents setup profile choices, it MUST limit those choices to profiles from the passed setup source and MUST NOT include default profile sources from pre-existing effective settings.
-18. When interactive `setup <source>` presents setup profile choices and the setup source declares an explicit `default_profile` that exists among those source choices, it MUST make that profile the prompt default and first displayed choice; pre-existing user defaults MUST NOT override that source default for the setup-source prompt.
-19. When interactive `setup <source>` presents setup profile choices and no source `default_profile` resolves, it SHOULD use the first loaded source profile as the prompt default.
-20. Interactive `setup <source>` MUST NOT present a default-profile choice before the setup-source welcome/import explanation.
-21. Interactive `setup <source>` MUST explain which setup source is being imported and MUST let the user choose whether to install profiles into user home or the current project before writing setup-source profiles/settings.
-22. Interactive `setup <source>` MUST present exactly one setup-source profile/default choice after the import target choice when setup-source profiles are available.
-23. When the interactive setup-source import target is user home, setup MUST copy missing source profiles into `~/.outfitter/profiles`, write the selected default profile to `~/.outfitter/settings.yml`, and preserve non-overwrite copy behavior.
-24. When the interactive setup-source import target is the current project, setup MUST copy missing source profiles into `<project>/.outfitter/profiles`, write the selected default profile to `<project>/.outfitter/settings.yml`, ensure that project settings expose `./profiles`, and preserve any existing user default profile.
-25. Setup-source copy mode MUST preserve flat profile files and shared setup resources required by those profiles.
-26. After interactive `setup <source>` imports the selected default profile, setup MUST offer to start Outfitter with that selected profile.
-27. When the user declines the post-import start offer, setup MUST exit without launching and show both `outfitter` for starting the configured default profile and `outfitter --profile <selected-profile>` for starting it explicitly.
-28. Non-interactive `setup <source>` completion MUST NOT launch Outfitter and MUST show the same default and explicit start command guidance.
-29. Interactive `setup <local-path>` MUST keep copy/import snapshot setup as the default behavior.
-30. Interactive `setup <local-path>` SHOULD offer an explicit symlink mode when the local source contains a `.outfitter` directory.
-31. When symlink mode is available, setup MUST explain that copy/import is an isolated snapshot while symlink mode links the target `.outfitter` to the local source `.outfitter` so shared-profile edits apply immediately during development.
-32. Symlink setup MUST NOT replace a non-empty target `.outfitter` directory without explicit user confirmation.
-33. Symlink setup MUST symlink the target `.outfitter` to the local source `.outfitter` and MUST NOT copy source files, create fallback profile directories, or mutate source settings unless a future explicit option authorizes source mutation.
+3. Initial generated user settings SHOULD demonstrate shared profiles with `remote_settings` for `github: ai-outfitter/default-profiles`, `ref: main`, and `path: settings.yml`.
+4. The `setup` command MUST create or copy a default user profile when no user default profile exists.
+5. The `setup` command MUST validate discovered settings files.
+6. The `setup` command MUST run sync behavior for remote settings sources and URI-based profile sources.
+7. The `setup` command SHOULD avoid overwriting existing user files unless a future explicit force option authorizes replacement.
+8. When provided a setup source URI, the `setup` command MUST use that source repository's Outfitter `settings.yml` and profiles as the initial setup starting point for the selected import target.
+9. When provided a local setup source path, the `setup` command MUST discover profiles and settings from the live local source `.outfitter` rather than from a setup-source cache.
+10. The interactive `setup` command MUST require interactive TTY streams on both stdin and stdout before prompting.
+11. The interactive `setup` command MUST synchronize remote settings sources and remote profile sources before any setup profile choice prompt.
+12. Initial interactive first-run setup MUST NOT ask a separate default-profile choice before welcome onboarding; the welcome shared-profile selection determines the generated local default profile.
+13. Initial interactive first-run setup MUST load available first-run choices from the synchronized shared settings source and preserve loaded profile IDs, labels, and descriptions.
+14. Interactive setup MUST render the shared Outfitter branded ASCII welcome before setup prompts.
+15. When the interactive `setup` command presents setup profile choices outside the initial welcome handoff, it MUST present discovered profile IDs as default-profile choices and preserve available display labels and descriptions in the prompt choices.
+16. Interactive setup profile choices MUST come from loaded profile sources and MUST NOT hardcode profile-repository IDs, labels, or descriptions in setup code.
+17. When the interactive `setup` command presents setup profile choices outside the initial welcome handoff, it MUST validate the selected default profile ID before writing it to `settings.yml`.
+18. After the interactive `setup` command writes a selected default profile, any newly-created fallback default profile file MUST correspond to the final selected default profile.
+19. When interactive `setup <source>` presents setup profile choices, it MUST limit those choices to profiles from the passed setup source and MUST NOT include default profile sources from pre-existing effective settings.
+20. When interactive `setup <source>` presents setup profile choices and the setup source declares an explicit `default_profile` that exists among those source choices, it MUST make that profile the prompt default and first displayed choice; pre-existing user defaults MUST NOT override that source default for the setup-source prompt.
+21. When interactive `setup <source>` presents setup profile choices and no source `default_profile` resolves, it SHOULD use the first loaded source profile as the prompt default.
+22. Interactive `setup <source>` MUST NOT present a default-profile choice before the setup-source welcome/import explanation.
+23. Interactive `setup <source>` MUST explain which setup source is being imported and MUST let the user choose whether to install profiles into user home or the current project before writing setup-source profiles/settings.
+24. Interactive `setup <source>` MUST present exactly one setup-source profile/default choice after the import target choice when setup-source profiles are available.
+25. When the interactive setup-source import target is user home, setup MUST copy missing source profiles into `~/.outfitter/profiles`, write the selected default profile to `~/.outfitter/settings.yml`, and preserve non-overwrite copy behavior.
+26. When the interactive setup-source import target is the current project, setup MUST copy missing source profiles into `<project>/.outfitter/profiles`, write the selected default profile to `<project>/.outfitter/settings.yml`, ensure that project settings expose `./profiles`, and preserve any existing user default profile.
+27. Setup-source copy mode MUST preserve flat profile files and shared setup resources required by those profiles.
+28. After interactive `setup <source>` imports the selected default profile, setup MUST offer to start Outfitter with that selected profile.
+29. When the user declines the post-import start offer, setup MUST exit without launching and show both `outfitter` for starting the configured default profile and `outfitter --profile <selected-profile>` for starting it explicitly.
+30. Non-interactive `setup <source>` completion MUST NOT launch Outfitter and MUST show the same default and explicit start command guidance.
+31. Interactive `setup <local-path>` MUST keep copy/import snapshot setup as the default behavior.
+32. Interactive `setup <local-path>` SHOULD offer an explicit symlink mode when the local source contains a `.outfitter` directory.
+33. When symlink mode is available, setup MUST explain that copy/import is an isolated snapshot while symlink mode links the target `.outfitter` to the local source `.outfitter` so shared-profile edits apply immediately during development.
+34. Symlink setup MUST NOT replace a non-empty target `.outfitter` directory without explicit user confirmation.
+35. Symlink setup MUST symlink the target `.outfitter` to the local source `.outfitter` and MUST NOT copy source files, create fallback profile directories, or mutate source settings unless a future explicit option authorizes source mutation.
 
 ### OFTR-004.2: Sync Command
 

--- a/docs/requirements/OFTR-004-sync-and-setup.md
+++ b/docs/requirements/OFTR-004-sync-and-setup.md
@@ -19,8 +19,8 @@ Outfitter provides setup and maintenance commands that create initial configurat
 9. When provided a local setup source path, the `setup` command MUST discover profiles and settings from the live local source `.outfitter` rather than from a setup-source cache.
 10. The interactive `setup` command MUST require interactive TTY streams on both stdin and stdout before prompting.
 11. The interactive `setup` command MUST synchronize remote settings sources and remote profile sources before any setup profile choice prompt.
-12. Initial interactive first-run setup MUST NOT ask a separate default-profile choice before welcome onboarding; the welcome shared-profile selection determines the generated local default profile.
-13. Initial interactive first-run setup MUST load available first-run choices from the synchronized shared settings source, preserve loaded profile IDs, labels, and descriptions, and leave welcome unanswered for the `/outfitter` handoff when no shared choices are available.
+12. Initial interactive first-run setup MUST NOT ask a default-profile choice before the first welcome setup-path question; catalog profile selection happens only after the user chooses a catalog path.
+13. Initial interactive first-run setup MUST ask whether to use the default Outfitter catalog, create a profile, or provide a different catalog to import before loading first-run profile choices.
 14. Interactive setup MUST render the shared Outfitter branded ASCII welcome before setup prompts.
 15. When the interactive `setup` command presents setup profile choices outside the initial welcome handoff, it MUST present discovered profile IDs as default-profile choices and preserve available display labels and descriptions in the prompt choices.
 16. Interactive setup profile choices MUST come from loaded profile sources and MUST NOT hardcode profile-repository IDs, labels, or descriptions in setup code.
@@ -30,7 +30,7 @@ Outfitter provides setup and maintenance commands that create initial configurat
 20. When interactive `setup <source>` presents setup profile choices and the setup source declares an explicit `default_profile` that exists among those source choices, it MUST make that profile the prompt default and first displayed choice; pre-existing user defaults MUST NOT override that source default for the setup-source prompt.
 21. When interactive `setup <source>` presents setup profile choices and no source `default_profile` resolves, it SHOULD use the first loaded source profile as the prompt default.
 22. Interactive `setup <source>` MUST NOT present a default-profile choice before the setup-source welcome/import explanation.
-23. Interactive `setup <source>` MUST explain which setup source is being imported and MUST let the user choose whether to install profiles into user home or the current project before writing setup-source profiles/settings.
+23. Interactive `setup <source>` MUST explain which setup source is being imported and MUST let the user choose whether to install profiles into user home or the current project before writing setup-source profiles/settings; user home MUST be the default install target.
 24. Interactive `setup <source>` MUST present exactly one setup-source profile/default choice after the import target choice when setup-source profiles are available.
 25. When the interactive setup-source import target is user home, setup MUST copy missing source profiles into `~/.outfitter/profiles`, write the selected default profile to `~/.outfitter/settings.yml`, and preserve non-overwrite copy behavior.
 26. When the interactive setup-source import target is the current project, setup MUST copy missing source profiles into `<project>/.outfitter/profiles`, write the selected default profile to `<project>/.outfitter/settings.yml`, ensure that project settings expose `./profiles`, and preserve any existing user default profile.
@@ -43,6 +43,8 @@ Outfitter provides setup and maintenance commands that create initial configurat
 33. When symlink mode is available, setup MUST explain that copy/import is an isolated snapshot while symlink mode links the target `.outfitter` to the local source `.outfitter` so shared-profile edits apply immediately during development.
 34. Symlink setup MUST NOT replace a non-empty target `.outfitter` directory without explicit user confirmation.
 35. Symlink setup MUST symlink the target `.outfitter` to the local source `.outfitter` and MUST NOT copy source files, create fallback profile directories, or mutate source settings unless a future explicit option authorizes source mutation.
+36. When interactive setup imports a local Git checkout without symlink mode, setup SHOULD prefer stable `remote_settings` and `profile_sources` entries derived from the checkout remote/ref over absolute local paths.
+37. If setup cannot derive a stable remote reference from a local Git checkout, it SHOULD ask the user for a catalog reference or fall back to snapshot import with a clear warning.
 
 ### OFTR-004.2: Sync Command
 

--- a/docs/requirements/OFTR-004-sync-and-setup.md
+++ b/docs/requirements/OFTR-004-sync-and-setup.md
@@ -20,7 +20,7 @@ Outfitter provides setup and maintenance commands that create initial configurat
 10. The interactive `setup` command MUST require interactive TTY streams on both stdin and stdout before prompting.
 11. The interactive `setup` command MUST synchronize remote settings sources and remote profile sources before any setup profile choice prompt.
 12. Initial interactive first-run setup MUST NOT ask a separate default-profile choice before welcome onboarding; the welcome shared-profile selection determines the generated local default profile.
-13. Initial interactive first-run setup MUST load available first-run choices from the synchronized shared settings source and preserve loaded profile IDs, labels, and descriptions.
+13. Initial interactive first-run setup MUST load available first-run choices from the synchronized shared settings source, preserve loaded profile IDs, labels, and descriptions, and leave welcome unanswered for the `/outfitter` handoff when no shared choices are available.
 14. Interactive setup MUST render the shared Outfitter branded ASCII welcome before setup prompts.
 15. When the interactive `setup` command presents setup profile choices outside the initial welcome handoff, it MUST present discovered profile IDs as default-profile choices and preserve available display labels and descriptions in the prompt choices.
 16. Interactive setup profile choices MUST come from loaded profile sources and MUST NOT hardcode profile-repository IDs, labels, or descriptions in setup code.

--- a/docs/requirements/OFTR-010-onboarding-welcome.md
+++ b/docs/requirements/OFTR-010-onboarding-welcome.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Outfitter welcome onboarding gets a new user to a productive Pi session by demonstrating shared profiles. The recommended path syncs `https://github.com/ai-outfitter/default-profiles`, makes the first question a choice among discovered default profiles, installs the selected profile as the default, and keeps `/outfitter` available inside Pi for later customization. If no default profiles are available, Outfitter opens `/outfitter` inside Pi so the user can configure a profile interactively.
+Outfitter welcome onboarding gets a new user to a productive Pi session by first asking whether to use the default Outfitter catalog, create a profile, or import a different catalog. The recommended path syncs `https://github.com/ai-outfitter/default-profiles`, then presents discovered default profiles, installs the selected profile as the default, and keeps `/outfitter` available inside Pi for later customization. If the user chooses profile creation or no catalog profiles are available, Outfitter opens `/outfitter` inside Pi so the user can configure a profile interactively.
 
 ## Requirements
 
@@ -12,7 +12,7 @@ Outfitter welcome onboarding gets a new user to a productive Pi session by demon
 2. Welcome text MUST use Outfitter-branded ASCII/text.
 3. Welcome text MUST reference `/outfitter` as the way to customize the profile after installation.
 4. Every interactive `outfitter setup` path MUST render the shared Outfitter-branded ASCII welcome before prompting.
-5. First-run welcome text MUST mention `https://github.com/ai-outfitter/default-profiles` before the user selects a shared profile.
+5. First-run welcome text MUST mention `https://github.com/ai-outfitter/default-profiles` before the user selects the default catalog or a shared profile.
 6. First-run welcome text MUST demonstrate that shared-profile setup is recorded with `remote_settings` using `github: ai-outfitter/default-profiles`, `ref: main`, and `path: settings.yml`.
 
 > Pi is a fully extensible agentic coding harness.
@@ -21,14 +21,16 @@ Outfitter welcome onboarding gets a new user to a productive Pi session by demon
 
 ### OFTR-010.2: Profile Installation
 
-1. The first-run welcome onboarding flow MUST synchronize and load the shared source through `remote_settings` before the profile choice is resolved.
-2. When loaded shared profiles are available, the first interactive question MUST present those profiles as keyboard-selectable choices derived from loaded profile data.
+1. The first-run welcome onboarding flow MUST make the first interactive question a setup-path choice between the default Outfitter catalog, creating a profile, and providing a different catalog to import.
+2. When loaded catalog profiles are available after a catalog is selected and loaded, the profile question MUST present those profiles as keyboard-selectable choices derived from loaded profile data.
 3. The shared profile choice list MUST preserve each loaded profile's `id`, `label`, and `description` when those fields are available.
 4. The first-run default selection path MUST NOT hardcode a founder/engineer/data analyst role catalog in setup or welcome code.
 5. If the selected shared profile cannot be mapped to an available loaded profile, Outfitter MUST warn the user and choose a deterministic fallback from the loaded choices rather than silently ignoring the selection.
 6. Persisting an accepted shared profile MUST copy the selected remote profile locally without overwriting an existing user profile file.
 7. When the selected profile exists in the shared source, persisted local profile content MUST come from that source and MUST NOT inject stale hardcoded role prompts.
-8. If no loaded shared profiles are available, first-run onboarding MUST skip profile installation and launch Pi with `/outfitter` prefilled and auto-submitted.
+8. If the user chooses profile creation or no loaded catalog profiles are available, first-run onboarding MUST skip profile installation and launch Pi with `/outfitter` prefilled and auto-submitted.
+9. When the default Outfitter catalog path is selected, the flow MUST synchronize and load the shared source through `remote_settings` before the profile choice is resolved.
+10. If the user chooses to provide a different catalog, first-run onboarding MUST prompt for the catalog source and use the setup-source import flow rather than falling through to the default catalog.
 
 ### OFTR-010.3: Shared Profile Loadout
 
@@ -43,12 +45,13 @@ Outfitter welcome onboarding gets a new user to a productive Pi session by demon
 ### OFTR-010.4: Pi Login Setup
 
 1. Before launching Pi after the welcome flow, Outfitter MUST detect whether native Pi appears to have no configured login state.
-2. If Pi is not logged in after an accepted shared-profile welcome flow, Outfitter MUST automatically invoke Pi's `/login` flow when Pi starts.
+2. If Pi is not logged in after an accepted profile-catalog welcome flow, Outfitter MUST automatically invoke Pi's `/login` flow when Pi starts.
 3. When Outfitter launches Pi interactively outside the welcome flow and Pi does not appear to be logged in, Outfitter MUST inform the user to run `/login` inside Pi.
 4. Non-interactive Pi launches MUST NOT auto-open `/login` or emit login guidance into the launch output stream.
 5. Pi login setup MUST NOT ask Outfitter to collect, echo, or persist provider API keys.
 
 ### OFTR-010.5: Slash Handoff Path
 
-1. If no shared default profiles are available during first-run welcome onboarding, Outfitter MUST launch Pi with `/outfitter` prefilled and auto-submitted so the user can configure a profile interactively on first session start.
-2. The profile install target MUST always be the user home directory (`~/.outfitter`); no installation scope prompt MUST be shown.
+1. If no shared default profiles are available during first-run welcome onboarding or the user chooses to create a profile, Outfitter MUST launch Pi with `/outfitter` prefilled and auto-submitted so the user can configure a profile interactively on first session start.
+2. The profile install target question MUST default to the user home directory (`~/.outfitter`) so the configuration is available across projects.
+3. The profile install target question MAY offer the current project directory (`<project>/.outfitter`) for repository-scoped configuration.

--- a/docs/requirements/OFTR-010-onboarding-welcome.md
+++ b/docs/requirements/OFTR-010-onboarding-welcome.md
@@ -2,37 +2,41 @@
 
 ## Overview
 
-Outfitter welcome onboarding gets a new user to a productive Pi session in one question. The
-recommended path installs the founder profile automatically; declining opens `/outfitter` inside Pi
-so the user can configure a profile interactively.
+Outfitter welcome onboarding gets a new user to a productive Pi session by demonstrating shared profiles. The recommended path syncs `https://github.com/ai-outfitter/default-profiles`, lets the user choose one discovered profile, installs that profile as the default, and keeps `/outfitter` available inside Pi for later customization. Declining opens `/outfitter` inside Pi so the user can configure a profile interactively.
 
 ## Requirements
 
 ### OFTR-010.1: Welcome Text
 
-1. Welcome text MUST be shown to the user explaining what Outfitter and Pi are and what the founder profile provides.
+1. Welcome text MUST be shown to the user explaining what Outfitter and Pi are and that Outfitter can start from shared profiles.
 2. Welcome text MUST use Outfitter-branded ASCII/text.
 3. Welcome text MUST reference `/outfitter` as the way to customize the profile after installation.
 4. Every interactive `outfitter setup` path MUST render the shared Outfitter-branded ASCII welcome before prompting.
+5. First-run welcome text MUST mention `https://github.com/ai-outfitter/default-profiles` before the user accepts shared-profile onboarding.
+6. First-run welcome text MUST demonstrate that shared-profile setup is recorded with `remote_settings` using `github: ai-outfitter/default-profiles`, `ref: main`, and `path: settings.yml`.
 
 > Pi is a fully extensible agentic coding harness.
-> The founder profile brings Pi to feature parity with dedicated agentic coding tools.
+> Outfitter configures Pi with shared profiles and extensions.
 > Run /outfitter inside Pi at any time to customize your profile.
 
 ### OFTR-010.2: Profile Installation
 
-1. The welcome onboarding flow MUST present a single accept/decline prompt for the founder profile.
-2. Accepting (default) MUST install the founder role and the full recommended loadout without further prompts.
-3. The founder role MUST be the default and fallback selection. Outfitter's built-in role catalog also includes `engineer` and `data_analyst`; these are accessible via `/outfitter` after first run.
-4. If the accepted role cannot be mapped to an available standard profile, Outfitter MUST warn the user and choose a deterministic fallback role rather than silently ignoring the selection.
+1. The first-run welcome onboarding flow MUST ask whether to use shared profiles from `https://github.com/ai-outfitter/default-profiles`.
+2. Accepting (default) MUST synchronize and load the shared source through `remote_settings` before the profile choice is resolved.
+3. Accepting MUST present available shared profiles as keyboard-selectable choices derived from loaded profile data.
+4. The shared profile choice list MUST preserve each loaded profile's `id`, `label`, and `description` when those fields are available.
+5. The first-run default selection path MUST NOT hardcode a founder/engineer/data analyst role catalog in setup or welcome code.
+6. If the selected shared profile cannot be mapped to an available loaded profile, Outfitter MUST warn the user and choose a deterministic fallback from the loaded choices rather than silently ignoring the selection.
+7. Persisting an accepted shared profile MUST copy the selected remote profile locally without overwriting an existing user profile file.
+8. When the selected profile exists in the shared source, persisted local profile content MUST come from that source and MUST NOT inject stale hardcoded role prompts.
 
-### OFTR-010.3: Loadout
+### OFTR-010.3: Shared Profile Loadout
 
-1. On acceptance, the full recommended loadout MUST be installed automatically with no item-level selection prompt.
-2. The default recommended loadout MUST include `git:github.com/ai-outfitter/deepwork`, `npm:@juicesharp/rpiv-ask-user-question`, `git:github.com/applepi-ai/ulta-tasklist`, `npm:pi-nolo`, `npm:pi-browser-harness`, `npm:@mjakl/pi-subagent`, `npm:@narumitw/pi-btw`, `npm:pi-must-have-extension`, `npm:pi-interactive-shell`, and `npm:pi-mcp-adapter` while those packages remain available.
-3. Loadout installation MUST be captured as structured onboarding data so profile creation can install the selected extensions deterministically.
+1. On acceptance, the selected shared profile MUST be installed automatically with no item-level loadout prompt.
+2. The default recommended loadout MUST be defined by the selected shared profile source rather than by a first-run hardcoded role catalog.
+3. Shared profile installation MUST be captured as structured onboarding data so profile persistence can install the selected profile deterministically.
 4. On acceptance, Outfitter MUST display a message directing users to `/outfitter` inside Pi and `outfitter profile list` in the terminal for post-install management.
-5. If a loadout item is unavailable or unsupported by the selected agent adapter, Outfitter MUST warn the user and continue with the remaining loadout items unless strict onboarding validation is enabled.
+5. If a shared profile or loadout item is unavailable or unsupported by the selected agent adapter, Outfitter MUST warn the user and continue with the remaining loaded profile data unless strict onboarding validation is enabled.
 6. The Outfitter npm package MUST publish a default Pi skill named `outfitter` for profile setup guidance from inside Pi.
 7. The Pi adapter MUST load the default Outfitter skill for normal profile launches.
 
@@ -46,5 +50,5 @@ so the user can configure a profile interactively.
 
 ### OFTR-010.5: Decline Path
 
-1. If the user declines the welcome profile, Outfitter MUST launch Pi with `/outfitter` prefilled and auto-submitted so the user can configure a profile interactively on first session start.
+1. If the user declines shared-profile welcome onboarding, Outfitter MUST launch Pi with `/outfitter` prefilled and auto-submitted so the user can configure a profile interactively on first session start.
 2. The profile install target MUST always be the user home directory (`~/.outfitter`); no installation scope prompt MUST be shown.

--- a/docs/requirements/OFTR-010-onboarding-welcome.md
+++ b/docs/requirements/OFTR-010-onboarding-welcome.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Outfitter welcome onboarding gets a new user to a productive Pi session by demonstrating shared profiles. The recommended path syncs `https://github.com/ai-outfitter/default-profiles`, lets the user choose one discovered profile, installs that profile as the default, and keeps `/outfitter` available inside Pi for later customization. Declining opens `/outfitter` inside Pi so the user can configure a profile interactively.
+Outfitter welcome onboarding gets a new user to a productive Pi session by demonstrating shared profiles. The recommended path syncs `https://github.com/ai-outfitter/default-profiles`, makes the first question a choice among discovered default profiles, installs the selected profile as the default, and keeps `/outfitter` available inside Pi for later customization. If no default profiles are available, Outfitter opens `/outfitter` inside Pi so the user can configure a profile interactively.
 
 ## Requirements
 
@@ -12,7 +12,7 @@ Outfitter welcome onboarding gets a new user to a productive Pi session by demon
 2. Welcome text MUST use Outfitter-branded ASCII/text.
 3. Welcome text MUST reference `/outfitter` as the way to customize the profile after installation.
 4. Every interactive `outfitter setup` path MUST render the shared Outfitter-branded ASCII welcome before prompting.
-5. First-run welcome text MUST mention `https://github.com/ai-outfitter/default-profiles` before the user accepts shared-profile onboarding.
+5. First-run welcome text MUST mention `https://github.com/ai-outfitter/default-profiles` before the user selects a shared profile.
 6. First-run welcome text MUST demonstrate that shared-profile setup is recorded with `remote_settings` using `github: ai-outfitter/default-profiles`, `ref: main`, and `path: settings.yml`.
 
 > Pi is a fully extensible agentic coding harness.
@@ -21,21 +21,21 @@ Outfitter welcome onboarding gets a new user to a productive Pi session by demon
 
 ### OFTR-010.2: Profile Installation
 
-1. The first-run welcome onboarding flow MUST ask whether to use shared profiles from `https://github.com/ai-outfitter/default-profiles`.
-2. Accepting (default) MUST synchronize and load the shared source through `remote_settings` before the profile choice is resolved.
-3. Accepting MUST present available shared profiles as keyboard-selectable choices derived from loaded profile data.
-4. The shared profile choice list MUST preserve each loaded profile's `id`, `label`, and `description` when those fields are available.
-5. The first-run default selection path MUST NOT hardcode a founder/engineer/data analyst role catalog in setup or welcome code.
-6. If the selected shared profile cannot be mapped to an available loaded profile, Outfitter MUST warn the user and choose a deterministic fallback from the loaded choices rather than silently ignoring the selection.
-7. Persisting an accepted shared profile MUST copy the selected remote profile locally without overwriting an existing user profile file.
-8. When the selected profile exists in the shared source, persisted local profile content MUST come from that source and MUST NOT inject stale hardcoded role prompts.
+1. The first-run welcome onboarding flow MUST synchronize and load the shared source through `remote_settings` before the profile choice is resolved.
+2. When loaded shared profiles are available, the first interactive question MUST present those profiles as keyboard-selectable choices derived from loaded profile data.
+3. The shared profile choice list MUST preserve each loaded profile's `id`, `label`, and `description` when those fields are available.
+4. The first-run default selection path MUST NOT hardcode a founder/engineer/data analyst role catalog in setup or welcome code.
+5. If the selected shared profile cannot be mapped to an available loaded profile, Outfitter MUST warn the user and choose a deterministic fallback from the loaded choices rather than silently ignoring the selection.
+6. Persisting an accepted shared profile MUST copy the selected remote profile locally without overwriting an existing user profile file.
+7. When the selected profile exists in the shared source, persisted local profile content MUST come from that source and MUST NOT inject stale hardcoded role prompts.
+8. If no loaded shared profiles are available, first-run onboarding MUST skip profile installation and launch Pi with `/outfitter` prefilled and auto-submitted.
 
 ### OFTR-010.3: Shared Profile Loadout
 
-1. On acceptance, the selected shared profile MUST be installed automatically with no item-level loadout prompt.
+1. On selection, the selected shared profile MUST be installed automatically with no item-level loadout prompt.
 2. The default recommended loadout MUST be defined by the selected shared profile source rather than by a first-run hardcoded role catalog.
 3. Shared profile installation MUST be captured as structured onboarding data so profile persistence can install the selected profile deterministically.
-4. On acceptance, Outfitter MUST display a message directing users to `/outfitter` inside Pi and `outfitter profile list` in the terminal for post-install management.
+4. On selection, Outfitter MUST display a message directing users to `/outfitter` inside Pi and `outfitter profile list` in the terminal for post-install management.
 5. If a shared profile or loadout item is unavailable or unsupported by the selected agent adapter, Outfitter MUST warn the user and continue with the remaining loaded profile data unless strict onboarding validation is enabled.
 6. The Outfitter npm package MUST publish a default Pi skill named `outfitter` for profile setup guidance from inside Pi.
 7. The Pi adapter MUST load the default Outfitter skill for normal profile launches.
@@ -43,12 +43,12 @@ Outfitter welcome onboarding gets a new user to a productive Pi session by demon
 ### OFTR-010.4: Pi Login Setup
 
 1. Before launching Pi after the welcome flow, Outfitter MUST detect whether native Pi appears to have no configured login state.
-2. If Pi is not logged in after the welcome flow, Outfitter MUST automatically invoke Pi's `/login` flow when Pi starts.
+2. If Pi is not logged in after an accepted shared-profile welcome flow, Outfitter MUST automatically invoke Pi's `/login` flow when Pi starts.
 3. When Outfitter launches Pi interactively outside the welcome flow and Pi does not appear to be logged in, Outfitter MUST inform the user to run `/login` inside Pi.
 4. Non-interactive Pi launches MUST NOT auto-open `/login` or emit login guidance into the launch output stream.
 5. Pi login setup MUST NOT ask Outfitter to collect, echo, or persist provider API keys.
 
-### OFTR-010.5: Decline Path
+### OFTR-010.5: Slash Handoff Path
 
-1. If the user declines shared-profile welcome onboarding, Outfitter MUST launch Pi with `/outfitter` prefilled and auto-submitted so the user can configure a profile interactively on first session start.
+1. If no shared default profiles are available during first-run welcome onboarding, Outfitter MUST launch Pi with `/outfitter` prefilled and auto-submitted so the user can configure a profile interactively on first session start.
 2. The profile install target MUST always be the user home directory (`~/.outfitter`); no installation scope prompt MUST be shown.

--- a/src/cli/commands/FirstRunWelcomeProfile.ts
+++ b/src/cli/commands/FirstRunWelcomeProfile.ts
@@ -1,10 +1,10 @@
 // Persists first-run welcome choices as a local profile used before launching Pi.
 import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 
 import { parse, stringify } from 'yaml';
 
-import type { WelcomeCommandResult } from './WelcomeCommand.js';
+import type { WelcomeCommandResult, WelcomeProfileChoice } from './WelcomeCommand.js';
 
 export interface PersistedFirstRunWelcomeProfile {
   readonly profileId: string;
@@ -22,106 +22,90 @@ export const persistFirstRunWelcomeProfile = (
   welcomeResult: WelcomeCommandResult | undefined,
   options: FirstRunWelcomeProfileOptions = {},
 ): PersistedFirstRunWelcomeProfile | undefined => {
-  if (welcomeResult === undefined || !welcomeResult.answered || welcomeResult.selectedRole === undefined) {
+  const selectedProfile = welcomeResult?.selectedProfile ?? welcomeResult?.selectedRole;
+
+  if (welcomeResult === undefined || !welcomeResult.answered || selectedProfile === undefined) {
     return undefined;
   }
 
-  const welcomeProfile = createFirstRunWelcomeProfile(welcomeResult, welcomeResult.selectedRole);
-  const profileDirectory = join(homeDirectory, '.outfitter', 'profiles', welcomeProfile.id);
-  const profilePath = join(profileDirectory, 'profile.yml');
-  const createdProfile = !existsSync(profilePath);
-  const messages: string[] = [];
-
-  if (createdProfile) {
-    if (options.sourceProfileDirectory !== undefined && existsSync(options.sourceProfileDirectory)) {
-      cpSync(options.sourceProfileDirectory, profileDirectory, { recursive: true, force: false });
-      updateCopiedProfile(profilePath, welcomeProfile.description, welcomeProfile.extensions);
-      excludeDefaultProfileSources(settingsPath, welcomeProfile.id);
-      messages.push(
-        `Copied the ${welcomeProfile.label} profile locally so your extension choices can be edited at ${profilePath}.`,
-      );
-    } else {
-      mkdirSync(profileDirectory, { recursive: true });
-      writeFileSync(profilePath, welcomeProfile.content);
-    }
-  }
+  const welcomeProfile = createFirstRunWelcomeProfile(welcomeResult, selectedProfile);
+  const persistedProfile = persistWelcomeProfileFiles(homeDirectory, settingsPath, welcomeProfile, options);
 
   updateSettingsDefaultProfile(settingsPath, welcomeProfile.id);
   return {
     profileId: welcomeProfile.id,
-    createdProfile,
-    ...(messages.length === 0 ? {} : { messages }),
+    createdProfile: persistedProfile.createdProfile,
+    ...(persistedProfile.messages.length === 0 ? {} : { messages: persistedProfile.messages }),
   };
+};
+
+interface FirstRunWelcomeProfile {
+  readonly id: string;
+  readonly label: string;
+  readonly description?: string;
+  readonly content: string;
+  readonly extensions: readonly string[];
+}
+
+const persistWelcomeProfileFiles = (
+  homeDirectory: string,
+  settingsPath: string,
+  welcomeProfile: FirstRunWelcomeProfile,
+  options: FirstRunWelcomeProfileOptions,
+): { readonly createdProfile: boolean; readonly messages: readonly string[] } => {
+  const profileDirectory = join(homeDirectory, '.outfitter', 'profiles', welcomeProfile.id);
+  const profilePath = join(profileDirectory, 'profile.yml');
+
+  if (existsSync(profilePath)) {
+    return { createdProfile: false, messages: [] };
+  }
+
+  if (options.sourceProfileDirectory !== undefined && existsSync(options.sourceProfileDirectory)) {
+    cpSync(options.sourceProfileDirectory, profileDirectory, { recursive: true, force: false });
+    updateSettingsProfileSources(settingsPath, welcomeProfile.id, true);
+    return {
+      createdProfile: true,
+      messages: [`Copied the ${welcomeProfile.label} profile locally so it can be edited at ${profilePath}.`],
+    };
+  }
+
+  mkdirSync(profileDirectory, { recursive: true });
+  writeFileSync(profilePath, welcomeProfile.content);
+  updateSettingsProfileSources(settingsPath, welcomeProfile.id, false);
+  return { createdProfile: true, messages: [] };
 };
 
 const createFirstRunWelcomeProfile = (
   welcomeResult: WelcomeCommandResult,
-  selectedRole: NonNullable<WelcomeCommandResult['selectedRole']>,
-): {
-  readonly id: string;
-  readonly label: string;
-  readonly description: string;
-  readonly content: string;
-  readonly extensions: readonly string[];
-} => {
-  const profileId = selectedRole.id;
+  selectedProfile: WelcomeProfileChoice,
+): FirstRunWelcomeProfile => {
+  const profileId = selectedProfile.id;
   const extensions = welcomeResult.selectedLoadout?.selectedItems.map((item) => item.source) ?? [];
-  const rolePrompt = firstRunWelcomeRolePrompts[selectedRole.id];
+  const label = selectedProfile.label ?? selectedProfile.id;
 
   return {
     id: profileId,
-    label: selectedRole.label,
-    description: selectedRole.description,
-    content: createFirstRunWelcomeProfileContent(
-      profileId,
-      selectedRole.label,
-      selectedRole.description,
-      rolePrompt,
-      extensions,
-    ),
+    label,
+    description: selectedProfile.description,
+    content: createFirstRunWelcomeProfileContent(profileId, label, selectedProfile.description, extensions),
     extensions,
   };
 };
 
-const firstRunWelcomeRolePrompts = {
-  founder:
-    "You are operating as a founder-operator agent: builder, product thinker, research auditor, dense-prose editor, and careful operator. Do not behave like a generic senior engineer or a pure project manager.\n\nThe repo is the brain. Chat history is transient. Durable facts, decisions, requirements, plans, review outcomes, and lessons belong in project files when the work is substantive.\n\nIf the user's intent and acceptance criteria are clear, proceed without needless confirmation. Ask briefly when missing information would materially change the artifact, risk profile, or implementation path.\n\nFor nontrivial work, keep a visible task list with one in-progress item and checkable completion conditions. Requirements and milestone specs should use RFC 2119 keywords and acceptance criteria that can be checked from repo state or named external evidence.\n\nUse DeepWork, reviews, tests, browser evidence, source checks, or human-meaningful validation before calling substantive work done.\n\nOptimize substantive prose for density. Remove filler, keep every sentence load-bearing, preserve nuance, and avoid summaries that erase interesting claims.\n\nNumbers, market claims, schedules, legal or regulatory claims, current facts, prices, and recommendations require source checks when there is a meaningful chance of drift or high-stakes error.\n\nNever push, tag, merge, publish, deploy, send external messages, type credentials, make payments, perform legal filings, mutate production, or make irreversible data changes without explicit user approval.",
-  engineer:
-    'You are operating as an engineering-focused coding agent.\nPrioritize maintainable implementation, clear tests, concise diffs, and verification evidence.\nBefore changing code, inspect the existing project conventions and reuse established patterns.',
-  data_analyst:
-    'You are operating as a data-analysis-focused agent.\nPrioritize careful data inspection, reproducible analysis steps, clear assumptions, and actionable summaries.\nWhen data or methodology is uncertain, call out limitations and validation checks explicitly.',
-} as const;
-
 const createFirstRunWelcomeProfileContent = (
   profileId: string,
-  roleLabel: string,
-  roleDescription: string,
-  rolePrompt: string,
+  profileLabel: string,
+  profileDescription: string | undefined,
   extensions: readonly string[],
 ): string => {
-  const lines = [`id: ${profileId}`, `label: ${roleLabel}`, `description: ${roleDescription}`, 'controls:'];
+  const profile = {
+    id: profileId,
+    label: profileLabel,
+    ...(profileDescription === undefined ? {} : { description: profileDescription }),
+    controls: extensions.length === 0 ? {} : { pi: { extensions } },
+  };
 
-  if (extensions.length > 0) {
-    lines.push('  pi:', '    extensions:', ...extensions.map((extension) => `      - ${extension}`));
-  }
-
-  lines.push('  append_system_prompt: |', ...rolePrompt.split('\n').map((line) => `    ${line}`), '');
-  return lines.join('\n');
-};
-
-const updateCopiedProfile = (profilePath: string, description: string, extensions: readonly string[]): void => {
-  const profile = readRecord(parse(readFileSync(profilePath, 'utf8')) as unknown);
-  const controls = readRecord(profile.controls);
-  const piControls = readRecord(controls.pi);
-
-  profile.description ??= description;
-  controls.extensions = [];
-  piControls.extensions = [...extensions];
-  controls.pi = piControls;
-  profile.controls = controls;
-
-  mkdirSync(dirname(profilePath), { recursive: true });
-  writeFileSync(profilePath, stringify(profile));
+  return stringify(profile);
 };
 
 const readRecord = (value: unknown): Record<string, unknown> =>
@@ -129,9 +113,14 @@ const readRecord = (value: unknown): Record<string, unknown> =>
 
 const defaultProfilesSourceGithub = 'ai-outfitter/default-profiles';
 const defaultProfilesSourcePath = 'profiles';
+const defaultProfilesSourceRef = 'main';
 const defaultProfilesSourceUri = 'https://github.com/ai-outfitter/default-profiles';
 
-const excludeDefaultProfileSources = (settingsPath: string, profileId: string): void => {
+const updateSettingsProfileSources = (
+  settingsPath: string,
+  profileId: string,
+  excludeCopiedRemoteProfile: boolean,
+): void => {
   const document = readRecord(parse(readFileSync(settingsPath, 'utf8')) as unknown);
   const rawProfileSources = document.profile_sources;
   const profileSources: readonly unknown[] = Array.isArray(rawProfileSources) ? rawProfileSources : [];
@@ -142,13 +131,49 @@ const excludeDefaultProfileSources = (settingsPath: string, profileId: string): 
       return source;
     }
 
-    const except = Array.isArray(record.except)
-      ? record.except.filter((item): item is string => typeof item === 'string')
-      : [];
-    return { ...record, except: [...new Set([...except, profileId])] };
+    return excludeCopiedRemoteProfile ? withExceptProfile(record, profileId) : record;
   });
 
-  writeFileSync(settingsPath, stringify({ ...document, profile_sources: nextProfileSources }));
+  const ensuredProfileSources = ensureLocalProfileSource(
+    ensureDefaultProfilesSource(nextProfileSources, profileId, excludeCopiedRemoteProfile),
+  );
+
+  writeFileSync(settingsPath, stringify({ ...document, profile_sources: ensuredProfileSources }));
+};
+
+const ensureDefaultProfilesSource = (
+  profileSources: readonly unknown[],
+  profileId: string,
+  excludeCopiedRemoteProfile: boolean,
+): readonly unknown[] => {
+  if (profileSources.some((source) => isDefaultProfilesSource(readRecord(source)))) {
+    return profileSources;
+  }
+
+  const defaultSource = {
+    github: defaultProfilesSourceGithub,
+    ref: defaultProfilesSourceRef,
+    path: defaultProfilesSourcePath,
+    ...(excludeCopiedRemoteProfile ? { except: [profileId] } : {}),
+  };
+
+  return [defaultSource, ...profileSources];
+};
+
+const ensureLocalProfileSource = (profileSources: readonly unknown[]): readonly unknown[] => {
+  if (profileSources.some((source) => readRecord(source).path === './profiles')) {
+    return profileSources;
+  }
+
+  return [...profileSources, { path: './profiles' }];
+};
+
+const withExceptProfile = (source: Record<string, unknown>, profileId: string): Record<string, unknown> => {
+  const except = Array.isArray(source.except)
+    ? source.except.filter((item): item is string => typeof item === 'string')
+    : [];
+
+  return { ...source, except: [...new Set([...except, profileId])] };
 };
 
 const isDefaultProfilesSource = (source: Record<string, unknown>): boolean => {

--- a/src/cli/commands/PiLoginLaunch.ts
+++ b/src/cli/commands/PiLoginLaunch.ts
@@ -41,6 +41,16 @@ export const preparePiLoginLaunchPlan = (input: PiLoginLaunchPlanInput): AgentLa
     launchPlan = addExtension(launchPlan, piConfigDirectory, 'outfitter-extension.js', piOutfitterExtensionContent);
   }
 
+  if (shouldAutoOpenOutfitterSkill(input.setupResult, input.launchPlan.args)) {
+    writePiLoginMessage(input.writeLine, outfitterSkillMessage);
+    return addExtension(
+      launchPlan,
+      piConfigDirectory,
+      'prefill-outfitter-extension.js',
+      piOutfitterPrefillExtensionContent,
+    );
+  }
+
   if (!hasConfiguredPiLoginState(piConfigDirectory)) {
     if (shouldAutoOpenPiLogin(input.setupResult, input.launchPlan.args)) {
       writePiLoginMessage(input.writeLine, automaticLoginMessage);
@@ -51,16 +61,6 @@ export const preparePiLoginLaunchPlan = (input: PiLoginLaunchPlanInput): AgentLa
       writePiLoginMessage(input.writeLine, manualLoginMessage);
     }
     return launchPlan;
-  }
-
-  if (shouldAutoOpenOutfitterSkill(input.setupResult, input.launchPlan.args)) {
-    writePiLoginMessage(input.writeLine, outfitterSkillMessage);
-    return addExtension(
-      launchPlan,
-      piConfigDirectory,
-      'prefill-outfitter-extension.js',
-      piOutfitterPrefillExtensionContent,
-    );
   }
 
   return launchPlan;

--- a/src/cli/commands/SetupCommand.ts
+++ b/src/cli/commands/SetupCommand.ts
@@ -34,7 +34,7 @@ import {
 import type { SyncCommandDependencies, SyncCommandResult } from './SyncCommand.js';
 import { executeSyncCommand } from './SyncCommand.js';
 import { executeWelcomeCommand, writeWelcomeIntro } from './WelcomeCommand.js';
-import type { WelcomeCommandDependencies, WelcomeCommandResult } from './WelcomeCommand.js';
+import type { WelcomeCommandDependencies, WelcomeCommandResult, WelcomeProfileChoice } from './WelcomeCommand.js';
 
 export interface SetupCommandInput {
   readonly homeDirectory: string;
@@ -193,10 +193,22 @@ export const executeSetupCommand = async (
   const rollbackCreatedSettings = createdSettings ? () => rmSync(settingsPath, { force: true }) : () => undefined;
   const syncResult = executeSyncCommand(input, dependencies);
   failOnInitialDefaultProfileSyncFailure(initialSettingsMissing, rollbackCreatedSettings, syncResult);
+  const syncedDefaultProfileId = resolveInitialDefaultProfileAfterSync(
+    input,
+    settingsPath,
+    defaultProfileId,
+    initialSettingsMissing,
+    starterLayout,
+  );
   const selectedDefaultProfileId = shouldSkipInitialDefaultProfilePrompt(initialSettingsMissing, dependencies)
-    ? defaultProfileId
-    : await selectDefaultProfileIfInteractive(input, settingsPath, defaultProfileId, dependencies, starterLayout);
-  const welcomeResult = await runWelcomeAfterInteractiveSetup(input, dependencies);
+    ? syncedDefaultProfileId
+    : await selectDefaultProfileIfInteractive(input, settingsPath, syncedDefaultProfileId, dependencies, starterLayout);
+  const welcomeResult = await runWelcomeAfterInteractiveSetup(
+    input,
+    dependencies,
+    selectedDefaultProfileId,
+    starterLayout,
+  );
   const welcomeProfile = persistWelcomeProfileForSetup(input, settingsPath, welcomeResult);
   const finalDefaultProfile = prepareFinalDefaultProfile(input.homeDirectory, selectedDefaultProfileId, welcomeProfile);
 
@@ -226,6 +238,7 @@ export const executeSetupCommand = async (
 /* eslint-enable complexity */
 
 const defaultProfilesSourceUri = 'git+https://github.com/ai-outfitter/default-profiles.git:profiles';
+const defaultProfilesRemoteSettingsUri = 'git+https://github.com/ai-outfitter/default-profiles.git#main:settings.yml';
 
 const failOnInitialDefaultProfileSyncFailure = (
   initialSettingsMissing: boolean,
@@ -237,7 +250,9 @@ const failOnInitialDefaultProfileSyncFailure = (
   }
 
   const failedDefaultProfilesSource = syncResult.sources.find(
-    (source) => source.uri === defaultProfilesSourceUri && source.status === 'failed',
+    (source) =>
+      (source.uri === defaultProfilesRemoteSettingsUri || source.uri === defaultProfilesSourceUri) &&
+      source.status === 'failed',
   );
 
   if (failedDefaultProfilesSource === undefined) {
@@ -250,6 +265,30 @@ const failOnInitialDefaultProfileSyncFailure = (
     `Cannot complete first-run setup because the default profiles source failed to sync: ${failedDefaultProfilesSource.message}. ` +
       'Fix the network/git issue and rerun `outfitter setup` once the source is reachable.',
   );
+};
+
+const resolveInitialDefaultProfileAfterSync = (
+  input: SetupCommandInput,
+  settingsPath: string,
+  fallbackDefaultProfileId: string,
+  initialSettingsMissing: boolean,
+  starterLayout: StarterLayout | undefined,
+): string => {
+  if (!initialSettingsMissing || starterLayout !== undefined) {
+    return fallbackDefaultProfileId;
+  }
+
+  const loadedSettings = loadSettingsWithCachedRemoteSettings(input);
+  const discoveredProfiles = discoverSetupProfileChoices(input, starterLayout);
+  const syncedDefaultProfileId = chooseSetupPromptDefault(
+    discoveredProfiles,
+    loadedSettings.settings.defaultProfile,
+    fallbackDefaultProfileId,
+  );
+
+  assertValidDefaultProfileId(syncedDefaultProfileId);
+  updateSettingsDefaultProfile(settingsPath, syncedDefaultProfileId);
+  return syncedDefaultProfileId;
 };
 
 interface InteractiveSetupSourceCommandInput {
@@ -708,14 +747,9 @@ const assertValidDefaultProfileId = (profileId: string): void => {
 };
 
 const createDefaultSettingsContent = (): string =>
-  [
-    'default_profile: engineer',
-    'profile_sources:',
-    '  - github: ai-outfitter/default-profiles',
-    '    path: profiles',
-    '  - path: ./profiles',
-    '',
-  ].join('\n');
+  ['remote_settings:', '  - github: ai-outfitter/default-profiles', '    ref: main', '    path: settings.yml', ''].join(
+    '\n',
+  );
 
 const createInitialSettingsIfMissing = (settingsPath: string, starterSettingsPath?: string): boolean => {
   if (existsSync(settingsPath)) {
@@ -1027,7 +1061,10 @@ const persistWelcomeProfileForSetup = (
   welcomeResult: WelcomeCommandResult | undefined,
 ): PersistedFirstRunWelcomeProfile | undefined =>
   persistFirstRunWelcomeProfile(input.homeDirectory, settingsPath, welcomeResult, {
-    sourceProfileDirectory: findWelcomeSourceProfileDirectory(input, welcomeResult?.selectedRole?.id),
+    sourceProfileDirectory: findWelcomeSourceProfileDirectory(
+      input,
+      welcomeResult?.selectedProfile?.id ?? welcomeResult?.selectedRole?.id,
+    ),
   });
 
 const findWelcomeSourceProfileDirectory = (
@@ -1061,6 +1098,8 @@ const findWelcomeSourceProfileDirectory = (
 const runWelcomeAfterInteractiveSetup = async (
   input: SetupCommandInput,
   dependencies: SetupCommandDependencies,
+  currentDefaultProfileId: string,
+  starterLayout?: StarterLayout,
 ): Promise<WelcomeCommandResult | undefined> => {
   if (dependencies.interactive !== true) {
     return undefined;
@@ -1070,7 +1109,14 @@ const runWelcomeAfterInteractiveSetup = async (
     return dependencies.runWelcome(input, dependencies);
   }
 
-  return executeWelcomeCommand(input, dependencies);
+  return executeWelcomeCommand(
+    {
+      ...input,
+      currentDefaultProfileId,
+      profileChoices: discoverWelcomeProfileChoices(input, starterLayout, currentDefaultProfileId),
+    },
+    dependencies,
+  );
 };
 
 const requireInteractiveTerminalIfNeeded = (dependencies: SetupCommandDependencies): void => {
@@ -1411,6 +1457,19 @@ const prioritizeSetupProfileChoice = (
   ...profiles.filter((profile) => profile.id === profileId),
   ...profiles.filter((profile) => profile.id !== profileId),
 ];
+
+const discoverWelcomeProfileChoices = (
+  input: SetupCommandInput,
+  starterLayout: StarterLayout | undefined,
+  currentDefaultProfileId: string,
+): readonly WelcomeProfileChoice[] =>
+  prioritizeSetupProfileChoice(discoverSetupProfileChoices(input, starterLayout), currentDefaultProfileId).map(
+    (profile) => ({
+      id: profile.id,
+      ...(profile.label === undefined ? {} : { label: profile.label }),
+      ...(profile.description === undefined ? {} : { description: profile.description }),
+    }),
+  );
 
 const discoverSetupProfileChoices = (
   input: SetupCommandInput,

--- a/src/cli/commands/SetupCommand.ts
+++ b/src/cli/commands/SetupCommand.ts
@@ -211,6 +211,7 @@ export const executeSetupCommand = async (
   );
   const welcomeProfile = persistWelcomeProfileForSetup(input, settingsPath, welcomeResult);
   const finalDefaultProfile = prepareFinalDefaultProfile(input.homeDirectory, selectedDefaultProfileId, welcomeProfile);
+  ensureUnansweredWelcomeProfileSource(input.homeDirectory, settingsPath, welcomeResult);
 
   return {
     settingsPath,
@@ -406,6 +407,18 @@ const prepareFinalDefaultProfile = (
     welcomeProfile?.createdProfile ?? createDefaultProfileIfMissing(finalDefaultProfilePath, finalDefaultProfileId);
 
   return { id: finalDefaultProfileId, path: finalDefaultProfilePath, created: createdDefaultProfile };
+};
+
+const ensureUnansweredWelcomeProfileSource = (
+  homeDirectory: string,
+  settingsPath: string,
+  welcomeResult: WelcomeCommandResult | undefined,
+): void => {
+  if (welcomeResult?.answered !== false) {
+    return;
+  }
+
+  ensureLocalProfileSource(settingsPath, join(homeDirectory, '.outfitter', 'profiles'));
 };
 
 interface SetupMessageInput {

--- a/src/cli/commands/WelcomeCommand.ts
+++ b/src/cli/commands/WelcomeCommand.ts
@@ -6,18 +6,22 @@ import type { Command } from 'commander';
 
 import type { CommandObject } from './CommandObject.js';
 
-export type WelcomeDefaultProfileRoleId = 'founder' | 'engineer' | 'data_analyst';
+export type WelcomeDefaultProfileRoleId = string;
 export type WelcomeLoadoutItemKind = 'extension' | 'package';
+
+export interface WelcomeProfileChoice {
+  readonly id: string;
+  readonly label?: string;
+  readonly description?: string;
+}
+
+export type WelcomeRoleChoice = WelcomeProfileChoice;
 
 export interface WelcomeCommandInput {
   readonly homeDirectory: string;
   readonly projectDirectory: string;
-}
-
-export interface WelcomeRoleChoice {
-  readonly id: WelcomeDefaultProfileRoleId;
-  readonly label: string;
-  readonly description: string;
+  readonly profileChoices?: readonly WelcomeProfileChoice[];
+  readonly currentDefaultProfileId?: string;
 }
 
 export interface WelcomeLoadoutItem {
@@ -41,13 +45,17 @@ export interface WelcomeLoadoutSelection {
 
 export interface WelcomePlan {
   readonly answerQuestions: boolean;
+  readonly selectedProfileId?: string;
+  /** @deprecated use selectedProfileId. Kept for compatibility with injected test/runtime selectors. */
   readonly selectedRoleId?: string;
   readonly loadoutItemIds?: readonly string[];
 }
 
 export interface WelcomeCommandResult {
   readonly answered: boolean;
-  readonly selectedRole?: WelcomeRoleChoice;
+  readonly selectedProfile?: WelcomeProfileChoice;
+  /** @deprecated use selectedProfile. */
+  readonly selectedRole?: WelcomeProfileChoice;
   readonly selectedLoadout?: WelcomeLoadoutSelection;
   readonly warnings: readonly string[];
   readonly messages: readonly string[];
@@ -63,6 +71,8 @@ export interface WelcomeCommandDependencies {
   readonly selectWelcomePlan?: (input: WelcomeCommandInput) => Promise<WelcomePlan>;
 }
 
+export const defaultSharedProfilesSourceUrl = 'https://github.com/ai-outfitter/default-profiles';
+
 const welcomeIntroLines = [
   String.raw`  ____        _    __ _ _   _            `,
   String.raw` / __ \      | |  / _(_) | | |           `,
@@ -73,36 +83,20 @@ const welcomeIntroLines = [
   '',
   'Welcome to Outfitter.',
   'Pi is a fully extensible agentic coding harness.',
-  'Outfitter configures Pi with profiles and extensions — turning it into a complete agentic development environment.',
+  'Outfitter configures Pi with shared profiles and extensions — turning it into a complete agentic development environment.',
   '',
-  'The founder profile brings Pi to feature parity with dedicated agentic coding tools:',
-  'task tracking, multi-step reviews, browser automation, subagents, interactive shell, and MCP support.',
+  `Outfitter can start you from shared profiles at ${defaultSharedProfilesSourceUrl}.`,
+  'First-run shared setup is recorded as:',
+  'remote_settings:',
+  '  - github: ai-outfitter/default-profiles',
+  '    ref: main',
+  '    path: settings.yml',
+  'Choose a profile now, then use /outfitter inside Pi any time to customize it.',
 ] as const;
 
 export const writeWelcomeIntro = (output: Pick<NodeJS.WritableStream, 'write'>): void => {
   output.write(`\n${welcomeIntroLines.join('\n')}\n`);
 };
-
-const defaultProfileRoleChoices: readonly WelcomeRoleChoice[] = [
-  {
-    id: 'founder',
-    label: 'Founder',
-    description:
-      'Founder-operator setup for building, product thinking, research checks, dense prose, and careful delivery.',
-  },
-  {
-    id: 'engineer',
-    label: 'Engineer',
-    description: 'Engineering setup for repository navigation, maintainable code changes, tests, and reviews.',
-  },
-  {
-    id: 'data_analyst',
-    label: 'Data Analyst',
-    description: 'Data analysis setup for careful inspection, reproducible methods, assumptions, and summaries.',
-  },
-];
-
-const fallbackRoleId: WelcomeDefaultProfileRoleId = 'founder';
 
 const recommendedPiLoadout: WelcomeLoadout = {
   id: 'recommended-pi',
@@ -183,21 +177,26 @@ export const executeWelcomeCommand = async (
       answered: false,
       warnings: [],
       messages: [
-        'Skipped default profile setup. Use /outfitter inside Pi or run `outfitter profile list` to manage profiles.',
+        'Skipped shared profile setup. Use /outfitter inside Pi or run `outfitter profile list` to manage profiles.',
       ],
     };
   }
 
-  const roleResolution = resolveSelectedRole(plan.selectedRoleId);
+  const profileResolution = resolveSelectedProfile(
+    plan.selectedProfileId ?? plan.selectedRoleId,
+    input.profileChoices ?? [],
+    input.currentDefaultProfileId,
+  );
   const loadoutResolution = resolveSelectedLoadout(plan.loadoutItemIds);
-  const warnings = [...roleResolution.warnings, ...loadoutResolution.warnings];
+  const warnings = [...profileResolution.warnings, ...loadoutResolution.warnings];
 
   return {
     answered: true,
-    selectedRole: roleResolution.role,
+    selectedProfile: profileResolution.profile,
+    selectedRole: profileResolution.profile,
     selectedLoadout: loadoutResolution.loadout,
     warnings,
-    messages: buildWelcomeMessages(warnings),
+    messages: buildWelcomeMessages(profileResolution.profile, warnings),
   };
 };
 
@@ -239,10 +238,13 @@ const selectWelcomePlan = async (
     return dependencies.selectWelcomePlan(input);
   }
 
-  return promptForWelcomePlan(dependencies);
+  return promptForWelcomePlan(input, dependencies);
 };
 
-const promptForWelcomePlan = async (dependencies: WelcomeCommandDependencies): Promise<WelcomePlan> => {
+const promptForWelcomePlan = async (
+  input: WelcomeCommandInput,
+  dependencies: WelcomeCommandDependencies,
+): Promise<WelcomePlan> => {
   /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
   const output = dependencies.output ?? process.stdout;
   /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
@@ -250,33 +252,101 @@ const promptForWelcomePlan = async (dependencies: WelcomeCommandDependencies): P
 
   try {
     writeWelcomeIntro(output);
-    const answer = (await readline.question('Install the founder profile? [Y/n]: ')).trim().toLowerCase();
+    const answer = (await readline.question(`Use shared profiles from ${defaultSharedProfilesSourceUrl}? [Y/n]: `))
+      .trim()
+      .toLowerCase();
     const answerQuestions = answer === '' || ['y', 'yes'].includes(answer);
 
     if (!answerQuestions) {
       return { answerQuestions: false };
     }
 
-    return { answerQuestions: true, selectedRoleId: 'founder' };
+    return {
+      answerQuestions: true,
+      selectedProfileId: await promptForWelcomeProfileWithReadline(readline, output, input),
+    };
   } finally {
     readline.close();
   }
 };
 
-const resolveSelectedRole = (
-  selectedRoleId: string | undefined,
-): { readonly role: WelcomeRoleChoice; readonly warnings: readonly string[] } => {
-  const roleId = selectedRoleId ?? fallbackRoleId;
-  const selectedRole = defaultProfileRoleChoices.find((role) => role.id === roleId);
+const promptForWelcomeProfileWithReadline = async (
+  readline: { question(query: string): Promise<string> },
+  output: Pick<NodeJS.WritableStream, 'write'>,
+  input: WelcomeCommandInput,
+): Promise<string | undefined> => {
+  const profiles = input.profileChoices ?? [];
 
-  if (selectedRole !== undefined) {
-    return { role: selectedRole, warnings: [] };
+  if (profiles.length === 0) {
+    return input.currentDefaultProfileId;
+  }
+
+  const defaultIndex = Math.max(
+    profiles.findIndex((profile) => profile.id === input.currentDefaultProfileId),
+    0,
+  );
+  output.write('\nChoose your default shared profile:\n');
+  profiles.forEach((profile, index) => {
+    output.write(`${index + 1}. ${formatProfileChoiceTitle(profile)}\n`);
+    if (profile.description !== undefined) {
+      output.write(`   ${profile.description}\n`);
+    }
+  });
+
+  const answer = await readline.question(`Default profile [${defaultIndex + 1}]: `);
+  const selectedIndex = Number.parseInt(answer.trim() || String(defaultIndex + 1), 10) - 1;
+  const selectedProfile = profiles[selectedIndex];
+
+  if (selectedProfile === undefined) {
+    throw new Error('Selected shared profile number is out of range.');
+  }
+
+  return selectedProfile.id;
+};
+
+const formatProfileChoiceTitle = (profile: WelcomeProfileChoice): string => {
+  if (profile.label === undefined || profile.label === profile.id) {
+    return profile.id;
+  }
+
+  return `${profile.id} - ${profile.label}`;
+};
+
+const resolveSelectedProfile = (
+  selectedProfileId: string | undefined,
+  profileChoices: readonly WelcomeProfileChoice[],
+  currentDefaultProfileId: string | undefined,
+): { readonly profile: WelcomeProfileChoice; readonly warnings: readonly string[] } => {
+  const fallbackProfile = selectFallbackProfile(profileChoices, currentDefaultProfileId, selectedProfileId);
+  const profileId = selectedProfileId ?? fallbackProfile.id;
+  const selectedProfile = profileChoices.find((profile) => profile.id === profileId);
+
+  if (selectedProfile !== undefined) {
+    return { profile: selectedProfile, warnings: [] };
+  }
+
+  if (profileChoices.length === 0) {
+    return { profile: fallbackProfile, warnings: [] };
   }
 
   return {
-    role: defaultProfileRoleChoices.find((role) => role.id === fallbackRoleId)!,
-    warnings: [`Welcome role '${roleId}' is not available; using fallback role '${fallbackRoleId}'.`],
+    profile: fallbackProfile,
+    warnings: [`Welcome profile '${profileId}' is not available; using fallback profile '${fallbackProfile.id}'.`],
   };
+};
+
+const selectFallbackProfile = (
+  profileChoices: readonly WelcomeProfileChoice[],
+  currentDefaultProfileId: string | undefined,
+  selectedProfileId: string | undefined,
+): WelcomeProfileChoice => {
+  const currentDefaultProfile = profileChoices.find((profile) => profile.id === currentDefaultProfileId);
+
+  if (currentDefaultProfile !== undefined) {
+    return currentDefaultProfile;
+  }
+
+  return profileChoices[0] ?? { id: currentDefaultProfileId ?? selectedProfileId ?? 'default' };
 };
 
 const resolveSelectedLoadout = (
@@ -306,8 +376,11 @@ const resolveSelectedLoadout = (
   };
 };
 
-const buildWelcomeMessages = (warnings: readonly string[]): readonly string[] => [
-  'Installed the founder profile. Use /outfitter inside Pi or run `outfitter profile list` to manage profiles.',
+const buildWelcomeMessages = (
+  selectedProfile: WelcomeProfileChoice,
+  warnings: readonly string[],
+): readonly string[] => [
+  `Selected default profile '${selectedProfile.id}' from shared profiles. Use /outfitter inside Pi or run \`outfitter profile list\` to manage profiles.`,
   ...warnings.map((warning) => `Warning: ${warning}`),
 ];
 

--- a/src/cli/commands/WelcomeCommand.ts
+++ b/src/cli/commands/WelcomeCommand.ts
@@ -91,7 +91,7 @@ const welcomeIntroLines = [
   '  - github: ai-outfitter/default-profiles',
   '    ref: main',
   '    path: settings.yml',
-  'Choose a profile now, then use /outfitter inside Pi any time to customize it.',
+  'Choose a profile now if shared profiles are available; otherwise Outfitter will open /outfitter inside Pi.',
 ] as const;
 
 export const writeWelcomeIntro = (output: Pick<NodeJS.WritableStream, 'write'>): void => {
@@ -252,19 +252,13 @@ const promptForWelcomePlan = async (
 
   try {
     writeWelcomeIntro(output);
-    const answer = (await readline.question(`Use shared profiles from ${defaultSharedProfilesSourceUrl}? [Y/n]: `))
-      .trim()
-      .toLowerCase();
-    const answerQuestions = answer === '' || ['y', 'yes'].includes(answer);
+    const selectedProfileId = await promptForWelcomeProfileWithReadline(readline, output, input);
 
-    if (!answerQuestions) {
+    if (selectedProfileId === undefined) {
       return { answerQuestions: false };
     }
 
-    return {
-      answerQuestions: true,
-      selectedProfileId: await promptForWelcomeProfileWithReadline(readline, output, input),
-    };
+    return { answerQuestions: true, selectedProfileId };
   } finally {
     readline.close();
   }
@@ -278,7 +272,8 @@ const promptForWelcomeProfileWithReadline = async (
   const profiles = input.profileChoices ?? [];
 
   if (profiles.length === 0) {
-    return input.currentDefaultProfileId;
+    output.write('\nNo shared default profiles were found. Outfitter will open /outfitter inside Pi instead.\n');
+    return undefined;
   }
 
   const defaultIndex = Math.max(

--- a/tests/unit/first-run-welcome-profile.test.ts
+++ b/tests/unit/first-run-welcome-profile.test.ts
@@ -53,8 +53,17 @@ const writeDefaultProfile = (
   );
 };
 
+const writeSharedSettings = (cachePath: string, defaultProfile = 'engineer'): void => {
+  mkdirSync(cachePath, { recursive: true });
+  writeFileSync(
+    join(cachePath, 'settings.yml'),
+    ['default_profile: ' + defaultProfile, 'profile_sources:', '  - path: ./profiles', ''].join('\n'),
+  );
+};
+
 const defaultProfileSynchronizer = {
   sync(_source: unknown, cachePath: string) {
+    writeSharedSettings(cachePath);
     const profilesDirectory = join(cachePath, 'profiles');
     writeDefaultProfile(profilesDirectory, 'engineer', ['git:github.com/ai-outfitter/deepwork']);
     writeDefaultProfile(profilesDirectory, 'data_analyst', [
@@ -69,6 +78,7 @@ const defaultProfileSynchronizer = {
 
 const engineerOnlySynchronizer = {
   sync(_source: unknown, cachePath: string) {
+    writeSharedSettings(cachePath);
     writeDefaultProfile(join(cachePath, 'profiles'), 'engineer', ['git:github.com/ai-outfitter/deepwork']);
     return 'updated' as const;
   },
@@ -124,7 +134,7 @@ describe('first-run welcome profile', () => {
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.2, OFTR-010.3).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('persists first-run welcome role selection with no loadout items before launching pi', async () => {
+  it('copies the selected shared profile before launching pi without loadout mutation', async () => {
     const root = createTemporaryRoot();
     const homeDirectory = join(root, 'home');
     const projectDirectory = join(root, 'project');
@@ -141,7 +151,7 @@ describe('first-run welcome profile', () => {
           return Promise.resolve('engineer');
         },
         selectWelcomePlan() {
-          return Promise.resolve({ answerQuestions: true, selectedRoleId: 'engineer', loadoutItemIds: [] });
+          return Promise.resolve({ answerQuestions: true, selectedProfileId: 'engineer', loadoutItemIds: [] });
         },
         launcher: {
           launch() {
@@ -153,9 +163,12 @@ describe('first-run welcome profile', () => {
 
     expect(result.profileId).toBe('engineer');
     expect(result.launchPlan.args).toContain('--append-system-prompt');
-    expect(readFileSync(join(homeDirectory, '.outfitter', 'profiles', 'engineer', 'profile.yml'), 'utf8')).toContain(
-      'extensions: []',
+    const copiedProfile = readFileSync(
+      join(homeDirectory, '.outfitter', 'profiles', 'engineer', 'profile.yml'),
+      'utf8',
     );
+    expect(copiedProfile).toContain('git:github.com/ai-outfitter/deepwork');
+    expect(copiedProfile).toContain('Default engineer prompt.');
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.4).
@@ -254,7 +267,7 @@ describe('first-run welcome profile', () => {
     );
   });
 
-  it('persists a role-only welcome result without loadout data', () => {
+  it('persists a profile-only welcome result without loadout data', () => {
     const root = createTemporaryRoot();
     const homeDirectory = join(root, 'home');
     const settingsPath = join(homeDirectory, '.outfitter', 'settings.yml');
@@ -274,10 +287,10 @@ describe('first-run welcome profile', () => {
 
     const profile = readFileSync(join(homeDirectory, '.outfitter', 'profiles', 'engineer', 'profile.yml'), 'utf8');
     expect(persisted).toEqual({ profileId: 'engineer', createdProfile: true });
-    expect(profile).toContain(
-      'description: Engineering setup for repository navigation, maintainable code changes, tests, and reviews.',
-    );
-    expect(profile).toContain('append_system_prompt: |');
+    expect(profile).toContain('description: Engineering setup for repository navigation, maintainable code');
+    expect(profile).toContain('changes, tests, and reviews.');
+    expect(profile).toContain('controls: {}');
+    expect(profile).not.toContain('append_system_prompt');
     expect(profile).not.toContain('extensions:');
     expect(readFileSync(settingsPath, 'utf8')).toContain('default_profile: engineer');
   });
@@ -314,12 +327,12 @@ describe('first-run welcome profile', () => {
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.2, OFTR-010.3).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('falls back to a generated welcome profile when the selected role is not cached', async () => {
+  it('falls back to a discovered shared profile when an injected selection is not available', async () => {
     const root = createTemporaryRoot();
     const homeDirectory = join(root, 'home');
     const projectDirectory = join(root, 'project');
 
-    await executeRunCommand(
+    const result = await executeRunCommand(
       { homeDirectory, projectDirectory },
       {
         interactive: true,
@@ -333,7 +346,7 @@ describe('first-run welcome profile', () => {
         selectWelcomePlan() {
           return Promise.resolve({
             answerQuestions: true,
-            selectedRoleId: 'data_analyst',
+            selectedProfileId: 'data_analyst',
             loadoutItemIds: ['deepwork'],
           });
         },
@@ -345,11 +358,11 @@ describe('first-run welcome profile', () => {
       },
     );
 
-    const profileDirectory = join(homeDirectory, '.outfitter', 'profiles', 'data_analyst');
-    expect(readFileSync(join(profileDirectory, 'profile.yml'), 'utf8')).toContain(
-      'git:github.com/ai-outfitter/deepwork',
+    expect(result.profileId).toBe('engineer');
+    expect(existsSync(join(homeDirectory, '.outfitter', 'profiles', 'data_analyst'))).toBe(false);
+    expect(readFileSync(join(homeDirectory, '.outfitter', 'settings.yml'), 'utf8')).toContain(
+      'default_profile: engineer',
     );
-    expect(existsSync(join(profileDirectory, 'cli_specific'))).toBe(false);
   });
 
   it('copies source profiles even when the profile and settings YAML are empty', () => {
@@ -382,7 +395,7 @@ describe('first-run welcome profile', () => {
       profileId: 'data_analyst',
       createdProfile: true,
       messages: [
-        `Copied the Data Analyst profile locally so your extension choices can be edited at ${join(
+        `Copied the Data Analyst profile locally so it can be edited at ${join(
           homeDirectory,
           '.outfitter',
           'profiles',
@@ -391,17 +404,20 @@ describe('first-run welcome profile', () => {
         )}.`,
       ],
     });
-    expect(readFileSync(settingsPath, 'utf8')).toContain('profile_sources: []');
-    expect(readFileSync(settingsPath, 'utf8')).toContain('default_profile: data_analyst');
+    const settings = readFileSync(settingsPath, 'utf8');
+    expect(settings).toContain('github: ai-outfitter/default-profiles');
+    expect(settings).toContain('ref: main');
+    expect(settings).toContain('- data_analyst');
+    expect(settings).toContain('path: ./profiles');
+    expect(settings).toContain('default_profile: data_analyst');
     const copiedProfile = readFileSync(
       join(homeDirectory, '.outfitter', 'profiles', 'data_analyst', 'profile.yml'),
       'utf8',
     );
-    expect(copiedProfile).toContain('description: Data analysis setup for careful inspection');
-    expect(copiedProfile).toContain('assumptions, and summaries.');
+    expect(copiedProfile).toBe('');
   });
 
-  it('handles malformed scalar source profiles when copying welcome choices', () => {
+  it('copies source profile files without injecting generated welcome content', () => {
     const root = createTemporaryRoot();
     const homeDirectory = join(root, 'home');
     const settingsPath = join(homeDirectory, '.outfitter', 'settings.yml');
@@ -439,13 +455,12 @@ describe('first-run welcome profile', () => {
       join(homeDirectory, '.outfitter', 'profiles', 'data_analyst', 'profile.yml'),
       'utf8',
     );
-    expect(copiedProfile).toContain('controls:');
-    expect(copiedProfile).toContain('git:x');
+    expect(copiedProfile).toBe('scalar-profile\n');
   });
 
-  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.3).
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.2, OFTR-010.3).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('adds copied profile exclusions to the default profile source', () => {
+  it('adds copied profile exclusions to the default profile source without mutating remote content', () => {
     const root = createTemporaryRoot();
     const homeDirectory = join(root, 'home');
     const settingsPath = join(homeDirectory, '.outfitter', 'settings.yml');
@@ -517,10 +532,9 @@ describe('first-run welcome profile', () => {
       join(homeDirectory, '.outfitter', 'profiles', 'data_analyst', 'profile.yml'),
       'utf8',
     );
-    expect(copiedProfile).toContain('extensions: []');
-    expect(copiedProfile).toContain('git:selected');
-    expect(copiedProfile).not.toContain('default-generic');
-    expect(copiedProfile).not.toContain('default-pi');
+    expect(copiedProfile).toContain('git:github.com/ai-outfitter/default-generic');
+    expect(copiedProfile).toContain('git:github.com/ai-outfitter/default-pi');
+    expect(copiedProfile).not.toContain('git:selected');
   });
 
   it('adds a default profile setting when persisting welcome into sparse settings', () => {
@@ -544,9 +558,9 @@ describe('first-run welcome profile', () => {
     expect(readFileSync(settingsPath, 'utf8')).toContain('default_profile: data_analyst');
   });
 
-  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.3).
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.2, OFTR-010.3).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('persists first-run welcome loadout selection before launching pi', async () => {
+  it('preserves selected shared profile resources before launching pi', async () => {
     const root = createTemporaryRoot();
     const homeDirectory = join(root, 'home');
     const projectDirectory = join(root, 'project');
@@ -565,7 +579,7 @@ describe('first-run welcome profile', () => {
         selectWelcomePlan() {
           return Promise.resolve({
             answerQuestions: true,
-            selectedRoleId: 'data_analyst',
+            selectedProfileId: 'data_analyst',
             loadoutItemIds: ['deepwork', 'pi-mcp-adapter'],
           });
         },
@@ -579,8 +593,9 @@ describe('first-run welcome profile', () => {
 
     expect(result.profileId).toBe('data_analyst');
     expect(result.launchPlan.args).toContain('git:github.com/ai-outfitter/deepwork');
-    expect(result.launchPlan.args).toContain('npm:pi-mcp-adapter');
-    expect(result.launchPlan.args).not.toContain('git:github.com/nhorton/pi-pr-alerts');
+    expect(result.launchPlan.args).toContain('git:github.com/nhorton/pi-pr-alerts');
+    expect(result.launchPlan.args).toContain('npm:pi-subagents');
+    expect(result.launchPlan.args).not.toContain('npm:pi-mcp-adapter');
     const settings = readFileSync(join(homeDirectory, '.outfitter', 'settings.yml'), 'utf8');
     const copiedProfile = readFileSync(
       join(homeDirectory, '.outfitter', 'profiles', 'data_analyst', 'profile.yml'),
@@ -591,8 +606,9 @@ describe('first-run welcome profile', () => {
     expect(settings).toContain('except:');
     expect(settings).toContain('- data_analyst');
     expect(copiedProfile).toContain('git:github.com/ai-outfitter/deepwork');
-    expect(copiedProfile).toContain('npm:pi-mcp-adapter');
-    expect(copiedProfile).not.toContain('git:github.com/nhorton/pi-pr-alerts');
+    expect(copiedProfile).toContain('git:github.com/nhorton/pi-pr-alerts');
+    expect(copiedProfile).toContain('npm:pi-subagents');
+    expect(copiedProfile).not.toContain('npm:pi-mcp-adapter');
     expect(
       existsSync(
         join(

--- a/tests/unit/first-run-welcome-profile.test.ts
+++ b/tests/unit/first-run-welcome-profile.test.ts
@@ -3,6 +3,7 @@
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -84,6 +85,14 @@ const engineerOnlySynchronizer = {
   },
 };
 
+const emptyDefaultProfileSynchronizer = {
+  sync(_source: unknown, cachePath: string) {
+    writeSharedSettings(cachePath);
+    mkdirSync(join(cachePath, 'profiles'), { recursive: true });
+    return 'updated' as const;
+  },
+};
+
 afterEach(() => {
   for (const root of temporaryRoots.splice(0)) {
     rmSync(root, { recursive: true, force: true });
@@ -93,7 +102,7 @@ afterEach(() => {
 describe('first-run welcome profile', () => {
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.1).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('leaves first-run welcome opt-out on the generated role profile before launching pi', async () => {
+  it('opens /outfitter on an unanswered first-run welcome before launching pi', async () => {
     const root = createTemporaryRoot();
     const homeDirectory = join(root, 'home');
     const projectDirectory = join(root, 'project');
@@ -124,12 +133,48 @@ describe('first-run welcome profile', () => {
 
     expect(result.profileId).toBe('engineer');
     expect(launches).toHaveLength(1);
+    expect(result.launchPlan.args[0]).toBe('--extension');
+    const outfitterExtensionContent = readFileSync(result.launchPlan.args[1] ?? '', 'utf8');
+    expect(outfitterExtensionContent).toContain('setEditorText("/outfitter")');
+    expect(outfitterExtensionContent).toContain('handleInput?.("\\r")');
     expect(readFileSync(join(homeDirectory, '.outfitter', 'settings.yml'), 'utf8')).toContain(
       'default_profile: engineer',
     );
     expect(readFileSync(join(homeDirectory, '.outfitter', 'profiles', 'engineer', 'profile.yml'), 'utf8')).toBe(
       'id: engineer\nlabel: Default\ncontrols: {}\n',
     );
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.2, OFTR-010.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('opens /outfitter when the shared default source has no profiles', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const input = Object.assign(new PassThrough(), { isTTY: true });
+    const output = Object.assign(new PassThrough(), { isTTY: true });
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        interactive: true,
+        input,
+        output,
+        synchronizer: emptyDefaultProfileSynchronizer,
+        writeLine: () => undefined,
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(result.profileId).toBe('engineer');
+    expect(result.launchPlan.args[0]).toBe('--extension');
+    const outfitterExtensionContent = readFileSync(result.launchPlan.args[1] ?? '', 'utf8');
+    expect(outfitterExtensionContent).toContain('setEditorText("/outfitter")');
+    expect(readFileSync(join(homeDirectory, '.outfitter', 'settings.yml'), 'utf8')).toContain('path: ./profiles');
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.2, OFTR-010.3).
@@ -194,7 +239,7 @@ describe('first-run welcome profile', () => {
           return Promise.resolve('engineer');
         },
         selectWelcomePlan() {
-          return Promise.resolve({ answerQuestions: false });
+          return Promise.resolve({ answerQuestions: true, selectedProfileId: 'engineer' });
         },
         launcher: {
           launch() {

--- a/tests/unit/profile-command.test.ts
+++ b/tests/unit/profile-command.test.ts
@@ -170,8 +170,12 @@ describe('profile command', () => {
       writeLine: (message) => setupMessages.push(message),
       synchronizer: {
         sync(_source, cachePath) {
-          mkdirSync(join(cachePath, 'profiles', 'engineer'), { recursive: true });
-          writeFileSync(join(cachePath, 'profiles', 'engineer', 'profile.yml'), 'id: engineer\ncontrols: {}\n');
+          mkdirSync(cachePath, { recursive: true });
+          writeFileSync(
+            join(cachePath, 'settings.yml'),
+            ['default_profile: engineer', 'profile_sources:', '  - path: ./profiles', ''].join('\n'),
+          );
+          writeProfile(join(cachePath, 'profiles'), 'engineer');
           return 'updated';
         },
       },

--- a/tests/unit/run-command.test.ts
+++ b/tests/unit/run-command.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 // Tests run command composite profile assembly, launch behavior, and error handling.
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -31,6 +32,15 @@ const writeProfile = (root: string, id: string, content: string): string => {
   const profilePath = join(profileDirectory, 'profile.yml');
   writeFileSync(profilePath, content);
   return profilePath;
+};
+
+const writeDefaultProfilesRemoteSettings = (cachePath: string, profileId = 'engineer'): void => {
+  mkdirSync(cachePath, { recursive: true });
+  writeFileSync(
+    join(cachePath, 'settings.yml'),
+    ['default_profile: ' + profileId, 'profile_sources:', '  - path: ./profiles', ''].join('\n'),
+  );
+  writeProfile(join(cachePath, 'profiles'), profileId, `id: ${profileId}\ncontrols: {}\n`);
 };
 
 const waitForFileContaining = async (path: string, content: string): Promise<void> => {
@@ -197,8 +207,7 @@ describe('run command', () => {
         synchronizer: {
           sync(source, cachePath) {
             syncedSources.push(source);
-            mkdirSync(join(cachePath, 'profiles', 'engineer'), { recursive: true });
-            writeFileSync(join(cachePath, 'profiles', 'engineer', 'profile.yml'), 'id: engineer\ncontrols: {}\n');
+            writeDefaultProfilesRemoteSettings(cachePath);
             return 'updated';
           },
         },
@@ -215,13 +224,13 @@ describe('run command', () => {
       expect.arrayContaining([
         'Pi does not appear to be logged in yet. After Pi starts, run `/login` and choose a subscription such as Codex or provide an API key from another model provider.',
         '→ resolving profile engineer',
-        `✓ profile layer engineer  ${join(homeDirectory, '.outfitter', 'profiles', 'engineer')}`,
+        expect.stringContaining('✓ profile layer engineer'),
         '✓ merged controls',
         `✓ prepared composite profile  ${result.compositeProfileDirectory}`,
         '↳ launching pi …',
       ]),
     );
-    expect(syncedSources).toEqual([{ github: 'ai-outfitter/default-profiles', path: 'profiles' }]);
+    expect(syncedSources).toEqual([{ github: 'ai-outfitter/default-profiles', ref: 'main', path: 'settings.yml' }]);
     expect(result.profileId).toBe('engineer');
     expect(existsSync(join(homeDirectory, '.outfitter', 'settings.yml'))).toBe(true);
     expect(existsSync(join(homeDirectory, '.outfitter', 'profiles', 'engineer', 'profile.yml'))).toBe(true);
@@ -373,8 +382,7 @@ describe('run command', () => {
         writeLine: () => undefined,
         synchronizer: {
           sync(_source, cachePath) {
-            mkdirSync(join(cachePath, 'profiles', 'engineer'), { recursive: true });
-            writeFileSync(join(cachePath, 'profiles', 'engineer', 'profile.yml'), 'id: engineer\ncontrols: {}\n');
+            writeDefaultProfilesRemoteSettings(cachePath);
             return 'updated';
           },
         },
@@ -402,8 +410,7 @@ describe('run command', () => {
         writeLine: () => undefined,
         synchronizer: {
           sync(_source, cachePath) {
-            mkdirSync(join(cachePath, 'profiles', 'engineer'), { recursive: true });
-            writeFileSync(join(cachePath, 'profiles', 'engineer', 'profile.yml'), 'id: engineer\ncontrols: {}\n');
+            writeDefaultProfilesRemoteSettings(cachePath);
             return 'updated';
           },
         },

--- a/tests/unit/setup-command.test.ts
+++ b/tests/unit/setup-command.test.ts
@@ -109,6 +109,11 @@ const captureProcessStdout = (chunks: string[]): void => {
 
 const defaultProfileSynchronizer = {
   sync(_source: unknown, cachePath: string) {
+    mkdirSync(cachePath, { recursive: true });
+    writeFileSync(
+      join(cachePath, 'settings.yml'),
+      ['default_profile: engineer', 'profile_sources:', '  - path: ./profiles', ''].join('\n'),
+    );
     writeCachedProfile(join(cachePath, 'profiles'), 'engineer');
     writeCachedProfile(join(cachePath, 'profiles'), 'data_analyst');
     return 'updated' as const;
@@ -142,11 +147,11 @@ describe('setup command', () => {
     expect(firstResult.createdDefaultProfile).toBe(true);
     expect(readFileSync(settingsPath, 'utf8')).toBe(
       [
-        'default_profile: engineer',
-        'profile_sources:',
+        'remote_settings:',
         '  - github: ai-outfitter/default-profiles',
-        '    path: profiles',
-        '  - path: ./profiles',
+        '    ref: main',
+        '    path: settings.yml',
+        'default_profile: engineer',
         '',
       ].join('\n'),
     );
@@ -154,7 +159,7 @@ describe('setup command', () => {
     expect(firstResult.messages).toContain("Selected default profile 'engineer'.");
     expect(firstResult.syncResult.sources).toHaveLength(1);
     expect(firstResult.syncResult.sources[0]?.uri).toBe(
-      'git+https://github.com/ai-outfitter/default-profiles.git:profiles',
+      'git+https://github.com/ai-outfitter/default-profiles.git#main:settings.yml',
     );
 
     writeFileSync(defaultProfilePath, 'id: default\nlabel: Custom\n');
@@ -166,6 +171,97 @@ describe('setup command', () => {
     expect(secondResult.createdSettings).toBe(false);
     expect(secondResult.createdDefaultProfile).toBe(false);
     expect(readFileSync(defaultProfilePath, 'utf8')).toBe('id: default\nlabel: Custom\n');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.1, OFTR-010.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('syncs shared remote settings and passes discovered remote profiles to first-run welcome', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const seenWelcomeChoices: unknown[] = [];
+
+    const result = await executeSetupCommand(
+      { homeDirectory, projectDirectory },
+      {
+        interactive: true,
+        input: { isTTY: true } as NodeJS.ReadableStream & { isTTY: true },
+        output: { isTTY: true } as NodeJS.WritableStream & { isTTY: true },
+        writeLine: () => undefined,
+        synchronizer: {
+          sync(source, cachePath) {
+            expect(source).toEqual({ github: 'ai-outfitter/default-profiles', ref: 'main', path: 'settings.yml' });
+            mkdirSync(cachePath, { recursive: true });
+            writeFileSync(
+              join(cachePath, 'settings.yml'),
+              ['default_profile: researcher', 'profile_sources:', '  - path: ./profiles', ''].join('\n'),
+            );
+            const profilesPath = join(cachePath, 'profiles');
+            writeCachedProfile(profilesPath, 'engineer');
+            writeFileSync(
+              join(profilesPath, 'engineer', 'profile.yml'),
+              [
+                'id: engineer',
+                'label: Engineer',
+                'description: Build, test, and review code from the shared source.',
+                'controls: {}',
+                '',
+              ].join('\n'),
+            );
+            writeCachedProfile(profilesPath, 'researcher');
+            writeFileSync(
+              join(profilesPath, 'researcher', 'profile.yml'),
+              [
+                'id: researcher',
+                'label: Researcher',
+                'description: Inspect sources and summarize evidence from the shared source.',
+                'controls: {}',
+                '',
+              ].join('\n'),
+            );
+            return 'updated';
+          },
+        },
+        selectDefaultProfile() {
+          throw new Error('first-run setup should let welcome choose from shared profiles');
+        },
+        selectWelcomePlan(input) {
+          expect(input.currentDefaultProfileId).toBe('researcher');
+          seenWelcomeChoices.push(...(input.profileChoices ?? []));
+          return Promise.resolve({ answerQuestions: true, selectedProfileId: 'engineer' });
+        },
+      },
+    );
+
+    expect(seenWelcomeChoices).toEqual([
+      {
+        id: 'researcher',
+        label: 'Researcher',
+        description: 'Inspect sources and summarize evidence from the shared source.',
+      },
+      {
+        id: 'engineer',
+        label: 'Engineer',
+        description: 'Build, test, and review code from the shared source.',
+      },
+    ]);
+    expect(result.welcomeResult?.selectedProfile).toEqual({
+      id: 'engineer',
+      label: 'Engineer',
+      description: 'Build, test, and review code from the shared source.',
+    });
+    const settings = readFileSync(join(homeDirectory, '.outfitter', 'settings.yml'), 'utf8');
+    expect(settings).toContain('remote_settings:');
+    expect(settings).toContain('github: ai-outfitter/default-profiles');
+    expect(settings).toContain('ref: main');
+    expect(settings).toContain('path: settings.yml');
+    expect(settings).toContain('default_profile: engineer');
+    expect(settings).toContain('except:');
+    expect(settings).toContain('- engineer');
+    expect(settings).toContain('path: ./profiles');
+    expect(readFileSync(join(homeDirectory, '.outfitter', 'profiles', 'engineer', 'profile.yml'), 'utf8')).toContain(
+      'description: Build, test, and review code from the shared source.',
+    );
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.1).
@@ -1509,7 +1605,7 @@ describe('setup command', () => {
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.2, OFTR-010.3).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('runs welcome onboarding after interactive setup completes', async () => {
+  it('runs shared-profile welcome onboarding after interactive setup completes', async () => {
     const root = createTemporaryRoot();
     const homeDirectory = join(root, 'home');
     const projectDirectory = join(root, 'project');
@@ -1528,7 +1624,7 @@ describe('setup command', () => {
         selectWelcomePlan() {
           return Promise.resolve({
             answerQuestions: true,
-            selectedRoleId: 'engineer',
+            selectedProfileId: 'engineer',
             loadoutItemIds: ['deepwork'],
           });
         },
@@ -1537,10 +1633,11 @@ describe('setup command', () => {
 
     expect(result.welcomeResult).toEqual({
       answered: true,
+      selectedProfile: {
+        id: 'engineer',
+      },
       selectedRole: {
         id: 'engineer',
-        label: 'Engineer',
-        description: 'Engineering setup for repository navigation, maintainable code changes, tests, and reviews.',
       },
       selectedLoadout: {
         id: 'recommended-pi',
@@ -1556,7 +1653,7 @@ describe('setup command', () => {
       },
       warnings: [],
       messages: [
-        'Installed the founder profile. Use /outfitter inside Pi or run `outfitter profile list` to manage profiles.',
+        "Selected default profile 'engineer' from shared profiles. Use /outfitter inside Pi or run `outfitter profile list` to manage profiles.",
       ],
     });
   });

--- a/tests/unit/setup-sources.test.ts
+++ b/tests/unit/setup-sources.test.ts
@@ -85,6 +85,11 @@ describe('setup sources', () => {
       {
         synchronizer: {
           sync(_source, cachePath) {
+            mkdirSync(cachePath, { recursive: true });
+            writeFileSync(
+              join(cachePath, 'settings.yml'),
+              ['default_profile: engineer', 'profile_sources:', '  - path: ./profiles', ''].join('\n'),
+            );
             writeCachedProfile(join(cachePath, 'profiles'), 'engineer');
             return 'updated';
           },

--- a/tests/unit/welcome-command.test.ts
+++ b/tests/unit/welcome-command.test.ts
@@ -144,7 +144,7 @@ describe('welcome command', () => {
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.1, OFTR-010.2).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('accepts shared profiles and chooses among remote profile labels and descriptions', async () => {
+  it('uses the first question to choose among remote profile labels and descriptions', async () => {
     const input = Object.assign(new PassThrough(), { isTTY: true });
     const output = Object.assign(new PassThrough(), { isTTY: true });
     let outputText = '';
@@ -160,10 +160,7 @@ describe('welcome command', () => {
       },
       { interactive: true, input, output },
     );
-    setImmediate(() => {
-      input.write('y\n');
-      setImmediate(() => input.end('2\n'));
-    });
+    setImmediate(() => input.end('2\n'));
     const result = await resultPromise;
 
     expect(outputText).toContain('____        _    __ _ _   _');
@@ -174,7 +171,7 @@ describe('welcome command', () => {
     expect(outputText).toContain('github: ai-outfitter/default-profiles');
     expect(outputText).toContain('ref: main');
     expect(outputText).toContain('path: settings.yml');
-    expect(outputText).toContain('Use shared profiles from https://github.com/ai-outfitter/default-profiles? [Y/n]:');
+    expect(outputText).not.toContain('Use shared profiles from');
     expect(outputText).toContain('1. engineer - Engineer');
     expect(outputText).toContain('Engineering setup from the shared default profiles repository.');
     expect(outputText).toContain('2. researcher - Researcher');
@@ -196,10 +193,7 @@ describe('welcome command', () => {
       },
       { interactive: true, input, output },
     );
-    setImmediate(() => {
-      input.write('\n');
-      setImmediate(() => input.end('\n'));
-    });
+    setImmediate(() => input.end('\n'));
     const result = await resultPromise;
 
     expect(result.answered).toBe(true);
@@ -207,17 +201,22 @@ describe('welcome command', () => {
     expect(result.selectedLoadout?.selectedItems.map((item) => item.source)).toEqual(defaultLoadoutSources);
   });
 
-  it('declines with N and returns unanswered', async () => {
+  it('returns unanswered when no shared default profiles are available', async () => {
     const input = Object.assign(new PassThrough(), { isTTY: true });
     const output = Object.assign(new PassThrough(), { isTTY: true });
-    const resultPromise = executeWelcomeCommand(
-      { homeDirectory: '/tmp/home', projectDirectory: '/work/acme' },
+    let outputText = '';
+    output.on('data', (chunk: Buffer | string) => {
+      outputText += chunk.toString();
+    });
+    const result = await executeWelcomeCommand(
+      { homeDirectory: '/tmp/home', projectDirectory: '/work/acme', profileChoices: [] },
       { interactive: true, input, output },
     );
-    setImmediate(() => input.end('n\n'));
-    const result = await resultPromise;
 
     expect(result.answered).toBe(false);
+    expect(outputText).toContain(
+      'No shared default profiles were found. Outfitter will open /outfitter inside Pi instead.',
+    );
     expect(result.messages).toEqual([
       'Skipped shared profile setup. Use /outfitter inside Pi or run `outfitter profile list` to manage profiles.',
     ]);

--- a/tests/unit/welcome-command.test.ts
+++ b/tests/unit/welcome-command.test.ts
@@ -19,6 +19,19 @@ const defaultLoadoutSources = [
   'npm:pi-mcp-adapter',
 ];
 
+const sharedProfileChoices = [
+  {
+    id: 'engineer',
+    label: 'Engineer',
+    description: 'Engineering setup from the shared default profiles repository.',
+  },
+  {
+    id: 'researcher',
+    label: 'Researcher',
+    description: 'Research setup with source checking and concise synthesis.',
+  },
+];
+
 describe('welcome command', () => {
   it('returns skipped onboarding without prompting when the selector opts out', async () => {
     const result = await executeWelcomeCommand(
@@ -34,68 +47,77 @@ describe('welcome command', () => {
       answered: false,
       warnings: [],
       messages: [
-        'Skipped default profile setup. Use /outfitter inside Pi or run `outfitter profile list` to manage profiles.',
+        'Skipped shared profile setup. Use /outfitter inside Pi or run `outfitter profile list` to manage profiles.',
       ],
     });
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.2, OFTR-010.3).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('returns selected default-profile role and recommended loadout data', async () => {
+  it('returns selected shared default-profile data and recommended loadout data', async () => {
     const result = await executeWelcomeCommand(
-      { homeDirectory: '/tmp/home', projectDirectory: '/work/acme/api' },
+      {
+        homeDirectory: '/tmp/home',
+        projectDirectory: '/work/acme/api',
+        profileChoices: sharedProfileChoices,
+        currentDefaultProfileId: 'engineer',
+      },
       {
         selectWelcomePlan() {
-          return Promise.resolve({ answerQuestions: true, selectedRoleId: 'data_analyst' });
+          return Promise.resolve({ answerQuestions: true, selectedProfileId: 'researcher' });
         },
       },
     );
 
     expect(result.answered).toBe(true);
-    expect(result.selectedRole).toEqual({
-      id: 'data_analyst',
-      label: 'Data Analyst',
-      description: 'Data analysis setup for careful inspection, reproducible methods, assumptions, and summaries.',
+    expect(result.selectedProfile).toEqual({
+      id: 'researcher',
+      label: 'Researcher',
+      description: 'Research setup with source checking and concise synthesis.',
     });
     expect(result.selectedLoadout?.id).toBe('recommended-pi');
     expect(result.selectedLoadout?.selectedItems.map((item) => item.source)).toEqual(defaultLoadoutSources);
     expect(result.warnings).toEqual([]);
     expect(result.messages).toEqual([
-      'Installed the founder profile. Use /outfitter inside Pi or run `outfitter profile list` to manage profiles.',
+      "Selected default profile 'researcher' from shared profiles. Use /outfitter inside Pi or run `outfitter profile list` to manage profiles.",
     ]);
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.2, OFTR-010.3).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('falls back for unknown roles and skips unknown loadout items', async () => {
+  it('falls back for unavailable shared profiles and skips unknown loadout items', async () => {
     const result = await executeWelcomeCommand(
-      { homeDirectory: '/tmp/home', projectDirectory: '/work/acme/api' },
+      {
+        homeDirectory: '/tmp/home',
+        projectDirectory: '/work/acme/api',
+        profileChoices: sharedProfileChoices,
+        currentDefaultProfileId: 'engineer',
+      },
       {
         selectWelcomePlan() {
           return Promise.resolve({
             answerQuestions: true,
-            selectedRoleId: 'reviewer',
+            selectedProfileId: 'reviewer',
             loadoutItemIds: ['deepwork', 'deepwork', 'missing-package'],
           });
         },
       },
     );
 
-    expect(result.selectedRole).toEqual({
-      id: 'founder',
-      label: 'Founder',
-      description:
-        'Founder-operator setup for building, product thinking, research checks, dense prose, and careful delivery.',
+    expect(result.selectedProfile).toEqual({
+      id: 'engineer',
+      label: 'Engineer',
+      description: 'Engineering setup from the shared default profiles repository.',
     });
     expect(result.selectedLoadout?.selectedItems.map((item) => item.source)).toEqual([
       'git:github.com/ai-outfitter/deepwork',
     ]);
     expect(result.warnings).toEqual([
-      "Welcome role 'reviewer' is not available; using fallback role 'founder'.",
+      "Welcome profile 'reviewer' is not available; using fallback profile 'engineer'.",
       "Loadout item 'missing-package' is not available for recommended-pi; skipping it.",
     ]);
     expect(result.messages).toContain(
-      "Warning: Welcome role 'reviewer' is not available; using fallback role 'founder'.",
+      "Warning: Welcome profile 'reviewer' is not available; using fallback profile 'engineer'.",
     );
   });
 
@@ -109,20 +131,20 @@ describe('welcome command', () => {
       output: { isTTY: true } as NodeJS.WritableStream & { isTTY: true },
       writeLine: (message) => messages.push(message),
       selectWelcomePlan() {
-        return Promise.resolve({ answerQuestions: true });
+        return Promise.resolve({ answerQuestions: true, selectedProfileId: 'engineer' });
       },
     }).register(program);
 
     await program.parseAsync(['node', 'outfitter', 'welcome']);
 
     expect(messages).toEqual([
-      'Installed the founder profile. Use /outfitter inside Pi or run `outfitter profile list` to manage profiles.',
+      "Selected default profile 'engineer' from shared profiles. Use /outfitter inside Pi or run `outfitter profile list` to manage profiles.",
     ]);
   });
 
-  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.1, OFTR-010.3).
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.1, OFTR-010.2).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('accepts with a single Y and installs the full founder loadout while showing welcome text', async () => {
+  it('accepts shared profiles and chooses among remote profile labels and descriptions', async () => {
     const input = Object.assign(new PassThrough(), { isTTY: true });
     const output = Object.assign(new PassThrough(), { isTTY: true });
     let outputText = '';
@@ -130,37 +152,58 @@ describe('welcome command', () => {
       outputText += chunk.toString();
     });
     const resultPromise = executeWelcomeCommand(
-      { homeDirectory: '/tmp/home', projectDirectory: '/work/acme/default' },
+      {
+        homeDirectory: '/tmp/home',
+        projectDirectory: '/work/acme/default',
+        profileChoices: sharedProfileChoices,
+        currentDefaultProfileId: 'engineer',
+      },
       { interactive: true, input, output },
     );
-    setImmediate(() => input.end('y\n'));
+    setImmediate(() => {
+      input.write('y\n');
+      setImmediate(() => input.end('2\n'));
+    });
     const result = await resultPromise;
 
     expect(outputText).toContain('____        _    __ _ _   _');
     expect(outputText).not.toContain('____  _');
     expect(outputText).toContain('Pi is a fully extensible agentic coding harness.');
-    expect(outputText).toContain(
-      '\n\nThe founder profile brings Pi to feature parity with dedicated agentic coding tools:',
-    );
-    expect(outputText).not.toContain('Press Y to install it now.');
-    expect(outputText).toContain('Install the founder profile? [Y/n]:');
+    expect(outputText).toContain('https://github.com/ai-outfitter/default-profiles');
+    expect(outputText).toContain('remote_settings:');
+    expect(outputText).toContain('github: ai-outfitter/default-profiles');
+    expect(outputText).toContain('ref: main');
+    expect(outputText).toContain('path: settings.yml');
+    expect(outputText).toContain('Use shared profiles from https://github.com/ai-outfitter/default-profiles? [Y/n]:');
+    expect(outputText).toContain('1. engineer - Engineer');
+    expect(outputText).toContain('Engineering setup from the shared default profiles repository.');
+    expect(outputText).toContain('2. researcher - Researcher');
+    expect(outputText).toContain('Research setup with source checking and concise synthesis.');
     expect(result.answered).toBe(true);
-    expect(result.selectedRole?.id).toBe('founder');
+    expect(result.selectedProfile?.id).toBe('researcher');
     expect(result.selectedLoadout?.selectedItems.map((item) => item.source)).toEqual(defaultLoadoutSources);
   });
 
-  it('accepts with Enter (default) and installs the full founder loadout', async () => {
+  it('accepts with Enter (default) and selects the current shared default profile', async () => {
     const input = Object.assign(new PassThrough(), { isTTY: true });
     const output = Object.assign(new PassThrough(), { isTTY: true });
     const resultPromise = executeWelcomeCommand(
-      { homeDirectory: '/tmp/home', projectDirectory: '/work/acme' },
+      {
+        homeDirectory: '/tmp/home',
+        projectDirectory: '/work/acme',
+        profileChoices: sharedProfileChoices,
+        currentDefaultProfileId: 'engineer',
+      },
       { interactive: true, input, output },
     );
-    setImmediate(() => input.end('\n'));
+    setImmediate(() => {
+      input.write('\n');
+      setImmediate(() => input.end('\n'));
+    });
     const result = await resultPromise;
 
     expect(result.answered).toBe(true);
-    expect(result.selectedRole?.id).toBe('founder');
+    expect(result.selectedProfile?.id).toBe('engineer');
     expect(result.selectedLoadout?.selectedItems.map((item) => item.source)).toEqual(defaultLoadoutSources);
   });
 
@@ -176,7 +219,7 @@ describe('welcome command', () => {
 
     expect(result.answered).toBe(false);
     expect(result.messages).toEqual([
-      'Skipped default profile setup. Use /outfitter inside Pi or run `outfitter profile list` to manage profiles.',
+      'Skipped shared profile setup. Use /outfitter inside Pi or run `outfitter profile list` to manage profiles.',
     ]);
   });
 


### PR DESCRIPTION
## Summary
- Replace first-run founder/role hardcoding with shared profile onboarding from ai-outfitter/default-profiles.
- Generate first-run settings with remote_settings using github/ref/path and show that shared source in the welcome text.
- Load profile ids, labels, and descriptions from the synchronized shared source; copy selected remote profile content locally without injecting stale hardcoded prompts.
- Update OFTR-004/OFTR-010 and architecture docs plus setup/welcome/first-run tests.

## Verification
- npm test -- tests/unit/welcome-command.test.ts tests/unit/setup-command.test.ts tests/unit/first-run-welcome-profile.test.ts
- npm test
- npm run typecheck
- npm run lint
- npx prettier --check docs/archtecture/README.md docs/requirements/OFTR-004-sync-and-setup.md docs/requirements/OFTR-010-onboarding-welcome.md src/cli/commands/FirstRunWelcomeProfile.ts src/cli/commands/SetupCommand.ts src/cli/commands/WelcomeCommand.ts tests/unit/first-run-welcome-profile.test.ts tests/unit/profile-command.test.ts tests/unit/run-command.test.ts tests/unit/setup-command.test.ts tests/unit/setup-sources.test.ts tests/unit/welcome-command.test.ts
- Manual requirements_file DeepSchema verification commands for OFTR-004 and OFTR-010

## Notes
- docs/mission.md is absent in this checkout; requirement updates cite existing OFTR files and architecture docs.
