### PR TITLE
docs(usecases): outline local inference profile overrides

### DIFF
--- a/docs/documentation/README.md
+++ b/docs/documentation/README.md
@@ -14,4 +14,5 @@ User-facing Outfitter documentation.
 
 - [Organization profile catalog](./usecases/orginization-profile-catalog.md) — Publish shared team roles so new users can start with organization-approved defaults.
 - [Engineering profile catalog](./usecases/engineering.md) — Package coding, platform, and review profiles for repeatable engineering workflows.
+- [Local inference profile overrides](./usecases/local-inference-overrides.md) — Switch between local and cloud Pi inference defaults with profile controls.
 - [Persona reviews](./usecases/persona-reviews.md) — Create customer personas to get feedback on ideas, documentation, and designs.

--- a/docs/documentation/usecases/local-inference-overrides.md
+++ b/docs/documentation/usecases/local-inference-overrides.md
@@ -1,0 +1,95 @@
+# Local Inference Profile Overrides
+
+Use local-inference overrides when the same Outfitter setup needs a fast private default for routine work and a cloud profile for higher-capability tasks. The profile switch should change only the Pi launch controls that matter: provider, model, thinking level, and the Pi extensions or skills that represent tool differences.
+
+The provider and model IDs below are examples. Exact provider and model names MUST match the providers and models installed, registered, and accepted by the user's Pi environment.
+
+## Home settings
+
+Point Outfitter at the user's profile directory and choose the local profile as the default for everyday runs.
+
+```yaml
+# ~/.outfitter/settings.yml
+default_agent: pi
+default_profile: local
+profile_sources:
+  - path: ./profiles
+```
+
+## Local profile
+
+The local profile keeps inference on the user's machine through Pi's `ollama` provider and `qwen` model. Current Outfitter profiles do not have a first-class `tools:` control; express tool differences through Pi extensions, Pi skills, native Pi settings or resources, and pass-through `args` only when Pi exposes a native flag that Outfitter does not model yet.
+
+```yaml
+# ~/.outfitter/profiles/local.yml
+id: local
+label: Local Inference
+description: Private local Pi defaults for routine coding and drafting.
+controls:
+  provider: ollama
+  model: qwen
+  extensions:
+    - ~/.outfitter/extensions/local-filesystem
+  skills:
+    - ~/.outfitter/skills/local-codebase
+```
+
+Run it with:
+
+```bash
+outfitter run --profile local
+```
+
+For this profile, current Outfitter code passes the merged controls to Pi as equivalent launch flags:
+
+```text
+--provider ollama
+--model qwen
+--extension ~/.outfitter/extensions/local-filesystem
+--skill ~/.outfitter/skills/local-codebase
+```
+
+## Cloud profile
+
+The cloud profile switches to the `chatgpt` provider, model `5.5`, and `xhigh` thinking for deeper work. It can also use a different set of Pi extensions and skills when cloud runs should expose different review, retrieval, or workflow affordances.
+
+```yaml
+# ~/.outfitter/profiles/cloud.yml
+id: cloud
+label: Cloud Inference
+description: Higher-capability Pi defaults for complex planning, reviews, and implementation.
+controls:
+  provider: chatgpt
+  model: '5.5'
+  thinking: xhigh
+  extensions:
+    - ~/.outfitter/extensions/team-review
+    - ~/.outfitter/extensions/project-docs
+  skills:
+    - ~/.outfitter/skills/deep-review
+    - ~/.outfitter/skills/release-planning
+```
+
+Run it with:
+
+```bash
+outfitter run --profile cloud
+```
+
+For this profile, current Outfitter code passes the merged controls to Pi as equivalent launch flags:
+
+```text
+--provider chatgpt
+--model 5.5
+--thinking xhigh
+--extension ~/.outfitter/extensions/team-review
+--extension ~/.outfitter/extensions/project-docs
+--skill ~/.outfitter/skills/deep-review
+--skill ~/.outfitter/skills/release-planning
+```
+
+## Operational pattern
+
+Use `local` for low-latency private work, quick repository navigation, and tasks that do not require a cloud model. Use `cloud` when the task benefits from stronger reasoning, broader context synthesis, or organization-provided skills and extensions.
+
+Keep the profiles small and explicit. If Pi adds a native flag that Outfitter has not modeled, place it in `controls.args`; otherwise prefer modeled controls such as `provider`, `model`, `thinking`, `extensions`, and `skills` so profile behavior remains readable and portable.

