### PR TITLE
chore(enterprise): define private catalog boundary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ review-results/
 # DeepWork local runtime state
 .deepwork/state/
 .deepwork/status/
+
+# Agent-local planning artifacts
+TASK.md
+PLAN.md

--- a/code/enterprise/privateCatalog.ts
+++ b/code/enterprise/privateCatalog.ts
@@ -1,0 +1,19 @@
+export type EnterpriseCatalogVisibility = 'private';
+
+export type EnterprisePrivateCatalogCredentialPolicy = 'ambient-git-only';
+
+export type EnterprisePrivateCatalogRuntimeSupport = 'boundary-only-no-runtime-behavior';
+
+export interface EnterprisePrivateCatalogBoundary {
+  readonly visibility: EnterpriseCatalogVisibility;
+  readonly credentialPolicy: EnterprisePrivateCatalogCredentialPolicy;
+  readonly runtimeSupport: EnterprisePrivateCatalogRuntimeSupport;
+  readonly strictPrivateRepositoryBlocking: false;
+}
+
+export const enterprisePrivateCatalogBoundary: EnterprisePrivateCatalogBoundary = {
+  visibility: 'private',
+  credentialPolicy: 'ambient-git-only',
+  runtimeSupport: 'boundary-only-no-runtime-behavior',
+  strictPrivateRepositoryBlocking: false,
+};

--- a/docs/archtecture/enterprise-private-catalog-boundary.md
+++ b/docs/archtecture/enterprise-private-catalog-boundary.md
@@ -1,0 +1,37 @@
+# Enterprise Private Catalog Boundary
+
+This document defines the enterprise/private profile catalog boundary for future Outfitter work. It is intentionally non-behavior-changing for the current CLI.
+
+## Current public behavior remains the default
+
+- First-run onboarding and setup continue to use the public default catalog, `github: ai-outfitter/default-profiles` with `path: profiles`.
+- `outfitter setup` without an explicit setup source continues to write public default catalog settings.
+- `outfitter sync` continues to use the existing profile-source URI/git synchronization path.
+- Local, public GitHub shorthand, and public URI profile sources remain supported exactly as they are today.
+
+## Enterprise-only scope
+
+Private profile catalog repository support is an enterprise capability boundary. Any future private-catalog enablement code must live under `code/enterprise/**` unless a later architecture decision deliberately promotes a shared primitive into `src/**`.
+
+The boundary may include enterprise-only types, adapters, policy descriptions, and tests that do not alter public runtime behavior. Public CLI commands in `src/**` must not import enterprise private-catalog modules unless a future feature explicitly changes the product boundary and updates the relevant docs, requirements, and tests.
+
+## Credential policy
+
+Outfitter does not collect, echo, persist, synthesize, or validate credentials for private profile catalogs. Future private repository access may rely on the user's existing local Git configuration, such as SSH agents, credential helpers, netrc, or CI-provided Git configuration, because current repository access delegates to `git`.
+
+This PR does not add strict runtime blocking or detection of ambient Git credentials. If strict private repository blocking is desired later, it should be designed as a separate feature with explicit requirements, user-facing behavior, and tests.
+
+## Non-goals for this boundary
+
+- No new private repository authentication flow.
+- No credential prompts, storage, generated tokens, or mocked real credentials.
+- No change to default public catalog selection.
+- No strict blocking of private repository URIs or ambient Git credentials.
+- No change to profile resolution, settings merge precedence, or composite profile assembly.
+
+## Implementation guardrails
+
+- Keep private-catalog enablement behind enterprise-only files under `code/enterprise/**`.
+- Keep public/default catalog tests passing unchanged.
+- Keep all URI/error reporting credential-redacted where existing sync/setup code returns messages.
+- Treat any future runtime behavior change as a separate requirements-backed feature, not as part of this boundary document.

--- a/docs/archtecture/file_structure.md
+++ b/docs/archtecture/file_structure.md
@@ -20,6 +20,7 @@ Outfitter is organized around clear TypeScript source boundaries, requirement do
 │   ├── archtecture/                   # architecture and internal design docs
 │   │   ├── README.md                  # architectural rationale and runtime file conventions
 │   │   ├── controllable-elements.md   # controllable element terminology and support matrix
+│   │   ├── enterprise-private-catalog-boundary.md # enterprise/private catalog boundary
 │   │   ├── file_structure.md          # repository file structure overview
 │   │   ├── integration_test_system.md # fixture-backed integration test design
 │   │   ├── onboarding.md              # Pi-native first-run onboarding and setup flow
@@ -43,6 +44,8 @@ Outfitter is organized around clear TypeScript source boundaries, requirement do
 │   ├── dev-setup-source               # local build helper for real setup-source targets
 │   ├── dev-tmp-home                   # isolated temporary HOME launch helper
 │   └── outfitter-docker-entrypoint     # release container entrypoint that adapts to bind-mount ownership
+├── code/                              # non-runtime implementation boundaries outside the public CLI build
+│   └── enterprise/                    # enterprise-only skeletons and types, including private catalog boundary types
 ├── src/                               # production TypeScript source
 │   ├── cli.ts                         # executable CLI entry point
 │   ├── cli/                           # CLI parser construction and command registration

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
     "skipLibCheck": true,
     "types": ["node", "vitest"]
   },
-  "include": ["src/**/*.ts", "tests/**/*.ts", "vitest.config.ts", "eslint.config.js"],
+  "include": ["src/**/*.ts", "code/**/*.ts", "tests/**/*.ts", "vitest.config.ts", "eslint.config.js"],
   "exclude": ["dist", "coverage", "node_modules"]
 }


### PR DESCRIPTION
## Summary
- document the enterprise/private profile catalog repository license boundary
- add an enterprise-only boundary/types skeleton under `code/enterprise/**`
- keep current public/default catalog sync and setup behavior unchanged

## Validation
- `npx vitest --run tests/unit/sync-command.test.ts tests/unit/setup-sources.test.ts`
- `npm run lint`
- `npx prettier --check code/enterprise/privateCatalog.ts docs/archtecture/enterprise-private-catalog-boundary.md docs/archtecture/file_structure.md tsconfig.json`
- `npm run build`

## Caveats
- `npm run typecheck` currently fails on an existing unrelated test type issue in `tests/unit/pi-login-launch.test.ts` (`reason` on `MockEvent`).
- This PR intentionally does not add strict private-repo blocking or credential collection.
- The local M1 staging branch was not present on origin, so this PR targets `main` directly.