### PR TITLE
docs(plans): assessment, update plan, issue queue, and launch artifacts

### DIFF
--- a/docs/plans/2026-07-01-comprehensive-assessment.md
+++ b/docs/plans/2026-07-01-comprehensive-assessment.md
@@ -1,0 +1,85 @@
+# Outfitter — Comprehensive Assessment (2026-07-01)
+
+Prepared from: full codebase review at v0.7.0, all repo docs, the Nicholas/Tyler demo-video dry run (Jul 1), the Tyler/Jamie Erickson call (Jun 29), Weekly Demo notes (Jun 29), and fresh market research.
+
+## TL;DR
+
+Outfitter's thesis is validated by the market, and the core engine is unusually well built for a three-week-old project. The product's biggest risk is concentrated in the first five minutes of user experience — the exact surface the demo and the pitch ("a fully configured Pi setup in five minutes") depend on. The demo dry run itself could not be completed cleanly. Fix the first-run path, scope the Claude claim honestly, clean the docs front door, and ship the research preview into the Pi ecosystem where there is zero incumbent.
+
+## 1. What Outfitter is (and the pitch that works)
+
+Outfitter composes reusable **agent profiles** — prompts, context, model/provider/thinking, Pi extensions, skills, subagents, MCP config, DeepWork jobs — and launches wrapped agent CLIs (Pi first, Claude Code partially) with a deterministic, layered merge (project-local > project > user > cached remote > defaults). Profiles are YAML, shareable via git-based catalog repos; `outfitter sync` pulls org/community catalogs; a temp "composite profile" directory is assembled per run with declarative state persistence (symlink/discard/warn/error).
+
+The value prop crystallized in the demo dry run is the right one:
+
+> **"Make, share, and switch the profiles your coding agents use — manually or programmatically."**
+
+The narrative arc (Nicholas the platform engineer gear-switching between feature work, prod incidents, and research spikes; loading everything at once degrades everything) is authentic, concrete, and matches documented market pain ("rule drift," context dilution). Jamie's field read: enterprises want exactly this shape (AI SDLC toolkits, federated context, governance planes) and _"Outfitter doesn't need more features — it needs polishing and release."_
+
+## 2. Demo vs. reality
+
+The Jul 1 dry run surfaced the gap precisely:
+
+- Old onboarding flow regression (stale profile prompts, then dumped into Pi with extension errors)
+- Extensions pointing at the old repo; slow first-boot extension download/build (shallow clones/caching floated)
+- Hardcoded bootstrap model `google/gemini-3.1-pro-preview` (PiLoginLaunch.ts:79) — silent, no fallback
+- First run hard-requires network + git clone of `ai-outfitter/default-profiles` (RunCommand.ts:410-418) — offline/corporate users dead-end
+- `outfitter --version` discoverability confusion; "update available" shown right after updating
+
+The pitch is a five-minute promise; the product currently cannot reliably keep it, including on the maintainers' own machines.
+
+## 3. Engineering assessment
+
+**Strengths** (full detail in the engineering review):
+
+- 254 tests, 99.3% statement coverage with 98% thresholds enforced in CI; golden-tree integration fixtures
+- Formal requirements (OFTR-001..010) pinned by do-not-modify tests
+- State-persistence model is genuinely good design (declarative per-path strategies, fingerprint diffing of undeclared writes)
+- Security hygiene above maturity level (credential redaction, ref-injection guards, path-traversal asserts, npm provenance)
+- First-run robustness engineering (bundled pi via `import.meta.resolve`, live composite regeneration)
+
+**Top risks**:
+
+1. Pi onboarding extension is a ~750-line untyped JS string inside the CLI (PiLoginLaunch.ts); `code/pi-extension/` is an empty TODO workspace
+2. Hardcoded bootstrap model; network-required first run (see §2)
+3. `prompt` state strategy is configurable but unimplemented (degrades silently to warn)
+4. Isolation is partly illusory: composite dirs symlink auth/settings/sessions to real `~/.pi/agent` / `~/.claude`; temp dirs never cleaned up (leak symlinks to auth state)
+5. Claude adapter materially behind the marketing (no MCP composition, no skills mapping, no onboarding)
+6. Requirement tests ossify dead deps (defu, glob, hosted-git-info, typebox)
+7. Single-platform CI (ubuntu only) with a symlink-centric runtime (Windows risk)
+8. Hard version coupling to Pi internals (`^0.78.1`, keybinding IDs, settings shapes)
+9. Complexity + lint escape hatches concentrated in SetupCommand (1,590 LoC) / PiLoginLaunch (885)
+10. State-write detection only at exit — nothing on crash/SIGKILL or during long sessions
+
+## 4. Docs & positioning assessment
+
+- `first-time-cli-agent-users.md` and `state.md` are excellent; quick start is genuinely 3 commands
+- AGENTS.md contradicts requirements ("Pi is the only day-one adapter" vs OFTR-006 mandating Claude); stale plan docs leak dev paths and private repo names
+- Headline feature (profile catalogs / sharing) gets 30 lines of user docs; no trust-model doc despite catalogs injecting extensions/args/env
+- `docs/archtecture/` and `orginization-profile-catalog.md` typos baked into public links; `philosophy.md` is an unedited draft linked from the index
+- Doc site has 2 pages; duplication risk with `/docs`
+- Grade for the new-user front door: C+ (internal engineer: B+)
+
+## 5. Market assessment
+
+- Pain is real and named: "rule drift" across CLAUDE.md/AGENTS.md/.cursorrules etc.; DORA 2025 validates org-level AI standardization via platform teams; CSA flags agent config/skills as attack surface
+- Rules-sync layer is commoditized (Ruler ~2.8k stars + a dozen clones incl. Block's); Outfitter's differentiation is **compose + launch + git-native org catalogs**, which no one else combines
+- Biggest threat: vendor absorption (Claude Code marketplaces + managed settings + Cowork provisioning; Codex Team Config) covers ~80% of the single-vendor case; standards (AGENTS.md/SKILL.md/MCP, all Linux Foundation) commoditize the substrate
+- Best beachhead: **the Pi companion** — Pi is deliberately minimal, has packages but no profile manager/launcher/onboarding; zero incumbent; audience is exactly harness tinkerers
+- Ranked wedges: (1) Pi companion, (2) launcher layer above rules-syncers ("kubectl context for agents"), (3) org catalogs for multi-agent/OSS teams, (4) persona/simulation profiles, (5) portability hedge
+- Awareness today: effectively zero (3 stars); **brand collision**: `outfitter-dev/agents` is an established, unrelated Claude plugin marketplace also called "Outfitter" that dominates search
+- Monetization sketch from the Jamie call fits: open/MIT for individual+team, enterprise license for private catalog features + training/support services
+
+## 6. Prioritized recommendations
+
+**A. Ship-blockers for the research preview (this week)**
+
+1. Make first run bulletproof: bundle a minimal offline default profile; degrade gracefully when default-profiles can't sync; kill the hardcoded gemini bootstrap model (query pi's catalog or omit `--model`)
+2. Fix the dry-run regressions: stale onboarding flow, extension repo pointers, post-update "update available"
+3. Speed first boot: shallow clones + extension caching (the demo stalls on this today)
+4. Add one real E2E smoke in CI: `npm pack` → global install → `outfitter` on a clean machine image — the exact demo path
+5. Record the demo with the "problem → make/share/switch → follow along, 5 minutes" script — it's the right script
+
+**B. Near-term (2–6 weeks)** 6. Extract the Pi extension into `code/pi-extension` as real, tested TypeScript 7. Scope the Claude claim ("experimental") or reach parity (MCP composition, skills, login path) 8. Docs front door: fix typo'd paths, rewrite philosophy.md, expand profile-repository.md (incl. trust model), align AGENTS.md with requirements, add a concepts page + CLI reference 9. Implement or remove the `prompt` persistence strategy; move write detection to near-real-time 10. Clean up composite temp dirs; matrix CI (ubuntu/macos/windows) 11. Distribution: awesome-cli-coding-agents listing, Pi Discord/packages channels, publish the doc site with real docs; consider the naming collision now, while renaming is cheap
+
+**C. Strategic (quarter)** 12. Own the Pi wedge publicly ("the quickest path to a great Pi loadout") before broadening the multi-agent story 13. Build the org-catalog governance story (approved stores, only/except policies, budget annotations) as the enterprise wedge — matches Jamie's field demand (federated context, control plane, auditability) 14. Persona profiles as a differentiated, product-shaped use case (already documented; no competitor serves it) 15. Decide the enterprise licensing split (public MIT / private BSL catalogs + training/support) and say it out loud in the README

