### PR TITLE
fix(run): launch bundled pi so first run works without a global pi install

### DIFF
--- a/code/cli/src/agents/AgentLaunch.ts
+++ b/code/cli/src/agents/AgentLaunch.ts
@@ -1,0 +1,126 @@
+// Turns a logical agent launch plan into an actual launched process: resolves the bundled pi
+// binary, runs the launcher, and translates a missing agent CLI into actionable install guidance.
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { AgentLaunchPlan } from './AgentAdapter.js';
+
+export interface AgentProcessLauncher {
+  launch(plan: AgentLaunchPlan): Promise<number>;
+}
+
+export const launchAgentProcess = async (
+  launcher: AgentProcessLauncher,
+  launchPlan: AgentLaunchPlan,
+  agentId: string,
+): Promise<number> => {
+  try {
+    return await launcher.launch(launchPlan);
+  } catch (error) {
+    if (isCommandNotFoundError(error)) {
+      throw new Error(formatMissingAgentCliMessage(agentId, launchPlan.command), { cause: error });
+    }
+
+    throw error;
+  }
+};
+
+// Pi is bundled with Outfitter, so prefer the bundled binary launched through the current Node
+// runtime. This avoids the `spawn pi ENOENT` first-run crash when pi is not on PATH. Other agents
+// (e.g. claude) are still resolved from PATH and fall back to actionable install guidance. This is
+// a launch-mechanism detail applied by the real spawn launcher; the reported launch plan stays
+// logical (`pi <args>`).
+export const resolveAgentLaunchExecutable = (launchPlan: AgentLaunchPlan): AgentLaunchPlan => {
+  if (launchPlan.command !== 'pi') {
+    return launchPlan;
+  }
+
+  const bundledPiLaunch = resolveBundledPiLaunch();
+
+  /* v8 ignore next 3 -- defensive: pi is a bundled dependency, so resolution succeeds in practice. */
+  if (bundledPiLaunch === undefined) {
+    return launchPlan;
+  }
+
+  return {
+    ...launchPlan,
+    command: bundledPiLaunch.command,
+    args: [...bundledPiLaunch.prefixArgs, ...launchPlan.args],
+  };
+};
+
+const isCommandNotFoundError = (error: unknown): boolean =>
+  error !== null && typeof error === 'object' && 'code' in error && (error as { code?: unknown }).code === 'ENOENT';
+
+const agentCliInstallHints: Readonly<Record<string, string>> = {
+  pi: 'Install Pi with `npm install -g @earendil-works/pi-coding-agent` (see https://pi.dev).',
+  claude: 'Install Claude Code from https://claude.com/claude-code, then rerun with `--agent claude`.',
+};
+
+const formatMissingAgentCliMessage = (agentId: string, command: string): string => {
+  const installHint = agentCliInstallHints[agentId];
+  const baseMessage = `Could not launch the '${agentId}' agent CLI: '${command}' is not installed or not on your PATH.`;
+
+  return installHint === undefined ? baseMessage : `${baseMessage} ${installHint}`;
+};
+
+interface BundledPiLaunch {
+  readonly command: string;
+  readonly prefixArgs: readonly string[];
+}
+
+const piPackageName = '@earendil-works/pi-coding-agent';
+
+const resolveBundledPiLaunch = (): BundledPiLaunch | undefined => {
+  const binPath = resolveBundledPiBinPath();
+
+  /* v8 ignore next 3 -- defensive: pi is a bundled dependency, so its bin resolves in practice. */
+  if (binPath === undefined) {
+    return undefined;
+  }
+
+  return { command: process.execPath, prefixArgs: [binPath] };
+};
+
+// Resolve the pi bin from its bundled package. Any failure (pi missing, malformed manifest, bin
+// file absent) throws and is caught so the caller falls back to a PATH lookup. Pi is ESM-only with
+// a restricted `exports` map, so the package directory is located by resolving its main entry and
+// walking up to the nearest package.json; its `bin.pi` then names the launchable script.
+const resolveBundledPiBinPath = (): string | undefined => {
+  try {
+    const packageRoot = findPiPackageRoot(fileURLToPath(import.meta.resolve(piPackageName)));
+    const manifest = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8')) as {
+      readonly bin: { readonly pi: string };
+    };
+    const binPath = join(packageRoot, manifest.bin.pi);
+
+    /* v8 ignore next 3 -- defensive: a resolved pi bin path exists on disk. */
+    if (!existsSync(binPath)) {
+      throw new Error(`Bundled pi bin '${binPath}' is missing.`);
+    }
+
+    return binPath;
+  } catch {
+    /* v8 ignore next -- defensive: resolution falls back to a PATH lookup when pi cannot be located. */
+    return undefined;
+  }
+};
+
+// The resolved entry lives inside the pi package, so the nearest ancestor package.json is pi's own.
+const findPiPackageRoot = (resolvedEntryPath: string): string => {
+  let directory = dirname(resolvedEntryPath);
+
+  while (!existsSync(join(directory, 'package.json'))) {
+    const parentDirectory = dirname(directory);
+
+    /* v8 ignore next 3 -- defensive: a resolved entry always has an ancestor package.json. */
+    if (parentDirectory === directory) {
+      throw new Error('Could not locate the bundled pi package root.');
+    }
+
+    directory = parentDirectory;
+  }
+
+  return directory;
+};

