### PR TITLE
ci: packaged E2E smoke, OS matrix, gated Docker publish (+review fixes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,25 @@ jobs:
 
       - name: Run CI checks
         run: npm run check-ci
+
+  # Exercises the shipped artifact (npm pack → global install → run the bin) so
+  # packaging regressions fail CI even when all in-process tests pass.
+  packaged-smoke:
+    name: Packaged E2E smoke
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.19.0'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run packaged E2E smoke test
+        run: bash scripts/e2e-smoke.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,12 @@ jobs:
   # The ubuntu leg runs the full check-ci gate (prettier, lint, coverage, docs); the
   # macos and windows legs run the test suite to enforce cross-platform compatibility.
   # Windows is experimental: the runtime is symlink-centric and Windows support has not
-  # been verified end to end, so its leg reports failures without blocking the suite.
+  # been verified end to end. Its test step continues on error so the suite is not
+  # blocked, but a failure is surfaced as a job-level warning annotation instead of
+  # being silently swallowed by a job-level continue-on-error.
   check:
     name: Check (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental }}
 
     strategy:
       fail-fast: false
@@ -45,8 +46,18 @@ jobs:
         run: npm run check-ci
 
       - name: Run test suite
-        if: matrix.os != 'ubuntu-latest'
+        if: matrix.os != 'ubuntu-latest' && !matrix.experimental
         run: npm test
+
+      - name: Run test suite (experimental platform)
+        id: experimental-tests
+        if: matrix.experimental
+        continue-on-error: true
+        run: npm test
+
+      - name: Surface experimental platform failure
+        if: matrix.experimental && steps.experimental-tests.outcome == 'failure'
+        run: echo "::warning title=Windows test suite failed::The experimental ${{ matrix.os }} leg failed; see the 'Run test suite (experimental platform)' step. This does not block the suite but should be triaged."
 
   # Exercises the shipped artifact (npm pack → global install → run the bin) so
   # packaging regressions fail CI even when all in-process tests pass.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,25 @@ on:
       - main
 
 jobs:
+  # The ubuntu leg runs the full check-ci gate (prettier, lint, coverage, docs); the
+  # macos and windows legs run the test suite to enforce cross-platform compatibility.
+  # Windows is experimental: the runtime is symlink-centric and Windows support has not
+  # been verified end to end, so its leg reports failures without blocking the suite.
   check:
-    name: Check
-    runs-on: ubuntu-latest
+    name: Check (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            experimental: false
+          - os: macos-latest
+            experimental: false
+          - os: windows-latest
+            experimental: true
 
     steps:
       - name: Checkout
@@ -25,7 +41,12 @@ jobs:
         run: npm ci
 
       - name: Run CI checks
+        if: matrix.os == 'ubuntu-latest'
         run: npm run check-ci
+
+      - name: Run test suite
+        if: matrix.os != 'ubuntu-latest'
+        run: npm test
 
   # Exercises the shipped artifact (npm pack → global install → run the bin) so
   # packaging regressions fail CI even when all in-process tests pass.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,9 @@ jobs:
   publish-docker:
     name: Publish Docker image to GHCR
     runs-on: ubuntu-latest
+    # Docker publishes only after the npm leg validates and ships, so the two
+    # release channels cannot diverge on a failed release.
+    needs: publish-npm
 
     permissions:
       contents: read
@@ -68,7 +71,9 @@ jobs:
         run: node scripts/sync-release-version.mjs "${GITHUB_REF_NAME}"
 
       - name: Resolve image name
-        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/outfitter" >> "$GITHUB_ENV"
+        run: |
+          echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/outfitter" >> "$GITHUB_ENV"
+          echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -77,14 +82,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # The version tag comes straight from the release ref so prereleases are
+      # tagged too; `latest` only moves on stable (non-prerelease) releases.
       - name: Resolve image metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE }}
           tags: |
-            type=semver,pattern={{version}}
-            type=raw,value=latest
+            type=raw,value=${{ env.VERSION }}
+            type=raw,value=latest,enable=${{ github.event.release.prerelease == false }}
 
       - name: Build image
         uses: docker/build-push-action@v6