--- a/docs/plans/2026-07-01-update-plan.md
+++ b/docs/plans/2026-07-01-update-plan.md
@@ -1,0 +1,305 @@
+# Outfitter Update Plan — Atomic Issues (2026-07-01)
+
+Derived from [the comprehensive assessment](./2026-07-01-comprehensive-assessment.md). Decisions locked with Tyler:
+
+- Track as **GitHub issues** on `ai-outfitter/outfitter` with specs in issue bodies (deeper specs in `docs/specs/` as each is picked up). **Nothing is filed without manual approval.**
+- **Claude adapter: full parity work now** (Milestone 3).
+- **Keep the Outfitter name**; differentiation/SEO work only.
+- **Scope: everything** — ship-blockers, hardening, Claude parity, docs, and strategic/distribution.
+
+Sizes: S (≤half day), M (1–2 days), L (3+ days). Dependencies are by issue number.
+
+---
+
+## Milestone 1 — Research-preview ship-blockers (first-run reliability + demo)
+
+### 1. Bundle an offline default profile; degrade gracefully when catalog sync fails
+
+**Why:** First run hard-requires network+git; sync failure of `ai-outfitter/default-profiles` is fatal (`RunCommand.ts:410-418`, `SetupCommand.ts:236-263`). Offline/proxied users dead-end.
+**Scope:** Ship a minimal built-in profile (id `starter`) inside the npm package; on sync failure, warn and fall back to built-ins instead of throwing; `outfitter sync` retries/refreshes later. Update OFTR-010 accordingly.
+**Acceptance:** With network blocked, `npm i -g && outfitter` reaches a working Pi session using the bundled profile; warning explains degraded mode; integration fixture covers offline path.
+**Size:** M
+
+### 2. Remove hardcoded bootstrap model from onboarding
+
+**Why:** `--model google/gemini-3.1-pro-preview` is silently injected (`PiLoginLaunch.ts:79`); catalog rotation breaks every new user with no fallback.
+**Scope:** Query pi for available/authenticated models and pick a sensible default, else omit `--model` and let pi decide. No model ID literals in src outside tests/fixtures.
+**Acceptance:** Onboarding works with zero configured providers (routes to `/login`), with only Anthropic, with only OpenAI; grep gate: no hardcoded model IDs.
+**Size:** S–M
+
+### 3. ~~Fix onboarding regression: stale flow shown on fresh install~~ — FIXED (v0.7.2)
+
+Resolved upstream: `a380826 fix(onboarding): create local profile source directory` (v0.7.2) fixed the onboarding failure chain, and `prepareFirstRunRuntimeOnboarding` force-syncs the default catalog (`fetch` + `pull --ff-only`) before the picker, so a stale cache cannot replay old profile lists. Issue draft removed 2026-07-01.
+
+### ~~3. (original)~~ Fix onboarding regression: stale flow shown on fresh install
+
+**Why:** Demo dry run (Jul 1): fresh install showed the old profile prompt (engineer/project-lead), then second-version-old flow, then dumped into Pi with extension errors. Root cause likely stale cache/settings interplay or old published extension content.
+**Scope:** Root-cause; add cache/settings versioning or invalidation so a new CLI version never replays an old onboarding flow; cover with a regression test simulating a stale `~/.outfitter` from prior versions.
+**Acceptance:** Upgrading from a v0.6.x home dir or fresh install always shows the current pi-native onboarding; repro test in CI.
+**Size:** M
+**Deps:** —
+
+### 4. ~~Fix extension sources pointing at the old repo~~ — FIXED (default-profiles)
+
+Resolved upstream in `ai-outfitter/default-profiles`: `c413d75 fix(founder): update ulta-tasklist owner` (applepi-ai → ai-outfitter) plus shortcut-conflict fixes `5bb551a`/`f2c8acc`. Onboarding syncs the catalog fresh, so all users get the corrected URIs. Issue draft removed 2026-07-01. The dead-URI CI guard idea is effectively covered by issue 7's onboarding smoke.
+
+### ~~4. (original)~~ Fix extension sources pointing at the old repo
+
+**Why:** Dry run: bootstrap extensions (e.g., task list) still resolve to the pre-rename repo, causing first-boot errors.
+**Scope:** Audit every extension/skill/source URI in shipped defaults, default-profiles catalog, and generated settings; point at current repos; add a lint/test that fails on known-dead source URIs.
+**Acceptance:** Fresh onboarding downloads all extensions without repo-not-found errors; URI audit test in CI.
+**Size:** S
+
+### 5. Fix "update available" notice shown immediately after updating
+
+**Why:** Dry run: `pi update`/install path still reports an update is available when current.
+**Scope:** Root-cause the version-check source (npm dist-tag vs installed version, caching); correct comparison; suppress within same version.
+**Acceptance:** After installing latest, no update notice; unit test on the comparator.
+**Size:** S
+
+### 6. First-boot speed follow-ups (re-scoped 2026-07-01 after v0.7.1)
+
+v0.7.1 (`4f1b2bb`) landed `PiExtensionCache`: shallow-cloned, dep-installed git-extension caching. Remaining scope: shallow catalog clones in `createGitSynchronizer`, a refresh policy for the git-extension cache (currently never updates — new staleness bug), and progress output during materialization (currently silent `spawn.sync`). See the re-scoped issue draft.
+
+### ~~6. (original)~~ Speed up first boot: shallow clones + extension/package caching
+
+**Why:** Dry run stalls minutes on cloning/building extensions ("maybe even make those shallow clones"); the pitch is a five-minute setup.
+**Scope:** `--depth 1` clones for catalog + extension sources; cache built extensions keyed by version/commit; warm-cache path skips rebuilds; progress messaging while downloading.
+**Acceptance:** Cold first boot on a clean machine measurably reduced (target: <60s on normal broadband, excluding model login); second boot near-instant; timing smoke recorded in CI logs.
+**Size:** M
+
+### 7. Add packaged E2E smoke to CI
+
+**Why:** All tests are in-process; the shipped artifact (`npm pack` → global install → run) is never exercised. This is the exact path that failed in the demo.
+**Scope:** CI job: `npm pack`, install into a temp prefix, run `outfitter --version`, `outfitter profile list`, and a `--smoke` run through onboarding with a fake/stubbed pi TTY where needed.
+**Acceptance:** CI fails if the published-artifact flow breaks; runs on every PR.
+**Size:** M
+**Deps:** 1–5 (to pass), but can land first as a failing/allow-fail canary.
+
+### 8. Record and publish the research-preview demo video
+
+**Why:** Launch asset; script already converged (problem → make/share/switch → "follow along, 5 minutes").
+**Scope:** Finalize script beats (Nicholas problem narrative, install, onboarding, profile switch `-p`, share via catalog); record (OBS, casual Imbue-style); publish to YouTube + README embed.
+**Acceptance:** Video live; README links it; total length ≤ 8 min.
+**Size:** M (non-code)
+**Deps:** 1–6.
+
+---
+
+## Milestone 2 — Engineering hardening
+
+### 9. Extract the Pi onboarding extension into `code/pi-extension` as typed TypeScript
+
+**Why:** ~750-line untyped JS string in `PiLoginLaunch.ts:127-150`; never linted/type-checked/tested; largest untested surface and the source of onboarding fragility; workspace TODO already exists.
+**Scope:** Real TS module in `code/pi-extension`, compiled at build; runtime values passed via env/JSON, not string interpolation; unit tests against pi-tui API surface; CLI consumes built artifact.
+**Acceptance:** No `String.raw` extension bodies in src; extension package has its own tests + type-checks against `@earendil-works/pi-tui`; onboarding behavior unchanged (covered by issue 7 smoke).
+**Size:** L
+**Deps:** 3 (root cause first).
+
+### 10. Implement the `prompt` state-persistence strategy
+
+**Why:** In the strategy union and allowed for most paths (`StatePersistence.ts:17`, `PiAdapter.ts:38-44`) but no prompting exists; degrades silently to warn. Profiles can configure behavior that doesn't exist.
+**Scope:** Interactive post-exit prompt (persist/discard/always-for-this-profile) when TTY; non-TTY falls back to warn with explicit notice; persist choice into profile `state_persistence`.
+**Acceptance:** `prompt` paths actually prompt; choice is honored and persisted; docs in `state.md` updated; requirement added/amended.
+**Size:** M
+
+### 11. Near-real-time undeclared-write detection (and crash coverage)
+
+**Why:** Detection only fires at clean exit (`RunCommand.ts:176-184`); multi-hour sessions get no feedback; crash/SIGKILL gets none.
+**Scope:** Extend `CompositeProfileWatcher` to flag undeclared writes as they happen (throttled notices); write a journal so a crashed session's writes are reported on next invocation.
+**Acceptance:** Undeclared write reported within seconds during a live session; post-crash report on next run; tests for both.
+**Size:** M
+**Deps:** 10 (shared UX for reporting).
+
+### 12. Clean up composite temp dirs on exit
+
+**Why:** Every run leaks `/tmp/outfitter-*` containing symlinks into auth/settings state (no `rmSync` in `RunCommand.ts`/`CompositeProfileAssembler.ts`).
+**Scope:** Remove composite dir on normal exit; keep with `--debug` (path printed); best-effort sweep of stale dirs older than N days on startup.
+**Acceptance:** No orphan dirs after clean exit; `--debug` preserves; test coverage.
+**Size:** S
+
+### 13. CI matrix (ubuntu/macos/windows) + Windows compatibility pass
+
+**Why:** ubuntu-only CI (`ci.yml:13`); symlink-centric state model and `process.env.HOME` fallbacks (`PiAdapter.ts:418,435`) are Windows hazards.
+**Scope:** Matrix CI; replace HOME with `os.homedir()`; junction/copy fallback where symlinks unavailable; document Windows support level honestly if not fully green.
+**Acceptance:** CI green on all three OSes, or Windows explicitly marked unsupported in README with a tracking issue.
+**Size:** M–L
+
+### 14. Amend OFTR-001.5 and remove dead dependencies
+
+**Why:** `defu`, `glob`, `hosted-git-info`, `typebox` declared but never imported; a do-not-modify test forbids removal (`tests/cli.test.ts:91-106`). Requirements are pinning history, not intent.
+**Scope:** Define a requirements-amendment process (doc note in requirements README); amend OFTR-001.5; drop deps; update pinned test.
+**Acceptance:** Deps removed; install size reduced; amendment process documented.
+**Size:** S
+
+### 15. Decompose SetupCommand / PiLoginLaunch; remove lint escape hatches
+
+**Why:** 1,590 + 885 LoC files opening with `eslint-disable max-lines`/`complexity` — quality gates disabled exactly where risk is highest.
+**Scope:** Extract flow modules (source import, interactive prompts, welcome persistence, login flow); delete the eslint-disable headers; no behavior change (guarded by existing suite + issue 7).
+**Acceptance:** No `eslint-disable max-lines|complexity` in `src/cli/commands`; coverage unchanged.
+**Size:** L
+**Deps:** 9 (extension extraction shrinks PiLoginLaunch first).
+
+### 16. Build and publish the Docker image from CI
+
+**Why:** Dockerfile + entrypoint are written and unit-tested but no workflow ships the image.
+**Scope:** GHCR publish on release (multi-arch if cheap); README usage section; version tags aligned with release-please.
+**Acceptance:** `docker run ghcr.io/ai-outfitter/outfitter` reaches onboarding; publish wired to releases.
+**Size:** S–M
+
+---
+
+## Milestone 3 — Claude Code adapter parity
+
+### 17. Claude adapter: MCP composition
+
+**Why:** `.mcp.json` merge is pi-only (`PiMcpConfig.ts`); Claude composite gets no MCP wiring.
+**Scope:** Generalize MCP fragment merging; emit `.mcp.json` (or `managed-mcp` equivalent) into `CLAUDE_CONFIG_DIR` composite; layer-precedence identical to pi.
+**Acceptance:** Profile with MCP servers launches Claude with them available; golden-tree fixture for claude composite.
+**Size:** M
+
+### 18. Claude adapter: map generic `skills` control
+
+**Why:** `controls.skills` unsupported on claude, only warns (`ClaudeAdapter.ts:21-35`), despite SKILL.md being a cross-tool standard.
+**Scope:** Materialize profile skills into the composite Claude skills directory; identity-dedupe consistent with pi.
+**Acceptance:** Same profile's skills appear in both pi and claude sessions; fixtures + support matrix updated.
+**Size:** M
+
+### 19. Claude adapter: first-run/login onboarding path
+
+**Why:** `PiLoginLaunch.ts:32-34` no-ops for claude; no onboarding parity.
+**Scope:** Detect missing claude binary/credentials; guided install + `claude /login` handoff; profile picker works with `--agent claude` on first run.
+**Acceptance:** Clean machine with claude installed: `outfitter run --agent claude` onboards to a working session; without claude: actionable install guidance.
+**Size:** M–L
+**Deps:** 9 (shared onboarding architecture).
+
+### 20. Claude adapter: control mapping completeness (`provider`, `thinking`, `prompt_template`, `deepwork`)
+
+**Why:** `thinking` loosely maps to `--effort` (`ClaudeAdapter.ts:181`); `provider`/`prompt_template`/`deepwork` warn-only.
+**Scope:** Precise thinking→effort table; decide + implement or explicitly document each remaining control (support matrix must match code); `--strict` behavior verified.
+**Acceptance:** `controllable-elements.md` matrix rows for Claude are all either Supported (with tests) or Roadmap (with warning text asserted in tests).
+**Size:** M
+
+### 21. Cross-adapter conformance test suite
+
+**Why:** Parity claims need an enforcement mechanism or they'll drift again.
+**Scope:** Shared conformance spec: for each generic control, a fixture profile and per-adapter expected composite output/flags; runs for pi and claude; matrix doc generated from results.
+**Acceptance:** One command proves the support matrix; docs table generated (or verified) from the suite.
+**Size:** M–L
+**Deps:** 17, 18, 20.
+
+---
+
+## Milestone 4 — Docs & site front door
+
+### 22. Fix typo'd paths and filenames (`docs/archtecture/`, `orginization-profile-catalog.md`)
+
+**Why:** Typos baked into public links while the repo is young; propagated into CONTRIBUTING.
+**Scope:** `git mv` to correct names; update all references; add redirects/notes where linked externally.
+**Acceptance:** No occurrences of `archtecture`/`orginization` in repo; links resolve.
+**Size:** S
+
+### 23. Rewrite `philosophy.md`
+
+**Why:** 16-line unedited draft with typos, linked from the user-facing index; it's also the best positioning material ("expeditious agents").
+**Scope:** Full rewrite: expeditious agents, context headroom, make/share/switch, individual→team→enterprise; keep it short but polished.
+**Acceptance:** Typo-free, coherent, linked from README; reads as the "why" page.
+**Size:** S
+
+### 24. Expand profile catalog docs + trust model
+
+**Why:** Headline feature has 30 lines of docs; catalogs inject extensions/args/env into agents — CSA-flagged supply-chain surface with no trust guidance.
+**Scope:** Grow `profile-repository.md`: authoring a catalog, `ref` pinning, `only`/`except`, private repos, `remote_settings`, versioning; new "Trust and review" section (what a catalog can do to your machine, review checklist).
+**Acceptance:** A team can publish + consume a catalog using only this doc; trust section exists and is linked from setup output.
+**Size:** M
+
+### 25. Reconcile AGENTS.md, mark superseded plans, scrub leaked paths
+
+**Why:** AGENTS.md says "Pi is the only day-one adapter" contradicting OFTR-006 and shipped code; `setup-flow-refactor-deepplan.md` documents the superseded terminal flow and leaks `/home/ncrmro/...` paths and private repo names.
+**Scope:** Update AGENTS.md to current adapter reality + doc conventions; add SUPERSEDED banners to stale plans; scrub personal paths/private names from public docs.
+**Acceptance:** No contradictions between AGENTS.md, requirements, and README; no personal machine paths in repo.
+**Size:** S
+
+### 26. Add a Concepts page and CLI command reference
+
+**Why:** Vocabulary is heavy (profile/composite/catalog/source/loadout/state paths) with no single map; command flags scattered across docs.
+**Scope:** `docs/documentation/concepts.md` (one diagram + one paragraph per concept, layer-precedence picture); `docs/documentation/cli.md` generated-or-verified from commander definitions.
+**Acceptance:** Every concept term links to Concepts; every command/flag documented; drift check (help text vs docs) in CI or a test.
+**Size:** M
+
+### 27. Single docs home: doc site renders `docs/documentation`
+
+**Why:** Two-page Nextra site duplicates/diverges from the real docs.
+**Scope:** Doc site consumes `docs/documentation/*` sources (contentlayer/symlink/build copy); nav mirrors the docs index; deploy pipeline.
+**Acceptance:** Publishing a doc change requires editing exactly one file; site deployed with full docs + landing page.
+**Size:** M–L
+**Deps:** 22, 26.
+
+### 28. Surface Supported-vs-Roadmap status in user docs
+
+**Why:** Users can't tell what works without reading an 872-line architecture file.
+**Scope:** Move/mirror the support matrix into user docs with per-adapter status badges; link from README.
+**Acceptance:** README links a matrix a new user can parse in 30 seconds; matrix consistent with issue 21's conformance results.
+**Size:** S
+**Deps:** 21 (ideally), 27.
+
+---
+
+## Milestone 5 — Distribution, positioning, and enterprise wedge (strategic)
+
+### 29. Differentiation & SEO pass (keep the name)
+
+**Why:** `outfitter-dev/agents` dominates "outfitter agents" search; awareness of ai-outfitter is ~zero, so positioning language must do the work.
+**Scope:** Consistent tagline everywhere ("Make, share, and switch your coding-agent profiles"); npm keywords; GitHub topics/description; doc site meta/OG; explicit "not affiliated with outfitter-dev" FAQ entry if collisions bite.
+**Acceptance:** Searching "outfitter pi agent profiles" surfaces ai-outfitter properties; consistent tagline across README/npm/site.
+**Size:** S
+
+### 30. Ecosystem listings & Pi community presence
+
+**Why:** Cheapest distribution: awesome-cli-coding-agents covers Pi/agent infra; Pi Discord/package channels are exactly the audience.
+**Scope:** PR to awesome-cli-coding-agents; Pi Discord announcement; explore listing the outfitter skill/extension in pi package channels; HN/launch post timing decision.
+**Acceptance:** Listed in at least two ecosystem directories; announcement posted alongside demo video (issue 8).
+**Size:** S (non-code)
+**Deps:** 8, M1 complete.
+
+### 31. State the licensing split publicly
+
+**Why:** Open/MIT individual+team, enterprise license for private-catalog features + paid training/support was the sketch (Jamie call, Weekly Demo); `code/enterprise` is an unexplained BSL shell.
+**Scope:** README "Licensing" section; `code/enterprise/README.md` explains what will live there; LICENSE.md clarity on boundaries.
+**Acceptance:** A prospective org user can answer "what's free, what will cost money" from the README.
+**Size:** S (decision + writing)
+
+### 32. Org-catalog governance features: design spec
+
+**Why:** The enterprise wedge (approved stores, `only`/`except` policy, budget annotations, model allowlists) matches field demand (UPS/Home Depot via Jamie: control plane, auditability).
+**Scope:** Design doc (docs/specs/): org-pinned `remote_settings`, source allowlists, policy enforcement vs warn, audit logging of profile provenance per session; identify which parts are OSS vs enterprise-licensed. Spec only — implementation issues spawn from it.
+**Acceptance:** Reviewed spec with explicit OSS/enterprise boundary and an implementation issue list.
+**Size:** M (spec)
+**Deps:** 24, 31.
+
+### 33. Persona-profiles showcase
+
+**Why:** Differentiated, product-shaped use case no competitor serves; docs exist (`usecases/persona-reviews.md`) but no runnable catalog.
+**Scope:** Publish a `persona-reviews` catalog in default-profiles (founder-operator, staff-engineer, EM, platform-lead reviewers); one-command demo (`outfitter run --profile persona/staff-engineer`); short write-up/blog.
+**Acceptance:** A user can run a persona review on their own docs in <5 minutes from the use-case page.
+**Size:** M
+**Deps:** M1.
+
+### 34. Federated-context pattern: worked example
+
+**Why:** The prompts-library pattern (atomic md files composed per-profile: codebases/teams/tools/models) is the answer to the "federated context layer" demand and already works via `append_system_prompt` includes; it's undocumented as a pattern.
+**Scope:** Example catalog repo with `/prompts/{codebases,teams,tools,models}` and profiles composing them; docs page walking the governance story (who owns the prompt library, review flow).
+**Acceptance:** Documented, cloneable example demonstrating 50-codebase-style composition; linked from org-catalog use case.
+**Size:** M
+**Deps:** 24.
+
+---
+
+## Sequencing summary
+
+- **Week 1 (launch):** 1–7 in parallel where possible (3→4→5 are quick kills; 1, 2, 6 are the meat; 7 lands as canary), then 8 (demo) ships the preview. 29–30 fire with the launch.
+- **Weeks 2–4:** 9 → 15, 10 → 11, 12, 13, 14, 16; docs 22–26 in parallel (small, independent).
+- **Weeks 3–6:** Claude parity 17, 18, 20 → 19 → 21 → 28; docs site 27.
+- **Quarter:** 31 → 32 (enterprise wedge), 33, 34.
+
+Total: 34 atomic issues (25 code, 9 docs/strategic).