--- a/docs/documentation/usecases/local-inference-overrides.md
+++ b/docs/documentation/usecases/local-inference-overrides.md
@@ -1,12 +1,18 @@
 # Local Inference Profile Overrides
 
-Use local-inference overrides when the same Outfitter setup needs a fast private default for routine work and a cloud profile for higher-capability tasks. The profile switch should change only the Pi launch controls that matter: provider, model, thinking level, and the Pi extensions or skills that represent tool differences.
+Use local-inference overrides when the same Outfitter setup needs a cloud model for general research and proof-of-concept work, then a local model for implementation inside a repository that should not grant external model access. The profile switch changes only the Pi launch controls that matter: provider, model, thinking level, and the Pi extensions or skills that represent tool differences.
 
-The provider and model IDs below are examples. Exact provider and model names MUST match the providers and models installed, registered, and accepted by the user's Pi environment.
+The provider and model IDs below are examples. Exact provider and model names MUST match the providers and models installed, registered, and accepted by the user's Pi environment. Profiles make the launch boundary explicit; they do not replace a repository's security policy, network controls, credential handling, or review requirements.
+
+## Story
+
+A developer is evaluating an implementation path for a private repository. They start with a cloud profile because the early work is generic: compare libraries, sketch architecture, draft a migration plan, and build throwaway proof-of-concept snippets that do not include proprietary source. The cloud model is useful here because it has stronger general reasoning and the user is not exposing restricted repository contents.
+
+When the work moves from research to implementation, the developer switches to the local profile before opening the restricted repository. Pi still has useful coding tools, but inference now runs through local Ollama/Qwen defaults. The repository can be read, searched, edited, and tested without routing source context to an external model provider.
 
 ## Home settings
 
-Point Outfitter at the user's profile directory and choose the local profile as the default for everyday runs.
+Point Outfitter at the user's profile directory and choose the local profile as the default for everyday repository work.
 
 ```yaml
 # ~/.outfitter/settings.yml
@@ -16,15 +22,15 @@ profile_sources:
   - path: ./profiles
 ```
 
-## Local profile
+## Local implementation profile
 
-The local profile keeps inference on the user's machine through Pi's `ollama` provider and `qwen` model. Current Outfitter profiles do not have a first-class `tools:` control; express tool differences through Pi extensions, Pi skills, native Pi settings or resources, and pass-through `args` only when Pi exposes a native flag that Outfitter does not model yet.
+The local profile keeps implementation inside the user's machine through Pi's `ollama` provider and `qwen` model. Current Outfitter profiles do not have a first-class `tools:` control; express tool differences through Pi extensions, Pi skills, native Pi settings or resources, and pass-through `args` only when Pi exposes a native flag that Outfitter does not model yet.
 
 ```yaml
 # ~/.outfitter/profiles/local.yml
 id: local
-label: Local Inference
-description: Private local Pi defaults for routine coding and drafting.
+label: Local Implementation
+description: Private local Pi defaults for restricted repository implementation.
 controls:
   provider: ollama
   model: qwen
@@ -32,6 +38,9 @@ controls:
     - ~/.outfitter/extensions/local-filesystem
   skills:
     - ~/.outfitter/skills/local-codebase
+  append_system_prompt: |
+    Work inside the repository using local inference. Do not assume external
+    model access is allowed for source code, logs, secrets, or proprietary data.
 ```
 
 Run it with:
@@ -47,27 +56,32 @@ For this profile, current Outfitter code passes the merged controls to Pi as equ
 --model qwen
 --extension ~/.outfitter/extensions/local-filesystem
 --skill ~/.outfitter/skills/local-codebase
+--append-system-prompt <local implementation guidance>
 ```
 
-## Cloud profile
+## Cloud research profile
 
-The cloud profile switches to the `chatgpt` provider, model `5.5`, and `xhigh` thinking for deeper work. It can also use a different set of Pi extensions and skills when cloud runs should expose different review, retrieval, or workflow affordances.
+The cloud profile switches to the `chatgpt` provider, model `5.5`, and `xhigh` thinking for general research, design exploration, and proof-of-concept work that does not require opening restricted repository contents. It can also use a different set of Pi extensions and skills when cloud runs should expose research, documentation, or review affordances instead of local implementation tools.
 
 ```yaml
 # ~/.outfitter/profiles/cloud.yml
 id: cloud
-label: Cloud Inference
-description: Higher-capability Pi defaults for complex planning, reviews, and implementation.
+label: Cloud Research
+description: Higher-capability Pi defaults for general research and proof-of-concept work.
 controls:
   provider: chatgpt
   model: '5.5'
   thinking: xhigh
   extensions:
-    - ~/.outfitter/extensions/team-review
+    - ~/.outfitter/extensions/web-research
     - ~/.outfitter/extensions/project-docs
   skills:
-    - ~/.outfitter/skills/deep-review
-    - ~/.outfitter/skills/release-planning
+    - ~/.outfitter/skills/architecture-notes
+    - ~/.outfitter/skills/proof-of-concept
+  append_system_prompt: |
+    Use this profile for general research, design tradeoffs, and disposable
+    examples. Do not inspect or quote restricted repository contents unless the
+    repository policy explicitly allows external model access.
 ```
 
 Run it with:
@@ -82,14 +96,15 @@ For this profile, current Outfitter code passes the merged controls to Pi as equ
 --provider chatgpt
 --model 5.5
 --thinking xhigh
---extension ~/.outfitter/extensions/team-review
+--extension ~/.outfitter/extensions/web-research
 --extension ~/.outfitter/extensions/project-docs
---skill ~/.outfitter/skills/deep-review
---skill ~/.outfitter/skills/release-planning
+--skill ~/.outfitter/skills/architecture-notes
+--skill ~/.outfitter/skills/proof-of-concept
+--append-system-prompt <cloud research guidance>
 ```
 
 ## Operational pattern
 
-Use `local` for low-latency private work, quick repository navigation, and tasks that do not require a cloud model. Use `cloud` when the task benefits from stronger reasoning, broader context synthesis, or organization-provided skills and extensions.
+Use `cloud` before implementation to research options, compare APIs, reason about generic architecture, and draft proof-of-concept code outside the restricted source tree. Use `local` when the task requires opening the actual repository, reading private files, running project-specific tests, or producing implementation patches.
 
 Keep the profiles small and explicit. If Pi adds a native flag that Outfitter has not modeled, place it in `controls.args`; otherwise prefer modeled controls such as `provider`, `model`, `thinking`, `extensions`, and `skills` so profile behavior remains readable and portable.


### PR DESCRIPTION
## Summary
- add a local/cloud inference profile override use case
- document Ollama/Qwen and ChatGPT/5.5 profile examples
- clarify that current tool differences are modeled through Pi extensions, skills, native Pi resources, or pass-through args rather than a first-class `tools:` control

## Verification
- `npx prettier --check docs/documentation/README.md docs/documentation/usecases/local-inference-overrides.md`

## Notes
- DeepWork review discovery from the surrounding monorepo reported unrelated parse errors under `unsupervised-main/**/.deepreview`; no Outfitter review rules were changed.