@@ -98,10 +105,9 @@ jobs:
       # owner) and verifies the CLI reports the release version before pushing.
       - name: Smoke test image
         run: |
-          version="${GITHUB_REF_NAME#v}"
-          output="$(docker run --rm "$IMAGE:$version" --version)"
-          if [ "$output" != "$version" ]; then
-            echo "Expected outfitter --version to print '$version' but got '$output'." >&2
+          output="$(docker run --rm "$IMAGE:$VERSION" --version)"
+          if [ "$output" != "$VERSION" ]; then
+            echo "Expected outfitter --version to print '$VERSION' but got '$output'." >&2
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,3 +45,65 @@ jobs:
 
       - name: Publish package to npm
         run: npm publish --workspace @ai-outfitter/outfitter --access public --provenance
+
+  # Builds the repository Dockerfile and publishes it to GHCR on every published
+  # release, tagged with the release version and `latest`. The image is linux/amd64
+  # only for now; multi-arch (adding linux/arm64 via QEMU or native arm runners) is a
+  # follow-up once release-path build time has been evaluated.
+  publish-docker:
+    name: Publish Docker image to GHCR
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Sync release version
+        run: node scripts/sync-release-version.mjs "${GITHUB_REF_NAME}"
+
+      - name: Resolve image name
+        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/outfitter" >> "$GITHUB_ENV"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # Runs the shipped entrypoint (including its UID remap for the mounted workdir
+      # owner) and verifies the CLI reports the release version before pushing.
+      - name: Smoke test image
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          output="$(docker run --rm "$IMAGE:$version" --version)"
+          if [ "$output" != "$version" ]; then
+            echo "Expected outfitter --version to print '$version' but got '$output'." >&2
+            exit 1
+          fi
+
+      - name: Push image
+        run: docker image push --all-tags "$IMAGE"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,10 +135,21 @@ HOME="$OUTFITTER_TEST_HOME" outfitter run --profile default -- --help
 
 Outfitter assembles a temporary composite profile under the system temp directory, sets `PI_CODING_AGENT_DIR` for pi, and passes arguments after the profile options through to pi.
 
+## Docker
+
+Each published release builds the repository `Dockerfile` and pushes a `linux/amd64` image to GitHub Container Registry as `ghcr.io/ai-outfitter/outfitter:<version>` and `ghcr.io/ai-outfitter/outfitter:latest` (see the `publish-docker` job in `.github/workflows/release.yml`).
+The image bundles Outfitter and pi, and its entrypoint remaps the container user to the owner of the mounted working directory.
+
+Run the published image:
+
+```sh
+docker run --rm -it ghcr.io/ai-outfitter/outfitter
+```
+
 ## Test profiles with a local container
 
-The current release workflow is CLI-only and publishes the npm package from the `code/cli` workspace.
-The Dockerfile remains useful for local smoke testing, but GitHub Container Registry image publishing is not part of the current release path.
+The release workflow publishes the npm package from the `code/cli` workspace and the container image to GHCR.
+The Dockerfile is also useful for local smoke testing.
 
 Build a local image from the repository root:
 

--- a/code/cli/src/agents/claude/ClaudeAdapter.ts
+++ b/code/cli/src/agents/claude/ClaudeAdapter.ts
@@ -1,4 +1,5 @@
 // Provides the Claude Code adapter for composite profile generation and native launch plans.
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 import type { AgentAdapter, AgentLaunchContext, AgentLaunchPlan, AgentCompositeProfilePlan } from '../AgentAdapter.js';
@@ -165,8 +166,8 @@ const resolveClaudeStateSourcePath = (
   }
 
   return join(
-    /* v8 ignore next -- run command always passes homeDirectory; environment fallbacks are defensive. */
-    homeDirectory ?? process.env.HOME ?? '.',
+    /* v8 ignore next -- run command always passes homeDirectory; the os fallback is defensive. */
+    homeDirectory ?? homedir(),
     '.claude',
     normalizedRelativePath,
   );

