### PR TITLE
feat(profiles): support typed prompt file includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For the full walkthrough, see [Getting started](./docs/documentation/getting-sta
 [Profiles](./docs/documentation/profiles.md) compose the context, tools, prompts, skills, extensions, subagents, and DeepWork workflows that shape an agent. Profiles can be shared using [Profile Catalog Repos](./docs/documentation/profile-repository.md).
 
 ```yaml
-# ~/.outfitter/profiles/home-default/profile.yml
+# ~/.outfitter/profiles/home-default.yml
 id: home-default
 label: Home Default
 description: Reusable personal defaults for Outfitter-managed Pi runs.
@@ -29,10 +29,12 @@ controls:
   provider: openai-codex
   model: gpt-5.5
   thinking: high
-  append_system_prompt: |
-    Use concise, evidence-backed engineering prose.
-    Prefer small, reviewable changes.
-    Keep durable decisions in repo files.
+  append_system_prompt:
+    - |
+      Use concise, evidence-backed engineering prose.
+      Prefer small, reviewable changes.
+      Keep durable decisions in repo files.
+    - repo_file: docs/architecture.md
 ```
 
 ## Repository map

--- a/code/cli/src/agents/AdapterProfileControls.ts
+++ b/code/cli/src/agents/AdapterProfileControls.ts
@@ -1,5 +1,5 @@
 // Shared helpers for adapter profile controls and argv construction.
-import type { ProfileControls } from '../profiles/Profile.js';
+import type { AppendSystemPromptControl, ProfileControls } from '../profiles/Profile.js';
 import { mergeLaunchResourceSources } from './LaunchResources.js';
 
 export const genericControlNames = new Set([
@@ -55,12 +55,23 @@ export const flagValue = (flag: string, value: string | undefined): readonly str
 export const repeatFlag = (flag: string, values: readonly string[] | undefined): readonly string[] =>
   values === undefined ? [] : values.flatMap((value) => [flag, value]);
 
-export const repeatFlagValue = (flag: string, value: string | readonly string[] | undefined): readonly string[] => {
+export const repeatFlagValue = (flag: string, value: AppendSystemPromptControl | undefined): readonly string[] => {
   if (value === undefined) {
     return [];
   }
 
-  return typeof value === 'string' ? [flag, value] : repeatFlag(flag, value);
+  if (typeof value === 'string') {
+    return [flag, value];
+  }
+
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return repeatFlag(
+    flag,
+    value.filter((entry): entry is string => typeof entry === 'string'),
+  );
 };
 
 export const findUnsupportedControlNames = (

--- a/code/cli/src/agents/AgentAdapter.ts
+++ b/code/cli/src/agents/AgentAdapter.ts
@@ -21,6 +21,7 @@ export interface AgentLaunchProfileLayer {
 export interface AgentLaunchContext {
   readonly profileFolders?: readonly string[];
   readonly profileLayers?: readonly AgentLaunchProfileLayer[];
+  readonly projectDirectory?: string;
 }
 
 export interface AgentCompositeProfilePlan {

--- a/code/cli/src/agents/claude/ClaudeAdapter.ts
+++ b/code/cli/src/agents/claude/ClaudeAdapter.ts
@@ -1,7 +1,7 @@
 // Provides the Claude Code adapter for composite profile generation and native launch plans.
 import { join } from 'node:path';
 
-import type { AgentAdapter, AgentLaunchPlan, AgentCompositeProfilePlan } from '../AgentAdapter.js';
+import type { AgentAdapter, AgentLaunchContext, AgentLaunchPlan, AgentCompositeProfilePlan } from '../AgentAdapter.js';
 import {
   findUnsupportedControlNames,
   flagValue,
@@ -12,6 +12,7 @@ import {
 } from '../AdapterProfileControls.js';
 import { createDeclaredStatePaths, findProfileStateSource } from '../AdapterStatePaths.js';
 import type { ClaudeProfileControls, Profile, ProfileControls } from '../../profiles/Profile.js';
+import { resolveAppendSystemPromptControl } from '../../profiles/PromptIncludes.js';
 import type { StatePathDeclaration, CompositeProfileStatePath } from '../../compositeProfile/StatePersistence.js';
 import type { CompositeProfile } from '../../compositeProfile/CompositeProfile.js';
 import { createCompositeProfile } from '../../compositeProfile/CompositeProfile.js';
@@ -79,21 +80,36 @@ export const createClaudeAdapter = (): AgentAdapter => ({
 
     return {
       compositeProfile,
-      warnings: this.getUnsupportedControls(profile).map(
-        (controlName) => `claude adapter cannot translate requested control '${controlName}'.`,
-      ),
+      warnings: [
+        ...this.getUnsupportedControls(profile).map(
+          (controlName) => `claude adapter cannot translate requested control '${controlName}'.`,
+        ),
+        ...resolveAppendSystemPromptControl({
+          fallback: mergeClaudeControls(profile.controls).appendSystemPrompt,
+          profileLayers: input.profileLayers,
+          agentKey: 'claude',
+          projectDirectory: input.projectDirectory,
+        }).diagnostics.map((diagnostic) => `claude ${diagnostic.message} (${diagnostic.path})`),
+      ],
     };
   },
   createLaunchPlan(
     compositeProfile: CompositeProfile,
     profile?: Profile,
     passThroughArgs: readonly string[] = [],
+    context: AgentLaunchContext = {},
   ): AgentLaunchPlan {
     const controls = mergeClaudeControls(profile?.controls ?? {});
+    const appendPrompt = resolveAppendSystemPromptControl({
+      fallback: controls.appendSystemPrompt,
+      profileLayers: context.profileLayers,
+      agentKey: 'claude',
+      projectDirectory: context.projectDirectory,
+    });
 
     return {
       command: 'claude',
-      args: [...createClaudeArgs(controls), ...passThroughArgs],
+      args: [...createClaudeArgs({ ...controls, appendSystemPrompt: appendPrompt.prompts }), ...passThroughArgs],
       env: {
         ...controls.environment,
         CLAUDE_CONFIG_DIR: compositeProfile.rootDirectory,

--- a/code/cli/src/agents/pi/PiAdapter.ts
+++ b/code/cli/src/agents/pi/PiAdapter.ts
@@ -21,6 +21,7 @@ import {
 import { createDeclaredStatePaths, findProfileStateSource } from '../AdapterStatePaths.js';
 import { filterPiSettingsPackagesDuplicatingExtensions } from './PiSettingsMergePolicy.js';
 import type { PiProfileControls, Profile, ProfileControls } from '../../profiles/Profile.js';
+import { resolveAppendSystemPromptControl } from '../../profiles/PromptIncludes.js';
 import type { CompositeProfile } from '../../compositeProfile/CompositeProfile.js';
 import { createCompositeProfile } from '../../compositeProfile/CompositeProfile.js';
 import { createCompositeProfileFile } from '../../compositeProfile/CompositeProfileFile.js';
@@ -93,6 +94,12 @@ export const createPiAdapter = (): AgentAdapter => ({
           (controlName) => `pi adapter cannot translate requested control '${controlName}'.`,
         ),
         ...createMissingNamedDeepWorkJobWarnings(input.profileLayers ?? []),
+        ...resolveAppendSystemPromptControl({
+          fallback: mergePiControls(profile.controls).appendSystemPrompt,
+          profileLayers: input.profileLayers,
+          agentKey: 'pi',
+          projectDirectory: input.projectDirectory,
+        }).diagnostics.map((diagnostic) => `pi ${diagnostic.message} (${diagnostic.path})`),
       ],
     };
   },
@@ -110,10 +117,19 @@ export const createPiAdapter = (): AgentAdapter => ({
       context.profileLayers ?? [],
     );
     const skillSources = createPiSkillSources(controls, profileFolders);
+    const appendPrompt = resolveAppendSystemPromptControl({
+      fallback: controls.appendSystemPrompt,
+      profileLayers: context.profileLayers,
+      agentKey: 'pi',
+      projectDirectory: context.projectDirectory,
+    });
 
     return {
       command: 'pi',
-      args: [...createPiArgs({ ...controls, skills: skillSources }), ...passThroughArgs],
+      args: [
+        ...createPiArgs({ ...controls, skills: skillSources, appendSystemPrompt: appendPrompt.prompts }),
+        ...passThroughArgs,
+      ],
       env: {
         ...controls.environment,
         ...(deepWorkJobsFolders === undefined ? {} : { DEEPWORK_ADDITIONAL_JOBS_FOLDERS: deepWorkJobsFolders }),

--- a/code/cli/src/cli/commands/RunCommand.ts
+++ b/code/cli/src/cli/commands/RunCommand.ts
@@ -116,6 +116,7 @@ export const executeRunCommand = async (
         {
           profileFolders: resolvedProfile.profileFolders,
           profileLayers: createLaunchProfileLayers(resolvedProfile.profileLayers),
+          projectDirectory: input.projectDirectory,
         },
       ),
       systemPromptExport.outputPath,
@@ -539,7 +540,7 @@ const findContributingProfileFolders = (
     loadedProfile.resourceRootPath === undefined ? [] : [loadedProfile.resourceRootPath],
   );
 
-const createLaunchProfileLayers = (loadedProfiles: readonly LoadedProfile[]) =>
+export const createLaunchProfileLayers = (loadedProfiles: readonly LoadedProfile[]) =>
   loadedProfiles.map((loadedProfile) => ({
     profile: loadedProfile.profile,
     profilePath: loadedProfile.profilePath,
@@ -554,7 +555,7 @@ const findContributingLoadedProfiles = (
 ): readonly LoadedProfile[] =>
   profileStack.flatMap((profile) => loadedProfiles.filter((loadedProfile) => loadedProfile.profile.id === profile.id));
 
-const loadProfileSources = (
+export const loadProfileSources = (
   homeDirectory: string,
   sources: readonly ProfileSourceReference[],
 ): {

--- a/code/cli/src/cli/commands/profile/Command.ts
+++ b/code/cli/src/cli/commands/profile/Command.ts
@@ -4,6 +4,7 @@ import type { Command } from 'commander';
 import type { CommandObject } from '../CommandObject.js';
 import { createProfileCreateCommand } from './CreateCommand.js';
 import { createProfileListCommand } from './ListCommand.js';
+import { createProfileLintCommand } from './LintCommand.js';
 import type { ProfileCommandDependencies } from './Shared.js';
 import { getOrCreateProfileCommander, profileCommandDescription, profileCommandName } from './Shared.js';
 
@@ -11,6 +12,7 @@ export const createProfileCommands = (dependencies: ProfileCommandDependencies =
   createProfileCommand(),
   createProfileListCommand(dependencies),
   createProfileCreateCommand(dependencies),
+  createProfileLintCommand(dependencies),
 ];
 
 export const createProfileCommand = (): CommandObject => {
@@ -27,3 +29,4 @@ export const createProfileCommand = (): CommandObject => {
 
 export { executeCreateProfileCommand } from './CreateCommand.js';
 export { executeListProfilesCommand } from './ListCommand.js';
+export { executeProfileLintCommand } from './LintCommand.js';

--- a/code/cli/src/cli/commands/profile/LintCommand.ts
+++ b/code/cli/src/cli/commands/profile/LintCommand.ts
@@ -1,0 +1,188 @@
+// Implements `outfitter profile lint` diagnostics for profile resolution and prompt includes.
+import { homedir } from 'node:os';
+
+import type { Command } from 'commander';
+
+import { createAgentAdapter } from '../../../agents/AgentRegistry.js';
+import { createCompositeProfileRootDirectory } from '../../../compositeProfile/CompositeProfileAssembler.js';
+import { createPromptIncludeDiagnostics } from '../../../profiles/PromptIncludes.js';
+import { resolveProfile } from '../../../profiles/ProfileMerger.js';
+import { loadSettingsWithCachedRemoteSettings } from '../../../settings/SettingsLoader.js';
+import { createLaunchProfileLayers, loadProfileSources } from '../RunCommand.js';
+import type { AgentLaunchProfileLayer } from '../../../agents/AgentAdapter.js';
+import type { Profile, ProfileControls } from '../../../profiles/Profile.js';
+import type { CommandObject } from '../CommandObject.js';
+import type { ProfileCommandDependencies } from './Shared.js';
+import { getOrCreateProfileCommander } from './Shared.js';
+
+export interface ProfileLintCommandInput {
+  readonly homeDirectory: string;
+  readonly projectDirectory: string;
+  readonly strict?: boolean;
+  readonly json?: boolean;
+}
+
+export interface ProfileLintDiagnostic {
+  readonly severity: 'error' | 'warning';
+  readonly path: string;
+  readonly message: string;
+}
+
+export interface ProfileLintCommandResult {
+  readonly diagnostics: readonly ProfileLintDiagnostic[];
+  readonly exitCode: number;
+}
+
+export const executeProfileLintCommand = (input: ProfileLintCommandInput): ProfileLintCommandResult => {
+  const diagnostics = collectProfileLintDiagnostics(input);
+  const hasErrors = diagnostics.some((diagnostic) => diagnostic.severity === 'error');
+  const hasWarnings = diagnostics.some((diagnostic) => diagnostic.severity === 'warning');
+  const exitCode = hasErrors || (input.strict === true && hasWarnings) ? 1 : 0;
+
+  return { diagnostics, exitCode };
+};
+
+export const createProfileLintCommand = (dependencies: ProfileCommandDependencies = {}): CommandObject => ({
+  name: 'profile lint',
+  description: 'Validate profiles, inheritance, and typed prompt includes.',
+  register(program: Command): void {
+    getOrCreateProfileCommander(program)
+      .command('lint')
+      .description('Validate profiles, inheritance, and typed prompt includes.')
+      .option('--strict', 'Exit non-zero when warnings are present')
+      .option('--json', 'Print diagnostics as JSON')
+      .action((options: { strict?: boolean; json?: boolean }) => {
+        const result = executeProfileLintCommand({
+          homeDirectory:
+            /* v8 ignore next -- CLI defaults are exercised manually; tests inject stable temp roots. */
+            dependencies.homeDirectory ?? homedir(),
+          projectDirectory:
+            /* v8 ignore next -- CLI defaults are exercised manually; tests inject stable temp roots. */
+            dependencies.projectDirectory ?? process.cwd(),
+          strict: options.strict,
+          json: options.json,
+        });
+        writeLintResult(
+          result,
+          options.json === true,
+          /* v8 ignore next -- CLI default writer is console.log; tests inject a collector. */
+          dependencies.writeLine ?? console.log,
+        );
+        process.exitCode = result.exitCode;
+      });
+  },
+});
+
+const collectProfileLintDiagnostics = (input: ProfileLintCommandInput): readonly ProfileLintDiagnostic[] => {
+  const settings = loadSettingsWithCachedRemoteSettings(input);
+  const settingsDiagnostics = settings.issues.map((issue): ProfileLintDiagnostic => ({
+    severity: 'error',
+    path: `${issue.filePath}#${issue.path}`,
+    message: issue.message,
+  }));
+
+  if (settingsDiagnostics.length > 0) {
+    return settingsDiagnostics;
+  }
+
+  const loadedProfiles = loadProfileSources(input.homeDirectory, settings.settings.profileSources!);
+  const loadDiagnostics = loadedProfiles.issues.map((issue): ProfileLintDiagnostic => ({
+    severity: 'error',
+    path: issue.path,
+    message: issue.message,
+  }));
+  const inheritanceDiagnostics = lintProfileInheritance(loadedProfiles.profiles);
+  const promptDiagnostics = createPromptIncludeDiagnostics(loadedProfiles.profiles, input.projectDirectory).map(
+    (diagnostic) => ({
+      severity: diagnostic.severity,
+      path: diagnostic.path,
+      message: diagnostic.message,
+    }),
+  );
+  const adapterDiagnostics = lintAdapterWarnings(loadedProfiles.profiles, input.projectDirectory);
+
+  return [...loadDiagnostics, ...inheritanceDiagnostics, ...promptDiagnostics, ...adapterDiagnostics];
+};
+
+const lintProfileInheritance = (
+  profiles: Parameters<typeof createPromptIncludeDiagnostics>[0],
+): readonly ProfileLintDiagnostic[] =>
+  [...new Set(profiles.map((profile) => profile.profile.id))].flatMap((profileId) =>
+    resolveProfile({ profiles, profileId }).issues.map((issue) => ({
+      severity: 'error' as const,
+      path: issue.path,
+      message: issue.message,
+    })),
+  );
+
+const lintAdapterWarnings = (
+  profiles: Parameters<typeof createPromptIncludeDiagnostics>[0],
+  projectDirectory: string,
+): readonly ProfileLintDiagnostic[] => {
+  const pi = createAgentAdapter('pi');
+
+  return [...new Set(profiles.map((profile) => profile.profile.id))].flatMap((profileId) => {
+    const resolution = resolveProfile({ profiles, profileId });
+
+    if (resolution.profile === undefined || resolution.issues.length > 0) {
+      return [];
+    }
+
+    const stackProfiles = profiles.filter((profile) =>
+      resolution.profileStack.some((stackProfile) => stackProfile.id === profile.profile.id),
+    );
+
+    return pi
+      .createCompositeProfile(omitPromptIncludes(resolution.profile), {
+        rootDirectory: createCompositeProfileRootDirectory(resolution.profile.id, pi.id),
+        profilePaths: profiles.map((profile) => profile.profilePath),
+        profileFolders: profiles.flatMap((profile) =>
+          profile.resourceRootPath === undefined ? [] : [profile.resourceRootPath],
+        ),
+        profileLayers: createLaunchProfileLayers(stackProfiles).map(omitPromptIncludesFromLayer),
+        projectDirectory,
+      })
+      .warnings.map((message) => ({ severity: 'warning' as const, path: `/profiles/${profileId}`, message }));
+  });
+};
+
+const omitPromptIncludesFromLayer = (layer: AgentLaunchProfileLayer): AgentLaunchProfileLayer => ({
+  ...layer,
+  profile: omitPromptIncludes(layer.profile),
+});
+
+const omitPromptIncludes = (profile: Profile): Profile => ({
+  ...profile,
+  controls: omitPromptIncludesFromControls(profile.controls),
+});
+
+const omitPromptIncludesFromControls = <Controls extends ProfileControls>(controls: Controls): Controls => {
+  const { appendSystemPrompt, pi, claude, ...rest } = controls;
+  void appendSystemPrompt;
+
+  return {
+    ...rest,
+    ...(pi === undefined ? {} : { pi: omitPromptIncludesFromControls(pi) }),
+    ...(claude === undefined ? {} : { claude: omitPromptIncludesFromControls(claude) }),
+  } as Controls;
+};
+
+const writeLintResult = (
+  result: ProfileLintCommandResult,
+  json: boolean,
+  writeLine: (message: string) => void,
+): void => {
+  if (json) {
+    writeLine(JSON.stringify(result.diagnostics, null, 2));
+    return;
+  }
+
+  if (result.diagnostics.length === 0) {
+    writeLine('No profile lint diagnostics.');
+    return;
+  }
+
+  for (const diagnostic of result.diagnostics) {
+    writeLine(`${diagnostic.severity}: ${diagnostic.path} ${diagnostic.message}`);
+  }
+};

--- a/code/cli/src/profiles/Profile.ts
+++ b/code/cli/src/profiles/Profile.ts
@@ -2,7 +2,14 @@
 import type { StatePersistenceStrategy } from '../compositeProfile/StatePersistence.js';
 
 export type StatePersistenceOverrides = Readonly<Record<string, StatePersistenceStrategy>>;
-export type AppendSystemPromptControl = string | readonly string[];
+export interface PromptFileInclude {
+  readonly file: string;
+}
+export interface PromptRepoFileInclude {
+  readonly repo_file: string;
+}
+export type AppendSystemPromptEntry = string | PromptFileInclude | PromptRepoFileInclude;
+export type AppendSystemPromptControl = AppendSystemPromptEntry | readonly AppendSystemPromptEntry[];
 
 export interface DeepWorkProfileControls {
   readonly jobs?: readonly string[];

--- a/code/cli/src/profiles/ProfileLoader.ts
+++ b/code/cli/src/profiles/ProfileLoader.ts
@@ -5,8 +5,11 @@ import { join } from 'node:path';
 import type { ValidationIssue } from '../validation/SchemaValidator.js';
 import { validateSchema } from '../validation/SchemaValidator.js';
 import { parseYamlDocument } from '../validation/YamlDocument.js';
+import { isPromptFileInclude, isPromptRepoFileInclude } from './PromptIncludes.js';
 import type {
   AgentSpecificProfileControls,
+  AppendSystemPromptControl,
+  AppendSystemPromptEntry,
   DeepWorkProfileControls,
   Profile,
   ProfileControls,
@@ -293,12 +296,19 @@ const readOptionalStringArray = (value: unknown): readonly string[] | undefined 
   return undefined;
 };
 
-const readOptionalStringOrStringArray = (value: unknown): string | readonly string[] | undefined => {
-  if (typeof value === 'string') {
+const readOptionalAppendSystemPrompt = (value: unknown): AppendSystemPromptControl | undefined => {
+  if (typeof value === 'string' || isPromptFileInclude(value) || isPromptRepoFileInclude(value)) {
     return value;
   }
 
-  return readOptionalStringArray(value);
+  if (Array.isArray(value)) {
+    return value.filter(
+      (item): item is AppendSystemPromptEntry =>
+        typeof item === 'string' || isPromptFileInclude(item) || isPromptRepoFileInclude(item),
+    );
+  }
+
+  return undefined;
 };
 
 const readControls = (value: unknown): ProfileControls => {
@@ -320,7 +330,7 @@ const readControls = (value: unknown): ProfileControls => {
     skills: readOptionalStringArray(controls.skills),
     promptTemplate: readOptionalString(controls.prompt_template),
     systemPrompt: readOptionalString(controls.system_prompt),
-    appendSystemPrompt: readOptionalStringOrStringArray(controls.append_system_prompt),
+    appendSystemPrompt: readOptionalAppendSystemPrompt(controls.append_system_prompt),
     deepwork: readDeepWorkControls(controls.deepwork),
     pi: readAgentSpecificControls(controls.pi),
     claude: readAgentSpecificControls(controls.claude),
@@ -359,7 +369,7 @@ const readAgentSpecificControls = (value: unknown): AgentSpecificProfileControls
     skills: readOptionalStringArray(controls.skills),
     promptTemplate: readOptionalString(controls.prompt_template),
     systemPrompt: readOptionalString(controls.system_prompt),
-    appendSystemPrompt: readOptionalStringOrStringArray(controls.append_system_prompt),
+    appendSystemPrompt: readOptionalAppendSystemPrompt(controls.append_system_prompt),
   });
 };
 

--- a/code/cli/src/profiles/PromptIncludes.ts
+++ b/code/cli/src/profiles/PromptIncludes.ts
@@ -1,0 +1,236 @@
+// Resolves typed append-system-prompt file includes against declaring profile source roots.
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, dirname, isAbsolute, join, normalize, resolve } from 'node:path';
+
+import type { AgentLaunchProfileLayer } from '../agents/AgentAdapter.js';
+import type { AppendSystemPromptControl, AppendSystemPromptEntry } from './Profile.js';
+import type { LoadedProfile } from './ProfileLoader.js';
+
+export interface PromptIncludeDiagnostic {
+  readonly severity: 'error' | 'warning';
+  readonly profileId: string;
+  readonly path: string;
+  readonly message: string;
+}
+
+export interface ResolvedAppendPromptResult {
+  readonly prompts: readonly string[];
+  readonly diagnostics: readonly PromptIncludeDiagnostic[];
+}
+
+export const isPromptFileInclude = (value: unknown): value is { readonly file: string } =>
+  value !== null &&
+  typeof value === 'object' &&
+  !Array.isArray(value) &&
+  Object.keys(value).length === 1 &&
+  typeof (value as { readonly file?: unknown }).file === 'string';
+
+export const isPromptRepoFileInclude = (value: unknown): value is { readonly repo_file: string } =>
+  value !== null &&
+  typeof value === 'object' &&
+  !Array.isArray(value) &&
+  Object.keys(value).length === 1 &&
+  typeof (value as { readonly repo_file?: unknown }).repo_file === 'string';
+
+export const normalizeAppendSystemPromptEntries = (
+  value: AppendSystemPromptControl | undefined,
+): readonly AppendSystemPromptEntry[] | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return typeof value === 'string' || isPromptFileInclude(value) || isPromptRepoFileInclude(value) ? [value] : value;
+};
+
+export const inferProfileIncludeSourceRoot = (input: {
+  readonly sourceRootPath?: string;
+  readonly profilePath: string;
+}): string | undefined => {
+  const conventionalRoot = findConventionalOutfitterRoot(input.profilePath);
+
+  return conventionalRoot ?? input.sourceRootPath;
+};
+
+export const resolveAppendSystemPromptControl = (input: {
+  readonly fallback: AppendSystemPromptControl | undefined;
+  readonly profileLayers?: readonly AgentLaunchProfileLayer[];
+  readonly agentKey?: 'pi' | 'claude';
+  readonly projectDirectory?: string;
+}): ResolvedAppendPromptResult => {
+  const layeredEntries = collectLayeredPromptEntries(input.profileLayers ?? [], input.agentKey);
+
+  if (layeredEntries.length === 0) {
+    return resolvePromptEntries({
+      entries: normalizeAppendSystemPromptEntries(input.fallback) ?? [],
+      projectDirectory: input.projectDirectory,
+    });
+  }
+
+  const diagnostics: PromptIncludeDiagnostic[] = [];
+  const prompts: string[] = [];
+
+  for (const entry of layeredEntries) {
+    const resolved = resolvePromptEntries({
+      entries: [entry.value],
+      layer: entry.layer,
+      projectDirectory: input.projectDirectory,
+    });
+    diagnostics.push(...resolved.diagnostics);
+    prompts.push(...resolved.prompts);
+  }
+
+  return { prompts, diagnostics };
+};
+
+export const createPromptIncludeDiagnostics = (
+  profileLayers: readonly LoadedProfile[],
+  projectDirectory?: string,
+): readonly PromptIncludeDiagnostic[] =>
+  profileLayers.flatMap((layer) => {
+    const launchLayer = toLaunchLayer(layer);
+    return [
+      ...resolvePromptEntries({
+        entries: readPromptEntries(layer.profile.controls.appendSystemPrompt),
+        layer: launchLayer,
+        projectDirectory,
+      }).diagnostics,
+      ...resolvePromptEntries({
+        entries: readPromptEntries(layer.profile.controls.pi?.appendSystemPrompt),
+        layer: launchLayer,
+        projectDirectory,
+      }).diagnostics,
+      ...resolvePromptEntries({
+        entries: readPromptEntries(layer.profile.controls.claude?.appendSystemPrompt),
+        layer: launchLayer,
+        projectDirectory,
+      }).diagnostics,
+    ];
+  });
+
+const collectLayeredPromptEntries = (
+  profileLayers: readonly AgentLaunchProfileLayer[],
+  agentKey: 'pi' | 'claude' | undefined,
+): readonly { readonly layer: AgentLaunchProfileLayer; readonly value: AppendSystemPromptEntry }[] =>
+  [...profileLayers]
+    .reverse()
+    .flatMap((layer) => readPromptEntries(selectLayerAppendPrompt(layer, agentKey)).map((value) => ({ layer, value })));
+
+const selectLayerAppendPrompt = (
+  layer: AgentLaunchProfileLayer,
+  agentKey: 'pi' | 'claude' | undefined,
+): AppendSystemPromptControl | undefined => {
+  const agentPrompt = agentKey === undefined ? undefined : layer.profile.controls[agentKey]?.appendSystemPrompt;
+
+  return agentPrompt ?? layer.profile.controls.appendSystemPrompt;
+};
+
+const resolvePromptEntries = (input: {
+  readonly entries: readonly AppendSystemPromptEntry[];
+  readonly layer?: AgentLaunchProfileLayer;
+  readonly projectDirectory?: string;
+}): ResolvedAppendPromptResult => {
+  const diagnostics: PromptIncludeDiagnostic[] = [];
+  const prompts: string[] = [];
+
+  for (const [index, entry] of input.entries.entries()) {
+    if (isPromptFileInclude(entry) || isPromptRepoFileInclude(entry)) {
+      const declaredFile = isPromptFileInclude(entry) ? entry.file : entry.repo_file;
+      const resolvedFile = isPromptFileInclude(entry)
+        ? resolvePromptIncludePath(input.layer, declaredFile)
+        : resolveRepoPromptIncludePath(input.projectDirectory, declaredFile);
+      const includeType = isPromptFileInclude(entry) ? 'file' : 'repo_file';
+
+      if (resolvedFile === undefined || !existsSync(resolvedFile)) {
+        diagnostics.push(
+          createDiagnostic(input.layer, index, `Prompt ${includeType} include '${declaredFile}' was not found.`),
+        );
+      } else {
+        prompts.push(readFileSync(resolvedFile, 'utf8'));
+      }
+    } else {
+      if (looksLikePromptFilePath(entry)) {
+        diagnostics.push(
+          createDiagnostic(
+            input.layer,
+            index,
+            `Raw append_system_prompt entry looks like a file path; use { file: '${entry}' }.`,
+          ),
+        );
+      }
+      prompts.push(entry);
+    }
+  }
+
+  return { prompts, diagnostics };
+};
+
+const readPromptEntries = (value: AppendSystemPromptControl | undefined): readonly AppendSystemPromptEntry[] =>
+  normalizeAppendSystemPromptEntries(value) ?? [];
+
+const resolvePromptIncludePath = (layer: AgentLaunchProfileLayer | undefined, filePath: string): string | undefined => {
+  if (isAbsolute(filePath)) {
+    return normalize(filePath);
+  }
+
+  const sourceRoot = layer?.sourceRootPath === undefined ? undefined : inferProfileIncludeSourceRoot(layer);
+
+  return sourceRoot === undefined ? undefined : resolve(sourceRoot, filePath);
+};
+
+const resolveRepoPromptIncludePath = (projectDirectory: string | undefined, filePath: string): string | undefined => {
+  if (isAbsolute(filePath)) {
+    return normalize(filePath);
+  }
+
+  return projectDirectory === undefined ? undefined : resolve(projectDirectory, filePath);
+};
+
+const createDiagnostic = (
+  layer: AgentLaunchProfileLayer | undefined,
+  index: number,
+  message: string,
+): PromptIncludeDiagnostic => ({
+  severity: 'warning',
+  profileId: layer?.profile.id ?? '<merged>',
+  path: `${layer?.profilePath ?? '<profile>'}#/controls/append_system_prompt/${index}`,
+  message,
+});
+
+export const looksLikePromptFilePath = (value: string): boolean => {
+  const trimmed = value.trim();
+
+  if (trimmed.includes('\n') || trimmed.includes(' ')) {
+    return false;
+  }
+
+  return /^(\.?\.?\/|~\/).+/u.test(trimmed) || /.+\/.+\.(md|markdown|txt|prompt)$/iu.test(trimmed);
+};
+
+const findConventionalOutfitterRoot = (profilePath: string): string | undefined => {
+  let current = dirname(profilePath);
+
+  while (current !== dirname(current)) {
+    const name = basename(current);
+
+    if (name === '.outfitter') {
+      return normalize(current) === normalize(join(homedir(), '.outfitter')) ? current : dirname(current);
+    }
+
+    if (name === 'outfitter') {
+      return dirname(current);
+    }
+
+    current = dirname(current);
+  }
+
+  return undefined;
+};
+
+const toLaunchLayer = (loadedProfile: LoadedProfile): AgentLaunchProfileLayer => ({
+  profile: loadedProfile.profile,
+  profilePath: loadedProfile.profilePath,
+  sourceRootPath: loadedProfile.sourceRootPath,
+  resourceRootPath: loadedProfile.resourceRootPath,
+  layout: loadedProfile.layout,
+});

--- a/code/cli/src/prompts/SystemPromptExport.ts
+++ b/code/cli/src/prompts/SystemPromptExport.ts
@@ -4,6 +4,7 @@ import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 
 import { mergeAgentSpecificControls } from '../agents/AdapterProfileControls.js';
 import type { Profile, ProfileControls } from '../profiles/Profile.js';
+import { normalizeAppendSystemPromptEntries } from '../profiles/PromptIncludes.js';
 import type { LoadedProfile } from '../profiles/ProfileLoader.js';
 import type { Settings } from '../settings/Settings.js';
 
@@ -77,7 +78,9 @@ const normalizeAppendSystemPrompt = (value: ProfileControls['appendSystemPrompt'
     return [];
   }
 
-  return typeof value === 'string' ? [value] : value;
+  return (normalizeAppendSystemPromptEntries(value) ?? []).filter(
+    (entry): entry is string => typeof entry === 'string',
+  );
 };
 
 const findSelectedProfileOwner = (

--- a/code/cli/src/schemas/profile.schema.json
+++ b/code/cli/src/schemas/profile.schema.json
@@ -129,12 +129,33 @@
   },
   "additionalProperties": true,
   "$defs": {
-    "appendSystemPrompt": {
+    "appendSystemPromptEntry": {
       "oneOf": [
         { "type": "string" },
         {
+          "type": "object",
+          "required": ["file"],
+          "properties": {
+            "file": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": ["repo_file"],
+          "properties": {
+            "repo_file": { "type": "string" }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "appendSystemPrompt": {
+      "oneOf": [
+        { "$ref": "#/$defs/appendSystemPromptEntry" },
+        {
           "type": "array",
-          "items": { "type": "string" }
+          "items": { "$ref": "#/$defs/appendSystemPromptEntry" }
         }
       ]
     }

--- a/code/cli/tests/unit/profile-command.test.ts
+++ b/code/cli/tests/unit/profile-command.test.ts
@@ -10,6 +10,7 @@ import {
   createProfileCommands,
   executeCreateProfileCommand,
   executeListProfilesCommand,
+  executeProfileLintCommand,
 } from '../../src/cli/commands/profile/Command.js';
 import { createSetupCommand } from '../../src/cli/commands/SetupCommand.js';
 import { createSyncCommand } from '../../src/cli/commands/SyncCommand.js';
@@ -253,6 +254,200 @@ describe('profile command', () => {
     });
     await allProgram.parseAsync(['node', 'outfitter', 'profile', 'list', '--all']);
     expect(allMessages).toContain('shared-prose (template)');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.1, OFTR-003.4, OFTR-003.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('lints profile schema, inheritance, and prompt include diagnostics with strict warnings', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const profilesRoot = join(homeDirectory, '.outfitter', 'profiles');
+    writeSettings(homeDirectory, 'profile_sources:\n  - path: ./profiles\n');
+    writeProfile(
+      profilesRoot,
+      'engineer',
+      'id: engineer\ninherits:\n  - missing\ncontrols:\n  append_system_prompt:\n    - file: prompts/missing.md\n    - ./prompts/raw.md\n',
+    );
+
+    const result = executeProfileLintCommand({ homeDirectory, projectDirectory, strict: true });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.diagnostics.map((diagnostic) => diagnostic.message)).toEqual(
+      expect.arrayContaining([
+        "Profile 'missing' was not found.",
+        "Prompt file include 'prompts/missing.md' was not found.",
+        "Raw append_system_prompt entry looks like a file path; use { file: './prompts/raw.md' }.",
+      ]),
+    );
+    expect(
+      result.diagnostics.filter((diagnostic) =>
+        diagnostic.message.includes("Prompt file include 'prompts/missing.md' was not found."),
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('lints prompt includes once when adapter-specific controls are present', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const profilesRoot = join(homeDirectory, '.outfitter', 'profiles');
+    writeSettings(homeDirectory, 'profile_sources:\n  - path: ./profiles\n');
+    writeProfile(
+      profilesRoot,
+      'engineer',
+      [
+        'id: engineer',
+        'controls:',
+        '  append_system_prompt:',
+        '    file: prompts/missing.md',
+        '  pi:',
+        '    append_system_prompt:',
+        '      file: prompts/pi-missing.md',
+        '  claude:',
+        '    append_system_prompt:',
+        '      file: prompts/claude-missing.md',
+        '',
+      ].join('\n'),
+    );
+
+    const result = executeProfileLintCommand({ homeDirectory, projectDirectory });
+
+    expect(result.diagnostics.map((diagnostic) => diagnostic.message)).toEqual([
+      "Prompt file include 'prompts/missing.md' was not found.",
+      "Prompt file include 'prompts/pi-missing.md' was not found.",
+      "Prompt file include 'prompts/claude-missing.md' was not found.",
+    ]);
+  });
+
+  it('exits non-zero for warning-only profile lint diagnostics in strict mode', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const profilesRoot = join(homeDirectory, '.outfitter', 'profiles');
+    writeSettings(homeDirectory, 'profile_sources:\n  - path: ./profiles\n');
+    writeProfile(
+      profilesRoot,
+      'engineer',
+      'id: engineer\ncontrols:\n  append_system_prompt:\n    - ./prompts/raw.md\n',
+    );
+
+    const result = executeProfileLintCommand({ homeDirectory, projectDirectory, strict: true });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.diagnostics).toEqual(
+      expect.arrayContaining([
+        {
+          severity: 'warning',
+          path: join(profilesRoot, 'engineer', 'profile.yml') + '#/controls/append_system_prompt/0',
+          message: "Raw append_system_prompt entry looks like a file path; use { file: './prompts/raw.md' }.",
+        },
+      ]),
+    );
+  });
+
+  it('prints profile lint diagnostics in human and JSON formats', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const profilesRoot = join(homeDirectory, '.outfitter', 'profiles');
+    const messages: string[] = [];
+    writeSettings(homeDirectory, 'profile_sources:\n  - path: ./profiles\n');
+    writeProfile(profilesRoot, 'engineer', 'id: engineer\ncontrols:\n  unsupported_control: true\n');
+
+    const program = new Command();
+    registerProfileCommands(program, {
+      homeDirectory,
+      projectDirectory,
+      writeLine: (message) => messages.push(message),
+    });
+    await program.parseAsync(['node', 'outfitter', 'profile', 'lint', '--json']);
+
+    expect(JSON.parse(messages[0] ?? '[]')).toEqual([
+      {
+        severity: 'warning',
+        path: '/profiles/engineer',
+        message: "pi adapter cannot translate requested control 'unsupported_control'.",
+      },
+    ]);
+
+    const humanMessages: string[] = [];
+    const humanProgram = new Command();
+    registerProfileCommands(humanProgram, {
+      homeDirectory,
+      projectDirectory,
+      writeLine: (message) => humanMessages.push(message),
+    });
+    await humanProgram.parseAsync(['node', 'outfitter', 'profile', 'lint']);
+    expect(humanMessages).toEqual([
+      "warning: /profiles/engineer pi adapter cannot translate requested control 'unsupported_control'.",
+    ]);
+
+    const consoleMessages: string[] = [];
+    const originalCwd = process.cwd();
+    const originalConsoleLog = console.log;
+    const defaultProjectDirectory = join(root, 'default-project');
+    mkdirSync(defaultProjectDirectory, { recursive: true });
+    console.log = (message?: unknown) => consoleMessages.push(String(message));
+    try {
+      process.chdir(defaultProjectDirectory);
+      const defaultWriterProgram = new Command();
+      registerProfileCommands(defaultWriterProgram, { homeDirectory });
+      await defaultWriterProgram.parseAsync(['node', 'outfitter', 'profile', 'lint']);
+    } finally {
+      process.chdir(originalCwd);
+      console.log = originalConsoleLog;
+    }
+    expect(consoleMessages).toEqual([
+      "warning: /profiles/engineer pi adapter cannot translate requested control 'unsupported_control'.",
+    ]);
+
+    const cleanMessages: string[] = [];
+    const cleanHomeDirectory = join(root, 'clean-home');
+    const cleanProfilesRoot = join(cleanHomeDirectory, '.outfitter', 'profiles');
+    writeSettings(cleanHomeDirectory, 'profile_sources:\n  - path: ./profiles\n');
+    writeProfile(cleanProfilesRoot, 'engineer');
+    const cleanProgram = new Command();
+    registerProfileCommands(cleanProgram, {
+      homeDirectory: cleanHomeDirectory,
+      projectDirectory,
+      writeLine: (message) => cleanMessages.push(message),
+    });
+    await cleanProgram.parseAsync(['node', 'outfitter', 'profile', 'lint']);
+
+    expect(cleanMessages).toEqual(['No profile lint diagnostics.']);
+  });
+
+  it('lints flat profiles without profile resource roots', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const profilesRoot = join(homeDirectory, '.outfitter', 'profiles');
+    mkdirSync(profilesRoot, { recursive: true });
+    writeSettings(homeDirectory, 'profile_sources:\n  - path: ./profiles\n');
+    writeFileSync(join(profilesRoot, 'engineer.yml'), 'id: engineer\ncontrols:\n  unsupported_control: true\n');
+
+    const result = executeProfileLintCommand({ homeDirectory, projectDirectory });
+
+    expect(result.diagnostics).toEqual([
+      {
+        severity: 'warning',
+        path: '/profiles/engineer',
+        message: "pi adapter cannot translate requested control 'unsupported_control'.",
+      },
+    ]);
+  });
+
+  it('reports settings errors from profile lint', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    writeSettings(homeDirectory, 'profile_sources:\n  - only: [bad]\n');
+
+    const result = executeProfileLintCommand({ homeDirectory, projectDirectory });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.diagnostics[0]?.severity).toBe('error');
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.5).

--- a/code/cli/tests/unit/prompt-includes.test.ts
+++ b/code/cli/tests/unit/prompt-includes.test.ts
@@ -1,0 +1,174 @@
+// Tests typed append-system-prompt file include resolution.
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { inferProfileIncludeSourceRoot, resolveAppendSystemPromptControl } from '../../src/profiles/PromptIncludes.js';
+import { loadLocalProfileSource, parseProfileYaml } from '../../src/profiles/ProfileLoader.js';
+
+const temporaryRoots: string[] = [];
+
+const createRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-prompt-includes-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('prompt includes', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.1, OFTR-003.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('parses literal and file append_system_prompt entries while rejecting unsupported typed entries', () => {
+    const profile = parseProfileYaml(
+      'id: engineer\ncontrols:\n  append_system_prompt:\n    - literal prompt\n    - file: prompts/team.md\n    - repo_file: docs/mission.md\n',
+      'engineer',
+    );
+    const unsupported = parseProfileYaml(
+      'id: engineer\ncontrols:\n  append_system_prompt:\n    - text: unsupported\n',
+      'engineer',
+    );
+
+    expect('message' in profile).toBe(false);
+    expect('message' in unsupported ? unsupported.message : '').toContain('must be string');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.6, OFTR-006.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('resolves file includes from each declaring outfitter source root in precedence order', () => {
+    const projectRoot = createRoot();
+    const outfitterRoot = join(projectRoot, '.outfitter');
+    const profilesRoot = join(outfitterRoot, 'profiles');
+    mkdirSync(join(profilesRoot, 'base'), { recursive: true });
+    mkdirSync(join(profilesRoot, 'engineer'), { recursive: true });
+    mkdirSync(join(outfitterRoot, 'prompts'), { recursive: true });
+    writeFileSync(join(outfitterRoot, 'prompts', 'base.md'), 'base include');
+    writeFileSync(join(outfitterRoot, 'prompts', 'engineer.md'), 'engineer include');
+    writeFileSync(
+      join(profilesRoot, 'base', 'profile.yml'),
+      'id: base\ncontrols:\n  append_system_prompt:\n    - file: .outfitter/prompts/base.md\n',
+    );
+    writeFileSync(
+      join(profilesRoot, 'engineer', 'profile.yml'),
+      'id: engineer\ninherits:\n  - base\ncontrols:\n  append_system_prompt:\n    - file: .outfitter/prompts/engineer.md\n',
+    );
+    const loaded = loadLocalProfileSource({ path: profilesRoot });
+
+    const result = resolveAppendSystemPromptControl({
+      fallback: undefined,
+      profileLayers: loaded.profiles.map((layer) => ({
+        profile: layer.profile,
+        profilePath: layer.profilePath,
+        sourceRootPath: layer.sourceRootPath,
+        resourceRootPath: layer.resourceRootPath,
+        layout: layer.layout,
+      })),
+      agentKey: 'pi',
+    });
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.prompts).toEqual(['engineer include', 'base include']);
+  });
+
+  it('infers include roots for home, project, catalog, and explicit profile sources', () => {
+    const root = createRoot();
+
+    expect(
+      inferProfileIncludeSourceRoot({
+        profilePath: join(homedir(), '.outfitter', 'profiles', 'engineer.yml'),
+        sourceRootPath: join(homedir(), '.outfitter', 'profiles'),
+      }),
+    ).toBe(join(homedir(), '.outfitter'));
+    expect(
+      inferProfileIncludeSourceRoot({
+        profilePath: join(root, '.outfitter', 'profiles', 'engineer.yml'),
+        sourceRootPath: join(root, '.outfitter', 'profiles'),
+      }),
+    ).toBe(root);
+    expect(
+      inferProfileIncludeSourceRoot({
+        profilePath: join(root, 'outfitter', 'profiles', 'engineer.yml'),
+        sourceRootPath: join(root, 'outfitter', 'profiles'),
+      }),
+    ).toBe(root);
+    expect(
+      inferProfileIncludeSourceRoot({
+        profilePath: join(root, 'profiles', 'engineer.yml'),
+        sourceRootPath: join(root, 'profiles'),
+      }),
+    ).toBe(join(root, 'profiles'));
+  });
+
+  it('resolves repo_file entries from the active project directory', () => {
+    const root = createRoot();
+    mkdirSync(join(root, 'docs'), { recursive: true });
+    writeFileSync(join(root, 'docs', 'mission.md'), 'project mission');
+
+    const result = resolveAppendSystemPromptControl({
+      fallback: [{ repo_file: 'docs/mission.md' }],
+      projectDirectory: root,
+    });
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.prompts).toEqual(['project mission']);
+  });
+
+  it('resolves absolute file and repo_file entries', () => {
+    const root = createRoot();
+    const catalogFile = join(root, 'catalog.md');
+    const repoFile = join(root, 'repo.md');
+    writeFileSync(catalogFile, 'catalog absolute');
+    writeFileSync(repoFile, 'repo absolute');
+
+    const result = resolveAppendSystemPromptControl({
+      fallback: [{ file: catalogFile }, { repo_file: repoFile }],
+    });
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.prompts).toEqual(['catalog absolute', 'repo absolute']);
+  });
+
+  it('warns for missing typed files and raw path-looking strings without warning for multiline prose', () => {
+    const root = createRoot();
+    const result = resolveAppendSystemPromptControl({
+      fallback: [
+        { file: 'prompts/missing.md' },
+        { repo_file: 'docs/missing.md' },
+        './prompts/raw.md',
+        'Line one\nLine two',
+      ],
+      projectDirectory: root,
+      profileLayers: [
+        {
+          profile: { id: 'engineer', inherits: [], controls: {} },
+          profilePath: join(root, '.outfitter', 'profiles', 'engineer', 'profile.yml'),
+          sourceRootPath: join(root, '.outfitter', 'profiles'),
+        },
+      ],
+    });
+
+    expect(result.prompts).toEqual(['./prompts/raw.md', 'Line one\nLine two']);
+    expect(result.diagnostics.map((diagnostic) => diagnostic.message)).toEqual([
+      "Prompt file include 'prompts/missing.md' was not found.",
+      "Prompt repo_file include 'docs/missing.md' was not found.",
+      "Raw append_system_prompt entry looks like a file path; use { file: './prompts/raw.md' }.",
+    ]);
+  });
+
+  it('warns when repo_file cannot resolve without a project directory', () => {
+    const result = resolveAppendSystemPromptControl({
+      fallback: [{ repo_file: 'docs/mission.md' }],
+    });
+
+    expect(result.prompts).toEqual([]);
+    expect(result.diagnostics.map((diagnostic) => diagnostic.message)).toEqual([
+      "Prompt repo_file include 'docs/mission.md' was not found.",
+    ]);
+  });
+});

--- a/code/cli/tests/unit/source-layout.test.ts
+++ b/code/cli/tests/unit/source-layout.test.ts
@@ -62,9 +62,10 @@ describe('source layout scaffolding', () => {
       'profile',
       'profile list',
       'profile create',
+      'profile lint',
     ]);
     expect(program.commands.map((command) => command.name())).toEqual(['run', 'setup', 'sync', 'welcome', 'profile']);
-    expect(program.commands.at(4)?.commands.map((command) => command.name())).toEqual(['list', 'create']);
+    expect(program.commands.at(4)?.commands.map((command) => command.name())).toEqual(['list', 'create', 'lint']);
     expect(describeCommandObject(createRunCommand())).toEqual({
       name: 'run',
       description: 'Assemble a profile compositeProfile and launch the selected agent CLI.',
@@ -84,7 +85,11 @@ describe('source layout scaffolding', () => {
       'welcome',
       'profile',
     ]);
-    expect(standaloneProgram.commands.at(3)?.commands.map((command) => command.name())).toEqual(['list', 'create']);
+    expect(standaloneProgram.commands.at(3)?.commands.map((command) => command.name())).toEqual([
+      'list',
+      'create',
+      'lint',
+    ]);
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.5).

--- a/docs/archtecture/README.md
+++ b/docs/archtecture/README.md
@@ -386,7 +386,8 @@ inherits:
 controls:
   model: anthropic/claude-sonnet-4
   system_prompt: ./prompts/system.md
-  append_system_prompt: ./prompts/company-policy.md
+  append_system_prompt:
+    - file: ./prompts/company-policy.md
   skills:
     - ./skills/debugging
   extensions:
@@ -411,7 +412,7 @@ Rules:
 - `cli_specific/<cli-name>/` contains files copied or translated directly into the generated composite profile for that CLI, plus resources that intentionally apply only to one adapter.
 - Pi profiles may provide `cli_specific/pi/.mcp.json`; Outfitter merges contributing profile fragments into the composite profile with unique array entries by identity and last writer wins for duplicate identities.
 - Pi-specific skills and DeepWork jobs may also live under `cli_specific/pi/skills/` and `cli_specific/pi/deepwork/jobs/` when they should not be exposed to other adapters.
-- `append_system_prompt` accepts a string or an ordered string array. When multiple resolved profile layers provide it, Outfitter composes the values into repeated agent append-prompt inputs in profile precedence order so shared prompt profiles do not need to use raw CLI `args`.
+- `append_system_prompt` accepts literal strings, multiline strings, `{ file: string }` profile-source includes, `{ repo_file: string }` active-project includes, or an ordered list mixing those entry types. `{ text: ... }` is intentionally unsupported. `file` includes resolve from the declaring profile layer's source root (`~/.outfitter` for home profiles, the repository root for project/catalog `.outfitter/` and catalog `outfitter/` sources, or the explicit source path otherwise). `repo_file` includes resolve from the active project directory so reusable profiles can request project docs such as `docs/mission.md`. When multiple resolved profile layers provide append prompts, Outfitter composes the values into repeated agent append-prompt inputs in profile precedence order so shared prompt profiles do not need to use raw CLI `args`.
 - Top-level `profile_export: true` on settings enables generated Pi prompt export by default for selected local profiles. Top-level `profile_export: true|false` on a profile overrides the settings default for that resolved profile.
 - Generated Pi prompt exports are seeded before launch and overwritten by Outfitter's Pi runtime extension from `ctx.getSystemPrompt()`, the same Pi primitive used by `pi-inspect`. Directory profiles write `generated-system-prompt.md`; flat profiles write `<profile-id>.generated-system-prompt.md` beside the flat YAML file so teams can commit or git-ignore the fully built runtime prompt artifact.
 - CLI-specific configuration wins over generic controls when both apply to the same generated artifact.
@@ -456,7 +457,8 @@ label: Shared Prose
 template: true
 
 controls:
-  append_system_prompt: ./prompts/prose.md
+  append_system_prompt:
+    - file: ./prompts/prose.md
 ```
 
 ```yaml
@@ -468,7 +470,8 @@ inherits:
   - shared-prose
 
 controls:
-  append_system_prompt: ./prompts/system.md
+  append_system_prompt:
+    - file: ./prompts/system.md
   skills:
     - ./skills/debugging
   pi:
@@ -507,7 +510,8 @@ inherits:
 
 controls:
   system_prompt: ./prompts/system.md
-  append_system_prompt: ./prompts/review.md
+  append_system_prompt:
+    - file: ./prompts/review.md
   extensions:
     - ./extensions/project-bootstrap
   session_directory: ./.outfitter/sessions/project-engineering

--- a/docs/archtecture/file_structure.md
+++ b/docs/archtecture/file_structure.md
@@ -37,8 +37,10 @@ Outfitter is organized around a private npm workspace root, clear TypeScript pac
 │   │   ├── src/                       # production TypeScript source
 │   │   │   ├── cli.ts                 # executable CLI entry point
 │   │   │   ├── cli/                   # CLI parser construction and command objects
+│   │   │   │   └── commands/profile/LintCommand.ts # `outfitter profile lint` implementation
 │   │   │   ├── settings/              # settings loading and merging
 │   │   │   ├── profiles/              # profile loading, validation, resolution, and merging
+│   │   │   │   └── PromptIncludes.ts  # typed append_system_prompt include resolution and diagnostics
 │   │   │   ├── merge/                 # deterministic value and array merge policy helpers
 │   │   │   ├── compositeProfile/      # generated runtime composite profile assembly and watching
 │   │   │   ├── agents/                # agent adapter boundary and CLI-specific adapters

--- a/docs/documentation/profiles.md
+++ b/docs/documentation/profiles.md
@@ -28,7 +28,7 @@ profile_sources:
   - path: ./profiles
 
 ---
-# ~/.outfitter/profiles/home-default/profile.yml
+# ~/.outfitter/profiles/home-default.yml
 id: home-default
 label: Home Default
 description: Reusable personal defaults for Outfitter-managed Pi runs.
@@ -36,10 +36,13 @@ controls:
   provider: openai-codex
   model: gpt-5.5
   thinking: high
-  append_system_prompt: |
-    Use concise, evidence-backed engineering prose.
-    Prefer small, reviewable changes.
-    Keep durable decisions in repo files.
+  append_system_prompt:
+    - |
+      Use concise, evidence-backed engineering prose.
+      Prefer small, reviewable changes.
+      Keep durable decisions in repo files.
+    - file: prompts/personal-policy.md
+    - repo_file: docs/mission.md
 
 ---
 # ~/repos/acme/example/.outfitter/settings.yml
@@ -61,10 +64,12 @@ inherits:
   - home-default
 controls:
   thinking: xhigh
-  append_system_prompt: |
-    You are working in ~/repos/acme/example.
-    Honor the project test contract before calling work complete.
-    Prefer repository-local conventions over personal defaults.
+  append_system_prompt:
+    - |
+      You are working in ~/repos/acme/example.
+      Honor the project test contract before calling work complete.
+      Prefer repository-local conventions over personal defaults.
+    - file: .outfitter/prompts/review-policy.md
   environment:
     ACME_PROJECT: example
 ```
@@ -73,6 +78,25 @@ controls:
 `acme-example` is the project profile: it inherits those defaults, then overrides the thinking level and adds project-specific prompt and environment settings.
 When a project `settings.yml` declares `profile_sources`, it SHOULD include any home profile source that project profiles inherit from.
 Because `append_system_prompt` composes instead of replacing, the higher-precedence project prompt is passed first and the inherited home prompt follows.
+Typed prompt includes read `{ file: string }` entries before launch and pass the file contents as repeated append-prompt text. Raw strings remain literal prompt text; if a raw string looks like a whole file path, Outfitter warns so the profile can be migrated to `{ file: ... }`.
+
+### Append prompt file includes
+
+`append_system_prompt` accepts a literal string, a multiline string, `{ file: string }`, `{ repo_file: string }`, or an ordered list mixing those entry types. Outfitter does not support `{ text: ... }`; use raw YAML strings for inline prompt text, `{ file: ... }` for maintained profile/catalog files, and `{ repo_file: ... }` for files that should come from the active project.
+
+Profile-owned file includes resolve from the source root of the profile layer that declares the entry, including inherited layers:
+
+| Declaring profile location                                                         | Include root               |
+| ---------------------------------------------------------------------------------- | -------------------------- |
+| `~/.outfitter/profiles/<id>/profile.yml` or `~/.outfitter/profiles/<id>.yml`       | `~/.outfitter`             |
+| `<project>/.outfitter/profiles/<id>/profile.yml`                                   | `<project>`                |
+| Catalog repo `outfitter/profiles/<id>/profile.yml`                                 | Catalog repository root    |
+| Explicit `profile_sources[].path` without `.outfitter/` or `outfitter/` convention | The configured source path |
+
+`repo_file:` resolves from the active project directory where Outfitter launches the agent. This lets a reusable catalog or home profile request project-local governance context such as `docs/mission.md` without copying those docs into the catalog.
+
+Run `outfitter profile lint` to report schema and inheritance errors, missing typed include files, and raw string append-prompt entries that look like file paths. Add `--strict` to exit non-zero for warnings, and `--json` for machine-readable diagnostics.
+
 With `profile_export: true`, the selected project directory profile can write `generated-system-prompt.md` beside `profile.yml`.
 For this example, the generated prompt fallback would show the composed prompt inputs like this:
 


### PR DESCRIPTION
## Summary
- add typed `append_system_prompt` entries for profile-owned `file:` includes and active-project `repo_file:` includes
- resolve typed includes before adapter launch, warning and continuing for missing files
- warn on raw string entries that look like file paths and add `outfitter profile lint --strict --json`
- document source-root behavior for home, `.outfitter`, and `outfitter` catalog layouts

## Why
Reusable profile catalogs need deterministic prompt-file resolution. `file:` reads catalog/profile-owned files from the declaring profile source root. `repo_file:` lets a shared base profile request active project docs such as `docs/mission.md` without copying those docs into the catalog.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test` — 43 files / 231 tests passed
- `npm run build`
- Link catalog validation with this branch: `node ../feat-prompt-file-includes/dist/cli.js profile lint --strict --json` => `[]`
- Default profiles validation with this branch: `node ../feat-prompt-file-includes/dist/cli.js profile lint --strict --json` => `[]`