--- a/code/cli/src/cli.ts
+++ b/code/cli/src/cli.ts
@@ -20,7 +20,12 @@ export const isDirectCliExecution = (moduleUrl: string, argvPath: string | undef
   }
 };
 
-/* v8 ignore next 3 -- direct bin execution is covered by local install smoke tests. */
+/* v8 ignore next 8 -- direct bin execution is covered by local install smoke tests. */
 if (isDirectCliExecution(import.meta.url, process.argv[1])) {
-  await createProgram().parseAsync(process.argv);
+  try {
+    await createProgram().parseAsync(process.argv);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
 }

--- a/code/cli/src/cli/commands/RunCommand.ts
+++ b/code/cli/src/cli/commands/RunCommand.ts
@@ -41,6 +41,8 @@ import type {
   CompositeProfileStateWriteIssue,
 } from '../../compositeProfile/StatePersistence.js';
 import { watchCompositeProfileInputs } from '../../compositeProfile/CompositeProfileWatcher.js';
+import type { AgentProcessLauncher } from '../../agents/AgentLaunch.js';
+import { launchAgentProcess, resolveAgentLaunchExecutable } from '../../agents/AgentLaunch.js';
 import type { CommandObject } from './CommandObject.js';
 import { isNonInteractivePiLaunch, preparePiLoginLaunchPlan } from './PiLoginLaunch.js';
 import type { SetupCommandDependencies } from './SetupCommand.js';
@@ -64,9 +66,8 @@ export interface RunCommandResult {
   readonly exitCode: number;
 }
 
-export interface AgentProcessLauncher {
-  launch(plan: AgentLaunchPlan): Promise<number>;
-}
+export type { AgentProcessLauncher } from '../../agents/AgentLaunch.js';
+export { resolveAgentLaunchExecutable } from '../../agents/AgentLaunch.js';
 
 export interface RunCommandDependencies extends SetupCommandDependencies {
   readonly adapter?: AgentAdapter;
@@ -167,7 +168,7 @@ export const executeRunCommand = async (
     const launcher =
       dependencies.launcher ??
       /* v8 ignore next -- tests inject launchers instead of spawning pi. */ createSpawnLauncher();
-    const exitCode = await launcher.launch(launchPlan);
+    const exitCode = await launchAgentProcess(launcher, launchPlan, adapter.id);
     const stateWriteWarnings = handleCompositeProfileStateWrites(
       adapter.id,
       compositeProfilePlan.compositeProfile.rootDirectory,
@@ -593,9 +594,11 @@ const materializeSource = (homeDirectory: string, source: ProfileSourceReference
 /* v8 ignore start -- the real child-process launcher is direct runtime behavior; tests inject a launcher. */
 const createSpawnLauncher = (): AgentProcessLauncher => ({
   launch(plan) {
+    const resolvedPlan = resolveAgentLaunchExecutable(plan);
+
     return new Promise((resolve, reject) => {
-      const child: ChildProcess = spawn(plan.command, plan.args, {
-        env: { ...process.env, ...plan.env },
+      const child: ChildProcess = spawn(resolvedPlan.command, resolvedPlan.args, {
+        env: { ...process.env, ...resolvedPlan.env },
         stdio: 'inherit',
       });
 

--- a/code/cli/tests/unit/agent-launch.test.ts
+++ b/code/cli/tests/unit/agent-launch.test.ts
@@ -1,0 +1,90 @@
+// Tests agent launch executable resolution and missing-CLI install guidance.
+import { describe, expect, it } from 'vitest';
+
+import type { AgentLaunchPlan } from '../../src/agents/AgentAdapter.js';
+import { launchAgentProcess, resolveAgentLaunchExecutable } from '../../src/agents/AgentLaunch.js';
+
+const createPiPlan = (): AgentLaunchPlan => ({
+  command: 'pi',
+  args: ['--model', 'pi-model', '--debug'],
+  env: { PI_CODING_AGENT_DIR: '/tmp/composite' },
+});
+
+const createEnoentError = (message: string): Error => Object.assign(new Error(message), { code: 'ENOENT' });
+
+describe('agent launch', () => {
+  it('resolves a logical pi launch to the bundled pi binary run through the current node', () => {
+    const piPlan = createPiPlan();
+
+    const resolved = resolveAgentLaunchExecutable(piPlan);
+
+    expect(resolved.command).toBe(process.execPath);
+    expect(resolved.args[0]).toMatch(/[\\/]@earendil-works[\\/]pi-coding-agent[\\/].*cli\.js$/u);
+    expect(resolved.args.slice(1)).toEqual(piPlan.args);
+    expect(resolved.env).toEqual(piPlan.env);
+  });
+
+  it('leaves non-pi launch plans untouched so they resolve from PATH', () => {
+    const claudePlan: AgentLaunchPlan = { command: 'claude', args: ['--foo'], env: {} };
+
+    expect(resolveAgentLaunchExecutable(claudePlan)).toBe(claudePlan);
+  });
+
+  it('returns the launcher exit code on a successful launch', async () => {
+    const exitCode = await launchAgentProcess({ launch: () => Promise.resolve(3) }, createPiPlan(), 'pi');
+
+    expect(exitCode).toBe(3);
+  });
+
+  it('translates a missing pi CLI into actionable install guidance', async () => {
+    const enoentError = createEnoentError('spawn pi ENOENT');
+
+    const thrownError = await launchAgentProcess(
+      { launch: () => Promise.reject(enoentError) },
+      createPiPlan(),
+      'pi',
+    ).catch((error: unknown) => error);
+
+    expect(thrownError).toBeInstanceOf(Error);
+    const message = (thrownError as Error).message;
+    expect(message).toContain("Could not launch the 'pi' agent CLI");
+    expect(message).toContain('is not installed or not on your PATH');
+    expect(message).toContain('npm install -g @earendil-works/pi-coding-agent');
+    expect((thrownError as Error).cause).toBe(enoentError);
+  });
+
+  it('translates a missing claude CLI into actionable install guidance', async () => {
+    const claudePlan: AgentLaunchPlan = { command: 'claude', args: [], env: {} };
+
+    const thrownError = await launchAgentProcess(
+      { launch: () => Promise.reject(createEnoentError('spawn claude ENOENT')) },
+      claudePlan,
+      'claude',
+    ).catch((error: unknown) => error);
+
+    expect((thrownError as Error).message).toContain("Could not launch the 'claude' agent CLI");
+    expect((thrownError as Error).message).toContain('https://claude.com/claude-code');
+  });
+
+  it('falls back to a base message for an agent without a known install hint', async () => {
+    const customPlan: AgentLaunchPlan = { command: 'node-agent', args: [], env: {} };
+
+    const thrownError = await launchAgentProcess(
+      { launch: () => Promise.reject(createEnoentError('spawn node-agent ENOENT')) },
+      customPlan,
+      'node-agent',
+    ).catch((error: unknown) => error);
+
+    expect((thrownError as Error).message).toBe(
+      "Could not launch the 'node-agent' agent CLI: 'node-agent' is not installed or not on your PATH.",
+    );
+  });
+
+  it('rethrows non-ENOENT launch failures unchanged', async () => {
+    const launchFailure = new Error('boom');
+
+    await expect(
+      launchAgentProcess({ launch: () => Promise.reject(launchFailure) }, createPiPlan(), 'pi'),
+    ).rejects.toBe(launchFailure);
+  });
+});


### PR DESCRIPTION
## Problem

A user who installed Outfitter and ran the documented quick start hit an unhandled crash:

```
↳ launching pi …
node:internal/child_process:285
      const err = new ErrnoException(exitCode, syscall);
                  ^
Error: spawn pi ENOENT
  ...
  syscall: 'spawn pi', path: 'pi', ...
```

`outfitter setup` completed fine; the crash was at the launch step.

## Root cause

Outfitter doesn't run pi itself — it shells out to the `pi` binary via `spawn('pi', …)`. Pi *is* a hard dependency (`@earendil-works/pi-coding-agent`), but a global `npm install -g @ai-outfitter/outfitter` only links **Outfitter's own** bin onto `PATH`. Pi's bin lands in Outfitter's nested `node_modules/.bin`, never on the user's `PATH`, so the bare `spawn('pi')` fails with `ENOENT`. That rejection propagated all the way up through `parseAsync` with no handler — hence the raw stack trace.

## Fix

- **Launch the bundled pi binary directly.** The new `src/agents/AgentLaunch.ts` resolves pi's bin from its bundled package (via `import.meta.resolve` + nearest-ancestor `package.json`, since pi is ESM-only with a restricted `exports` map) and launches it through the current Node runtime. So Outfitter works out of the box, no separate `pi` install required.
  - The reported launch plan stays logical (`pi <args>`); resolution is a launch-mechanism detail applied only by the real spawn launcher, so adapter/launch-plan contracts (and the golden-fixture integration tests) are unchanged.
- **Actionable guidance as a fallback.** If an agent CLI genuinely can't be found (e.g. `claude`, which isn't bundled), the `ENOENT` is translated into an install hint instead of a raw stack trace.
- **Clean CLI errors.** `cli.ts` now prints `error.message` and sets a non-zero exit code instead of dumping a stack trace.

## Testing

- New `tests/unit/agent-launch.test.ts` covers bundled-pi resolution, the PATH passthrough for non-pi agents, the success path, ENOENT→install-guidance translation (pi, claude, and the no-hint fallback), and non-ENOENT rethrow. `AgentLaunch.ts` is at 100% coverage.
- Verified end-to-end: with `pi` removed from `PATH`, `outfitter` now launches the bundled pi (`node_modules/@earendil-works/pi-coding-agent/dist/cli.js`) and exits cleanly — no `spawn pi ENOENT`.
- `npm run typecheck` and `npm run lint` pass. Full suite: 230 passing; the single failure (`run-command-system-prompt-export` watcher-refresh) is a pre-existing fs-watch timing flake that fails identically on the unmodified tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)