--- a/code/cli/src/agents/pi/PiAdapter.ts
+++ b/code/cli/src/agents/pi/PiAdapter.ts
@@ -1,5 +1,6 @@
 // Provides the pi adapter for composite profile generation and native pi launch plans.
 import { existsSync, readdirSync, readFileSync, statSync, type Dirent } from 'node:fs';
+import { homedir } from 'node:os';
 import { delimiter, dirname, isAbsolute, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -408,8 +409,8 @@ const resolvePiStateSourcePath = (
   const configuredCacheDirectory =
     cacheDirectory ??
     join(
-      /* v8 ignore next -- run command always passes homeDirectory; environment fallbacks are defensive. */
-      homeDirectory ?? process.env.HOME ?? '.',
+      /* v8 ignore next -- run command always passes homeDirectory; the os fallback is defensive. */
+      homeDirectory ?? homedir(),
       '.outfitter',
       'cache',
     );
@@ -425,8 +426,8 @@ const resolvePiStateSourcePath = (
   }
 
   return join(
-    /* v8 ignore next -- run command always passes homeDirectory; environment fallbacks are defensive. */
-    homeDirectory ?? process.env.HOME ?? '.',
+    /* v8 ignore next -- run command always passes homeDirectory; the os fallback is defensive. */
+    homeDirectory ?? homedir(),
     '.pi',
     'agent',
     normalizedRelativePath,

--- a/code/cli/src/compositeProfile/StatePersistence.ts
+++ b/code/cli/src/compositeProfile/StatePersistence.ts
@@ -1,5 +1,6 @@
 // Defines composite profile state persistence declarations, strategies, and write detection helpers.
 import {
+  copyFileSync,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -38,16 +39,22 @@ export interface CompositeProfileStateWriteIssue {
   readonly unknown: boolean;
 }
 
+export interface StateMaterializationDependencies {
+  readonly symlink?: typeof symlinkSync;
+  readonly warn?: (message: string) => void;
+}
+
 export const materializeCompositeProfileStatePath = (
   rootDirectory: string,
   statePath: CompositeProfileStatePath,
+  dependencies: StateMaterializationDependencies = {},
 ): void => {
   if (statePath.strategy === 'symlink') {
     if (statePath.sourcePath === undefined) {
       throw new Error(`State path '${statePath.relativePath}' uses symlink without a source path.`);
     }
 
-    materializeSymlink(rootDirectory, statePath.relativePath, statePath.sourcePath, statePath.directory);
+    materializeSymlink(rootDirectory, statePath.relativePath, statePath.sourcePath, statePath.directory, dependencies);
     return;
   }
 
@@ -201,6 +208,7 @@ const materializeSymlink = (
   relativePath: string,
   sourcePath: string,
   directory: boolean,
+  dependencies: StateMaterializationDependencies,
 ): void => {
   const outputPath = resolveCompositeProfileStateOutputPath(rootDirectory, relativePath);
   mkdirSync(dirname(outputPath), { recursive: true });
@@ -210,8 +218,46 @@ const materializeSymlink = (
   }
 
   ensureStateSourcePath(sourcePath, directory);
-  symlinkSync(sourcePath, outputPath, directory ? 'dir' : 'file');
+  const symlink = dependencies.symlink ?? symlinkSync;
+
+  try {
+    symlink(sourcePath, outputPath, directory ? 'dir' : 'file');
+  } catch (error) {
+    if (!isSymlinkPermissionError(error)) {
+      throw error;
+    }
+
+    materializeSymlinkFallback(symlink, relativePath, sourcePath, outputPath, directory, dependencies.warn);
+  }
 };
+
+// Windows without Developer Mode (and some filesystems) rejects symlink creation with
+// EPERM. Directories fall back to junctions, which need no privilege but require an
+// absolute target; files fall back to a one-way copy with a warning because agent writes
+// to the copy cannot persist back to the source.
+const materializeSymlinkFallback = (
+  symlink: typeof symlinkSync,
+  relativePath: string,
+  sourcePath: string,
+  outputPath: string,
+  directory: boolean,
+  warn: ((message: string) => void) | undefined,
+): void => {
+  if (directory) {
+    symlink(resolve(sourcePath), outputPath, 'junction');
+    return;
+  }
+
+  copyFileSync(sourcePath, outputPath);
+  /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a warn writer. */
+  (warn ?? console.error)(
+    `State path '${relativePath}' could not be symlinked (symlinks are unavailable on this platform); ` +
+      `copied '${sourcePath}' instead, so writes to it will not persist back.`,
+  );
+};
+
+const isSymlinkPermissionError = (error: unknown): boolean =>
+  isNodeError(error) && (error.code === 'EPERM' || error.code === 'EACCES');
 
 const pathLexicallyExists = (path: string): boolean => {
   try {

--- a/code/cli/tests/unit/docs-hygiene.test.ts
+++ b/code/cli/tests/unit/docs-hygiene.test.ts
@@ -12,7 +12,7 @@ const selfPath = fileURLToPath(import.meta.url);
 
 // Directories that must not be scanned: dependencies, git internals, build
 // artifacts, and docs/plans (which intentionally records historical typos).
-const excludedDirectories = new Set(['node_modules', '.git', 'dist', 'coverage']);
+const excludedDirectories = new Set(['node_modules', '.git', '.claude', 'dist', 'coverage']);
 const excludedRelativePaths = new Set(['docs/plans']);
 
 function collectFiles(directory: string, results: string[]): string[] {

--- a/code/cli/tests/unit/docs-hygiene.test.ts
+++ b/code/cli/tests/unit/docs-hygiene.test.ts
@@ -1,6 +1,7 @@
 // Docs hygiene: guards against reintroducing known path typos anywhere in the repo.
-import { readdirSync, readFileSync, statSync } from 'node:fs';
-import { join, relative, sep } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { lstatSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
@@ -10,44 +11,38 @@ const TYPO_PATTERN = /archtecture|orginization/i;
 const repoRoot = fileURLToPath(new URL('../../../..', import.meta.url));
 const selfPath = fileURLToPath(import.meta.url);
 
-// Directories that must not be scanned: dependencies, git internals, build
-// artifacts, and docs/plans (which intentionally records historical typos).
-const excludedDirectories = new Set(['node_modules', '.git', '.claude', 'dist', 'coverage']);
-const excludedRelativePaths = new Set(['docs/plans']);
+// docs/plans intentionally records historical typos and is excluded. Only
+// git-tracked files are scanned: untracked scratch files, broken symlinks, and
+// symlink cycles in the working tree must not affect the suite.
+const excludedPrefixes = ['docs/plans/'];
 
-function collectFiles(directory: string, results: string[]): string[] {
-  for (const entry of readdirSync(directory)) {
-    const entryPath = join(directory, entry);
-    const relativePath = relative(repoRoot, entryPath).split(sep).join('/');
-    if (excludedRelativePaths.has(relativePath)) {
-      continue;
-    }
-    const stats = statSync(entryPath);
-    if (stats.isDirectory()) {
-      if (!excludedDirectories.has(entry)) {
-        collectFiles(entryPath, results);
-      }
-    } else if (stats.isFile() && entryPath !== selfPath) {
-      results.push(entryPath);
-    }
-  }
-  return results;
+function collectTrackedFiles(): string[] {
+  const output = execFileSync('git', ['-C', repoRoot, 'ls-files', '-z'], { encoding: 'utf8' });
+  return output
+    .split('\0')
+    .filter(Boolean)
+    .filter((path) => !excludedPrefixes.some((prefix) => path.startsWith(prefix)))
+    .filter((path) => join(repoRoot, path) !== selfPath)
+    .filter((path) => {
+      const stats = lstatSync(join(repoRoot, path), { throwIfNoEntry: false });
+      return stats?.isFile() === true && !stats.isSymbolicLink();
+    });
 }
 
 describe('docs hygiene', () => {
   it('contains no known path typos (archtecture, orginization) anywhere in the repo', () => {
     const offenders: string[] = [];
-    for (const filePath of collectFiles(repoRoot, [])) {
-      const contents = readFileSync(filePath, 'utf8');
+    for (const path of collectTrackedFiles()) {
+      const contents = readFileSync(join(repoRoot, path), 'utf8');
       if (TYPO_PATTERN.test(contents)) {
-        offenders.push(relative(repoRoot, filePath));
+        offenders.push(path);
       }
     }
     expect(offenders, `Typo strings found in: ${offenders.join(', ')}`).toEqual([]);
   });
 
   it('has no files or directories with typo names', () => {
-    const offenders = collectFiles(repoRoot, []).filter((filePath) => TYPO_PATTERN.test(relative(repoRoot, filePath)));
-    expect(offenders.map((filePath) => relative(repoRoot, filePath))).toEqual([]);
+    const offenders = collectTrackedFiles().filter((path) => TYPO_PATTERN.test(path));
+    expect(offenders).toEqual([]);
   });
 });

--- a/code/cli/tests/unit/state-persistence-symlink-fallback.test.ts
+++ b/code/cli/tests/unit/state-persistence-symlink-fallback.test.ts
@@ -1,0 +1,89 @@
+// Tests the symlink fallback behavior for platforms/filesystems that deny symlink creation
+// (e.g. Windows without Developer Mode): directories fall back to junctions and files fall
+// back to a copy with a warning.
+import { lstatSync, mkdtempSync, readFileSync, readlinkSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  ensureStateSourcePath,
+  materializeCompositeProfileStatePath,
+} from '../../src/compositeProfile/StatePersistence.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-symlink-fallback-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('state persistence symlink fallback', () => {
+  it('falls back to junctions for directories and copies for files when symlink creation is denied', () => {
+    const root = createTemporaryRoot();
+    const sourceFile = ensureStateSourcePath(join(root, 'source', 'settings.json'), false);
+    const sourceDirectory = ensureStateSourcePath(join(root, 'source', 'plugins'), true);
+    writeFileSync(sourceFile, '{"kept":true}\n');
+    const symlinkTypes: (string | undefined)[] = [];
+    const denyingSymlink = ((target: string, path: string, type?: string) => {
+      symlinkTypes.push(type);
+
+      if (type === 'dir') {
+        throw Object.assign(new Error('EPERM: operation not permitted, symlink'), { code: 'EPERM' });
+      }
+
+      if (type === 'file') {
+        throw Object.assign(new Error('EACCES: permission denied, symlink'), { code: 'EACCES' });
+      }
+
+      symlinkSync(target, path);
+    }) as typeof symlinkSync;
+    const warnings: string[] = [];
+    const dependencies = { symlink: denyingSymlink, warn: (message: string) => warnings.push(message) };
+
+    materializeCompositeProfileStatePath(
+      root,
+      { relativePath: 'plugins/', strategy: 'symlink', sourcePath: sourceDirectory, directory: true },
+      dependencies,
+    );
+    materializeCompositeProfileStatePath(
+      root,
+      { relativePath: 'settings.json', strategy: 'symlink', sourcePath: sourceFile, directory: false },
+      dependencies,
+    );
+
+    expect(symlinkTypes).toEqual(['dir', 'junction', 'file']);
+    expect(lstatSync(join(root, 'plugins')).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(root, 'plugins'))).toBe(resolve(sourceDirectory));
+    expect(lstatSync(join(root, 'settings.json')).isSymbolicLink()).toBe(false);
+    expect(readFileSync(join(root, 'settings.json'), 'utf8')).toBe('{"kept":true}\n');
+    expect(warnings).toEqual([
+      `State path 'settings.json' could not be symlinked (symlinks are unavailable on this platform); ` +
+        `copied '${sourceFile}' instead, so writes to it will not persist back.`,
+    ]);
+  });
+
+  it('rethrows symlink failures that are not permission errors', () => {
+    const root = createTemporaryRoot();
+    const sourceFile = ensureStateSourcePath(join(root, 'source', 'settings.json'), false);
+    const brokenSymlink = (() => {
+      throw Object.assign(new Error('EEXIST: file already exists, symlink'), { code: 'EEXIST' });
+    }) as unknown as typeof symlinkSync;
+
+    expect(() =>
+      materializeCompositeProfileStatePath(
+        root,
+        { relativePath: 'settings.json', strategy: 'symlink', sourcePath: sourceFile, directory: false },
+        { symlink: brokenSymlink },
+      ),
+    ).toThrow('EEXIST: file already exists, symlink');
+  });
+});

--- a/docs/specs/org-catalog-governance.md
+++ b/docs/specs/org-catalog-governance.md
@@ -271,6 +271,6 @@ Dependencies: 1 → 2 → {4, 8}; 5 → {6, 10, 12}; 7 → 8 → 9; 3 alongside 
 
 - `docs/requirements/OFTR-002-settings.md` (settings precedence, profile sources, remote settings)
 - `docs/requirements/OFTR-004-sync-and-setup.md` (sync caching, private-catalog enterprise precedent)
-- `docs/documentation/usecases/orginization-profile-catalog.md` (role catalog + budget annotation pattern)
+- `docs/documentation/usecases/organization-profile-catalog.md` (role catalog + budget annotation pattern)
 - `docs/plans/2026-07-01-comprehensive-assessment.md` §5–6 (market, enterprise wedge)
 - `docs/plans/2026-07-01-update-plan.md` issues 24, 31, 32, 34

--- a/project-plan.md
+++ b/project-plan.md
@@ -22,7 +22,7 @@ Strategy stair-steps: individual → team → enterprise; TUI → GUI; open → 
 - `code/cli/` — the product (~8.6k LoC): `src/agents/` (adapter contract, pi + claude adapters, launch), `src/profiles/` (loading, multi-inheritance merge with cycle detection, remote cache), `src/compositeProfile/` (temp-dir assembly, Liquid templating with `[[= ]]` delimiters, fs watcher, state persistence), `src/settings/` (user/project/project-local/remote settings), `src/cli/commands/` (run, setup, sync, welcome, profile list/create/lint).
 - `code/pi-extension/` — placeholder; the real Pi onboarding extension is currently a ~750-line JS string in `PiLoginLaunch.ts` (known debt).
 - `code/doc_site/` — Nextra site, 2 pages so far.
-- `docs/` — user docs (`documentation/`), architecture (`archtecture/` [sic]), formal requirements OFTR-001..010, plans, specs.
+- `docs/` — user docs (`documentation/`), architecture (`architecture/`, typo fixed 2026-07-01), formal requirements OFTR-001..010, plans, specs.
 - Testing: vitest, 254 tests, ~99% coverage with 98% thresholds enforced in CI; golden-tree integration fixtures; requirement-pinning "do not modify" tests. CI: ubuntu-only; release-please + npm publish workflows; Dockerfile exists but image not published.
 
 ## How it works (core flow)

--- a/scripts/e2e-smoke.sh
+++ b/scripts/e2e-smoke.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Packaged end-to-end smoke test: packs the CLI workspace exactly as `npm publish`
+# would, installs the tarball globally into a throwaway npm prefix, and exercises the
+# shipped `outfitter` bin against a fixture HOME. This catches packaging regressions
+# (missing bin wiring, unresolvable bundled pi, broken dist assets) that in-process
+# tests can never see. Runs locally (`bash scripts/e2e-smoke.sh`) and in CI.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/outfitter-e2e-smoke.XXXXXX")"
+trap 'rm -rf "$work_dir"' EXIT
+
+log() {
+  printf '\n[e2e-smoke] %s\n' "$1"
+}
+
+fail() {
+  printf '[e2e-smoke] FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+expected_version="$(node -p "require('$repo_root/code/cli/package.json').version")"
+
+log "Packing @ai-outfitter/outfitter v$expected_version"
+npm pack --workspace @ai-outfitter/outfitter --pack-destination "$work_dir" --prefix "$repo_root" >/dev/null
+tarball="$(ls "$work_dir"/ai-outfitter-outfitter-*.tgz)"
+log "Created tarball $(basename "$tarball")"
+
+# Install the tarball globally into an isolated npm prefix, exactly like a user's
+# `npm install -g @ai-outfitter/outfitter` (dependencies resolved from the registry).
+install_prefix="$work_dir/npm-prefix"
+mkdir -p "$install_prefix"
+log 'Installing tarball into temp global prefix'
+npm install --global --prefix "$install_prefix" "$tarball" >/dev/null
+
+outfitter_bin="$install_prefix/bin/outfitter"
+[ -x "$outfitter_bin" ] || fail "installed global bin not found at $outfitter_bin"
+
+# Fixture HOME: minimal Outfitter settings plus one local profile so every command
+# below works offline against the installed artifact (no network, no real \$HOME).
+fixture_home="$work_dir/home"
+mkdir -p "$fixture_home/.outfitter/profiles/smoke"
+cat >"$fixture_home/.outfitter/settings.yml" <<'SETTINGS'
+default_profile: smoke
+default_agent: pi
+cache_directory: ./cache
+profile_sources:
+  - path: ./profiles
+SETTINGS
+cat >"$fixture_home/.outfitter/profiles/smoke/profile.yml" <<'PROFILE'
+id: smoke
+label: Packaged Smoke Profile
+controls:
+  environment:
+    OUTFITTER_SMOKE: 'enabled'
+PROFILE
+
+project_dir="$work_dir/project"
+mkdir -p "$project_dir"
+
+run_outfitter() {
+  HOME="$fixture_home" "$outfitter_bin" "$@"
+}
+
+log 'Checking `outfitter --version` (cold start)'
+cold_start=$(node -p 'Date.now()')
+version_output="$(run_outfitter --version)"
+cold_duration=$(( $(node -p 'Date.now()') - cold_start ))
+[ "$version_output" = "$expected_version" ] || fail "--version printed '$version_output', expected '$expected_version'"
+log "--version OK ($version_output, cold ${cold_duration}ms)"
+
+warm_start=$(node -p 'Date.now()')
+run_outfitter --version >/dev/null
+warm_duration=$(( $(node -p 'Date.now()') - warm_start ))
+log "--version warm rerun OK (${warm_duration}ms)"
+
+log 'Checking `outfitter --help`'
+help_output="$(run_outfitter --help)"
+case "$help_output" in
+  *'Usage: outfitter'*) ;;
+  *) fail '--help output is missing the usage banner' ;;
+esac
+for expected_command in run setup sync profile; do
+  case "$help_output" in
+    *"$expected_command"*) ;;
+    *) fail "--help output is missing the '$expected_command' command" ;;
+  esac
+done
+log '--help OK'
+
+log 'Checking `outfitter profile list` against the fixture HOME'
+profile_list_output="$(cd "$project_dir" && run_outfitter profile list)"
+[ "$profile_list_output" = 'smoke' ] || fail "profile list printed '$profile_list_output', expected 'smoke'"
+log 'profile list OK'
+
+# Non-interactive `outfitter run`: pass `--version` through to the agent so the
+# bundled pi resolves, launches, prints its version, and exits without a TTY. This
+# exercises profile resolution, composite profile assembly, and bundled-pi bin
+# resolution (AgentLaunch) inside the packed artifact.
+log 'Checking non-interactive `outfitter run -p smoke -- --version` (bundled pi)'
+run_output="$( (cd "$project_dir" && run_outfitter run -p smoke -- --version) 2>&1 )" ||
+  fail "outfitter run exited non-zero: $run_output"
+case "$run_output" in
+  *'launching'*'pi'*) ;;
+  *) fail "outfitter run output did not report a pi launch: $run_output" ;;
+esac
+log 'outfitter run OK'
+
+log "All packaged smoke checks passed (cold ${cold_duration}ms, warm ${warm_duration}ms)"

--- a/scripts/e2e-smoke.sh
+++ b/scripts/e2e-smoke.sh
@@ -19,6 +19,19 @@ fail() {
   exit 1
 }
 
+# Millisecond timestamps without spawning a Node process, so measured durations
+# do not include interpreter startup cost. EPOCHREALTIME is bash>=5; fall back to
+# date +%s%3N (GNU) or python3 for portability.
+now_ms() {
+  if [ -n "${EPOCHREALTIME:-}" ]; then
+    echo $(( ${EPOCHREALTIME/./} / 1000 ))
+  elif date +%s%3N 2>/dev/null | grep -qv N; then
+    date +%s%3N
+  else
+    python3 -c 'import time; print(int(time.time()*1000))'
+  fi
+}
+
 expected_version="$(node -p "require('$repo_root/code/cli/package.json').version")"
 
 log "Packing @ai-outfitter/outfitter v$expected_version"
@@ -63,15 +76,15 @@ run_outfitter() {
 }
 
 log 'Checking `outfitter --version` (cold start)'
-cold_start=$(node -p 'Date.now()')
+cold_start=$(now_ms)
 version_output="$(run_outfitter --version)"
-cold_duration=$(( $(node -p 'Date.now()') - cold_start ))
+cold_duration=$(( $(now_ms) - cold_start ))
 [ "$version_output" = "$expected_version" ] || fail "--version printed '$version_output', expected '$expected_version'"
 log "--version OK ($version_output, cold ${cold_duration}ms)"
 
-warm_start=$(node -p 'Date.now()')
+warm_start=$(now_ms)
 run_outfitter --version >/dev/null
-warm_duration=$(( $(node -p 'Date.now()') - warm_start ))
+warm_duration=$(( $(now_ms) - warm_start ))
 log "--version warm rerun OK (${warm_duration}ms)"
 
 log 'Checking `outfitter --help`'

--- a/scripts/file-issues.mjs
+++ b/scripts/file-issues.mjs
@@ -10,7 +10,18 @@ const ISSUES_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', 'docs', '
 const args = process.argv.slice(2);
 const doFile = args.includes('--file');
 const onlyArg = args.find((a) => a.startsWith('--only'));
-const only = onlyArg ? (onlyArg.split('=')[1] ?? args[args.indexOf(onlyArg) + 1]).split(',') : null;
+let only = null;
+if (onlyArg) {
+  const rawValue = onlyArg.includes('=') ? onlyArg.split('=')[1] : args[args.indexOf(onlyArg) + 1];
+  only = (rawValue ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => /^\d{2}$/.test(s));
+  if (only.length === 0) {
+    console.error('Usage: --only NN[,NN...] (two-digit draft numbers, e.g. --only 01,06)');
+    process.exit(1);
+  }
+}
 
 function parse(path) {
   const raw = readFileSync(path, 'utf8');


### PR DESCRIPTION
Stacked PR 3/10 — base: `sprint/02-docs-front-door`.

CI/packaging hardening plus the fixes from a high-effort code review of this layer:
- **Packaged E2E smoke** (`scripts/e2e-smoke.sh` + CI job): npm pack → global install → `--version`/`--help`/`profile list`/non-interactive `run` with bundled pi. The demo-breaking path now fails CI instead of recordings.
- **OS matrix** (ubuntu/macos/windows): `os.homedir()` replacements, symlink→junction/copy fallback; windows leg is experimental with failures surfaced as **warning annotations**, not hidden by job-level continue-on-error.
- **Docker publish to GHCR** on release — gated on `needs: publish-npm`, version tag from the release ref (prereleases included), `latest` only on stable releases.
- Review fixes: git-tracked-files-only hygiene scan, robust `--only` arg parsing, bash-native smoke timings.

Fork issues: [#5](https://github.com/tylerwillis/outfitter/issues/5), [#11](https://github.com/tylerwillis/outfitter/issues/11), [#14](https://github.com/tylerwillis/outfitter/issues/14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