--- a/docs/plans/demo-video-script.md
+++ b/docs/plans/demo-video-script.md
@@ -1,0 +1,146 @@
+# Demo video shooting script — Outfitter research preview
+
+Prep artifact for fork issue #6 (Record and publish the research-preview demo video). This covers the script and rehearsal plan only; recording, editing, and publishing remain open on the issue.
+
+- **Format:** casual one-take feel (Imbue-style), OBS, solo or two-presenter open.
+- **Target length:** ≤ 8 minutes total. Beat timings below sum to 7:55.
+- **The promise the video makes:** "Follow along and you'll have a fully configured Pi setup in five minutes." The install-to-working-session segment must be real time — no cuts hiding failures.
+- **Value prop line (say it verbatim, at least twice):** _"Make, share, and switch the profiles your coding agents use — manually or programmatically."_
+
+---
+
+## Beat sheet
+
+### Beat 1 — Cold open / intro (0:00–0:20, 20s)
+
+| SAY                                                                                                                                                                                                                                                           | SHOW                                                                                                                                |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| "Hey — we're going to show you Outfitter, a research preview we've been building. It's a small tool that makes, shares, and switches the profiles your coding agents use. In about five minutes of following along, you'll have a fully configured Pi setup." | Presenter(s) on camera, or face-cam corner over a clean desktop. Title card: "Outfitter — research preview" + repo URL lower-third. |
+
+**Notes:** No feature tour language. State it's a research preview in the first 20 seconds so the framing is honest from the start.
+
+### Beat 2 — The problem: Nicholas's day (0:20–1:20, 60s)
+
+| SAY                                                                                                                                                                                                                                                                                                                                                                                                                           | SHOW                                                                                                                                                                                                      |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "Here's the problem. Nicholas is a platform engineer. In a single day he's doing feature work, then he's paged into a prod incident, then he's off on a research spike. Each of those needs a different agent: different context, different tools, different model, different level of caution."                                                                                                                              | Screen: a bloated agent config — a giant system prompt file, a wall of MCP servers/extensions, dozens of skills. Optionally a quick three-panel graphic: "feature work / prod incident / research spike." |
+| "The usual answer is to load everything at once — every tool, every skill, all the context. And that degrades the agent everywhere. The context window fills with stuff that's irrelevant to the task at hand, tool choice gets noisy, and the agent gets slower and dumber at all three jobs. What Nicholas actually wants is to gear-switch: a focused loadout per kind of work, and a way to flip between them instantly." | Scroll the bloated config slowly while talking — let the excess make the point. End the beat on the word "gear-switch."                                                                                   |
+
+**Notes:** This is the authentic narrative from the dry run. Keep it concrete — name the three modes of work every time.
+
+### Beat 3 — Value prop + the hook (1:20–1:50, 30s)
+
+| SAY                                                                                                                                                                                                                                         | SHOW                                                                                                                                                          |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "That's Outfitter: make, share, and switch the profiles your coding agents use — manually or programmatically. A profile is just YAML: prompts, context, model, thinking level, extensions, skills — composed and launched as one loadout." | Cut to a short, readable `profile.yml` (the `engineer` example) — one screenful, big font. Highlight `model`, `thinking`, `append_system_prompt` with cursor. |
+| "And this isn't a talk — follow along, and you'll have a fully configured Pi setup in five minutes. Starting the clock now."                                                                                                                | On-screen timer starts (small, persistent corner element in OBS). Cut to an empty terminal.                                                                   |
+
+**Notes:** The visible timer is the credibility device. It stays on screen through Beat 5.
+
+### Beat 4 — Live: install and first run (1:50–3:20, 90s)
+
+| SAY                                                                                                                                                                                     | SHOW                                                                                               |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| "One install. Outfitter wraps agent CLIs — Pi first — so you install it globally and just run it."                                                                                      | Type, live: `npm install -g @ai-outfitter/outfitter`. Let it run for real.                         |
+| "Now the whole thing is one command." (While onboarding assets download: narrate what it's doing — syncing the default profile catalog, fetching extensions — don't dead-air the wait.) | Type: `outfitter`. First-run onboarding begins inside Pi. Keep the terminal full-screen, big font. |
+
+**Notes:** This is the segment that must not be cut. If provider login is needed, do it on camera — it's part of the honest five minutes (see failure points).
+
+### Beat 5 — Onboarding: pick a profile, land in Pi (3:20–4:50, 90s)
+
+| SAY                                                                                                                                                                                                                         | SHOW                                                                                                                                                                                          |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "Onboarding runs natively inside Pi. It asks who you are, not fifty config questions. I'll take engineer — but notice founder and data analyst are right there. These come from a shared catalog repo, which we'll get to." | The profile picker: **founder / engineer / data analyst**. Arrow through all three so viewers see the descriptions, select `engineer`.                                                        |
+| "And that's it — I'm in a Pi session, configured as an engineer: the prompt, the skills, the extensions, the model and thinking level all came from the profile. Check the clock."                                          | Land in the live Pi session. Show the loadout evidence: run a quick command or open the skills/tools listing so the engineer-specific setup is visibly present. Point at the on-screen timer. |
+
+**Notes:** Under five minutes on the timer here is the payoff of the hook. Rehearse until this lands with margin (target ~4:30 wall time from Beat 3's clock start).
+
+### Beat 6 — The money shot: switching loadouts (4:50–6:00, 70s)
+
+| SAY                                                                                                                                                                                                                                                                                                                                                                                                                       | SHOW                                                                                                                                                                                                                                                          |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "Here's the part that changes Nicholas's day. Watch me gear-switch."                                                                                                                                                                                                                                                                                                                                                      | Exit Pi. Type: `outfitter -p founder` (or `outfitter -p data-analyst` — pick the profile with the most visibly different loadout).                                                                                                                            |
+| "Same machine, same command, completely different agent: different system prompt, different skills, different tools, different model and thinking level. Feature work, prod incident, research spike — each gets its own focused loadout, and none of them pays the context tax of the others. And because it's a flag, it's scriptable — switch profiles programmatically from CI, cron, whatever launches your agents." | Side-by-side or quick back-to-back: show the skills/tools listing in this session vs. the engineer session. The visual delta between the two lists IS the shot — linger on it. Optionally a third fast switch (`outfitter -p engineer`) to show it's instant. |
+
+**Notes:** Rehearse the exact evidence commands so the two loadout listings are obviously different at a glance. This beat carries the whole thesis.
+
+### Beat 7 — Make your own (6:00–6:50, 50s)
+
+| SAY                                                                                                                                                                                                                                          | SHOW                                                                                                                                                                                              |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "Making a profile doesn't require a manual. You're already sitting inside an agent — so ask it. 'Make me a profile for reviewing pull requests on this repo.' It writes the YAML; profiles are just files, so you can read the whole thing." | From inside the Pi session, type a natural-language request: _make me a profile for X_ (pick a concrete, rehearsed X). Show the generated profile YAML — scroll it, it should fit in ~one screen. |
+| "Tweak it like any file, and it's in your picker next launch."                                                                                                                                                                               | Quick flash: the new profile appearing in `outfitter profile list` or the picker.                                                                                                                 |
+
+**Notes:** Keep the generation request small and rehearsed so the YAML comes out clean on camera.
+
+### Beat 8 — Share it: catalog repos (6:50–7:30, 40s)
+
+| SAY                                                                                                                                                                                                                                                                                                                                    | SHOW                                                                                                                                                                               |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "Because profiles are files, sharing is a git repo. Those founder, engineer, and data analyst profiles came from our default catalog. Point Outfitter at your team's repo — `outfitter setup <repo-url>` — and everyone on the team gets the same roles, synced with `outfitter sync`. That's the 'share' in make, share, and switch." | Show the default-profiles repo on GitHub (profiles/ tree), then the one-liner: `outfitter setup https://github.com/<org>/<catalog>`. No need to run a second full setup on camera. |
+
+**Notes:** Say the value prop line again here, in full — this is its second and final verbatim appearance.
+
+### Beat 9 — Close (7:30–7:55, 25s)
+
+| SAY                                                                                                                                                                                                           | SHOW                                                                                                                                                 |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "Outfitter is a research preview — it's early, it's open source, and Pi is the first-class path today. If you live in a terminal agent, try it, break it, and tell us. Repo link below. Thanks for watching." | End card: repo URL (`github.com/ai-outfitter/outfitter`), `npm install -g @ai-outfitter/outfitter`, "Research preview" label, link to docs. Hold 5s. |
+
+**Total: 7:55.**
+
+---
+
+## Pre-flight checklist
+
+Machine and environment:
+
+- [ ] **Clean machine or VM decided and prepared.** Recommendation: record on a fresh VM (or a scrubbed macOS user account) so the install is genuinely first-run — no `~/.outfitter`, no `~/.pi`, no global install, no npm cache surprises. Snapshot the VM so retakes reset in seconds.
+- [ ] **Warm vs. cold cache decision made and written down.** The honest default is **cold** for Beat 4–5 (the five-minute promise is a cold-start promise). If cold first-boot cannot reliably land under the timer on normal broadband, that is a ship-blocker on the recording (see fork issues #1/#4), not something to hide with a warm cache. If a warm cache is used anyway, say so on camera in one sentence.
+- [ ] **Network verified:** stable broadband, no corporate proxy/VPN, GitHub and npm reachable. Run a full timed cold rehearsal on this exact network the same day.
+- [ ] **Provider login state decided:** either pre-authenticated (and say so) or the login flow is rehearsed and included in the timed segment.
+- [ ] **Pinned versions:** note the exact `@ai-outfitter/outfitter` and Pi versions being demoed; do not record across a release boundary.
+
+Terminal presentation:
+
+- [ ] Terminal font size 18–22pt minimum; verify legibility at 1080p **and** in a 480p preview (most viewers watch small).
+- [ ] High-contrast theme; no transparency; window sized to the OBS canvas exactly (no scaling blur).
+- [ ] Shell prompt minimal (no personal hostname/paths); `cd` into a neutral demo directory.
+- [ ] Shell history cleaned or fresh user (no autosuggest leaking previous takes).
+- [ ] Notifications off (OS Do Not Disturb), no menu-bar clutter, dock hidden.
+
+OBS:
+
+- [ ] **Scenes built:** (1) full-screen terminal, (2) terminal + face-cam corner, (3) browser (GitHub repo) for Beat 8, (4) title/end cards, (5) side-by-side layout for Beat 6 if used.
+- [ ] **On-screen timer element** configured for Beats 3–5 (stopwatch source or scripted text source), start/stop hotkeys bound.
+- [ ] Mic checked at speaking distance; record a 30s test and listen back; audio levels around −12 dB peak.
+- [ ] Recording at 1080p/30 minimum, high bitrate; local recording (not just stream).
+- [ ] Scene-switch hotkeys rehearsed so switching doesn't require mousing through OBS on camera.
+
+Content:
+
+- [ ] Profile picker shows exactly **founder / engineer / data analyst** with sensible descriptions (verify against the current default-profiles catalog before recording).
+- [ ] The two loadout-evidence commands for Beat 6 chosen and rehearsed; the visual diff between profiles is obvious.
+- [ ] The "make me a profile for X" request chosen, rehearsed, and produces clean YAML.
+- [ ] End-card links verified (repo URL, npm package name).
+
+---
+
+## Failure points to rehearse (with fallbacks)
+
+Run at least two full cold-start rehearsals, timed, before the real take. Known risks, in order of likelihood:
+
+1. **First-boot extension download/build stall.** The dry run stalled for minutes cloning and building extensions. Rehearse the exact cold-start timing on the recording network. Mitigation: verify the extension-caching and shallow-clone work (fork issues #1/#4) is released before recording; have narration ready that fills up to ~45s of download honestly ("it's pulling the catalog and extensions — this is the slow part, once, on first boot"). Abort criterion: if cold boot exceeds ~90s in both rehearsals, do not record — fix the boot first.
+2. **Provider login flow.** First run may route through login/auth. Rehearse both paths: pre-authenticated (say so on camera) and live login (know exactly which screens appear, have credentials ready, confirm no secrets are visible on screen — use a demo account). Decide before recording which path the take uses.
+3. **Stale onboarding / cache interplay.** A previous take's `~/.outfitter` or `~/.pi` state can replay an old flow or skip the picker. Always reset from the VM snapshot between takes; never re-record over a dirty home dir.
+4. **Bootstrap model availability.** Onboarding historically injected a hardcoded model; catalog rotation breaks it silently. Verify on the rehearsal day that the onboarding model path works with the demo account's providers (fork issue #2).
+5. **"Update available" notice right after installing.** Ruins the "fresh install" credibility shot. Verify the notice is absent on the pinned version (fork issue #3); if present, mention it as known-preview jank in one clause rather than pretending it isn't there.
+6. **Network flake mid-take.** git clone or npm fetch fails transiently. Fallback: VM snapshot + restart the take; do not splice.
+7. **Profile-generation beat produces bad YAML.** The "make me a profile" request is model-dependent. Rehearse the exact phrasing; if output is ugly on the take, edit it on camera briefly — "profiles are just files" makes that recoverable, not embarrassing.
+8. **Timer overrun.** If the Beat 3–5 segment crosses five minutes on the take, do not fake it: either keep the take and own it ("okay, six minutes with the login") or reset and re-take. Never trim the timer segment in edit.
+
+---
+
+## Publishing (tracked on fork issue #6, not covered by this script)
+
+YouTube upload, README embed/link, and doc-site link land with the issue itself. Acceptance criteria there: video live, README links it, ≤ 8 minutes, install-to-working-session segment real-time.

--- a/docs/plans/issues/01-offline-default-profile.md
+++ b/docs/plans/issues/01-offline-default-profile.md
@@ -1,0 +1,28 @@
+---
+title: Bundle an offline default profile; degrade gracefully when catalog sync fails
+labels: [enhancement, m1-ship-blockers, plan-2026-07]
+size: M
+---
+
+## Problem
+
+First run hard-requires network + git. With no `~/.outfitter/settings.yml`, `outfitter` throws if `ai-outfitter/default-profiles` cannot be cloned (`code/cli/src/cli/commands/RunCommand.ts:410-418`; same for setup, `SetupCommand.ts:236-263`). Offline, proxied, or corporate-network users are dead-ended on the flagship `npm i -g && outfitter` flow. There is no bundled fallback profile despite `createDefaultSettingsContent` existing (`SetupCommand.ts:734`).
+
+## Scope
+
+- Ship a minimal built-in profile (working id: `starter`) inside the npm package — sane engineering defaults, no remote extensions required.
+- On default-catalog sync failure during onboarding, warn clearly and fall back to the built-in profile instead of throwing ("degraded mode"). A later `outfitter sync` upgrades to the full catalog.
+- Keep behavior identical when sync succeeds.
+- Amend OFTR-010 to reflect degraded-mode onboarding as a requirement.
+
+## Acceptance criteria
+
+- With network blocked, `npm i -g @ai-outfitter/outfitter && outfitter` reaches a working Pi session using the bundled profile.
+- Warning output names the failed source and explains how to retry (`outfitter sync`).
+- Integration fixture covers the offline path; requirement test updated.
+
+## References
+
+- `code/cli/src/cli/commands/RunCommand.ts:410-418`
+- `code/cli/src/cli/commands/SetupCommand.ts:236-263,734`
+- `docs/requirements/OFTR-010`

--- a/docs/plans/issues/02-remove-hardcoded-bootstrap-model.md
+++ b/docs/plans/issues/02-remove-hardcoded-bootstrap-model.md
@@ -1,0 +1,25 @@
+---
+title: Remove hardcoded bootstrap model from onboarding
+labels: [bug, m1-ship-blockers, plan-2026-07]
+size: M
+---
+
+## Problem
+
+First-run onboarding silently injects `--model google/gemini-3.1-pro-preview` (`code/cli/src/cli/commands/PiLoginLaunch.ts:79`) with no fallback logic. When Pi rotates its model catalog, the flagship `npm i -g && outfitter` flow starts erroring for every new user, and nothing in the output explains why.
+
+## Scope
+
+- Remove the hardcoded model ID.
+- Query pi for available/authenticated models and pick a sensible default; if none can be determined, omit `--model` entirely and let pi apply its own default.
+- Add a grep-style test gate: no model ID literals in `src/` outside test fixtures.
+
+## Acceptance criteria
+
+- Onboarding works with zero configured providers (routes into `/login`), with only Anthropic configured, and with only OpenAI configured.
+- No hardcoded model identifiers remain in `code/cli/src/`.
+- Regression test covers the "model no longer in catalog" scenario.
+
+## References
+
+- `code/cli/src/cli/commands/PiLoginLaunch.ts:79`

--- a/docs/plans/issues/05-fix-false-update-notice.md
+++ b/docs/plans/issues/05-fix-false-update-notice.md
@@ -1,0 +1,24 @@
+---
+title: Fix "update available" notice shown immediately after updating
+labels: [bug, m1-ship-blockers, plan-2026-07]
+size: S
+---
+
+## Problem
+
+During the demo dry run (2026-07-01), an "update available" message appeared right after updating to the latest version. Undermines trust in the update mechanism and looks broken on camera.
+
+## Scope
+
+- Root-cause the version-check path (npm dist-tag lookup vs installed version, stale cache of the check result).
+- Correct the comparison; suppress the notice when installed version >= latest.
+- Unit-test the comparator including prerelease/equal/newer-local cases.
+
+## Acceptance criteria
+
+- After installing the latest release, no update notice is shown.
+- Comparator unit tests cover equal, older, newer-local, and prerelease versions.
+
+## References
+
+- Demo dry-run transcript (2026-07-01)

--- a/docs/plans/issues/06-first-boot-speed-shallow-clones-caching.md
+++ b/docs/plans/issues/06-first-boot-speed-shallow-clones-caching.md
@@ -1,0 +1,33 @@
+---
+title: 'First-boot speed follow-ups: shallow catalog clones, extension cache refresh, progress output'
+labels: [enhancement, m1-ship-blockers, plan-2026-07]
+size: M
+---
+
+## Problem
+
+v0.7.1 (`4f1b2bb`) added `PiExtensionCache`: git extensions are shallow-cloned (`--depth 1`) and cached under `~/.outfitter/cache/extensions/git/<hash>` with deps installed once — a big first-boot win. Three gaps remain:
+
+1. **Catalog clones are still full clones.** `createGitSynchronizer` runs `git clone --` with no `--depth` (`code/cli/src/cli/commands/SyncCommand.ts`). Cheap for default-profiles; expensive for large org catalogs.
+2. **The git-extension cache never refreshes.** `materializePiExtensionSource` returns the cached path whenever it exists (`PiExtensionCache.ts`) — a `git:` extension tracking a branch never receives updates, and `outfitter sync` does not touch this cache. This is a new staleness bug introduced by the perf work.
+3. **Materialization is silent and blocking.** Clones and `npm ci` run via `spawn.sync` with `stdio: 'pipe'` — zero output before launch. First boot with several git extensions reproduces the "is it hung?" experience from the 2026-07-01 demo dry run, now at the outfitter layer.
+
+## Scope
+
+- Shallow-clone catalog sources in `createGitSynchronizer` (`--depth 1 --single-branch`); verify `fetch` + `pull --ff-only` and `ref` checkout still work against shallow caches.
+- Define and implement a refresh policy for the git-extension cache: refresh on `outfitter sync` (and/or TTL); pinned `#ref` entries stay immutable; document the policy.
+- Progress output during extension materialization and catalog sync (per-source "cloning…/installing…" lines), so no silent multi-second stall precedes launch.
+- Keep/confirm cold-boot timing measurement in the packaged E2E smoke (issue 07).
+
+## Acceptance criteria
+
+- Catalog cache directories contain shallow clones; sync/update paths tested against them.
+- `outfitter sync` refreshes branch-tracking git extensions; `#ref`-pinned entries untouched; test coverage for both.
+- Any network/build step prints progress; no silent stall > ~2s before launch.
+- Cold first boot < 60s on normal broadband (excluding model login); warm boot does no clone/build work.
+
+## References
+
+- `code/cli/src/agents/pi/PiExtensionCache.ts` (v0.7.1, `4f1b2bb`)
+- `code/cli/src/cli/commands/SyncCommand.ts` (`createGitSynchronizer`)
+- Demo dry-run transcript (2026-07-01)

--- a/docs/plans/issues/07-packaged-e2e-smoke-ci.md
+++ b/docs/plans/issues/07-packaged-e2e-smoke-ci.md
@@ -1,0 +1,29 @@
+---
+title: Add packaged E2E smoke test to CI (npm pack → global install → run)
+labels: [enhancement, testing, m1-ship-blockers, plan-2026-07]
+size: M
+depends_on: [1, 2, 5]
+---
+
+## Problem
+
+All 254 existing tests run in-process; the actual shipped artifact is never exercised. The exact flow that broke the demo recording — `npm install -g` on a machine that isn't a maintainer's — has zero CI coverage. Golden-tree fixtures verify composition logic but not packaging, bin wiring, bundled-pi resolution, or onboarding entry.
+
+## Scope
+
+- New CI job: `npm pack` in `code/cli`, install the tarball globally into a temp prefix, then run:
+  - `outfitter --version` and `outfitter --help`
+  - `outfitter profile list` against a fixture home
+  - a smoke run through onboarding (`--smoke`-style flag or scripted TTY via `expect`/pty) far enough to prove pi launches with a composite profile
+- Run on every PR; can land first as an allowed-failure canary, flip to required once M1 fixes are in.
+- Log cold/warm first-boot timing (pairs with the first-boot-speed issue).
+
+## Acceptance criteria
+
+- CI fails when the published-artifact flow breaks (bin missing, bundled pi unresolvable, onboarding crash).
+- Job runs in < ~5 minutes.
+
+## References
+
+- `code/cli/src/agents/AgentLaunch.ts:29-51` (bundled pi resolution — the kind of logic only a packaged test exercises)
+- `.github/workflows/ci.yml`

--- a/docs/plans/issues/08-record-demo-video.md
+++ b/docs/plans/issues/08-record-demo-video.md
@@ -1,0 +1,30 @@
+---
+title: Record and publish the research-preview demo video
+labels: [launch, m1-ship-blockers, plan-2026-07]
+size: M
+depends_on: [1, 2, 5, 6]
+---
+
+## Problem
+
+Launch needs its primary asset. The script converged in the 2026-07-01 working session; the recording was blocked by first-run bugs (tracked separately).
+
+## Scope
+
+Script beats (as agreed):
+
+1. ~20s intro (two-presenter open or solo casual, Imbue-style)
+2. Problem narrative: platform engineer constantly gear-switching (feature work / prod incident / research spike); one bloated setup degrades everything
+3. Value prop: **"Make, share, and switch the profiles your coding agents use — manually or programmatically"**
+4. Hook: "follow along and you'll have a fully configured Pi setup in five minutes"
+5. Live: `npm install -g @ai-outfitter/outfitter` → `outfitter` → onboarding → profile picker → in Pi
+6. The money shot: switch loadouts (`outfitter -p debug`) — different skills/tools/context instantly
+7. Make-your-own ("make me a profile for X") + share via catalog repo
+8. Close: repo link, research preview framing
+
+Production: OBS; casual one-take feel; ≤ 8 minutes. Publish to YouTube; embed/link in README and doc site.
+
+## Acceptance criteria
+
+- Video live and linked from README.
+- The install-to-working-session segment is real-time (no cuts hiding failures).

--- a/docs/plans/issues/09-extract-pi-extension-typescript.md
+++ b/docs/plans/issues/09-extract-pi-extension-typescript.md
@@ -1,0 +1,27 @@
+---
+title: Extract the Pi onboarding extension into code/pi-extension as typed TypeScript
+labels: [enhancement, tech-debt, m2-hardening, plan-2026-07]
+size: L
+---
+
+## Problem
+
+The Pi onboarding extension is a ~750-line untyped JavaScript string built with `String.raw` template interpolation (`code/cli/src/cli/commands/PiLoginLaunch.ts:127-150`), importing `@earendil-works/pi-tui` internals. It is never type-checked, linted, or executed against real pi in tests. Any pi-tui API change breaks onboarding at runtime with no compile-time signal. `code/pi-extension/` exists solely as a TODO acknowledging this (`code/pi-extension/README.md:3`). This is the single largest untested surface in the project — and it is the onboarding.
+
+## Scope
+
+- Implement the extension as real TypeScript in the `code/pi-extension` workspace, compiled at build time.
+- Pass runtime values (settings paths, profile options, flags) via env vars/JSON file instead of string interpolation.
+- CLI consumes the built artifact (bundled file or workspace dep).
+- Unit tests against the pi-tui API surface; type-check against `@earendil-works/pi-tui` so pi upgrades fail loudly at build time.
+
+## Acceptance criteria
+
+- No `String.raw` extension bodies remain in `code/cli/src/`.
+- `code/pi-extension` has its own tsconfig, tests, and lint; included in CI.
+- Onboarding behavior unchanged (verified by the packaged E2E smoke).
+
+## References
+
+- `code/cli/src/cli/commands/PiLoginLaunch.ts:127-150`
+- `code/pi-extension/README.md`

--- a/docs/plans/issues/10-implement-prompt-state-strategy.md
+++ b/docs/plans/issues/10-implement-prompt-state-strategy.md
@@ -1,0 +1,27 @@
+---
+title: Implement the `prompt` state-persistence strategy
+labels: [enhancement, m2-hardening, plan-2026-07]
+size: M
+---
+
+## Problem
+
+`prompt` is in the strategy union (`code/cli/src/compositeProfile/StatePersistence.ts:17`) and allowed for most pi/claude state paths (`PiAdapter.ts:38-44`, `ClaudeAdapter.ts:52-56`), but no code prompts anywhere — it silently degrades to a post-exit warning (`RunCommand.ts:368-374`). Profiles can configure behavior that does not exist; validation passes; the user is never asked.
+
+## Scope
+
+- On agent exit, for each `prompt`-strategy path with changes: interactive TTY prompt — persist / discard / always-persist-for-this-profile (writes the choice into the profile's `state_persistence`).
+- Non-TTY (CI/scripted) falls back to `warn` with an explicit "prompt skipped: non-interactive" notice.
+- Update `docs/documentation/state.md`; add/amend the relevant OFTR requirement.
+
+## Acceptance criteria
+
+- `prompt` paths actually prompt in a TTY; choices are honored and (for "always") persisted.
+- Non-TTY behavior explicit and tested.
+- Docs updated; no strategy in the union is a no-op.
+
+## References
+
+- `code/cli/src/compositeProfile/StatePersistence.ts:17`
+- `code/cli/src/agents/PiAdapter.ts:38-44`, `ClaudeAdapter.ts:52-56`
+- `code/cli/src/cli/commands/RunCommand.ts:368-374`

--- a/docs/plans/issues/11-realtime-undeclared-write-detection.md
+++ b/docs/plans/issues/11-realtime-undeclared-write-detection.md
@@ -1,0 +1,28 @@
+---
+title: Near-real-time undeclared-write detection and crash coverage
+labels: [enhancement, m2-hardening, plan-2026-07]
+size: M
+depends_on: [10]
+---
+
+## Problem
+
+Undeclared-write detection only fires at clean process exit via fingerprint diffing (`code/cli/src/cli/commands/RunCommand.ts:176-184`, `StatePersistence.ts:63-120`). Multi-hour sessions get no feedback until the end; crashed or SIGKILLed sessions get none at all — writes are silently lost from the accounting, undermining "unknown writes are never silently persisted."
+
+## Scope
+
+- Extend the existing composite watcher (`CompositeProfileWatcher.ts`) to flag undeclared writes as they happen, with throttled/deduped notices.
+- Persist a lightweight session journal (baseline fingerprint + observed writes) so a crashed session's undeclared writes are reported on the next invocation.
+- Keep exit-time diff as the authoritative final pass.
+
+## Acceptance criteria
+
+- An undeclared write during a live session surfaces a notice within seconds.
+- After a simulated crash (SIGKILL), the next `outfitter` invocation reports the prior session's undeclared writes.
+- Tests for live-notice and post-crash paths.
+
+## References
+
+- `code/cli/src/compositeProfile/StatePersistence.ts:63-120`
+- `code/cli/src/compositeProfile/CompositeProfileWatcher.ts:33-58`
+- `code/cli/src/cli/commands/RunCommand.ts:176-184`

--- a/docs/plans/issues/12-cleanup-composite-temp-dirs.md
+++ b/docs/plans/issues/12-cleanup-composite-temp-dirs.md
@@ -1,0 +1,26 @@
+---
+title: Clean up composite temp dirs on exit
+labels: [bug, security, m2-hardening, plan-2026-07]
+size: S
+---
+
+## Problem
+
+Composite profile directories are created with `mkdtemp` (`CompositeProfileAssembler.ts:20-21`) but never removed — there is no `rmSync` in `RunCommand.ts` or the assembler. Every run leaks a `$TMPDIR/outfitter-<profile>-<agent>-<random>/` directory containing symlinks into real auth/settings state (`~/.pi/agent/auth.json`, `~/.claude/*`). Accumulating dirs with auth-adjacent symlinks is both hygiene and mild security debt.
+
+## Scope
+
+- Remove the composite dir on normal agent exit (and on handled signals).
+- Keep the dir when `--debug` is passed, printing its path.
+- Best-effort startup sweep of stale `outfitter-*` dirs older than N days.
+
+## Acceptance criteria
+
+- No orphaned composite dirs after a clean run.
+- `--debug` preserves the dir and says so.
+- Tests cover cleanup, debug-preserve, and the sweep.
+
+## References
+
+- `code/cli/src/compositeProfile/CompositeProfileAssembler.ts:20-21`
+- `code/cli/src/agents/PiAdapter.ts:406-440`, `ClaudeAdapter.ts:148-173` (symlinked state)

--- a/docs/plans/issues/13-ci-matrix-windows-compat.md
+++ b/docs/plans/issues/13-ci-matrix-windows-compat.md
@@ -1,0 +1,27 @@
+---
+title: CI matrix (ubuntu/macos/windows) + Windows compatibility pass
+labels: [enhancement, testing, m2-hardening, plan-2026-07]
+size: L
+---
+
+## Problem
+
+CI runs on `ubuntu-latest` only (`.github/workflows/ci.yml:13`) while the runtime is symlink-centric (`StatePersistence.ts:213` uses `symlinkSync`, which requires Developer Mode/admin on Windows) and uses `process.env.HOME` fallbacks (`PiAdapter.ts:418,435`) that are undefined on Windows. macOS happens to work but nothing enforces it.
+
+## Scope
+
+- Matrix CI across ubuntu, macos, windows for unit + integration suites (and the packaged smoke where feasible).
+- Replace `process.env.HOME` with `os.homedir()` throughout.
+- Symlink fallback strategy on Windows (junctions for dirs; copy+writeback or warn for files) or an explicit, tested "Windows unsupported" gate with a clear error.
+- Document the actual support level in README.
+
+## Acceptance criteria
+
+- CI green on all three OSes, or Windows explicitly marked unsupported in README with a tracking issue and a clean error at runtime.
+- No `process.env.HOME` reads remain in `src/`.
+
+## References
+
+- `.github/workflows/ci.yml:13`
+- `code/cli/src/compositeProfile/StatePersistence.ts:213`
+- `code/cli/src/agents/PiAdapter.ts:418,435`

--- a/docs/plans/issues/14-amend-oftr-001-5-drop-dead-deps.md
+++ b/docs/plans/issues/14-amend-oftr-001-5-drop-dead-deps.md
@@ -1,0 +1,26 @@
+---
+title: Amend OFTR-001.5 and remove dead dependencies
+labels: [tech-debt, m2-hardening, plan-2026-07]
+size: S
+---
+
+## Problem
+
+`defu`, `glob`, `hosted-git-info`, and `typebox` are declared in `code/cli/package.json` but never imported anywhere in `src/`. A do-not-modify requirement test forbids removing them (`code/cli/tests/cli.test.ts:91-106`, pinning OFTR-001.5). The requirements-governance process is pinning a stale decision instead of tracking reality — and shipping unused supply-chain surface to every install.
+
+## Scope
+
+- Document a lightweight requirements-amendment process (note in `docs/requirements/README` or equivalent): how a pinned requirement gets revised, by whom, with what trace.
+- Amend OFTR-001.5 to the actual dependency set.
+- Remove the four dead deps; update the pinned test accordingly.
+
+## Acceptance criteria
+
+- Dead deps removed; `npm ls` clean; install size reduced.
+- Amendment process documented; the pinned test references the amended requirement.
+
+## References
+
+- `code/cli/package.json`
+- `code/cli/tests/cli.test.ts:91-106`
+- `docs/requirements/OFTR-001`

--- a/docs/plans/issues/15-decompose-setup-and-login-commands.md
+++ b/docs/plans/issues/15-decompose-setup-and-login-commands.md
@@ -1,0 +1,26 @@
+---
+title: Decompose SetupCommand/PiLoginLaunch; remove lint escape hatches
+labels: [tech-debt, m2-hardening, plan-2026-07]
+size: L
+depends_on: [9]
+---
+
+## Problem
+
+The three highest-risk orchestration files disable the project's own quality gates: `SetupCommand.ts` (1,590 LoC), `PiLoginLaunch.ts` (885 LoC), and `RunCommand.ts` (640 LoC) open with `/* eslint-disable max-lines */` (plus `complexity` disables at `SetupCommand.ts:156`, `PiLoginLaunch.ts:1`). Complexity is concentrating exactly where onboarding bugs live, and ~90 `/* v8 ignore */` pragmas indicate coverage is partly satisfied by exclusion.
+
+## Scope
+
+- Extract flow modules: catalog source import, interactive prompt flows, welcome/settings persistence, login flow, run orchestration steps.
+- Delete the `eslint-disable max-lines`/`complexity` headers; conform to the repo's `complexity: 10` / `max-lines: 500` rules.
+- No behavior change — guarded by the existing suite plus the packaged E2E smoke.
+- Reduce `/* v8 ignore */` count where extraction makes paths testable.
+
+## Acceptance criteria
+
+- No `eslint-disable max-lines|complexity` in `code/cli/src/cli/commands/`.
+- Coverage thresholds still met without new ignore pragmas.
+
+## References
+
+- `code/cli/src/cli/commands/SetupCommand.ts`, `PiLoginLaunch.ts`, `RunCommand.ts`

--- a/docs/plans/issues/16-publish-docker-image.md
+++ b/docs/plans/issues/16-publish-docker-image.md
@@ -1,0 +1,26 @@
+---
+title: Build and publish the Docker image from CI
+labels: [enhancement, m2-hardening, plan-2026-07]
+size: M
+---
+
+## Problem
+
+The Dockerfile (node:22, bundles outfitter + pi) and its UID-remapping entrypoint are written and unit-tested (`tests/unit/container-entrypoint.test.ts`), but no workflow builds or publishes the image. Container-image publishing was dropped from the release path (CONTRIBUTING). Users who want a containerized/sandboxed agent loadout — a natural fit for the product story — have to build it themselves.
+
+## Scope
+
+- GitHub Actions job: build and push to GHCR on release (tags aligned with release-please versions + `latest`); multi-arch (amd64/arm64) if build time is acceptable.
+- Smoke the image in CI: `docker run … outfitter --version` and entrypoint UID remap.
+- README section: running Outfitter via Docker.
+
+## Acceptance criteria
+
+- `docker run ghcr.io/ai-outfitter/outfitter` reaches onboarding.
+- Image published automatically on each release.
+
+## References
+
+- `Dockerfile`, `bin/outfitter-docker-entrypoint`
+- `code/cli/tests/unit/container-entrypoint.test.ts`
+- `.github/workflows/release.yml`

--- a/docs/plans/issues/17-claude-mcp-composition.md
+++ b/docs/plans/issues/17-claude-mcp-composition.md
@@ -1,0 +1,28 @@
+---
+title: 'Claude adapter: MCP composition'
+labels: [enhancement, claude-adapter, m3-claude-parity, plan-2026-07]
+size: M
+---
+
+## Problem
+
+MCP fragment merging is pi-only (`code/cli/src/compositeProfile/PiMcpConfig.ts`); the Claude composite gets no MCP wiring at all. A profile that declares MCP servers works in pi and silently lacks them in claude — a parity gap in one of the highest-value controls.
+
+## Scope
+
+- Generalize MCP fragment merging out of the pi-specific module.
+- Emit merged MCP config into the Claude composite (`CLAUDE_CONFIG_DIR`) in the format Claude Code reads (`.mcp.json` / managed MCP equivalent — verify current claude behavior).
+- Layer precedence identical to pi (project-local > project > user > remote).
+- Support `cli_specific/claude/` fragments alongside generic ones.
+
+## Acceptance criteria
+
+- A profile with MCP servers launches Claude Code with those servers available.
+- Golden-tree integration fixture for the claude composite including MCP output.
+- Support matrix updated.
+
+## References
+
+- `code/cli/src/compositeProfile/PiMcpConfig.ts`
+- `code/cli/src/agents/ClaudeAdapter.ts:115` (CLAUDE_CONFIG_DIR)
+- `docs/archtecture/controllable-elements.md`

--- a/docs/plans/issues/18-claude-skills-mapping.md
+++ b/docs/plans/issues/18-claude-skills-mapping.md
@@ -1,0 +1,26 @@
+---
+title: 'Claude adapter: map generic skills control'
+labels: [enhancement, claude-adapter, m3-claude-parity, plan-2026-07]
+size: M
+---
+
+## Problem
+
+Generic `controls.skills` is unsupported on the claude adapter and only warns (`code/cli/src/agents/ClaudeAdapter.ts:21-35`) — even though SKILL.md is now a cross-tool open standard read natively by Claude Code. Profiles with skills lose them silently (modulo a warning) when launched with `--agent claude`.
+
+## Scope
+
+- Materialize profile skills into the Claude composite's skills directory (verify current Claude Code skills discovery paths under `CLAUDE_CONFIG_DIR`).
+- Apply the same unique-by-normalized-identity dedup used for pi (`ProfileMerger.ts:47-85`).
+- Handle directory-layout profile skills (`skills/` subdir) and inherited skills.
+
+## Acceptance criteria
+
+- The same profile's skills are available in both pi and claude sessions.
+- Golden-tree fixture covers claude skills materialization.
+- Support matrix updated; warning removed.
+
+## References
+
+- `code/cli/src/agents/ClaudeAdapter.ts:21-35`
+- `code/cli/src/profiles/ProfileMerger.ts:47-85`

--- a/docs/plans/issues/19-claude-onboarding-login.md
+++ b/docs/plans/issues/19-claude-onboarding-login.md
@@ -1,0 +1,29 @@
+---
+title: 'Claude adapter: first-run/login onboarding path'
+labels: [enhancement, claude-adapter, m3-claude-parity, plan-2026-07]
+size: L
+depends_on: [9]
+---
+
+## Problem
+
+Onboarding is pi-only: `PiLoginLaunch.ts:32-34` no-ops for claude. There is no first-run experience for `--agent claude` — no binary detection guidance beyond a PATH error, no credential/login handoff, no profile picker parity. Claude is marketed as a peer adapter but a claude-first user gets none of the onboarding polish.
+
+## Scope
+
+- Detect missing claude binary; print guided install instructions (npm/brew per platform).
+- Detect missing credentials; hand off to `claude /login` (or launch claude so its own login flow runs), returning to a working profile-driven session.
+- Profile picker works on first run with `--agent claude` (terminal-side picker is acceptable; claude has no pi-tui equivalent for embedded UI).
+- Respect the "credentials never touch Outfitter" rule.
+
+## Acceptance criteria
+
+- Clean machine with claude installed: `outfitter run --agent claude` reaches a working session with the chosen profile.
+- Without claude installed: actionable guidance, no stack trace.
+- Covered by integration tests with a stubbed claude binary.
+
+## References
+
+- `code/cli/src/cli/commands/PiLoginLaunch.ts:32-34`
+- `code/cli/src/agents/ClaudeAdapter.ts`
+- `docs/archtecture/onboarding.md`

--- a/docs/plans/issues/20-claude-control-mapping-completeness.md
+++ b/docs/plans/issues/20-claude-control-mapping-completeness.md
@@ -1,0 +1,26 @@
+---
+title: 'Claude adapter: control mapping completeness (provider, thinking, prompt_template, deepwork)'
+labels: [enhancement, claude-adapter, m3-claude-parity, plan-2026-07]
+size: M
+---
+
+## Problem
+
+Beyond MCP and skills (tracked separately), the claude adapter's generic-control coverage is loose or absent: `thinking` maps approximately to `--effort` (`ClaudeAdapter.ts:181`), while `provider`, `prompt_template`, and `deepwork` controls are warn-only (`ClaudeAdapter.ts:21-35`). The support matrix in `docs/archtecture/controllable-elements.md` marks Claude "Supported" for rows the code only partially honors.
+
+## Scope
+
+- Precise `thinking` → `--effort` mapping table (document each level's translation).
+- For each remaining control (`provider`, `prompt_template`, `deepwork`, plus the five both-adapter Roadmap rows): decide implement vs. explicitly-Roadmap; implement the feasible ones; for the rest, ensure the warning text is accurate and asserted in tests.
+- Verify `--strict` escalates every unsupported control to a failure.
+- Reconcile the support matrix with actual behavior.
+
+## Acceptance criteria
+
+- Every Claude row in `controllable-elements.md` is either Supported (with a test) or Roadmap (with warning text asserted in a test).
+- `--strict` behavior verified for all unsupported controls.
+
+## References
+
+- `code/cli/src/agents/ClaudeAdapter.ts:21-35,181`
+- `docs/archtecture/controllable-elements.md`

--- a/docs/plans/issues/21-cross-adapter-conformance-suite.md
+++ b/docs/plans/issues/21-cross-adapter-conformance-suite.md
@@ -1,0 +1,27 @@
+---
+title: Cross-adapter conformance test suite
+labels: [testing, claude-adapter, m3-claude-parity, plan-2026-07]
+size: L
+depends_on: [17, 18, 20]
+---
+
+## Problem
+
+Adapter parity claims have no enforcement mechanism — the claude adapter drifted behind the marketing once already, and nothing structural prevents it happening again as pi evolves or new adapters land. The support matrix is hand-maintained prose.
+
+## Scope
+
+- A conformance spec: for each generic control, a fixture profile plus per-adapter expected composite output/flags/warnings.
+- Runs against every registered adapter (pi, claude today); an adapter declares Supported/Roadmap per control and the suite verifies the declaration matches behavior (supported ⇒ correct output; roadmap ⇒ correct warning; `--strict` ⇒ failure).
+- Generate (or verify) the user-facing support matrix from suite results so docs cannot drift from code.
+
+## Acceptance criteria
+
+- One command proves the support matrix for all adapters.
+- Adding a new adapter requires passing/declaring every conformance row.
+- Docs matrix generated from or checked against results in CI.
+
+## References
+
+- `docs/archtecture/controllable-elements.md`
+- `code/cli/tests/fixtures/integration/` (golden-tree pattern to build on)

--- a/docs/plans/issues/22-fix-typo-paths.md
+++ b/docs/plans/issues/22-fix-typo-paths.md
@@ -1,0 +1,25 @@
+---
+title: Fix typo'd doc paths (docs/archtecture, orginization-profile-catalog.md)
+labels: [documentation, m4-docs, plan-2026-07]
+size: S
+---
+
+## Problem
+
+Two typos are baked into public link paths while the repo is young: the `docs/archtecture/` directory ("architecture") and `docs/documentation/usecases/orginization-profile-catalog.md` ("organization"). The archtecture typo is propagated into CONTRIBUTING.md links. Every week these survive, more external links accrue.
+
+## Scope
+
+- `git mv docs/archtecture docs/architecture`; rename the use-case file.
+- Update every in-repo reference (README, CONTRIBUTING, docs index, doc site, requirement docs, code comments).
+- Grep gate in CI or a test: `archtecture|orginization` must not appear.
+
+## Acceptance criteria
+
+- Zero occurrences of the typo'd strings in the repo.
+- All internal links resolve (link check).
+
+## References
+
+- `docs/archtecture/`, `docs/documentation/usecases/orginization-profile-catalog.md`
+- `CONTRIBUTING.md`

--- a/docs/plans/issues/23-rewrite-philosophy.md
+++ b/docs/plans/issues/23-rewrite-philosophy.md
@@ -1,0 +1,28 @@
+---
+title: Rewrite philosophy.md
+labels: [documentation, m4-docs, plan-2026-07]
+size: S
+---
+
+## Problem
+
+`docs/philosophy.md` is a 16-line unedited draft with heavy typos ("Philosphy", "acchomplish", "signal to ration", "sub agen deligation", "whic feeds") — and it is linked from the user-facing documentation index. It is also the project's best positioning material: the "expeditious agents" idea is the intellectual core of the product.
+
+## Scope
+
+Full rewrite, short but polished:
+
+- Expeditious agents: tight, focused profiles preserve context headroom → better decisions, faster sessions.
+- The one-liner: make, share, and switch the profiles your coding agents use — manually or programmatically.
+- Why composition beats one bloated setup (the 20%-worse-at-everything problem).
+- The stair-step: individual → team → enterprise.
+
+## Acceptance criteria
+
+- Typo-free, coherent, ≤ ~1 page.
+- Linked from README as the "why" page; consistent with the tagline used elsewhere.
+
+## References
+
+- `docs/philosophy.md`
+- Demo dry-run + Jamie call framing (2026-06-29 / 2026-07-01)

--- a/docs/plans/issues/24-catalog-docs-trust-model.md
+++ b/docs/plans/issues/24-catalog-docs-trust-model.md
@@ -1,0 +1,25 @@
+---
+title: Expand profile catalog docs + trust model
+labels: [documentation, security, m4-docs, plan-2026-07]
+size: M
+---
+
+## Problem
+
+Profile catalogs are the headline sharing feature ("Individuals, teams, and organizations can share and compose repeatable agent profiles") but `docs/documentation/profile-repository.md` is ~30 lines. There is no guidance on authoring, versioning/`ref` pinning, `only`/`except` filters, private repos, or `remote_settings` — those details live only in OFTR-002 and the 872-line architecture README. Critically, there is no trust-model documentation, even though an imported catalog can inject extensions, args, and env into agent launches (a CSA-flagged supply-chain surface; Pi's own docs warn packages run with full system access).
+
+## Scope
+
+- Expand `profile-repository.md`: authoring a catalog repo, layout conventions, `ref` pinning, `only`/`except`, private repos/auth, `remote_settings`, versioning and update flow (`outfitter sync`).
+- New "Trust and review" section: what a catalog can do to your machine, a review checklist before adding a source, recommendation to pin `ref`s for org catalogs.
+- Link the trust section from `outfitter setup` output when adding a remote source.
+
+## Acceptance criteria
+
+- A team can publish and consume a catalog using only this doc.
+- Trust section exists, is linked from setup output, and is honest about the execution surface.
+
+## References
+
+- `docs/documentation/profile-repository.md`
+- `docs/requirements/OFTR-002`, `OFTR-004`

--- a/docs/plans/issues/25-reconcile-agents-md-scrub-paths.md
+++ b/docs/plans/issues/25-reconcile-agents-md-scrub-paths.md
@@ -1,0 +1,30 @@
+---
+title: Reconcile AGENTS.md, mark superseded plans, scrub leaked paths
+labels: [documentation, m4-docs, plan-2026-07]
+size: S
+---
+
+## Problem
+
+Three front-door consistency issues:
+
+1. `AGENTS.md:14` says "Pi is the only day-one adapter. Claude is roadmap-only unless requirements change" — contradicting OFTR-006 ("Outfitter MUST support Claude Code"), the architecture README, getting-started examples, and shipped code. Contributing agents get actively misled.
+2. `docs/plans/setup-flow-refactor-deepplan.md` documents the superseded terminal setup flow (ASCII banner, terminal prompts) that OFTR-010 now forbids; nothing marks it superseded.
+3. That plan leaks a developer's machine paths (`/home/ncrmro/repos/unsupervised/...`) and private repo names into the public repo.
+
+## Scope
+
+- Update AGENTS.md to current adapter reality and doc conventions.
+- Add a SUPERSEDED banner convention for plan docs; apply to stale plans.
+- Scrub personal machine paths and private repo names from all public docs.
+
+## Acceptance criteria
+
+- No contradictions between AGENTS.md, requirements, and README on adapter support.
+- Superseded plans carry a banner naming what replaced them.
+- No `/home/<user>` paths or private repo names in the repo.
+
+## References
+
+- `AGENTS.md:14`, `docs/requirements/OFTR-006`, `OFTR-010`
+- `docs/plans/setup-flow-refactor-deepplan.md`

--- a/docs/plans/issues/26-concepts-page-cli-reference.md
+++ b/docs/plans/issues/26-concepts-page-cli-reference.md
@@ -1,0 +1,26 @@
+---
+title: Add a Concepts page and CLI command reference
+labels: [documentation, m4-docs, plan-2026-07]
+size: M
+---
+
+## Problem
+
+The concept vocabulary is heavy — profile, composite profile, catalog, profile source, settings scope, loadout, remote settings, state paths — and there is no single page tying it together; the best mental-model text is buried in the 872-line architecture README. There is also no CLI reference: flags for `run`, `--strict`, `--agent`, `profile lint` are scattered across docs, and `outfitter welcome` appears in getting-started with zero explanation.
+
+## Scope
+
+- `docs/documentation/concepts.md`: one diagram (settings → sources → profile stack → composite → adapter → agent), one short paragraph per concept, the layer-precedence picture.
+- `docs/documentation/cli.md`: every command and flag, generated from or verified against the commander definitions.
+- Drift check: a test comparing `--help` output to the documented command surface.
+- Link concept terms from other docs pages; explain or remove `welcome` from getting-started.
+
+## Acceptance criteria
+
+- Every concept term used in docs links to Concepts.
+- Every command/flag documented; drift check in CI.
+
+## References
+
+- `docs/documentation/README.md`, `getting-started.md`
+- `code/cli/src/cli/commands/`

--- a/docs/plans/issues/27-single-docs-home.md
+++ b/docs/plans/issues/27-single-docs-home.md
@@ -1,0 +1,27 @@
+---
+title: 'Single docs home: doc site renders docs/documentation'
+labels: [documentation, m4-docs, plan-2026-07]
+size: L
+depends_on: [22, 26]
+---
+
+## Problem
+
+`code/doc_site` (Nextra/Next 16) has exactly two pages (landing + state-persistence) while the real documentation lives in `docs/documentation/`. Two doc surfaces guarantee divergence — the state-persistence page already duplicates `state.md` content.
+
+## Scope
+
+- Doc site consumes `docs/documentation/*` as its content source (build-time copy, symlink, or content pipeline) so a doc change edits exactly one file.
+- Site nav mirrors the documentation index; landing page keeps the marketing copy.
+- Deploy pipeline (Vercel/Pages) wired to main.
+- Fix the landing page's fictional details flagged in review (e.g., `github:nhorton/agent-profiles` example, invented "17 controls merged" output) to use real, reproducible examples.
+
+## Acceptance criteria
+
+- Publishing a doc change requires editing one file under `docs/documentation/`.
+- Site deployed with full docs; no duplicated content files.
+
+## References
+
+- `code/doc_site/app/page.mdx`, `app/state-persistence/page.mdx`
+- `docs/documentation/`

--- a/docs/plans/issues/28-support-matrix-user-docs.md
+++ b/docs/plans/issues/28-support-matrix-user-docs.md
@@ -1,0 +1,26 @@
+---
+title: Surface Supported-vs-Roadmap status in user docs
+labels: [documentation, m4-docs, plan-2026-07]
+size: S
+depends_on: [21, 27]
+---
+
+## Problem
+
+A new user cannot tell what works per adapter without reading `docs/archtecture/controllable-elements.md` (an architecture file). Meanwhile README/docs present Claude as a peer even where support is partial — the honest matrix exists but is invisible to the audience that needs it.
+
+## Scope
+
+- Move or mirror the support matrix into `docs/documentation/` with per-adapter status badges (Supported / Partial / Roadmap).
+- Link prominently from README ("What works today").
+- Once the cross-adapter conformance suite lands, generate or verify this table from suite results.
+
+## Acceptance criteria
+
+- README links a matrix a new user can parse in 30 seconds.
+- Matrix consistent with conformance-suite results (CI-checked once available).
+
+## References
+
+- `docs/archtecture/controllable-elements.md`
+- Cross-adapter conformance suite issue

--- a/docs/plans/issues/29-differentiation-seo.md
+++ b/docs/plans/issues/29-differentiation-seo.md
@@ -1,0 +1,21 @@
+---
+title: Differentiation & SEO pass (keep the name, own the tagline)
+labels: [strategy, launch, m5-strategic, plan-2026-07]
+size: S
+---
+
+## Problem
+
+`outfitter-dev/agents` is an established, unrelated Claude Code plugin marketplace also called "Outfitter" that currently dominates search for "outfitter agents." Awareness of ai-outfitter is effectively zero (3 stars), so positioning language has to do the differentiation work. Decision: keep the name; differentiate deliberately.
+
+## Scope
+
+- One consistent tagline everywhere: "Make, share, and switch the profiles your coding agents use — manually or programmatically" (README, npm description, GitHub repo description, doc site title/meta/OG).
+- npm keywords + GitHub topics: pi, agent-profiles, agent-configuration, claude-code, coding-agents, mcp, etc.
+- Doc site meta/OG images; sitemap.
+- FAQ entry pre-empting the collision ("Is this outfitter-dev?" → no, unaffiliated) to add if/when confusion appears.
+
+## Acceptance criteria
+
+- Searching "outfitter pi agent profiles" surfaces ai-outfitter properties on page one.
+- Identical tagline across README/npm/GitHub/site.

--- a/docs/plans/issues/30-ecosystem-listings.md
+++ b/docs/plans/issues/30-ecosystem-listings.md
@@ -1,0 +1,26 @@
+---
+title: Ecosystem listings & Pi community presence
+labels: [strategy, launch, m5-strategic, plan-2026-07]
+size: S
+depends_on: [8]
+---
+
+## Problem
+
+Distribution is the cheapest lever right now and it's unpulled: zero listings, zero community presence. The Pi ecosystem is the beachhead (no incumbent profile manager/launcher; audience is exactly harness tinkerers) and `awesome-cli-coding-agents` already covers Pi and agent infrastructure.
+
+## Scope
+
+- PR to `bradAGI/awesome-cli-coding-agents` (agent-infrastructure section).
+- Announce in Pi's Discord / package channels; explore listing the Outfitter extension in pi package indexes.
+- Decide timing for a launch post (HN "Show HN" / blog) — coordinated with the demo video.
+- Track other relevant directories (MCP/agent tooling lists) opportunistically.
+
+## Acceptance criteria
+
+- Listed in at least two ecosystem directories.
+- Announcement posted alongside the demo video.
+
+## References
+
+- Market research report (2026-07-01): distribution recommendations

--- a/docs/plans/issues/31-licensing-split-statement.md
+++ b/docs/plans/issues/31-licensing-split-statement.md
@@ -1,0 +1,25 @@
+---
+title: State the licensing split publicly
+labels: [strategy, m5-strategic, plan-2026-07]
+size: S
+---
+
+## Problem
+
+`code/enterprise/` is a BSL-style license shell with zero code and no explanation — an enterprise ambition visible in the tree but unexplained to users. The working model (from the 2026-06-29 discussions): open/MIT for individual + team use, enterprise license for private-catalog/org features, monetize training and support early. Prospective org adopters currently cannot answer "what's free, what will cost money?"
+
+## Scope
+
+- README "Licensing" section: what is MIT/open today, what the enterprise license will cover (private catalog features, org governance), and the training/support offering posture.
+- `code/enterprise/README.md`: explain what will live there and why it exists now.
+- Verify LICENSE.md boundaries are unambiguous about which paths carry which license.
+
+## Acceptance criteria
+
+- A prospective org user can answer the free-vs-paid question from the README alone.
+- Enterprise directory no longer reads as an unexplained mystery.
+
+## References
+
+- `code/enterprise/LICENSE`, `code/enterprise/README.md`, `LICENSE.md`
+- Jamie call + Weekly Demo notes (2026-06-29): public-MIT / private-enterprise licensing sketch

--- a/docs/plans/issues/32-org-governance-design-spec.md
+++ b/docs/plans/issues/32-org-governance-design-spec.md
@@ -1,0 +1,31 @@
+---
+title: 'Org-catalog governance features: design spec'
+labels: [strategy, design-spec, m5-strategic, plan-2026-07]
+size: M
+depends_on: [24, 31]
+---
+
+## Problem
+
+The enterprise wedge is org-approved profile governance — the exact demand heard from the field (via Jamie, 2026-06-29: UPS/Home Depot wanting AI SDLC toolkits, approved stores, cost controls, auditability; DORA 2025 validating org-level AI standardization by platform teams). Pieces exist (`remote_settings`, `only`/`except` filters, budget-annotation pattern in the org use-case doc) but there is no coherent design for governance as a feature set, nor a decided OSS/enterprise boundary.
+
+## Scope
+
+Design spec only (docs/specs/); implementation issues spawn from it. Cover:
+
+- Org-pinned `remote_settings`: approved profile sources, source allowlists, `ref` pinning policy.
+- Enforcement modes: warn vs enforce when a user launches outside approved profiles.
+- Audit trail: recording profile provenance (source, ref, resolved stack) per session.
+- Model/cost policy: approved-model lists, default-model policy per role, budget annotations formalized.
+- Federated context governance: who owns the prompts library, review flow (ties to the federated-context example issue).
+- Explicit OSS vs enterprise-licensed boundary per feature.
+
+## Acceptance criteria
+
+- Reviewed spec with the OSS/enterprise boundary decided and an enumerated implementation-issue list.
+
+## References
+
+- `docs/documentation/usecases/orginization-profile-catalog.md`
+- `docs/requirements/OFTR-002`
+- Assessment §5 (market) and Jamie-call field signals

--- a/docs/plans/issues/33-persona-profiles-showcase.md
+++ b/docs/plans/issues/33-persona-profiles-showcase.md
@@ -1,0 +1,25 @@
+---
+title: Persona-profiles showcase
+labels: [strategy, enhancement, m5-strategic, plan-2026-07]
+size: M
+---
+
+## Problem
+
+Persona reviews are a differentiated, product-shaped use case no competitor serves (rules-syncers and vendor marketplaces don't do it), and the docs already describe it well (`docs/documentation/usecases/persona-reviews.md`) — but there is no runnable catalog. A user convinced by the doc has to build everything from scratch.
+
+## Scope
+
+- Publish a `persona-reviews` set in the `ai-outfitter/default-profiles` catalog: founder-operator, staff-engineer, engineering-manager, platform-lead reviewer personas with the structured output shape from the doc (persona, artifact reviewed, first impression, top blocker, …).
+- One-command path from the doc: `outfitter run --profile persona/staff-engineer` (or equivalent) against the user's artifact.
+- Short write-up/blog post demonstrating a real review (e.g., personas reviewing Outfitter's own README — the docs already do this self-referentially).
+
+## Acceptance criteria
+
+- A user can run a persona review on their own docs in < 5 minutes starting from the use-case page.
+- Personas ship in the default catalog with descriptions visible in the picker.
+
+## References
+
+- `docs/documentation/usecases/persona-reviews.md`
+- `ai-outfitter/default-profiles` (companion repo work)

--- a/docs/plans/issues/34-federated-context-example.md
+++ b/docs/plans/issues/34-federated-context-example.md
@@ -1,0 +1,26 @@
+---
+title: 'Federated-context pattern: worked example'
+labels: [strategy, documentation, m5-strategic, plan-2026-07]
+size: M
+depends_on: [24]
+---
+
+## Problem
+
+The "federated context layer" is named enterprise demand (Home Depot via Jamie, 2026-06-29: 50 legacy repos, per-team context selection without bloating any one context window). Outfitter already supports the answer — atomic markdown libraries (`/prompts/{codebases,teams,tools,models}`) composed per-profile via `append_system_prompt` file/repo_file includes — but it exists only as conversation, not as a documented pattern anyone can adopt.
+
+## Scope
+
+- Example catalog repo demonstrating the pattern: a `prompts/` library of atomic files (several fake codebases, teams, tool policies, model policies) plus profiles that compose subsets ("java-modernization" pulls 2 codebases + 1 team + tool policy).
+- Docs page walking the pattern: structure, composition mechanics, the governance angle (a governance team owns the prompts library; profiles stay thin), scaling notes and honest limits (it's real work to author; agents can draft but humans must review).
+- Link from the org-catalog use case.
+
+## Acceptance criteria
+
+- Cloneable example demonstrating 50-codebase-style composition.
+- Docs page published and linked from the org use case.
+
+## References
+
+- `docs/documentation/profiles.md` (append_system_prompt file/repo_file)
+- Jamie call transcript (2026-06-29): federated context discussion

--- a/docs/plans/issues/README.md
+++ b/docs/plans/issues/README.md
@@ -59,3 +59,7 @@ Milestone labels: `m1-ship-blockers`, `m2-hardening`, `m3-claude-parity`, `m4-do
 | 32     | Org-catalog governance features: design spec                                                                                                              | M5        | M    |
 | 33     | Persona-profiles showcase                                                                                                                                 | M5        | M    |
 | 34     | Federated-context pattern: worked example                                                                                                                 | M5        | M    |
+
+## Filed (2026-07-01, fork tylerwillis/outfitter)
+
+All 32 drafts filed. Mapping (draft → fork issue): 01→#1, 02→#2, 05→#3, 06→#4, 07→#5, 08→#6, 09→#7, 10→#8, 11→#9, 12→#10, 13→#11, 14→#12, 15→#13, 16→#14, 17→#15, 18→#16, 19→#17, 20→#18, 21→#19, 22→#20, 23→#21, 24→#22, 25→#23, 26→#24, 27→#25, 28→#26, 29→#27, 30→#28, 31→#29, 32→#30, 33→#31, 34→#32.

--- a/docs/plans/issues/README.md
+++ b/docs/plans/issues/README.md
@@ -1,0 +1,61 @@
+# Local issue drafts (2026-07 update plan)
+
+Draft GitHub issues for the [2026-07-01 update plan](../2026-07-01-update-plan.md). **Local only for now** — iterate here; nothing is filed until we explicitly run the filing script.
+
+## Format
+
+One file per issue: `NN-slug.md`. YAML frontmatter carries the metadata; everything after the `---` is the verbatim GitHub issue body.
+
+```yaml
+---
+title: <issue title>
+labels: [<type>, <milestone-label>, plan-2026-07]
+size: S|M|L
+depends_on: [<issue numbers>] # optional
+---
+```
+
+Milestone labels: `m1-ship-blockers`, `m2-hardening`, `m3-claude-parity`, `m4-docs`, `m5-strategic`.
+
+## Filing later
+
+`node scripts/file-issues.mjs` — dry-run by default (prints what would be created). Use `--file` to actually create issues via `gh`, `--only 01,03` to file a subset. Requires the labels to exist (script creates missing ones with `--file`).
+
+## Index
+
+| #      | Issue                                                                                                                                                     | Milestone | Size |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ---- |
+| 01     | Bundle offline default profile; degrade gracefully when catalog sync fails                                                                                | M1        | M    |
+| 02     | Remove hardcoded bootstrap model from onboarding                                                                                                          | M1        | S–M  |
+| ~~03~~ | ~~Fix onboarding regression: stale flow~~ — fixed in v0.7.2 (`a380826`); onboarding also force-syncs the catalog                                          | —         | —    |
+| ~~04~~ | ~~Fix extension sources pointing at the old repo~~ — fixed in default-profiles (`c413d75` + shortcut-conflict follow-ups)                                 | —         | —    |
+| 05     | Fix "update available" notice shown immediately after updating                                                                                            | M1        | S    |
+| 06     | First-boot speed follow-ups: shallow catalog clones, extension cache refresh, progress output (re-scoped after v0.7.1 `4f1b2bb` landed extension caching) | M1        | M    |
+| 07     | Add packaged E2E smoke test to CI                                                                                                                         | M1        | M    |
+| 08     | Record and publish the research-preview demo video                                                                                                        | M1        | M    |
+| 09     | Extract Pi onboarding extension into code/pi-extension as typed TS                                                                                        | M2        | L    |
+| 10     | Implement the `prompt` state-persistence strategy                                                                                                         | M2        | M    |
+| 11     | Near-real-time undeclared-write detection + crash coverage                                                                                                | M2        | M    |
+| 12     | Clean up composite temp dirs on exit                                                                                                                      | M2        | S    |
+| 13     | CI matrix (ubuntu/macos/windows) + Windows compatibility pass                                                                                             | M2        | M–L  |
+| 14     | Amend OFTR-001.5 and remove dead dependencies                                                                                                             | M2        | S    |
+| 15     | Decompose SetupCommand/PiLoginLaunch; remove lint escape hatches                                                                                          | M2        | L    |
+| 16     | Build and publish the Docker image from CI                                                                                                                | M2        | S–M  |
+| 17     | Claude adapter: MCP composition                                                                                                                           | M3        | M    |
+| 18     | Claude adapter: map generic skills control                                                                                                                | M3        | M    |
+| 19     | Claude adapter: first-run/login onboarding path                                                                                                           | M3        | M–L  |
+| 20     | Claude adapter: control mapping completeness                                                                                                              | M3        | M    |
+| 21     | Cross-adapter conformance test suite                                                                                                                      | M3        | M–L  |
+| 22     | Fix typo'd doc paths (archtecture, orginization)                                                                                                          | M4        | S    |
+| 23     | Rewrite philosophy.md                                                                                                                                     | M4        | S    |
+| 24     | Expand profile catalog docs + trust model                                                                                                                 | M4        | M    |
+| 25     | Reconcile AGENTS.md, mark superseded plans, scrub leaked paths                                                                                            | M4        | S    |
+| 26     | Add Concepts page and CLI command reference                                                                                                               | M4        | M    |
+| 27     | Single docs home: doc site renders docs/documentation                                                                                                     | M4        | M–L  |
+| 28     | Surface Supported-vs-Roadmap status in user docs                                                                                                          | M4        | S    |
+| 29     | Differentiation & SEO pass (keep the name)                                                                                                                | M5        | S    |
+| 30     | Ecosystem listings & Pi community presence                                                                                                                | M5        | S    |
+| 31     | State the licensing split publicly                                                                                                                        | M5        | S    |
+| 32     | Org-catalog governance features: design spec                                                                                                              | M5        | M    |
+| 33     | Persona-profiles showcase                                                                                                                                 | M5        | M    |
+| 34     | Federated-context pattern: worked example                                                                                                                 | M5        | M    |

--- a/docs/plans/launch/ecosystem-listings.md
+++ b/docs/plans/launch/ecosystem-listings.md
@@ -1,0 +1,82 @@
+# Ecosystem listings + announcement copy
+
+Prep artifact for fork issue #28 (Ecosystem listings & Pi community presence). Copy below is ready to submit; the submissions themselves are human actions and stay open on the issue. Timing per the update plan: fire alongside the demo video (fork issue #6), after M1 lands.
+
+Verification notes (2026-07-01):
+
+- `bradAGI/awesome-cli-coding-agents` exists and is active (~707 stars, 90+ entries). Structure: **Terminal-native coding agents** (Open Source / OpenClaw ecosystem / Closed Source) and **Harnesses & orchestration** (Session managers & parallel runners / Orchestrators & autonomous loops / **Agent infrastructure**). Contribution requirements from the repo: CLI/terminal interface (not IDE-only); autonomous code read/write or command execution; valid active links; correct position by star count within the section.
+- Pi's official community Discord is linked from https://pi.dev ("Get involved with Pi" → community server: https://discord.com/invite/nKXTsAcmbT). Pi packages are shared via npm and Discord per the Pi coding-agent README.
+- `hesreallyhim/awesome-claude-code` exists (curated skills/hooks/commands/orchestrators for Claude Code).
+
+---
+
+## (a) awesome-cli-coding-agents entry (ready to submit)
+
+Target section: **Harnesses & orchestration → Agent infrastructure**, positioned by star count (Outfitter is currently at the bottom; update the `⭐` count to the live number on submission day — their reviewers check ordering).
+
+Entry, in their exact list format (`**[Name](url)** \`⭐ N\` — description`):
+
+```markdown
+**[Outfitter](https://github.com/ai-outfitter/outfitter)** `⭐ 3` — Profile manager and launcher for coding-agent CLIs: compose prompts, model/thinking settings, skills, extensions, and MCP config into switchable YAML profiles, shared via git catalogs. Pi-first, with Claude Code support.
+```
+
+PR title: `Add Outfitter (agent infrastructure)`
+
+PR description (one paragraph):
+
+> Adds Outfitter to Agent infrastructure. It's a launcher/profile layer above agent CLIs (Pi first, Claude Code partial): profiles are YAML composing prompts, models, skills, extensions, and MCP config; catalogs are git repos so teams share and pin loadouts; `outfitter -p <profile>` switches the whole loadout per launch. Terminal-native, open source (research preview). Meets the criteria via the wrapped agents' autonomous read/write/exec; Outfitter itself is the config/launch infrastructure around them.
+
+Fit check against their criteria: CLI/terminal ✓; autonomous read/write/exec — Outfitter launches agents that do this (same category basis as other infrastructure entries) ✓; links valid ✓; ordering by stars — verify on the day ✓.
+
+## (b) Pi Discord announcement (~150 words)
+
+Post in the community server's most fitting channel (look for show-and-tell / packages / projects; read the channel norms first). Draft:
+
+> Hey all — we built a thing for a problem we kept hitting with Pi and figured this crowd hits it too.
+>
+> One of us is a platform engineer who bounces between feature work, prod incidents, and research spikes all day. Each needs a different agent setup — different context, tools, model, thinking level. Loading everything at once just makes the agent worse at all of it.
+>
+> So: **Outfitter**. Profiles are plain YAML — prompts, model/thinking, skills, extensions, MCP config — and `outfitter -p incident` launches Pi with that whole loadout. Profiles live in git repos, so teams can share and pin them. Pi is the first-class target; there's a recommended engineering loadout out of the box.
+>
+> It's an open-source research preview, so it's early and we want it broken: https://github.com/ai-outfitter/outfitter — install is `npm i -g @ai-outfitter/outfitter`, then `outfitter`. Feedback very welcome.
+
+(~145 words. Adjust the greeting/channel etiquette to whatever the server actually uses; attach the demo video link once it exists.)
+
+## (c) Show HN draft
+
+**Title** (79 chars, fits HN's 80-char limit):
+
+> Show HN: Outfitter – Make, share, and switch the profiles your coding agents use
+
+**First comment** (post immediately after submitting):
+
+> Hi HN — we're the maintainers. Outfitter is a small open-source launcher that sits above coding-agent CLIs (Pi today, Claude Code partially).
+>
+> The itch: if you use a terminal agent for real work, you end up with one bloated setup — every MCP server, every skill, a kitchen-sink system prompt — because reconfiguring per task is annoying. That degrades the agent everywhere: irrelevant context and noisy tool choices make it slower and dumber at each individual job.
+>
+> Outfitter makes the setup a first-class, switchable thing. A profile is YAML composing prompts/context, model + thinking level, skills, extensions, and MCP config. `outfitter -p incident` launches your agent with that loadout; `-p research` swaps the whole thing. Profiles inherit (base → role → project) with deterministic precedence, and catalogs are just git repos, so a team can publish pinned, reviewed loadouts and everyone syncs them.
+>
+> Honest framing: this is a research preview, about a month old. Pi is the first-class path; the Claude Code adapter is real but behind (no MCP composition yet). Rough edges we know about are in the issue tracker. What we think is actually novel is the compose + launch + git-native-catalog combination — rules-file syncers exist, but nothing that owns the whole loadout and the launch.
+>
+> Things we'd love takes on: the state-persistence model (per-path symlink/discard/warn/error strategies for what agents write during a run), and whether org-pinned profile catalogs are something your platform team would actually adopt.
+>
+> Repo: https://github.com/ai-outfitter/outfitter — demo video in the README follows the install to a working session in real time.
+
+Timing: coordinate with the demo video going live; submit on a weekday morning US time; don't ask for votes anywhere.
+
+## (d) Other venues checklist
+
+Priority order. "Verified" = existence checked 2026-07-01; others need a look before submitting.
+
+- [ ] **bradAGI/awesome-cli-coding-agents** — https://github.com/bradAGI/awesome-cli-coding-agents — entry in (a). Verified. Best single listing: exactly the audience, already covers Pi and agent infrastructure.
+- [ ] **Pi community Discord** — https://discord.com/invite/nKXTsAcmbT (linked from https://pi.dev) — announcement in (b). Verified. Also ask in-channel how Pi package/extension authors list their packages (README says packages are shared via npm and Discord) and list the Outfitter onboarding extension there.
+- [ ] **npm discovery** — https://www.npmjs.com/package/@ai-outfitter/outfitter — not a submission, but the same lever: keywords (`pi`, `coding-agent`, `agent-profiles`, `claude-code`, `mcp`, `cli`) overlap fork issue #27 (differentiation/SEO); make sure they land before the listings drive traffic.
+- [ ] **GitHub topics** — on the repo itself: `coding-agents`, `agent-infrastructure`, `pi`, `claude-code`, `mcp`, `developer-tools`. Same rationale; GitHub topic pages are directories too.
+- [ ] **hesreallyhim/awesome-claude-code** — https://github.com/hesreallyhim/awesome-claude-code — Verified. Fit is honest only for the Claude adapter; submit under a tooling/orchestrators section **after** Claude parity (M3, fork issues #15–#19) so the listing doesn't overclaim. Check their CONTRIBUTING (they use a structured resource-submission flow, not free-form README edits).
+- [ ] **e2b-dev/awesome-ai-agents** — https://github.com/e2b-dev/awesome-ai-agents — broad AI-agents directory; weaker fit (Outfitter is infrastructure, not an agent) but high traffic. Not yet verified; check section fit before submitting.
+- [ ] **Terminal Trove** — https://terminaltrove.com — directory of terminal tools with a submission flow; good fit for a terminal-native launcher. Not yet verified; confirm submission process.
+- [ ] **MCP directories (mcp.so, PulseMCP, punkpeye/awesome-mcp-servers)** — https://mcp.so, https://www.pulsemcp.com, https://github.com/punkpeye/awesome-mcp-servers — **weak fit today**: Outfitter composes MCP config but is not an MCP server; most of these lists are server-only. Revisit only if an Outfitter MCP server or a clear "MCP tooling" category exists. Not yet verified.
+- [ ] **Show HN** — https://news.ycombinator.com/showhn.html — copy in (c); gated on the demo video.
+- [ ] **Launch blog post** — on the doc site; canonical home for the demo video + the Show HN narrative; every listing above links back to it or the README.
+
+Acceptance target from the issue: listed in at least two ecosystem directories, announcement posted alongside the demo video.

--- a/docs/specs/org-catalog-governance.md
+++ b/docs/specs/org-catalog-governance.md
@@ -1,0 +1,276 @@
+# Design spec: Org-catalog governance
+
+Status: draft for review (2026-07). Design only — implementation issues spawn from §9.
+
+Scope: the feature set that turns a shared profile catalog into an organization control plane: approved profile stores, enforcement, session auditability, model/cost policy, and governed shared context. Decides the OSS vs. enterprise-licensed boundary per feature.
+
+## 1. Motivation
+
+Field demand is concrete and repeated. Enterprise platform teams (UPS- and Home Depot-scale organizations, via the 2026-06-29 field call) are asking for the same four things:
+
+1. **Approved profile stores** — "our engineers launch agents only from configurations we published and reviewed."
+2. **Cost controls** — role-shaped defaults so high-volume low-risk work doesn't run on the most expensive model at the highest thinking level.
+3. **Auditability** — when an agent session did something, be able to answer _which profile, from which source, at which ref, with which model_ ran it.
+4. **Federated context** — a governed, composable prompt/context library ("50 codebases, one prompts repo") instead of per-repo rule-file drift.
+
+DORA 2025 independently validates the shape: organizations that standardize AI-agent configuration at the platform-team level outperform teams doing ad-hoc per-developer setup. And the CSA has flagged agent configuration — extensions, skills, injected args/env — as a supply-chain attack surface, which makes "who reviewed this profile" a security question, not just a tidiness question.
+
+Outfitter is well positioned for this wedge because its primitives are already git-native: catalogs are repos, refs are pinnable, and settings merge is deterministic and layered. What is missing is a coherent policy layer on top and a decided OSS/enterprise boundary. The assessment (§5, §6.C) names this the enterprise wedge.
+
+## 2. Current primitives (what exists today)
+
+Per OFTR-002 and OFTR-004, shipped behavior already provides the raw material:
+
+- **`remote_settings`** (OFTR-002.6): `settings.yml` may pull settings-style YAML from a remote repo (`uri` or `github` shorthand, required `path`, optional `ref`). Cached copies are used at resolve time. **Precedence today: local discovered settings win over remote settings** — an org can suggest, not require.
+- **`profile_sources` with `only` / `except`** (OFTR-002.5): a source entry can allowlist (`only`) or denylist (`except`) profile IDs from that source. This filters _what a source contributes_, but nothing constrains _which sources a user may add_.
+- **`ref` pinning** (OFTR-002.5.6, OFTR-002.6.4): both profile sources and remote settings can pin a branch, tag, or commit. Pinned sources cache under `~/.outfitter/cache/repos/<encoded-uri-and-ref>/` (OFTR-004.2.4). No policy exists about _requiring_ pins.
+- **`sync` hygiene** (OFTR-004.2): validates settings before syncing, validates synced profiles, reports per-source status, and redacts credentials from output. No lockfile/reproducibility guarantee yet (explicitly deferred, OFTR-004.2.8).
+- **Enterprise flag precedent** (OFTR-004.2.10–17): `enterprise.private_profile_catalogs: true` in `~/.outfitter/settings.yml` already establishes the pattern of informational commercial governance — a home-settings boolean gating an enterprise-licensed capability, with prescribed prompt text and no credential handling.
+- **Budget annotation pattern** (org use-case doc): `budget_units` exists only as a comment convention explaining relative cost/latency per role. Nothing is machine-readable.
+
+The gap: every primitive is opt-in and user-overridable. There is no way for an org to _pin_ policy, no enforcement, no audit trail, and no machine-readable cost/model policy.
+
+## 3. Feature A — Org-pinned `remote_settings` with source allowlists
+
+### Design
+
+Two additions: a `pinned` marker on a `remote_settings` entry, and an `org_policy` block that the pinned remote settings file may contain.
+
+```yaml
+# ~/.outfitter/settings.yml (written once, e.g. by `outfitter setup <org-policy-repo>`)
+remote_settings:
+  - github: acme/outfitter-policy
+    path: policy/settings.yml
+    ref: v2026.07 # tag; orgs SHOULD pin a tag or commit, not a branch
+    pinned: true # this entry's org_policy block outranks local settings
+```
+
+```yaml
+# acme/outfitter-policy → policy/settings.yml (the org-controlled file)
+org_policy:
+  id: acme
+  version: 1
+  source_allowlist:
+    # Users may only load profiles from sources matching one of these entries.
+    - github: acme/outfitter-catalog
+      ref: v2026.07 # allowlist entries may require a ref (pin policy)
+    - uri: https://git.acme.example/platform/outfitter-catalog.git
+    - path_prefix: ~/.outfitter/profiles # local personal profiles allowed (or omit to forbid)
+  require_ref_pinning: true # remote sources without ref are policy violations
+```
+
+Semantics:
+
+- **Settings key:** `org_policy` is valid **only** inside a `remote_settings` file whose local entry carries `pinned: true`. An `org_policy` block found in local settings, or in a non-pinned remote, is a validation error (prevents self-granted "policy").
+- **Precedence:** this deliberately inverts OFTR-002.6.6 for exactly one namespace. Ordinary settings keys in the pinned remote still lose to local settings (unchanged). The `org_policy` block is evaluated as a constraint layer _after_ the normal merge: the merged Settings object is checked against it, it is not merged into it. This keeps OFTR-002 precedence intact rather than special-casing merge order.
+- **Allowlist matching:** a configured `profile_sources` entry is allowed iff it matches an allowlist entry (same repo identity after URI normalization; ref matching honors the allowlist's `ref` when present; `path_prefix` covers local paths). Non-matching sources are policy violations handled per the enforcement mode (§4).
+- **Failure mode:** if the pinned remote settings cannot be fetched, the cached copy is used (existing OFTR-002.6.5 behavior). If **no cached copy exists** (first run, cache wiped): `warn` mode proceeds with a prominent notice; `enforce` mode refuses to launch with an actionable error ("cannot verify org policy; run `outfitter sync` on a network with access to acme/outfitter-policy"). A `max_policy_age_days` knob (enterprise) can additionally treat a stale cache as unfetched.
+
+### Open questions
+
+- Should multiple `pinned: true` entries be allowed (e.g., org + business-unit policy)? Proposal: yes, evaluated in order, most-restrictive-wins — but defer until asked for.
+- Should the allowlist also constrain `remote_settings` entries themselves (a rogue second remote)? Likely yes; needs a rule that the pinned entry cannot be allowlisted away.
+- URI normalization rules (ssh vs https forms of the same repo) need a precise equivalence spec.
+
+### OSS / enterprise
+
+**OSS.** The pin + allowlist mechanism is a trust feature individuals and small teams also want (CSA supply-chain angle), and shipping it open builds trust in the format. Rationale for the line: mechanisms are OSS; what orgs pay for is operating them at scale (§4–§6).
+
+## 4. Feature B — Enforcement modes: `warn` | `enforce`
+
+### Design
+
+```yaml
+# policy/settings.yml (org-controlled)
+org_policy:
+  id: acme
+  enforcement: warn # warn | enforce (default: warn)
+```
+
+- **`warn`** (default): a launch that violates policy — profile resolved from a non-allowlisted source, unpinned source where pinning is required, model outside the approved list (§6) — proceeds, with a single prominent, non-suppressible diagnostic naming the violated rule and the policy id/version. Violations are recorded in the audit log (§5) when enabled.
+- **`enforce`**: the same violations abort the launch before the agent CLI starts, with an actionable error (which rule, which source/profile/model, and the org-designated contact/URL via an optional `org_policy.help: <url>` field). Escape hatch: `--no-policy` is **not** provided; the escape is editing local settings to drop the pinned remote — which is visible, deliberate, and (with §5) auditable, rather than a flag someone puts in a shell alias.
+
+Diagnostic text follows the OFTR-004.2.12 precedent: exact prescribed wording lives in the requirement when this is implemented, so tests pin it.
+
+### Open questions
+
+- Granularity: one global mode, or per-rule modes (`source_allowlist: enforce`, `models: warn`)? Proposal: start global; per-rule is a compatible extension (`enforcement: { sources: enforce, models: warn }`).
+- Does `enforce` apply to `outfitter sync` (refuse to sync non-allowlisted sources) or only to `run`? Proposal: both — sync-time refusal gives earlier, friendlier failure.
+
+### OSS / enterprise
+
+**`warn` is OSS; `enforce` is enterprise-licensed** (a home-settings gate in the style of `enterprise.private_profile_catalogs`, e.g. `enterprise.policy_enforcement: true`). Rationale: warning-grade guardrails are a community trust feature and make the format credible; hard enforcement is only meaningful inside a managed org (an individual can always edit their own settings), so it is precisely the org-scale control plane the enterprise license covers. This is the cleanest expression of the default rule: the mechanism (policy evaluation, diagnostics) is OSS and identical in both modes; the org-scale posture (blocking) is paid.
+
+## 5. Feature C — Session provenance audit log
+
+### Design
+
+**What is recorded** — one event per launch (and one per exit), capturing provenance, not content:
+
+- timestamp, event type (`session_start` / `session_end`), outfitter version
+- adapter (`pi` / `claude`) and adapter/agent CLI version when cheaply known
+- selected profile id and the **resolved profile stack**: for each layer, profile id, source identity (normalized URI or local path class), `ref` as configured, and resolved commit SHA for git-backed sources
+- effective model, provider, and thinking level after merge
+- policy context: `org_policy.id`, `version`, enforcement mode, and any violations (rule + subject) — including warned-and-proceeded ones
+- session correlation id (random UUID) so start/end pair up
+
+**Where:** append-only JSONL at `~/.outfitter/state/audit/sessions.jsonl` (rotated by size; e.g. `sessions.jsonl.1` …). This sits under Outfitter's own state home, not in any profile or composite dir, so it survives runs and is never synced into catalogs.
+
+```json
+{
+  "ts": "2026-07-01T18:22:41Z",
+  "event": "session_start",
+  "session": "0d5c…",
+  "outfitter": "0.7.2",
+  "adapter": "pi",
+  "profile": "engineer",
+  "stack": [
+    {
+      "id": "base-acme",
+      "source": "github:acme/outfitter-catalog",
+      "ref": "v2026.07",
+      "commit": "9a1f3c…"
+    },
+    {
+      "id": "engineer",
+      "source": "github:acme/outfitter-catalog",
+      "ref": "v2026.07",
+      "commit": "9a1f3c…"
+    }
+  ],
+  "model": "anthropic/claude-sonnet-4",
+  "provider": "anthropic",
+  "thinking": "high",
+  "policy": { "id": "acme", "version": 1, "enforcement": "warn", "violations": [] }
+}
+```
+
+**Privacy notes (normative):**
+
+- No prompt text, no conversation content, no file contents, no repo file paths. The working directory is recorded only as a salted hash by default (`cwd_hash`), with a settings opt-in for cleartext.
+- No credentials ever (extends OFTR-004.2.9/17 redaction guarantees to audit output).
+- The log is **local-only** in OSS. Nothing ships telemetry; there is no default network sink. Users can read their own log (`outfitter audit list` convenience command, or plain `jq`).
+- Enabling/disabling: `audit.enabled` in settings; org policy may set `audit: required` (a §4 rule — warn or enforce when the local log is disabled).
+
+### Open questions
+
+- Should `session_end` capture state-persistence outcomes (undeclared-write reports)? Natural fit with the near-real-time detection work (update-plan issue 11) — proposal: yes, as a follow-up field.
+- Log integrity: is append-only-by-convention enough, or do enterprise deployments need hash-chained entries? Defer; collectors (below) can sign on ingest.
+- Multi-user machines: per-user home is assumed; no shared-log design needed now.
+
+### OSS / enterprise
+
+**Split.** The local JSONL log, its schema, and `audit list` are **OSS** — individuals debugging "which profile was I actually running Tuesday?" get real value, and an open schema lets orgs build their own pipelines. **Enterprise:** collectors/forwarders (ship to S3/Splunk/OTLP), retention policy, org-wide reporting, and the `audit: required` policy rule under `enforce`. Mechanism OSS, org-scale audit tooling paid — the default rule verbatim.
+
+## 6. Feature D — Model/cost policy
+
+### Design
+
+Two halves: formalize the budget annotation, and let policy constrain models.
+
+**Formalized `budget_units`** — promote the existing comment convention in the org use-case doc to a schema field on profiles:
+
+```yaml
+# profiles/platform-operator/profile.yml
+id: platform-operator
+inherits: [base-acme]
+budget:
+  units: 8 # relative spend/latency estimate, NOT currency; catalog-defined scale
+  rationale: Infra mistakes dominate token spend; xhigh thinking is deliberate.
+controls:
+  model: anthropic/claude-opus-4
+  thinking: xhigh
+```
+
+`budget.units` stays deliberately relative (the doc's existing weighting guidance — thinking_weight low=1 / medium=2 / high=4 / xhigh=8 — moves into the schema description). Outfitter surfaces it (`outfitter profile list` column, session-start line, audit log) but never converts to currency.
+
+**Policy constraints** — in `org_policy`:
+
+```yaml
+org_policy:
+  models:
+    approved:
+      - anthropic/claude-sonnet-4
+      - anthropic/claude-opus-4
+      - openai/gpt-4.1-mini
+      - openai/gpt-4.1
+    # Optional per-role tightening; keys are profile IDs (or glob patterns) from allowlisted sources.
+    roles:
+      support-triage:
+        approved: [openai/gpt-4.1-mini]
+        max_budget_units: 2
+      platform-operator:
+        max_thinking: xhigh
+  default_role_budget:
+    max_budget_units: 4 # roles not listed above
+```
+
+Semantics: after the merge produces the effective `model`/`thinking` (including project-local overrides — this is exactly the hole to close), the result is checked against `approved` (global, then role). Violations follow §4 enforcement. `max_budget_units` compares against the _declared_ `budget.units` of the resolved profile; a profile with no declaration counts as unknown → warn-grade violation when a max is set.
+
+### Open questions
+
+- Model ID drift: approved lists rot as providers rotate models. Support globs (`anthropic/claude-*`)? Proposal: exact IDs + trailing-`*` globs only.
+- Is `max_budget_units` per-launch declaration checking actually useful without runtime metering? It is honest (it governs _configuration_, not spend) — but the docs must say clearly this is not billing enforcement. Runtime token metering is out of scope for this spec.
+- Interaction with local inference / provider-less setups: approved lists should probably be per-provider optional.
+
+### OSS / enterprise
+
+**Split.** `budget.units` schema field, its display, and warn-grade approved-model checking: **OSS** (teams sharing a public catalog want the same hygiene). Per-role model policy under `enforce`, plus any future spend reporting built on audit data: **enterprise**. Same rule: the vocabulary and mechanism are open; the org-scale control posture is paid.
+
+## 7. Feature E — Prompts-library / federated-context governance
+
+### Design
+
+The federated-context pattern already works mechanically: catalogs hold atomic prompt files (`/prompts/{codebases,teams,tools,models}/…`) and profiles compose them via `append_system_prompt` `{ file: … }` includes resolved from the catalog root. What is missing is the governance story — this feature is mostly **pattern + policy hooks**, not new runtime machinery:
+
+- **Ownership:** the prompts library lives in the org catalog repo (or a dedicated `acme/outfitter-prompts` consumed as a second allowlisted source). Ownership is expressed with the host's native review controls — `CODEOWNERS` mapping `/prompts/teams/payments/**` to the payments platform leads, branch protection on the catalog repo, releases tagged (`v2026.07`) so `require_ref_pinning` (§3) means consumers only ever see _reviewed, released_ context.
+- **Review flow:** documented convention (in the federated-context worked example, update-plan issue 34): propose prompt changes by PR; reviewers are the owning team plus the platform team; releases roll up prompt changes; orgs point `source_allowlist` refs at the new tag when ready. Rollback = repoint the ref.
+- **Policy hooks (the only new mechanism):** because §3 pins sources and §5 records resolved commit SHAs per layer, every session is attributable to an exact reviewed state of the prompt library. No additional runtime feature is required for v1 beyond one guard: when `require_ref_pinning` is on, `{ repo_file: … }` includes (project-controlled, not catalog-controlled) get flagged in the audit record so orgs can see where non-governed context enters sessions.
+
+### Open questions
+
+- Should Outfitter verify prompt provenance more strongly (signed tags)? Defer; git host branch protection covers the realistic threat model for now.
+- Do orgs need `only`/`except`-style filtering for prompt files (not just profiles)? Watch for demand from the worked example before designing.
+
+### OSS / enterprise
+
+**OSS**, essentially entirely: the pattern, docs, worked example, and the `repo_file` audit flag. Rationale: this is adoption surface — the thing that makes the catalog format worth standardizing on. Enterprise touchpoints arrive indirectly via §4 (`enforce` on ref pinning) and §5 (audit collectors), plus paid services (catalog/prompt-library setup and training — the services sketch from the field call) rather than a licensed feature.
+
+## 8. OSS / enterprise boundary — summary
+
+Default rule applied throughout: **mechanisms and schemas are OSS; org-scale policy posture and audit tooling are enterprise-licensed**, gated by `enterprise.*` home-settings booleans following the OFTR-004.2.10 precedent.
+
+| Feature                                       | OSS                                                     | Enterprise                                                              |
+| --------------------------------------------- | ------------------------------------------------------- | ----------------------------------------------------------------------- |
+| A. Pinned remote settings + source allowlists | All of it                                               | —                                                                       |
+| B. Enforcement modes                          | Policy evaluation + `warn`                              | `enforce` (`enterprise.policy_enforcement`)                             |
+| C. Session provenance audit                   | Local JSONL log, schema, `audit list`                   | Collectors/forwarders, retention, org reporting, `audit: required` rule |
+| D. Model/cost policy                          | `budget.units` schema, display, warn-grade model checks | Per-role policy under enforce; spend reporting on audit data            |
+| E. Federated-context governance               | Pattern, docs, worked example, `repo_file` audit flag   | — (monetized via services + B/C)                                        |
+
+## 9. Implementation issues (proposed)
+
+Sizes follow the update-plan convention (S ≤ half day, M 1–2 days, L 3+ days). Ordering respects dependencies.
+
+1. **Settings schema: `pinned` remote_settings entries + `org_policy` block (validation only)** — S–M
+2. **Policy evaluation engine: source-allowlist + ref-pinning checks, `warn` diagnostics** — M
+3. **OFTR amendment: new requirement doc for org policy (OFTR-011), precedence carve-out spelled out against OFTR-002.6.6** — S
+4. **Enforce mode behind `enterprise.policy_enforcement` (launch + sync refusal, prescribed error text)** — M
+5. **Audit log v1: JSONL writer, session_start/end events, rotation, privacy redaction tests** — M
+6. **`outfitter audit list` command** — S
+7. **`budget` profile schema field + surfacing in `profile list` and session start line** — S–M
+8. **Model-policy checks (global approved list, warn-grade) wired into policy engine** — M
+9. **Per-role model/budget policy under enforce (enterprise)** — M
+10. **`repo_file` include flagging in audit records when `require_ref_pinning` is set** — S
+11. **Docs: governance guide for catalog admins (setup repo → policy repo → allowlist → audit), linked from the org-catalog use case** — M
+12. **Enterprise collector interface spec (out-of-repo follow-up; defines the JSONL contract as stable)** — S (spec)
+
+Dependencies: 1 → 2 → {4, 8}; 5 → {6, 10, 12}; 7 → 8 → 9; 3 alongside 1–2; 11 last.
+
+## 10. References
+
+- `docs/requirements/OFTR-002-settings.md` (settings precedence, profile sources, remote settings)
+- `docs/requirements/OFTR-004-sync-and-setup.md` (sync caching, private-catalog enterprise precedent)
+- `docs/documentation/usecases/orginization-profile-catalog.md` (role catalog + budget annotation pattern)
+- `docs/plans/2026-07-01-comprehensive-assessment.md` §5–6 (market, enterprise wedge)
+- `docs/plans/2026-07-01-update-plan.md` issues 24, 31, 32, 34

--- a/project-log.md
+++ b/project-log.md
@@ -1,0 +1,28 @@
+# Outfitter — Project Log
+
+Chronological log of development activities, changes, and lessons learned. Append new entries; never remove old ones.
+
+## 2026-07-01 (later) — Update plan drafted as local issue queue (Claude session)
+
+**What was done:**
+
+- Built the comprehensive update plan from the assessment: `docs/plans/2026-07-01-update-plan.md` — 34 atomic issues across 5 milestones (M1 ship-blockers, M2 hardening, M3 Claude parity, M4 docs, M5 strategic/distribution).
+- Decisions locked with Tyler: GitHub issues + repo specs for tracking (manual approval required before filing anything), full Claude adapter parity now, keep the Outfitter name (differentiate via SEO/positioning), scope includes strategic work.
+- Stored all 34 issues as ready-to-file drafts under `docs/plans/issues/` (frontmatter metadata + verbatim GitHub issue bodies) — **local only for now**, to be filed later via `scripts/file-issues.mjs` (dry-run by default; `--file` to create; `--only NN,NN` for subsets). Dry run verified all 34 parse.
+
+## 2026-07-01 — Comprehensive product/market assessment (Claude session)
+
+**What was done:**
+
+- Deep review of the full repo at v0.7.0 (architecture, code quality, maturity), all docs (`docs/`, doc_site, requirements OFTR-001..010), and release/packaging setup.
+- Pulled and analyzed the demo context: Nicholas/Tyler demo-video dry run transcript (Jul 1), Tyler/Jamie Erickson call (Jun 29, Grain), Weekly Demo notes (Jun 29, Grain).
+- Fresh market research (mid-2026): competitive landscape (Ruler/rulesync/block-ai-rules; AGENTS.md + SKILL.md + MCP registry standards; Claude Code marketplaces / Codex Team Config; Docker cagent; Pi packages), demand signals (rule drift, DORA 2025, SO 2025, CSA attack-surface note), market sizing, positioning wedges.
+- Produced prioritized assessment: `docs/plans/2026-07-01-comprehensive-assessment.md`. Created `project-plan.md` and this log.
+
+**Key findings / lessons:**
+
+- Core engine is production-quality with exceptional test discipline (99% coverage enforced, requirement-pinning tests, strong state-persistence design, real security hygiene).
+- Risk is concentrated in the first five minutes: network-required first run, hardcoded `google/gemini-3.1-pro-preview` bootstrap model, ~750-line untyped JS onboarding extension string, onboarding regressions that broke the demo dry run itself.
+- Claude adapter is materially behind the multi-agent marketing; either scope the claim or reach parity.
+- Market: pain validated ("rule drift", DORA org-standardization), but rules-sync layer commoditized and vendors are absorbing single-vendor catalogs. Defensible ground = vendor-neutral compose-and-launch + git org catalogs, anchored in the Pi ecosystem (zero incumbent). Brand collision with unrelated `outfitter-dev/agents` marketplace.
+- Jamie (field/sales) signal: enterprises want AI SDLC toolkits / federated context / governance planes; his verdict — "doesn't need more features, needs polishing and release."

--- a/project-plan.md
+++ b/project-plan.md
@@ -1,0 +1,51 @@
+# Outfitter — Project Plan
+
+_Last updated: 2026-07-01. Companion chronological log: [project-log.md](./project-log.md)._
+
+## What it is
+
+Outfitter builds effective **agent profiles** and launches them through wrapped agent CLIs — Pi first (`@earendil-works/pi-coding-agent`, bundled), Claude Code partially, more adapters planned. Individuals, teams, and organizations can make, share, and switch repeatable agent loadouts, manually or programmatically.
+
+One-line value prop (from the demo script work, Jul 2026): **"Make, share, and switch the profiles your coding agents use — manually or programmatically."**
+
+## Who it serves
+
+- **Individuals**: rapid loadout switching (engineer / prod-debug / research / founder profiles) so each session gets narrow, relevant context instead of one bloated setup ("expeditious agents" philosophy — tight profiles preserve context headroom).
+- **Teams**: share iterated profiles via git-based profile catalog repos; org-approved default stores.
+- **Enterprises** (future): governance plane — approved profile stores, federated context libraries (atomic markdown composed into system prompts), cost/model policies, auditability. Enterprise features to live under `code/enterprise/` (BSL license shell exists, no code yet).
+
+Strategy stair-steps: individual → team → enterprise; TUI → GUI; open → paid. Monetization sketch: MIT/open for individual+team, enterprise license for private catalog features, plus training/support services.
+
+## Tech stack & repo structure
+
+- Node 22+, strict TypeScript, npm workspaces. Published as `@ai-outfitter/outfitter` (v0.7.0, npm provenance).
+- `code/cli/` — the product (~8.6k LoC): `src/agents/` (adapter contract, pi + claude adapters, launch), `src/profiles/` (loading, multi-inheritance merge with cycle detection, remote cache), `src/compositeProfile/` (temp-dir assembly, Liquid templating with `[[= ]]` delimiters, fs watcher, state persistence), `src/settings/` (user/project/project-local/remote settings), `src/cli/commands/` (run, setup, sync, welcome, profile list/create/lint).
+- `code/pi-extension/` — placeholder; the real Pi onboarding extension is currently a ~750-line JS string in `PiLoginLaunch.ts` (known debt).
+- `code/doc_site/` — Nextra site, 2 pages so far.
+- `docs/` — user docs (`documentation/`), architecture (`archtecture/` [sic]), formal requirements OFTR-001..010, plans, specs.
+- Testing: vitest, 254 tests, ~99% coverage with 98% thresholds enforced in CI; golden-tree integration fixtures; requirement-pinning "do not modify" tests. CI: ubuntu-only; release-please + npm publish workflows; Dockerfile exists but image not published.
+
+## How it works (core flow)
+
+settings.yml layers (user `~/.outfitter`, project `.outfitter`, project-local, remote) select profile sources and defaults → profile stack resolves with deterministic precedence (project-local > project > user > cached remote > inherits > built-ins) → adapter translates generic controls into a **composite profile** (mkdtemp dir: merged prompts, `.mcp.json`, keybindings, settings) → agent launched with `PI_CODING_AGENT_DIR` / `CLAUDE_CONFIG_DIR` pointed at it → declared state paths symlink/discard/warn/error back to real state (`~/.pi/agent`, `~/.claude`); undeclared writes detected by fingerprint diff at exit. `outfitter sync` refreshes remote catalogs into `~/.outfitter/cache/`. First run triggers Pi-native onboarding (syncs `ai-outfitter/default-profiles`, profile picker: founder/engineer/data_analyst).
+
+## Current status (2026-07-01)
+
+Public research preview being launched. Core engine (profiles → composite → pi launch) is production-quality; risk concentrated in first-run/onboarding surface (see assessment). Demo video in progress with Nicholas; dry run exposed onboarding regressions.
+
+## Planned improvements / roadmap
+
+See [docs/plans/2026-07-01-comprehensive-assessment.md](./docs/plans/2026-07-01-comprehensive-assessment.md) for the full prioritized list. Headlines:
+
+1. Bulletproof first run (offline default profile, remove hardcoded bootstrap model, graceful degraded sync, faster first boot)
+2. Extract Pi extension to typed workspace; implement or remove `prompt` persistence strategy
+3. Claude adapter: label experimental or reach parity
+4. Docs front door cleanup (typo'd dirs, philosophy draft, catalog trust model, AGENTS.md contradiction)
+5. Distribution: Pi ecosystem beachhead, awesome-lists, resolve "Outfitter" name collision with `outfitter-dev/agents`
+
+## Related tools / context
+
+- **Pi** (pi.dev): minimal, extensible agent harness Outfitter wraps first. Everything is an extension; Outfitter is "the quickest path to a recommended Pi loadout."
+- **DeepWork**: multi-step workflow system, deeply integrated into Outfitter profiles (deepwork jobs are a profile control).
+- **Panopticon**: sibling Unsupervised tool — multi-session agent control plane / orchestrator TUI (separate repo, launching around the same time).
+- Company context: Unsupervised pivoting to "product research lab" building agent-control utilities (per Tyler, Jun 2026).

--- a/scripts/file-issues.mjs
+++ b/scripts/file-issues.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// Files docs/plans/issues/*.md as GitHub issues via `gh`.
+// Dry-run by default; pass --file to create. --only 01,03 files a subset.
+import { execFileSync } from 'node:child_process';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ISSUES_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', 'docs', 'plans', 'issues');
+const args = process.argv.slice(2);
+const doFile = args.includes('--file');
+const onlyArg = args.find((a) => a.startsWith('--only'));
+const only = onlyArg ? (onlyArg.split('=')[1] ?? args[args.indexOf(onlyArg) + 1]).split(',') : null;
+
+function parse(path) {
+  const raw = readFileSync(path, 'utf8');
+  const m = raw.match(/^---\n([\s\S]*?)\n---\n?/);
+  if (!m) throw new Error(`No frontmatter in ${path}`);
+  const meta = {};
+  for (const line of m[1].split('\n')) {
+    const kv = line.match(/^(\w+):\s*(.*)$/);
+    if (!kv) continue;
+    const [, key, value] = kv;
+    meta[key] = value.startsWith('[')
+      ? value
+          .slice(1, -1)
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : value.trim().replace(/^(["'])(.*)\1$/, '$2');
+  }
+  return { meta, body: raw.slice(m[0].length).trim() };
+}
+
+const files = readdirSync(ISSUES_DIR)
+  .filter((f) => /^\d{2}-.*\.md$/.test(f))
+  .sort()
+  .filter((f) => !only || only.includes(f.slice(0, 2)));
+
+const allLabels = new Set();
+const parsed = files.map((f) => {
+  const { meta, body } = parse(join(ISSUES_DIR, f));
+  (meta.labels ?? []).forEach((l) => allLabels.add(l));
+  return { file: f, meta, body };
+});
+
+if (!doFile) {
+  for (const { file, meta } of parsed) {
+    console.log(`[dry-run] ${file}: "${meta.title}" labels=${(meta.labels ?? []).join(',')}`);
+  }
+  console.log(`\n${parsed.length} issue(s). Run with --file to create them via gh.`);
+  process.exit(0);
+}
+
+for (const label of allLabels) {
+  try {
+    execFileSync('gh', ['label', 'create', label, '--force'], { stdio: 'pipe' });
+  } catch (error) {
+    console.warn(`label ${label}: ${error.message}`);
+  }
+}
+
+for (const { file, meta, body } of parsed) {
+  const out = execFileSync(
+    'gh',
+    ['issue', 'create', '--title', meta.title, '--body', body, ...(meta.labels ?? []).flatMap((l) => ['--label', l])],
+    { encoding: 'utf8' },
+  );
+  console.log(`${file} -> ${out.trim()}`);
+}


### PR DESCRIPTION
First PR of a 10-PR stacked series (each targets the previous branch; merge in order, GitHub retargets as bases merge). The whole integrated result also lives on `sprint/2026-07-full` and has been running green there: 465 CLI tests + 61 pi-extension tests + 104 conformance tests, docs build, packaged E2E smoke.

Adds the planning layer everything else references: comprehensive product/market assessment, the 34-issue update plan, the local issue-draft queue (filed as issues on the tylerwillis fork — links throughout the series point there), the demo-video shooting script, the org-catalog governance design spec, and ecosystem-listing/announcement drafts.

Docs only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


