### PR TITLE
chore(test): enforce coverage debt budget

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,8 +194,9 @@ npm run check-ci
 ```
 
 Both commands run the coverage suite.
-Coverage thresholds are intentionally set to 100% for statements, branches, functions, and lines.
 Coverage includes all `code/cli/src/**/*.ts` files through the CLI workspace Vitest configuration, so new source files need tests even if they are only scaffolding.
+Coverage thresholds use Vitest's absolute uncovered-item budget mode, which keeps existing uncovered debt fixed without requiring routine `v8 ignore` annotations.
+Adding uncovered statements, branches, functions, or lines fails the coverage gate unless the added behavior is tested or the project intentionally updates the budget.
 
 ## Commit and release workflow
 

--- a/code/cli/src/agents/AdapterStatePaths.ts
+++ b/code/cli/src/agents/AdapterStatePaths.ts
@@ -54,7 +54,6 @@ export const resolveStateStrategy = (
 ): StatePersistenceStrategy => {
   const strategy = profile.statePersistence?.[relativePath] ?? declaration.defaultStrategy;
 
-  /* v8 ignore next -- Adapter declarations define defaults; this guards future declaration regressions. */
   if (strategy === undefined) {
     throw new Error(`missing state_persistence strategy for "${relativePath}"`);
   }

--- a/code/cli/src/agents/AgentLaunch.ts
+++ b/code/cli/src/agents/AgentLaunch.ts
@@ -38,7 +38,6 @@ export const resolveAgentLaunchExecutable = (launchPlan: AgentLaunchPlan): Agent
 
   const bundledPiLaunch = resolveBundledPiLaunch();
 
-  /* v8 ignore next 3 -- defensive: pi is a bundled dependency, so resolution succeeds in practice. */
   if (bundledPiLaunch === undefined) {
     return launchPlan;
   }
@@ -75,7 +74,6 @@ const piPackageName = '@earendil-works/pi-coding-agent';
 const resolveBundledPiLaunch = (): BundledPiLaunch | undefined => {
   const binPath = resolveBundledPiBinPath();
 
-  /* v8 ignore next 3 -- defensive: pi is a bundled dependency, so its bin resolves in practice. */
   if (binPath === undefined) {
     return undefined;
   }
@@ -95,14 +93,12 @@ const resolveBundledPiBinPath = (): string | undefined => {
     };
     const binPath = join(packageRoot, manifest.bin.pi);
 
-    /* v8 ignore next 3 -- defensive: a resolved pi bin path exists on disk. */
     if (!existsSync(binPath)) {
       throw new Error(`Bundled pi bin '${binPath}' is missing.`);
     }
 
     return binPath;
   } catch {
-    /* v8 ignore next -- defensive: resolution falls back to a PATH lookup when pi cannot be located. */
     return undefined;
   }
 };
@@ -114,7 +110,6 @@ const findPiPackageRoot = (resolvedEntryPath: string): string => {
   while (!existsSync(join(directory, 'package.json'))) {
     const parentDirectory = dirname(directory);
 
-    /* v8 ignore next 3 -- defensive: a resolved entry always has an ancestor package.json. */
     if (parentDirectory === directory) {
       throw new Error('Could not locate the bundled pi package root.');
     }

--- a/code/cli/src/agents/claude/ClaudeAdapter.ts
+++ b/code/cli/src/agents/claude/ClaudeAdapter.ts
@@ -164,12 +164,7 @@ const resolveClaudeStateSourcePath = (
     return profileSource;
   }
 
-  return join(
-    /* v8 ignore next -- run command always passes homeDirectory; environment fallbacks are defensive. */
-    homeDirectory ?? process.env.HOME ?? '.',
-    '.claude',
-    normalizedRelativePath,
-  );
+  return join(homeDirectory ?? process.env.HOME ?? '.', '.claude', normalizedRelativePath);
 };
 
 const mergeClaudeControls = (controls: ProfileControls): ClaudeProfileControls =>

--- a/code/cli/src/agents/pi/PiAdapter.ts
+++ b/code/cli/src/agents/pi/PiAdapter.ts
@@ -262,7 +262,6 @@ const createPiKeybindingsTransformFile = (
   });
 };
 
-/* v8 ignore next -- fallback source discovery is exercised by adapter integration fixtures. */
 const shouldReadPiKeybindingsSource = (
   sourcePath: string,
   input: { readonly homeDirectory?: string; readonly profileFolders?: readonly string[] },
@@ -372,7 +371,7 @@ const normalizePiKey = (key: string): string => {
     .split('+')
     .map((part) => part.trim())
     .filter((part) => part.length > 0);
-  /* v8 ignore next -- empty keybinding strings are schema-invalid defensive input. */
+
   const keyName = parts.at(-1) ?? '';
   const modifiers = new Set(parts.slice(0, -1));
   const sortedModifiers = ['ctrl', 'shift', 'alt'].filter((modifier) => modifiers.has(modifier));
@@ -412,13 +411,7 @@ const resolvePiStateSourcePath = (
 ): string => {
   const normalizedRelativePath = directory ? relativePath.slice(0, -1) : relativePath;
   const configuredCacheDirectory =
-    cacheDirectory ??
-    join(
-      /* v8 ignore next -- run command always passes homeDirectory; environment fallbacks are defensive. */
-      homeDirectory ?? process.env.HOME ?? '.',
-      '.outfitter',
-      'cache',
-    );
+    cacheDirectory ?? join(homeDirectory ?? process.env.HOME ?? '.', '.outfitter', 'cache');
 
   if (relativePath === 'utilities/' || relativePath === 'bin/') {
     return join(configuredCacheDirectory, 'utilities');
@@ -430,13 +423,7 @@ const resolvePiStateSourcePath = (
     return profileSource;
   }
 
-  return join(
-    /* v8 ignore next -- run command always passes homeDirectory; environment fallbacks are defensive. */
-    homeDirectory ?? process.env.HOME ?? '.',
-    '.pi',
-    'agent',
-    normalizedRelativePath,
-  );
+  return join(homeDirectory ?? process.env.HOME ?? '.', '.pi', 'agent', normalizedRelativePath);
 };
 
 const deepWorkAdditionalJobsFoldersEnv = 'DEEPWORK_ADDITIONAL_JOBS_FOLDERS';
@@ -493,7 +480,6 @@ const resolveNamedDeepWorkJobFolders = (profileLayers: readonly AgentLaunchProfi
 const resolveNamedDeepWorkJobFolder = (profileLayer: AgentLaunchProfileLayer, jobName: string): readonly string[] =>
   sharedDeepWorkJobRootsForLayer(profileLayer).filter((jobsFolder) => isFile(join(jobsFolder, jobName, 'job.yml')));
 
-/* v8 ignore next -- warning-only DeepWork job absence is covered by higher-level run command behavior. */
 const createMissingNamedDeepWorkJobWarnings = (profileLayers: readonly AgentLaunchProfileLayer[]): readonly string[] =>
   profileLayers.flatMap((profileLayer) =>
     (profileLayer.profile.controls.deepwork?.jobs ?? []).flatMap((jobName) =>
@@ -504,7 +490,6 @@ const createMissingNamedDeepWorkJobWarnings = (profileLayers: readonly AgentLaun
   );
 
 const sharedDeepWorkJobRootsForLayer = (profileLayer: AgentLaunchProfileLayer): readonly string[] => {
-  /* v8 ignore next -- source-less synthetic layers do not expose shared DeepWork jobs. */
   if (profileLayer.sourceRootPath === undefined) {
     return [];
   }

--- a/code/cli/src/cli.ts
+++ b/code/cli/src/cli.ts
@@ -20,7 +20,6 @@ export const isDirectCliExecution = (moduleUrl: string, argvPath: string | undef
   }
 };
 
-/* v8 ignore next 8 -- direct bin execution is covered by local install smoke tests. */
 if (isDirectCliExecution(import.meta.url, process.argv[1])) {
   try {
     await createProgram().parseAsync(process.argv);

--- a/code/cli/src/cli/OutfitterCli.ts
+++ b/code/cli/src/cli/OutfitterCli.ts
@@ -13,7 +13,6 @@ import { createWelcomeCommand } from './commands/WelcomeCommand.js';
 export const createDefaultCommands = (): CommandObject[] => [
   createRunCommand(),
   createSetupCommand({
-    /* v8 ignore next -- covered by end-to-end CLI smoke usage; unit tests inject this dependency. */
     async launchSetupSourceProfile(input) {
       await executeRunCommand({ ...input, profileId: input.profileId });
     },

--- a/code/cli/src/cli/commands/PiLoginLaunch.ts
+++ b/code/cli/src/cli/commands/PiLoginLaunch.ts
@@ -79,7 +79,6 @@ const addFirstRunBootstrapModelIfNeeded = (launchPlan: AgentLaunchPlan): AgentLa
   return { ...launchPlan, args: ['--model', 'google/gemini-3.1-pro-preview', ...launchPlan.args] };
 };
 
-/* v8 ignore next -- arg parser supports both spellings; integration smoke covers explicit --model passthrough. */
 const hasPiModelArg = (args: readonly string[]): boolean =>
   args.some((arg) => arg === '--model' || arg.startsWith('--model='));
 
@@ -91,7 +90,7 @@ const writeQuietPiStartupSettings = (piConfigDirectory: string): void => {
   if (existsSync(settingsPath)) {
     try {
       const parsed: unknown = JSON.parse(readFileSync(settingsPath, 'utf8'));
-      /* v8 ignore next -- defensive against hand-edited Pi settings with non-object JSON. */
+
       settings =
         parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
           ? (parsed as Record<string, unknown>)
@@ -821,7 +820,6 @@ const createUserProfileContent = (profileId, label) =>
 };
 
 const writePiLaunchMessage = (writeLine: ((message: string) => void) | undefined, message: string): void => {
-  /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer for launch messages. */
   (writeLine ?? console.log)(message);
 };
 

--- a/code/cli/src/cli/commands/RunCommand.ts
+++ b/code/cli/src/cli/commands/RunCommand.ts
@@ -164,14 +164,12 @@ export const executeRunCommand = async (
         compositeProfile.files.map((file) => file.outputPath),
       );
     },
-    /* v8 ignore next -- watcher warnings are covered in CompositeProfileWatcher tests; this adapter passes the stderr writer through. */
+
     warn: (message) => (dependencies.writeError ?? console.error)(message),
   });
 
   try {
-    const launcher =
-      dependencies.launcher ??
-      /* v8 ignore next -- tests inject launchers instead of spawning pi. */ createSpawnLauncher();
+    const launcher = dependencies.launcher ?? createSpawnLauncher();
     const exitCode = await launchAgentProcess(launcher, launchPlan, adapter.id);
     const stateWriteWarnings = handleCompositeProfileStateWrites(
       adapter.id,
@@ -196,7 +194,6 @@ export const executeRunCommand = async (
   }
 };
 
-/* v8 ignore start -- Commander registration is exercised through CLI integration, while command behavior is unit-tested through executeRunCommand. */
 export const createRunCommand = (dependencies: RunCommandDependencies = {}): CommandObject => {
   const command: CommandObject = {
     name: 'run',
@@ -246,8 +243,6 @@ const configureRunCommander = (
     .allowExcessArguments(true)
     .action(action);
 };
-
-/* v8 ignore stop */
 
 interface ResolvedRunProfile {
   readonly profile: Profile;
@@ -407,7 +402,6 @@ const prepareFirstRunRuntimeOnboarding = (
 
   const syncResult = syncProfileSource(input.homeDirectory, defaultProfilesSource, dependencies.synchronizer);
 
-  /* v8 ignore next -- network/cache failure path is integration-level behavior; setup fallback message is deterministic. */
   if (syncResult.status === 'failed') {
     throw new Error(
       `Cannot start Pi-native onboarding because the default profiles source failed to sync: ${syncResult.message}. ` +
@@ -425,7 +419,6 @@ const shouldUsePiNativeFirstRunOnboarding = (input: RunCommandInput, dependencie
 
   const selectedAgentId = dependencies.adapter?.id ?? selectRunAgentId(input.agentId, undefined);
 
-  /* v8 ignore next -- explicit profile/non-pi paths are covered by normal run command selection tests. */
   if (input.profileId !== undefined || selectedAgentId !== 'pi') {
     return false;
   }
@@ -442,9 +435,8 @@ const isInteractiveRunLaunch = (dependencies: RunCommandDependencies): boolean =
     return dependencies.interactive;
   }
 
-  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
   const inputIsTty = (dependencies.input ?? process.stdin).isTTY === true;
-  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
+
   const outputIsTty = (dependencies.output ?? process.stdout).isTTY === true;
 
   return inputIsTty && outputIsTty;
@@ -595,7 +587,6 @@ const materializeSource = (homeDirectory: string, source: ProfileSourceReference
   };
 };
 
-/* v8 ignore start -- the real child-process launcher is direct runtime behavior; tests inject a launcher. */
 const createSpawnLauncher = (): AgentProcessLauncher => ({
   launch(plan) {
     const resolvedPlan = resolveAgentLaunchExecutable(plan);
@@ -611,7 +602,6 @@ const createSpawnLauncher = (): AgentProcessLauncher => ({
     });
   },
 });
-/* v8 ignore stop */
 
 export const resolveChildExitCode = (code: number | null, signal: NodeJS.Signals | null): number => {
   if (code !== null) {

--- a/code/cli/src/cli/commands/SetupCommand.ts
+++ b/code/cli/src/cli/commands/SetupCommand.ts
@@ -296,7 +296,7 @@ const executeInteractiveSetupSourceCommand = async ({
 }: InteractiveSetupSourceCommandInput): Promise<SetupCommandResult> => {
   const onboarding = await runSetupSourceOnboarding(input, dependencies, starterLayout, currentDefaultProfileId);
   const appliedImport = applySetupSourceImport(input, starterLayout, onboarding);
-  /* v8 ignore next -- setup-source rollback only runs when a home import creates settings and default-profile sync fails. */
+
   const rollbackCreatedSettings = appliedImport.createdSettings
     ? () => rmSync(appliedImport.settingsPath, { force: true })
     : () => undefined;
@@ -447,7 +447,6 @@ const formatRunProfileExample = (profileId: string): string =>
 
 const formatRunDefaultProfileExample = (): string => `Start the current default profile:\n  outfitter`;
 
-/* v8 ignore start -- setup-source launch visibility fallbacks are exercised through integration-style CLI flows; unit tests cover the primary imported-profile outcomes. */
 const formatSetupSourceExitMessages = (
   input: SetupCommandInput,
   importTarget: SetupSourceImportTarget,
@@ -545,7 +544,6 @@ const selectSetupSourceLaunchAction = async (
   return promptForSetupSourceLaunchAction(profileId, launchTarget, dependencies);
 };
 
-/* v8 ignore stop */
 const capitalize = (value: string): string => `${value.slice(0, 1).toUpperCase()}${value.slice(1)}`;
 
 export const createSetupCommand = (dependencies: SetupCommandDependencies = {}): CommandObject => {
@@ -558,9 +556,8 @@ export const createSetupCommand = (dependencies: SetupCommandDependencies = {}):
         .description(command.description)
         .action(async (source?: string) => {
           const input = {
-            /* v8 ignore next -- default process home is exercised by the direct CLI entrypoint, not unit tests. */
             homeDirectory: dependencies.homeDirectory ?? homedir(),
-            /* v8 ignore next -- default process cwd is exercised by the direct CLI entrypoint, not unit tests. */
+
             projectDirectory: dependencies.projectDirectory ?? process.cwd(),
             setupSourceUri: source,
           };
@@ -656,7 +653,6 @@ const runGit = (args: readonly string[], sensitiveUri: string): void => {
   const result = spawn.sync('git', args, { stdio: 'pipe', encoding: 'utf8' });
 
   if (result.status !== 0) {
-    /* v8 ignore next -- the final fallback only applies if git emits no stdout or stderr. */
     throw new Error(
       redactSensitiveText((result.stderr || result.stdout || `git ${args.join(' ')} failed`).trim(), sensitiveUri),
     );
@@ -767,7 +763,6 @@ const readStarterSettingsContent = (starterSettingsPath: string): string => {
   return `default_profile: engineer\n${content}`;
 };
 
-/* v8 ignore start -- setup-source filesystem import variants are covered by integration-style fixtures; core settings outcomes are unit covered. */
 const applySetupSourceImport = (
   input: SetupCommandInput,
   starterLayout: StarterLayout,
@@ -852,8 +847,6 @@ const applySetupSourceCopyImport = (
   };
 };
 
-/* v8 ignore stop */
-/* v8 ignore start -- local setup-source path probing and symlink safety are covered by filesystem integration tests. */
 const resolveLocalSetupSourceOutfitterPath = (input: SetupCommandInput): string | undefined =>
   input.setupSourceUri === undefined
     ? undefined
@@ -893,7 +886,6 @@ const symlinkLocalOutfitterSource = (sourceOutfitterPath: string, targetOutfitte
   symlinkSync(sourceOutfitterPath, targetOutfitterPath, 'dir');
 };
 
-/* v8 ignore stop */
 const createSetupSourceImportTargetLayout = (
   input: SetupCommandInput,
   target: SetupSourceImportTarget,
@@ -925,7 +917,7 @@ const createImportSettingsIfMissing = (
   mkdirSync(dirname(settingsPath), { recursive: true });
   writeFileSync(
     settingsPath,
-    /* v8 ignore next -- setup-source tests exercise starter settings; missing starter settings is defensive fallback. */
+
     starterSettingsPath === undefined
       ? createLocalProfileSettingsContent(selectedProfileId)
       : readStarterSettingsContent(starterSettingsPath),
@@ -945,7 +937,7 @@ const ensureLocalProfileSource = (settingsPath: string, profilesPath: string): v
   }
 
   const document = readYamlRecord(settingsPath);
-  /* v8 ignore next -- appending to existing non-local source lists is equivalent to the covered empty-source case. */
+
   const existingSources: readonly unknown[] = Array.isArray(document.profile_sources) ? document.profile_sources : [];
   writeFileSync(
     settingsPath,
@@ -955,7 +947,7 @@ const ensureLocalProfileSource = (settingsPath: string, profilesPath: string): v
 
 const readYamlRecord = (path: string): Record<string, unknown> => {
   const parsed = parse(readFileSync(path, 'utf8')) as unknown;
-  /* v8 ignore next -- settings schema validation guarantees object documents before this helper mutates them. */
+
   return parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
     ? { ...(parsed as Record<string, unknown>) }
     : {};
@@ -1068,7 +1060,6 @@ const findWelcomeSourceProfileDirectory = (
 
   const loadedSettings = loadSettingsWithCachedRemoteSettings(input);
 
-  /* v8 ignore next -- setup already rejected invalid settings; this fallback handles cache mutation during welcome. */
   if (loadedSettings.issues.length > 0) {
     return undefined;
   }
@@ -1106,9 +1097,8 @@ const requireInteractiveTerminalIfNeeded = (dependencies: SetupCommandDependenci
     return;
   }
 
-  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
   const inputIsTty = (dependencies.input ?? process.stdin).isTTY === true;
-  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
+
   const outputIsTty = (dependencies.output ?? process.stdout).isTTY === true;
 
   if (!inputIsTty || !outputIsTty) {
@@ -1121,7 +1111,6 @@ const shouldSkipInitialDefaultProfilePrompt = (
   dependencies: SetupCommandDependencies,
 ): boolean => initialSettingsMissing && dependencies.interactive === true;
 
-/* v8 ignore next -- default process stdout is direct terminal behavior; tests inject writable streams. */
 const resolveReadlineOutput = (dependencies: SetupCommandDependencies): NodeJS.WritableStream =>
   typeof dependencies.output?.write === 'function' ? dependencies.output : process.stdout;
 
@@ -1139,7 +1128,6 @@ const resolvePromptOutput = (dependencies: SetupCommandDependencies): Pick<NodeJ
     };
   }
 
-  /* v8 ignore next 7 -- defensive non-writable injected output fallback; normal tests inject writeLine or writable output. */
   if (dependencies.output !== undefined) {
     return {
       write() {
@@ -1180,7 +1168,6 @@ const runSetupSourceOnboarding = async (
   return { importTarget, selectedProfileId, importMode };
 };
 
-/* v8 ignore start -- readline fallback is smoke-tested through terminal streams; injected selector paths carry deterministic setup-source coverage. */
 const promptForSetupSourceOnboarding = async (
   input: SetupCommandInput & { readonly setupSourceUri: string },
   profiles: readonly SetupProfileChoice[],
@@ -1189,7 +1176,7 @@ const promptForSetupSourceOnboarding = async (
   dependencies: SetupCommandDependencies,
 ): Promise<SetupSourceOnboardingResult> => {
   const output = resolvePromptOutput(dependencies);
-  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
+
   const readline = createInterface({
     input: dependencies.input ?? process.stdin,
     output: resolveReadlineOutput(dependencies),
@@ -1238,7 +1225,6 @@ const writeSetupSourceWelcome = (
 };
 
 const formatSetupSourceProfileList = (profiles: readonly SetupProfileChoice[]): string => {
-  /* v8 ignore next -- setup-source profile prompts normally require discovered source profiles. */
   if (profiles.length === 0) {
     return '';
   }
@@ -1249,7 +1235,6 @@ const formatSetupSourceProfileList = (profiles: readonly SetupProfileChoice[]): 
 const selectSetupSourceImportTarget = async (
   dependencies: SetupCommandDependencies,
 ): Promise<SetupSourceImportTarget> => {
-  /* v8 ignore else -- mixed dependency injection path; the full readline path prompts with one shared readline. */
   if (dependencies.selectSetupSourceImportTarget !== undefined) {
     const selectedTarget = await dependencies.selectSetupSourceImportTarget(setupSourceImportTargetChoices, 'home');
     assertValidSetupSourceImportTarget(selectedTarget);
@@ -1283,7 +1268,6 @@ const assertValidSetupSourceImportMode = (mode: SetupSourceImportMode): void => 
 };
 
 const assertValidSetupSourceImportTarget = (target: SetupSourceImportTarget): void => {
-  /* v8 ignore next -- defensive validation for custom dependency injection. */
   if (setupSourceImportTargetChoices.every((choice) => choice.target !== target)) {
     throw new Error(`Selected setup-source import target '${target}' is not available.`);
   }
@@ -1342,7 +1326,6 @@ const promptForSetupSourceImportModeWithReadline = async (
   return selectedChoice.mode;
 };
 
-/* v8 ignore next -- covered by interactive CLI smoke tests; unit tests inject the launch choice. */
 const promptForSetupSourceLaunchAction = async (
   profileId: string,
   launchTarget: SetupSourcePostImportLaunchTarget,
@@ -1365,7 +1348,6 @@ const promptForSetupSourceLaunchAction = async (
   }
 };
 
-/* v8 ignore stop */
 const selectDefaultProfileIfInteractive = async (
   input: SetupCommandInput,
   settingsPath: string,
@@ -1529,7 +1511,7 @@ const promptForSetupProfile = async (
   dependencies: SetupCommandDependencies,
 ): Promise<string> => {
   const output = resolvePromptOutput(dependencies);
-  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
+
   const readline = createInterface({
     input: dependencies.input ?? process.stdin,
     output: resolveReadlineOutput(dependencies),

--- a/code/cli/src/cli/commands/SyncCommand.ts
+++ b/code/cli/src/cli/commands/SyncCommand.ts
@@ -105,16 +105,14 @@ export const createSyncCommand = (dependencies: SyncCommandDependencies = {}): C
         .action(() => {
           const result = executeSyncCommand(
             {
-              /* v8 ignore next -- default process home is exercised by the direct CLI entrypoint, not unit tests. */
               homeDirectory: dependencies.homeDirectory ?? homedir(),
-              /* v8 ignore next -- default process cwd is exercised by the direct CLI entrypoint, not unit tests. */
+
               projectDirectory: dependencies.projectDirectory ?? process.cwd(),
             },
             dependencies,
           );
 
           for (const message of result.messages) {
-            /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
             (dependencies.writeLine ?? console.log)(message);
           }
         });
@@ -237,7 +235,6 @@ const runGit = (args: readonly string[]): void => {
   const result = spawn.sync('git', args, { stdio: 'pipe', encoding: 'utf8' });
 
   if (result.status !== 0) {
-    /* v8 ignore next -- the final fallback only applies if git emits no stdout or stderr. */
     throw new Error((result.stderr || result.stdout || `git ${args.join(' ')} failed`).trim());
   }
 };

--- a/code/cli/src/cli/commands/WelcomeCommand.ts
+++ b/code/cli/src/cli/commands/WelcomeCommand.ts
@@ -212,16 +212,14 @@ export const createWelcomeCommand = (dependencies: WelcomeCommandDependencies = 
         .action(async () => {
           const result = await executeWelcomeCommand(
             {
-              /* v8 ignore next -- default process home is exercised by the direct CLI entrypoint, not unit tests. */
               homeDirectory: dependencies.homeDirectory ?? homedir(),
-              /* v8 ignore next -- default process cwd is exercised by the direct CLI entrypoint, not unit tests. */
+
               projectDirectory: dependencies.projectDirectory ?? process.cwd(),
             },
             { ...dependencies, interactive: true },
           );
 
           for (const message of result.messages) {
-            /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
             (dependencies.writeLine ?? console.log)(message);
           }
         });
@@ -243,9 +241,8 @@ const selectWelcomePlan = async (
 };
 
 const promptForWelcomePlan = async (dependencies: WelcomeCommandDependencies): Promise<WelcomePlan> => {
-  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
   const output = dependencies.output ?? process.stdout;
-  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
+
   const readline = createInterface({ input: dependencies.input ?? process.stdin, output });
 
   try {
@@ -316,9 +313,8 @@ const requireInteractiveTerminalIfNeeded = (dependencies: WelcomeCommandDependen
     return;
   }
 
-  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
   const inputIsTty = (dependencies.input ?? process.stdin).isTTY === true;
-  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
+
   const outputIsTty = (dependencies.output ?? process.stdout).isTTY === true;
 
   if (!inputIsTty || !outputIsTty) {

--- a/code/cli/src/cli/commands/profile/CreateCommand.ts
+++ b/code/cli/src/cli/commands/profile/CreateCommand.ts
@@ -56,9 +56,9 @@ const createProfileCreateCommander = (dependencies: ProfileCommandDependencies):
         name,
         scope: readCreateProfileScope(options.scope),
         path: options.path,
-        /* v8 ignore next -- default process home is exercised by the direct CLI entrypoint, not unit tests. */
+
         homeDirectory: dependencies.homeDirectory ?? homedir(),
-        /* v8 ignore next -- default process cwd is exercised by the direct CLI entrypoint, not unit tests. */
+
         projectDirectory: dependencies.projectDirectory ?? process.cwd(),
       });
 
@@ -113,7 +113,6 @@ export const executeCreateProfileCommand = (input: CreateProfileInput): CreatePr
 
 const emitMessages = (messages: readonly string[], writeLine: ((message: string) => void) | undefined): void => {
   for (const message of messages) {
-    /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
     (writeLine ?? console.log)(message);
   }
 };
@@ -143,7 +142,7 @@ const resolveProfileRoot = (input: CreateProfileInput): string => {
       return join(input.projectDirectory, '.outfitter', 'profiles');
     case 'project-local':
       return join(input.projectDirectory, '.outfitter', 'local', 'profiles');
-    /* v8 ignore next 2 -- assertValidCreateProfileInput rejects missing scopes before this exhaustive guard. */
+
     default:
       throw new Error('Create profile requires exactly one destination: --scope or --path.');
   }

--- a/code/cli/src/cli/commands/profile/LintCommand.ts
+++ b/code/cli/src/cli/commands/profile/LintCommand.ts
@@ -53,19 +53,15 @@ export const createProfileLintCommand = (dependencies: ProfileCommandDependencie
       .option('--json', 'Print diagnostics as JSON')
       .action((options: { strict?: boolean; json?: boolean }) => {
         const result = executeProfileLintCommand({
-          homeDirectory:
-            /* v8 ignore next -- CLI defaults are exercised manually; tests inject stable temp roots. */
-            dependencies.homeDirectory ?? homedir(),
-          projectDirectory:
-            /* v8 ignore next -- CLI defaults are exercised manually; tests inject stable temp roots. */
-            dependencies.projectDirectory ?? process.cwd(),
+          homeDirectory: dependencies.homeDirectory ?? homedir(),
+          projectDirectory: dependencies.projectDirectory ?? process.cwd(),
           strict: options.strict,
           json: options.json,
         });
         writeLintResult(
           result,
           options.json === true,
-          /* v8 ignore next -- CLI default writer is console.log; tests inject a collector. */
+
           dependencies.writeLine ?? console.log,
         );
         process.exitCode = result.exitCode;

--- a/code/cli/src/cli/commands/profile/ListCommand.ts
+++ b/code/cli/src/cli/commands/profile/ListCommand.ts
@@ -52,9 +52,8 @@ const createProfileListCommander = (dependencies: ProfileCommandDependencies): C
     .option('--all', 'Include template profiles that are intended only for inheritance.')
     .action((options: { all?: boolean }) => {
       const result = executeListProfilesCommand({
-        /* v8 ignore next -- default process home is exercised by the direct CLI entrypoint, not unit tests. */
         homeDirectory: dependencies.homeDirectory ?? homedir(),
-        /* v8 ignore next -- default process cwd is exercised by the direct CLI entrypoint, not unit tests. */
+
         projectDirectory: dependencies.projectDirectory ?? process.cwd(),
         includeTemplates: options.all,
       });
@@ -91,7 +90,6 @@ export const executeListProfilesCommand = (input: ListProfilesInput): ListProfil
 
 const emitMessages = (messages: readonly string[], writeLine: ((message: string) => void) | undefined): void => {
   for (const message of messages) {
-    /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
     (writeLine ?? console.log)(message);
   }
 };

--- a/code/cli/src/compositeProfile/CompositeProfileTemplate.ts
+++ b/code/cli/src/compositeProfile/CompositeProfileTemplate.ts
@@ -84,7 +84,6 @@ const renderCompositeProfileFile = (
 const renderTemplateContent = (content: string, context: Readonly<Record<string, unknown>>): string => {
   const renderedContent: unknown = outfitterTemplateEngine.parseAndRenderSync(content, context);
 
-  /* v8 ignore next -- LiquidJS renders string content to strings; this guards future API regressions. */
   if (typeof renderedContent !== 'string') {
     throw new Error('LiquidJS returned non-string template output.');
   }

--- a/code/cli/src/compositeProfile/CompositeProfileWatcher.ts
+++ b/code/cli/src/compositeProfile/CompositeProfileWatcher.ts
@@ -33,23 +33,27 @@ export const createCompositeProfileWatchPlanForCompositeProfile = (
 export const watchCompositeProfileInputs = (input: WatchCompositeProfileInput): CompositeProfileWatcherHandle => {
   const watchPaths = createCompositeProfileWatchPlanForCompositeProfile(input.compositeProfile).paths;
   const watchers: FSWatcher[] = [];
+  let closed = false;
 
   for (const watchPath of watchPaths) {
     try {
-      watchers.push(
-        watch(
-          watchPath,
-          /* v8 ignore next -- fs.watch delivery is platform-timed; the static watch plan is covered deterministically. */
-          () => updateCompositeProfileFromWatchedInput(input, watchPath),
-        ),
-      );
+      watchers.push(watch(watchPath, () => updateCompositeProfileFromWatchedInput(input, watchPath)));
     } catch (error) {
       input.warn(`Could not watch composite profile input ${watchPath}: ${formatError(error)}`);
     }
   }
 
+  if (watchPaths.length > 0) {
+    setImmediate(() => {
+      if (!closed) {
+        updateCompositeProfileFromWatchedInput(input, watchPaths[0]);
+      }
+    });
+  }
+
   return {
     close() {
+      closed = true;
       for (const watcher of watchers) {
         watcher.close();
       }
@@ -70,7 +74,6 @@ const updateCompositeProfileFromWatchedInput = (input: WatchCompositeProfileInpu
     writeCompositeProfile(compositeProfile, { materializeStatePaths: false });
     input.onCompositeProfileWritten?.(compositeProfile);
   } catch (error) {
-    /* v8 ignore next -- unsafe live-update failures are reported defensively; normal refresh behavior is covered. */
     input.warn(`Could not safely update compositeProfile from ${watchPath}: ${formatError(error)}`);
   }
 };

--- a/code/cli/src/compositeProfile/StatePersistence.ts
+++ b/code/cli/src/compositeProfile/StatePersistence.ts
@@ -186,12 +186,10 @@ const getExistingSourceType = (sourcePath: string): 'file' | 'directory' | undef
     const stat = statSync(sourcePath);
     return stat.isDirectory() ? 'directory' : 'file';
   } catch (error) {
-    /* v8 ignore next -- non-ENOENT stat failures should surface as actionable filesystem errors. */
     if (isNodeError(error) && error.code === 'ENOENT') {
       return undefined;
     }
 
-    /* v8 ignore next -- non-ENOENT stat failures should surface as actionable filesystem errors. */
     throw error;
   }
 };
@@ -218,12 +216,10 @@ const pathLexicallyExists = (path: string): boolean => {
     lstatSync(path);
     return true;
   } catch (error) {
-    /* v8 ignore next -- non-ENOENT lstat failures should surface as actionable filesystem errors. */
     if (isNodeError(error) && error.code === 'ENOENT') {
       return false;
     }
 
-    /* v8 ignore next -- non-ENOENT lstat failures should surface as actionable filesystem errors. */
     throw error;
   }
 };

--- a/code/cli/src/profiles/ProfileLoader.ts
+++ b/code/cli/src/profiles/ProfileLoader.ts
@@ -133,7 +133,6 @@ export const loadLocalProfileSource = (source: ProfileSourceReference): ProfileL
     if (entry.isFile()) {
       const fallbackId = readFlatProfileSlug(entryName);
 
-      /* v8 ignore next -- flat file fallback slug rejection is covered by schema-level profile-source validation. */
       if (fallbackId !== undefined) {
         addProfileFromPath({
           source,

--- a/code/cli/src/prompts/SystemPromptExport.ts
+++ b/code/cli/src/prompts/SystemPromptExport.ts
@@ -20,7 +20,6 @@ export interface SystemPromptExportResult {
   readonly outputPath?: string;
 }
 
-/* v8 ignore start -- rare skip/error branches are defensive around external profile ownership; main export behavior is unit covered. */
 export const exportSystemPromptIfEnabled = (input: SystemPromptExportInput): SystemPromptExportResult => {
   if (!isSystemPromptExportEnabled(input.profile, input.settings)) {
     return {};
@@ -48,8 +47,6 @@ export const exportSystemPromptIfEnabled = (input: SystemPromptExportInput): Sys
   return { outputPath };
 };
 
-/* v8 ignore stop */
-/* v8 ignore next -- fallback precedence is schema-level behavior; enabled/disabled outcomes are covered. */
 export const isSystemPromptExportEnabled = (profile: Profile, settings: Settings): boolean =>
   profile.profileExport ?? settings.profileExport ?? false;
 
@@ -98,7 +95,6 @@ const resolveSystemPromptExportPath = (profile: Profile, owner: LoadedProfile): 
   return assertInsideRoot(root, outputPath);
 };
 
-/* v8 ignore start -- path escape protection is defensive; normal generated output path behavior is unit covered. */
 const assertInsideRoot = (root: string, path: string): string => {
   const resolvedRoot = resolve(root);
   const resolvedPath = resolve(path);
@@ -114,9 +110,7 @@ const assertInsideRoot = (root: string, path: string): string => {
 const isRelativePathInsideRoot = (relativePath: string): boolean =>
   relativePath !== '..' && !relativePath.startsWith(`..${sep}`) && !isAbsolute(relativePath);
 
-/* v8 ignore stop */
 const isCacheBackedProfile = (owner: LoadedProfile, cacheDirectory: string): boolean => {
-  /* v8 ignore next -- remote-source ownership is a defensive skip path for generated prompt export. */
   if (owner.source.uri !== undefined || owner.source.github !== undefined) {
     return true;
   }

--- a/code/cli/src/settings/SettingsLoader.ts
+++ b/code/cli/src/settings/SettingsLoader.ts
@@ -161,7 +161,6 @@ const discoverRemoteSettingsLocations = (
 };
 
 const formatRemoteSettingsPathError = (error: unknown): string => {
-  /* v8 ignore next -- repository subpath validation throws Error instances. */
   if (!(error instanceof Error)) {
     return String(error);
   }

--- a/code/cli/tests/cli.test.ts
+++ b/code/cli/tests/cli.test.ts
@@ -69,10 +69,10 @@ describe('project foundation', () => {
     expect(vitestConfigSource).toContain('all: true');
     expect(vitestConfigSource).toContain("include: ['src/**/*.ts']");
     expect(vitestConfigSource).toContain("provider: 'v8'");
-    expect(vitestConfigSource).toContain('statements: 98');
-    expect(vitestConfigSource).toContain('branches: 98');
-    expect(vitestConfigSource).toContain('functions: 98');
-    expect(vitestConfigSource).toContain('lines: 98');
+    expect(vitestConfigSource).toContain('statements: -72');
+    expect(vitestConfigSource).toContain('branches: -108');
+    expect(vitestConfigSource).toContain('functions: -12');
+    expect(vitestConfigSource).toContain('lines: -69');
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-001.3).

--- a/code/cli/vitest.config.ts
+++ b/code/cli/vitest.config.ts
@@ -7,10 +7,11 @@ const coverage = {
   provider: 'v8' as const,
   reporter: ['text-summary', 'html'],
   thresholds: {
-    statements: 98,
-    branches: 98,
-    functions: 98,
-    lines: 98,
+    // Negative thresholds cap uncovered item counts, avoiding routine source-level coverage ignores.
+    statements: -72,
+    branches: -108,
+    functions: -12,
+    lines: -69,
   },
 };
 

--- a/docs/archtecture/README.md
+++ b/docs/archtecture/README.md
@@ -17,7 +17,7 @@ Formal implementation requirements live in [`../requirements/`](../requirements/
 6. **JSON Schema for validation**: every YAML file format has a corresponding JSON Schema used wherever the file is read.
 7. **Deterministic merging**: settings and profile layers merge predictably using normal precedence: project-local, project, then user.
 8. **Warn on partial support**: if a profile asks for a control an agent adapter cannot support, Outfitter warns to stderr; `--strict` makes unsupported controls fatal.
-9. **Complete test coverage early**: the project starts with a test framework and a 100% global coverage requirement.
+9. **Coverage debt stays fixed**: the project starts with a test framework and global uncovered-item budgets for all source files.
 10. **Complexity limits early**: ESLint is configured immediately with maximum complexity `10`.
 
 ## Runtime and Tooling Baseline
@@ -30,7 +30,7 @@ Formal implementation requirements live in [`../requirements/`](../requirements/
   Commander is the initial choice because it supports default commands, command aliases, `allowUnknownOption`, pass-through argument collection, and testable parser construction without spawning child processes.
 - Test framework: Vitest `^4` with `@vitest/coverage-v8`.
   Pi currently uses Vitest, and Vitest is well suited to TypeScript unit tests around command objects and generated launch plans.
-- Coverage: 100% global threshold for statements, branches, functions, and lines from the first implementation.
+- Coverage: global uncovered-item budgets for statements, branches, functions, and lines across all CLI source files.
 - Linting: ESLint `^10`, `@eslint/js`, and `typescript-eslint`, with `complexity: ["error", 10]`.
 - Schema and validation: TypeBox for schema authoring where TypeScript-schema coupling is useful, JSON Schema artifacts for persisted format contracts, and AJV for runtime validation.
 - YAML: `yaml`, matching pi's dependency choice.
@@ -850,7 +850,7 @@ The test suite should be created before feature implementation becomes large.
 
 Requirements:
 
-- global coverage threshold: 100% for statements, branches, functions, and lines;
+- global uncovered-item coverage budgets for statements, branches, functions, and lines;
 - deterministic tests for settings precedence;
 - deterministic tests for profile inheritance and cycle detection;
 - deterministic tests for URI cache path encoding;

--- a/docs/archtecture/file_structure.md
+++ b/docs/archtecture/file_structure.md
@@ -19,6 +19,7 @@ Outfitter is organized around a private npm workspace root, clear TypeScript pac
 ├── docs/                              # documentation, architecture, requirements, plans, and specs
 │   ├── archtecture/                   # architecture and internal design docs
 │   ├── documentation/                 # user-facing Outfitter docs
+│   ├── plans/                         # implementation plans and work breakdowns
 │   ├── requirements/                  # formal OUTFITTER requirement documents
 │   └── specs/                         # detailed supporting specs
 ├── .prettierignore                    # Prettier ignore rules

--- a/docs/plans/coverage-policy-debt-budget.md
+++ b/docs/plans/coverage-policy-debt-budget.md
@@ -1,0 +1,55 @@
+# Implementation Plan
+
+## Goal
+
+Stop requiring routine `v8 ignore` annotations to preserve coverage by changing the CLI coverage gate from percentage chasing to an absolute uncovered-item budget.
+
+## Branch
+
+- **Name**: `codex/chore/coverage-policy`
+- **Worktree**: `.claude/worktrees/codex-chore-coverage-policy`
+
+## Scope
+
+- **Change type**: TypeScript CLI workspace test/config policy
+- **Build strategy**: npm validation from the repository root
+- **Affected modules**: `code/cli/vitest.config.ts`, CLI source files with `v8 ignore` comments, foundation tests, contributor/architecture docs
+
+## Validation Criteria
+
+These criteria must be satisfied before the work is considered complete:
+
+1. `npm test --workspace @ai-outfitter/outfitter -- tests/cli.test.ts` passes and verifies the new coverage policy text.
+2. `npm run coverage` passes with absolute uncovered-item thresholds.
+3. `npm run lint` passes after removing coverage comments and updating configuration.
+4. `npx prettier --write <changed files>` leaves changed files formatted.
+
+## Steps
+
+### 1. Stabilize coverage validation
+
+- **File**: `code/cli/src/compositeProfile/CompositeProfileWatcher.ts` or related watcher flow
+- **Change**: Make the profile refresh behavior deterministic enough that the coverage suite can run reliably.
+
+### 2. Switch coverage thresholds to absolute budgets
+
+- **File**: `code/cli/vitest.config.ts`
+- **Change**: Replace percentage thresholds with negative thresholds that cap uncovered statements, branches, functions, and lines.
+
+### 3. Remove routine source coverage annotations
+
+- **File**: `code/cli/src/**/*.ts`
+- **Change**: Remove `v8 ignore` annotations that only exist to satisfy global percentage thresholds.
+
+### 4. Update tests and docs
+
+- **File**: `code/cli/tests/cli.test.ts`
+- **Change**: Assert the coverage configuration uses V8 with absolute uncovered-item budgets.
+- **File**: `CONTRIBUTING.md`, `docs/requirements/OFTR-001-project-foundation.md`, `docs/archtecture/README.md`
+- **Change**: Document that coverage is still comprehensive, but enforced by fixed uncovered-item budgets instead of constant V8-ignore churn.
+
+## Risks
+
+- The uncovered-item budget must be calibrated from the coverage report after removing annotations.
+- A too-large budget can hide new untested behavior, while a too-small budget recreates the original comment-chasing problem.
+- The watcher test must stay aligned with OFTR-005.7 and should not weaken the requirement it validates.

--- a/docs/requirements/OFTR-001-project-foundation.md
+++ b/docs/requirements/OFTR-001-project-foundation.md
@@ -22,7 +22,7 @@ This document specifies the baseline runtime, language, test, lint, and document
 1. The project MUST use Vitest as its test framework before implementing substantial runtime behavior.
 2. The test command MUST be runnable from package scripts.
 3. The coverage command MUST use `@vitest/coverage-v8`.
-4. The test configuration MUST enforce at least 99% global coverage for statements, branches, functions, and lines.
+4. The test configuration MUST enforce global uncovered-item budgets for statements, branches, functions, and lines.
 5. The coverage configuration MUST include all `code/cli/src/**/*.ts` files even when a source file is not imported by any test.
 6. Tests that validate formal requirements MUST follow the traceability format required by OFTR-008.3.
 


### PR DESCRIPTION
## Summary
- switch Vitest coverage enforcement from percentage thresholds to absolute uncovered-item budgets
- remove routine V8 ignore annotations from CLI source
- stabilize profile watcher refresh to avoid a launch-time update race
- update coverage policy docs and requirements

## Validation
- npm test --workspace @ai-outfitter/outfitter -- tests/cli.test.ts
- npm run coverage
- npm run lint
- npm run typecheck
- npm run build
- targeted Prettier check