### PR TITLE
chore(license): define enterprise license boundary

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 Portions of this software are licensed as follows:
 
-* All content that resides under the `code/enterprise/` directory of this repository, if that directory exists, is licensed under the license defined in `code/enterprise/LICENSE`.
-* Content outside of the above mentioned directory or restrictions above is available under the MIT license as defined below.
+- All content that resides under the `code/enterprise/` directory of this repository, if that directory exists, is licensed under the license defined in `code/enterprise/LICENSE`.
+- Content outside of the above mentioned directory or restrictions above is available under the MIT license as defined below.
 
 ---
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,58 +1,28 @@
-# Business Source License 1.1
+Portions of this software are licensed as follows:
 
-## Parameters
-
-**Licensor:** Unsupervised.com, Inc.
-
-**Licensed Work:** Outfitter
-
-The Licensed Work is © 2026 Unsupervised.com, Inc.
-
-**Additional Use Grant:** You may use the Licensed Work without a commercial license only when it is used with or for:
-
-- repositories that are publicly available under an open source license approved by the Open Source Initiative; or
-- repositories with fewer than 10 contributors.
-
-Use of the Licensed Work with or for a private repository with 10 or more contributors requires a commercial license from the Licensor.
-
-**Change Date:** 2030-01-14
-
-**Change License:** Apache License, Version 2.0
+* All content that resides under the `code/enterprise/` directory of this repository, if that directory exists, is licensed under the license defined in `code/enterprise/LICENSE`.
+* Content outside of the above mentioned directory or restrictions above is available under the MIT license as defined below.
 
 ---
 
-## License Terms
+MIT License
 
-The Licensor hereby grants you the right to copy, modify, create derivative works, redistribute, and make non-production use of the Licensed Work.
-The Licensor may make an Additional Use Grant, above, permitting limited production use.
+Copyright (c) 2026 Unsupervised
 
-Effective on the Change Date, or the fourth anniversary of the first publicly available distribution of a specific version of the Licensed Work under this License, whichever comes first, the Licensor hereby grants you rights under the terms of the Change License, and the rights granted in the paragraph above terminate.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-If your use of the Licensed Work does not comply with the requirements currently in effect as described in this License, you must purchase a commercial license from the Licensor, its affiliated entities, or authorized resellers, or you must refrain from using the Licensed Work.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-All copies of the original and modified Licensed Work, and derivative works of the Licensed Work, are subject to this License.
-This License applies separately for each version of the Licensed Work and the Change Date may vary for each version of the Licensed Work released by Licensor.
-
-You must conspicuously display this License on each original or modified copy of the Licensed Work.
-If you receive the Licensed Work in original or modified form from a third party, the terms and conditions set forth in this License apply to your use of that work.
-
-Any use of the Licensed Work in violation of this License will automatically terminate your rights under this License for the current and all other versions of the Licensed Work.
-
-This License does not grant you any right in any trademark or logo of Licensor or its affiliates (provided that you may use a trademark or logo of Licensor as expressly required by this License).
-
-TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN "AS IS" BASIS.
-LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
-
----
-
-## Prohibited Uses
-
-You may not use the Licensed Work with or for a private repository with 10 or more contributors unless you have purchased a commercial license from the Licensor, its affiliated entities, or authorized resellers.
-
-For purposes of this License, a repository's contributor count is the number of people who have made commits or other accepted contributions to that repository, or who otherwise have permission to contribute code to that repository, whichever is greater.
-
-**Clarification**: This prohibition does not prevent you from using the Licensed Work without a commercial license with or for:
-
-- repositories that are publicly available under an open source license approved by the Open Source Initiative, regardless of contributor count;
-- private repositories with fewer than 10 contributors;
-- educational or research contexts that satisfy one of the preceding repository-use allowances.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/code/enterprise/LICENSE
+++ b/code/enterprise/LICENSE
@@ -1,0 +1,58 @@
+# Business Source License 1.1
+
+## Parameters
+
+**Licensor:** Unsupervised.com, Inc.
+
+**Licensed Work:** Outfitter Enterprise code under `code/enterprise/**`
+
+The Licensed Work is © 2026 Unsupervised.com, Inc.
+
+**Additional Use Grant:** You may use the Licensed Work without a commercial license only when it is used with or for:
+
+- repositories that are publicly available under an open source license approved by the Open Source Initiative; or
+- repositories with fewer than 10 contributors.
+
+Use of the Licensed Work with or for a private repository with 10 or more contributors requires a commercial license from the Licensor.
+
+**Change Date:** 2030-01-14
+
+**Change License:** Apache License, Version 2.0
+
+---
+
+## License Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative works, redistribute, and make non-production use of the Licensed Work.
+The Licensor may make an Additional Use Grant, above, permitting limited production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly available distribution of a specific version of the Licensed Work under this License, whichever comes first, the Licensor hereby grants you rights under the terms of the Change License, and the rights granted in the paragraph above terminate.
+
+If your use of the Licensed Work does not comply with the requirements currently in effect as described in this License, you must purchase a commercial license from the Licensor, its affiliated entities, or authorized resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works of the Licensed Work, are subject to this License.
+This License applies separately for each version of the Licensed Work and the Change Date may vary for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy of the Licensed Work.
+If you receive the Licensed Work in original or modified form from a third party, the terms and conditions set forth in this License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically terminate your rights under this License for the current and all other versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of Licensor or its affiliates (provided that you may use a trademark or logo of Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN "AS IS" BASIS.
+LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+
+---
+
+## Prohibited Uses
+
+You may not use the Licensed Work with or for a private repository with 10 or more contributors unless you have purchased a commercial license from the Licensor, its affiliated entities, or authorized resellers.
+
+For purposes of this License, a repository's contributor count is the number of people who have made commits or other accepted contributions to that repository, or who otherwise have permission to contribute code to that repository, whichever is greater.
+
+**Clarification**: This prohibition does not prevent you from using the Licensed Work without a commercial license with or for:
+
+- repositories that are publicly available under an open source license approved by the Open Source Initiative, regardless of contributor count;
+- private repositories with fewer than 10 contributors;
+- educational or research contexts that satisfy one of the preceding repository-use allowances.

--- a/code/enterprise/LICENSE
+++ b/code/enterprise/LICENSE
@@ -1,58 +1,35 @@
-# Business Source License 1.1
+The Unsupervised Enterprise license (the "Enterprise License")
+Copyright (c) 2026 - present Unsupervised.com, Inc.
 
-## Parameters
+With regard to the Unsupervised Software:
 
-**Licensor:** Unsupervised.com, Inc.
+This software and associated documentation files (the "Software") may only be
+used in production, if you (and any entity that you represent) have agreed to,
+and are in compliance with, the Unsupervised Subscription Terms of Service,
+available via email (info@unsupervised.com) (the "Enterprise Terms"), or other
+agreement governing the use of the Software, as agreed by you and Unsupervised,
+and otherwise have a valid Unsupervised Enterprise license for the correct
+number of user seats. Subject to the foregoing sentence, you are free to modify
+this Software and publish patches to the Software. You agree that Unsupervised
+and/or its licensors (as applicable) retain all right, title and interest in and
+to all such modifications and/or patches, and all such modifications and/or
+patches may only be used, copied, modified, displayed, distributed, or otherwise
+exploited with a valid Unsupervised Enterprise license for the correct number of
+user seats. Notwithstanding the foregoing, you may copy and modify the Software
+for development and testing purposes, without requiring a subscription. You agree
+that Unsupervised and/or its licensors (as applicable) retain all right, title
+and interest in and to all such modifications. You are not granted any other
+rights beyond what is expressly stated herein. Subject to the foregoing, it is
+forbidden to copy, merge, publish, distribute, sublicense, and/or sell the
+Software.
 
-**Licensed Work:** Outfitter Enterprise code under `code/enterprise/**`
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-The Licensed Work is © 2026 Unsupervised.com, Inc.
-
-**Additional Use Grant:** You may use the Licensed Work without a commercial license only when it is used with or for:
-
-- repositories that are publicly available under an open source license approved by the Open Source Initiative; or
-- repositories with fewer than 10 contributors.
-
-Use of the Licensed Work with or for a private repository with 10 or more contributors requires a commercial license from the Licensor.
-
-**Change Date:** 2030-01-14
-
-**Change License:** Apache License, Version 2.0
-
----
-
-## License Terms
-
-The Licensor hereby grants you the right to copy, modify, create derivative works, redistribute, and make non-production use of the Licensed Work.
-The Licensor may make an Additional Use Grant, above, permitting limited production use.
-
-Effective on the Change Date, or the fourth anniversary of the first publicly available distribution of a specific version of the Licensed Work under this License, whichever comes first, the Licensor hereby grants you rights under the terms of the Change License, and the rights granted in the paragraph above terminate.
-
-If your use of the Licensed Work does not comply with the requirements currently in effect as described in this License, you must purchase a commercial license from the Licensor, its affiliated entities, or authorized resellers, or you must refrain from using the Licensed Work.
-
-All copies of the original and modified Licensed Work, and derivative works of the Licensed Work, are subject to this License.
-This License applies separately for each version of the Licensed Work and the Change Date may vary for each version of the Licensed Work released by Licensor.
-
-You must conspicuously display this License on each original or modified copy of the Licensed Work.
-If you receive the Licensed Work in original or modified form from a third party, the terms and conditions set forth in this License apply to your use of that work.
-
-Any use of the Licensed Work in violation of this License will automatically terminate your rights under this License for the current and all other versions of the Licensed Work.
-
-This License does not grant you any right in any trademark or logo of Licensor or its affiliates (provided that you may use a trademark or logo of Licensor as expressly required by this License).
-
-TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN "AS IS" BASIS.
-LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
-
----
-
-## Prohibited Uses
-
-You may not use the Licensed Work with or for a private repository with 10 or more contributors unless you have purchased a commercial license from the Licensor, its affiliated entities, or authorized resellers.
-
-For purposes of this License, a repository's contributor count is the number of people who have made commits or other accepted contributions to that repository, or who otherwise have permission to contribute code to that repository, whichever is greater.
-
-**Clarification**: This prohibition does not prevent you from using the Licensed Work without a commercial license with or for:
-
-- repositories that are publicly available under an open source license approved by the Open Source Initiative, regardless of contributor count;
-- private repositories with fewer than 10 contributors;
-- educational or research contexts that satisfy one of the preceding repository-use allowances.
+For all third party components incorporated into the Unsupervised Software,
+those components are licensed under the original license provided by the owner of
+the applicable component.

--- a/code/enterprise/README.md
+++ b/code/enterprise/README.md
@@ -1,0 +1,5 @@
+# Outfitter Enterprise Code
+
+Files in this directory and its descendants are licensed under the Outfitter Enterprise/Business Source License in [`LICENSE`](./LICENSE).
+
+Everything outside `code/enterprise/**` is licensed under the root [`LICENSE.md`](../../LICENSE.md) terms.

--- a/docs/archtecture/file_structure.md
+++ b/docs/archtecture/file_structure.md
@@ -38,6 +38,8 @@ Outfitter is organized around clear TypeScript source boundaries, requirement do
 ├── .prettierrc.json                   # Prettier formatting configuration
 ├── .snapperrc.toml                    # Snapper Markdown formatting configuration
 ├── CONTRIBUTING.md                    # local install and contributor workflow guide
+├── code/                              # code with license boundaries that differ from root terms
+│   └── enterprise/                    # enterprise/business licensed code; see code/enterprise/LICENSE
 ├── bin/                               # local executable development helpers
 │   ├── dev-container-setup            # clean container helper for setup smoke tests
 │   ├── dev-setup-source               # local build helper for real setup-source targets

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@ai-outfitter/outfitter",
       "version": "0.6.1",
-      "license": "BUSL-1.1",
+      "license": "SEE LICENSE IN LICENSE.md",
       "repository": {
         "type": "git",
         "url": "https://github.com/ai-outfitter/outfitter.git"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "requirements",
     "src/schemas",
     "doc",
+    "code/enterprise/LICENSE",
+    "code/enterprise/README.md",
     "README.md",
     "LICENSE.md"
   ],
@@ -81,7 +83,7 @@
       "./skills"
     ]
   },
-  "license": "BUSL-1.1",
+  "license": "SEE LICENSE IN LICENSE.md",
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
## Summary
- Add a Panopticon-style split-license notice at the repository root
- Move restrictive Business Source License terms to `code/enterprise/LICENSE`
- Include enterprise license/README in npm package contents and set package metadata to `SEE LICENSE IN LICENSE.md`
- Document the `code/enterprise` boundary in the repository file-structure doc

## Validation
- [x] `npm run lint`
- [x] `npm test` — 42 files / 232 tests passed
- [x] `npm pack --dry-run` — includes `LICENSE.md`, `code/enterprise/LICENSE`, and `code/enterprise/README.md`
- [ ] `npm run typecheck` — blocked by existing unrelated error: `tests/unit/pi-login-launch.test.ts(287,19): 'reason' does not exist in type 'MockEvent'`

## Notes
- No onboarding behavior changes.
- Release creation remains delegated to release-please.