### PR TITLE
fix: first-run reliability — offline fallback, no hardcoded model, faster first boot

### DIFF
--- a/code/cli/src/agents/AgentAdapter.ts
+++ b/code/cli/src/agents/AgentAdapter.ts
@@ -23,6 +23,7 @@ export interface AgentLaunchContext {
   readonly profileLayers?: readonly AgentLaunchProfileLayer[];
   readonly projectDirectory?: string;
   readonly cacheDirectory?: string;
+  readonly onProgress?: (message: string) => void;
 }
 
 export interface AgentCompositeProfilePlan {

--- a/code/cli/src/agents/AgentLaunch.ts
+++ b/code/cli/src/agents/AgentLaunch.ts
@@ -47,6 +47,11 @@ export const resolveAgentLaunchExecutable = (launchPlan: AgentLaunchPlan): Agent
     ...launchPlan,
     command: bundledPiLaunch.command,
     args: [...bundledPiLaunch.prefixArgs, ...launchPlan.args],
+    // The bundled pi is version-pinned by Outfitter's own dependency, so pi's startup self-update
+    // notice ("Update Available … run pi update") is misleading here: `pi update` cannot update the
+    // bundled copy, and right after updating Outfitter the pinned pi can still lag pi.dev's latest.
+    // Skip pi's self-version check for bundled launches; profiles may override via environment.
+    env: { PI_SKIP_VERSION_CHECK: '1', ...launchPlan.env },
   };
 };
 

--- a/code/cli/src/agents/pi/PiAdapter.ts
+++ b/code/cli/src/agents/pi/PiAdapter.ts
@@ -118,7 +118,10 @@ export const createPiAdapter = (): AgentAdapter => ({
       args: [
         ...createPiArgs({
           ...controls,
-          extensions: materializePiExtensionSources(controls.extensions, { cacheDirectory: context.cacheDirectory }),
+          extensions: materializePiExtensionSources(controls.extensions, {
+            cacheDirectory: context.cacheDirectory,
+            onProgress: context.onProgress,
+          }),
           skills: skillSources,
           appendSystemPrompt: appendPrompt.prompts,
         }),

--- a/code/cli/src/agents/pi/PiExtensionCache.ts
+++ b/code/cli/src/agents/pi/PiExtensionCache.ts
@@ -1,12 +1,18 @@
 // Caches remote Pi extension packages as local directories before launch.
+//
+// Refresh policy: caches for `#ref`-pinned sources are immutable once created. Caches for
+// branch-tracking (ref-less) sources are refreshed by `outfitter sync` through
+// refreshPiExtensionCaches, which fast-forwards the shallow clone and reinstalls dependencies
+// when the tip moved. Launch-time materialization never refreshes an existing cache.
 import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 import spawn from 'cross-spawn';
 
 export interface PiExtensionCacheOptions {
   readonly cacheDirectory?: string;
+  readonly onProgress?: (message: string) => void;
 }
 
 interface GitExtensionSource {
@@ -23,10 +29,14 @@ export const materializePiExtensionSources = (
   }
 
   const { cacheDirectory } = options;
-  return sources.map((source) => materializePiExtensionSource(source, cacheDirectory));
+  return sources.map((source) => materializePiExtensionSource(source, cacheDirectory, options.onProgress));
 };
 
-const materializePiExtensionSource = (source: string, cacheDirectory: string): string => {
+const materializePiExtensionSource = (
+  source: string,
+  cacheDirectory: string,
+  onProgress?: (message: string) => void,
+): string => {
   const gitSource = parseGitExtensionSource(source);
 
   if (gitSource === undefined) {
@@ -37,15 +47,139 @@ const materializePiExtensionSource = (source: string, cacheDirectory: string): s
 
   if (!existsSync(cachePath)) {
     try {
+      onProgress?.(`outfitter: caching extension ${source}…`);
       cloneGitExtension(gitSource, cachePath);
-      installGitExtensionDependencies(cachePath);
+      installGitExtensionDependencies(cachePath, source, onProgress);
+      writeCacheSourceMetadata(cachePath, source, gitSource.ref);
     } catch (error) {
       rmSync(cachePath, { recursive: true, force: true });
+      rmSync(cacheSourceMetadataPath(cachePath), { force: true });
       throw error;
     }
   }
 
   return cachePath;
+};
+
+export interface PiExtensionCacheRefreshResult {
+  readonly source: string;
+  readonly cachePath: string;
+  readonly status: 'refreshed' | 'unchanged' | 'pinned' | 'failed';
+  readonly message: string;
+}
+
+// Refreshes branch-tracking git-extension caches under `<cacheDirectory>/extensions/git`.
+// `#ref`-pinned entries are reported as pinned and left untouched. Entries without source
+// metadata (created before metadata existed) are skipped silently.
+export const refreshPiExtensionCaches = (
+  cacheDirectory: string,
+  options: Pick<PiExtensionCacheOptions, 'onProgress'> = {},
+): readonly PiExtensionCacheRefreshResult[] => {
+  const gitCacheRoot = join(cacheDirectory, 'extensions', 'git');
+
+  if (!existsSync(gitCacheRoot)) {
+    return [];
+  }
+
+  return readdirSync(gitCacheRoot)
+    .filter((entryName) => entryName.endsWith(cacheSourceMetadataSuffix))
+    .sort()
+    .flatMap((entryName) => {
+      const result = refreshPiExtensionCache(gitCacheRoot, entryName, options.onProgress);
+      return result === undefined ? [] : [result];
+    });
+};
+
+const refreshPiExtensionCache = (
+  gitCacheRoot: string,
+  metadataFileName: string,
+  onProgress?: (message: string) => void,
+): PiExtensionCacheRefreshResult | undefined => {
+  const cachePath = join(gitCacheRoot, metadataFileName.slice(0, -cacheSourceMetadataSuffix.length));
+  const metadata = readCacheSourceMetadata(join(gitCacheRoot, metadataFileName));
+
+  if (metadata === undefined || !existsSync(cachePath)) {
+    return undefined;
+  }
+
+  if (metadata.ref !== undefined) {
+    return {
+      source: metadata.source,
+      cachePath,
+      status: 'pinned',
+      message: `pinned to #${metadata.ref}; cache left unchanged`,
+    };
+  }
+
+  onProgress?.(`outfitter: refreshing extension ${metadata.source}…`);
+  return pullBranchTrackingExtensionCache(metadata.source, cachePath, onProgress);
+};
+
+const pullBranchTrackingExtensionCache = (
+  source: string,
+  cachePath: string,
+  onProgress?: (message: string) => void,
+): PiExtensionCacheRefreshResult => {
+  const headBeforePull = readCacheHead(cachePath);
+  const pullResult = runCommand('git', ['pull', '--ff-only'], cachePath);
+
+  if (pullResult.status !== 0) {
+    return {
+      source,
+      cachePath,
+      status: 'failed',
+      message: commandError('git', ['pull', '--ff-only'], pullResult).message,
+    };
+  }
+
+  const headAfterPull = readCacheHead(cachePath);
+
+  if (headAfterPull === headBeforePull) {
+    return { source, cachePath, status: 'unchanged', message: 'already up to date' };
+  }
+
+  try {
+    installGitExtensionDependencies(cachePath, source, onProgress);
+  } catch (error) {
+    return { source, cachePath, status: 'failed', message: error instanceof Error ? error.message : String(error) };
+  }
+
+  return { source, cachePath, status: 'refreshed', message: `updated to ${headAfterPull}` };
+};
+
+const cacheSourceMetadataSuffix = '.source.json';
+
+const cacheSourceMetadataPath = (cachePath: string): string => `${cachePath}${cacheSourceMetadataSuffix}`;
+
+const writeCacheSourceMetadata = (cachePath: string, source: string, ref: string | undefined): void => {
+  writeFileSync(cacheSourceMetadataPath(cachePath), `${JSON.stringify({ source, ref }, null, 2)}\n`);
+};
+
+const readCacheSourceMetadata = (
+  metadataPath: string,
+): { readonly source: string; readonly ref?: string } | undefined => {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(metadataPath, 'utf8'));
+
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return undefined;
+    }
+
+    const record = parsed as { readonly source?: unknown; readonly ref?: unknown };
+
+    if (typeof record.source !== 'string') {
+      return undefined;
+    }
+
+    return { source: record.source, ref: typeof record.ref === 'string' ? record.ref : undefined };
+  } catch {
+    return undefined;
+  }
+};
+
+const readCacheHead = (cachePath: string): string => {
+  const result = runCommand('git', ['rev-parse', 'HEAD'], cachePath);
+  return result.status === 0 ? String(result.stdout).trim() : '';
 };
 
 const parseGitExtensionSource = (source: string): GitExtensionSource | undefined => {
@@ -133,11 +267,16 @@ const cloneGitExtension = (source: GitExtensionSource, cachePath: string): void 
   }
 };
 
-const installGitExtensionDependencies = (cachePath: string): void => {
+const installGitExtensionDependencies = (
+  cachePath: string,
+  source: string,
+  onProgress?: (message: string) => void,
+): void => {
   if (!existsSync(join(cachePath, 'package.json'))) {
     return;
   }
 
+  onProgress?.(`outfitter: installing dependencies for extension ${source}…`);
   const npmArgs = existsSync(join(cachePath, 'package-lock.json')) ? ['ci', '--omit=dev'] : ['install', '--omit=dev'];
   const result = runCommand('npm', npmArgs, cachePath);
 

--- a/code/cli/src/cli/commands/PiLoginLaunch.ts
+++ b/code/cli/src/cli/commands/PiLoginLaunch.ts
@@ -46,9 +46,11 @@ export const preparePiLoginLaunchPlan = (input: PiLoginLaunchPlanInput): AgentLa
     return launchPlan;
   }
 
+  // First-run onboarding intentionally passes no `--model`: pi applies its own default from the
+  // models it knows about, and the runtime extension opens `/login` when no model is available.
+  // Injecting a hardcoded model ID here would break every new user when pi rotates its catalog.
   if (input.runtimeOnboarding?.autoOpenOutfitter === true) {
     writeQuietPiStartupSettings(piConfigDirectory);
-    launchPlan = addFirstRunBootstrapModelIfNeeded(launchPlan);
   }
 
   writePiOutfitterEnterpriseSupportFiles(piConfigDirectory);
@@ -73,18 +75,6 @@ export const preparePiLoginLaunchPlan = (input: PiLoginLaunchPlanInput): AgentLa
 
   return launchPlan;
 };
-
-const addFirstRunBootstrapModelIfNeeded = (launchPlan: AgentLaunchPlan): AgentLaunchPlan => {
-  if (hasPiModelArg(launchPlan.args)) {
-    return launchPlan;
-  }
-
-  return { ...launchPlan, args: ['--model', 'google/gemini-3.1-pro-preview', ...launchPlan.args] };
-};
-
-/* v8 ignore next -- arg parser supports both spellings; integration smoke covers explicit --model passthrough. */
-const hasPiModelArg = (args: readonly string[]): boolean =>
-  args.some((arg) => arg === '--model' || arg.startsWith('--model='));
 
 const writeQuietPiStartupSettings = (piConfigDirectory: string): void => {
   const settingsPath = join(piConfigDirectory, 'settings.json');

--- a/code/cli/src/cli/commands/RunCommand.ts
+++ b/code/cli/src/cli/commands/RunCommand.ts
@@ -51,7 +51,7 @@ import { launchAgentProcess, resolveAgentLaunchExecutable } from '../../agents/A
 import type { CommandObject } from './CommandObject.js';
 import { isNonInteractivePiLaunch, preparePiLoginLaunchPlan } from './PiLoginLaunch.js';
 import type { SetupCommandDependencies } from './SetupCommand.js';
-import { syncProfileSource, type RemoteProfileSource } from './SyncCommand.js';
+import { createGitSynchronizer, syncProfileSource, type RemoteProfileSource } from './SyncCommand.js';
 
 export interface RunCommandInput {
   readonly homeDirectory: string;
@@ -126,6 +126,7 @@ export const executeRunCommand = async (
           profileLayers: createLaunchProfileLayers(resolvedProfile.profileLayers),
           projectDirectory: input.projectDirectory,
           cacheDirectory: resolvedProfile.cacheDirectory,
+          onProgress: resolveRunProgressWriter(dependencies),
         },
       ),
       systemPromptExport.outputPath,
@@ -411,7 +412,11 @@ const prepareFirstRunRuntimeOnboarding = (
     return undefined;
   }
 
-  const syncResult = syncProfileSource(input.homeDirectory, defaultProfilesSource, dependencies.synchronizer);
+  const syncResult = syncProfileSource(
+    input.homeDirectory,
+    defaultProfilesSource,
+    dependencies.synchronizer ?? createGitSynchronizer(resolveRunProgressWriter(dependencies)),
+  );
 
   if (syncResult.status === 'failed') {
     (dependencies.writeError ?? console.error)(formatDegradedOnboardingWarning(syncResult.message));
@@ -446,6 +451,12 @@ const shouldUsePiNativeFirstRunOnboarding = (input: RunCommandInput, dependencie
 
   return isInteractiveRunLaunch(dependencies);
 };
+
+// Network/build steps (catalog clones, extension caching) report per-source progress through this
+// writer so first boot never stalls silently before launch.
+const resolveRunProgressWriter = (dependencies: RunCommandDependencies): ((message: string) => void) =>
+  /* v8 ignore next -- console fallback is direct CLI behavior; tests inject writeLine. */
+  dependencies.writeLine ?? console.log;
 
 const isInteractiveRunLaunch = (dependencies: RunCommandDependencies): boolean => {
   if (dependencies.interactive !== undefined) {

--- a/code/cli/src/cli/commands/RunCommand.ts
+++ b/code/cli/src/cli/commands/RunCommand.ts
@@ -17,6 +17,11 @@ import {
   redactProfileSourceUriCredentials,
   resolveRemoteRepositorySubpath,
 } from '../../profiles/ProfileCache.js';
+import {
+  builtinStarterProfileId,
+  createBuiltinProfilesCachePath,
+  materializeBuiltinProfiles,
+} from '../../profiles/BuiltinProfiles.js';
 import { loadLocalProfileSource } from '../../profiles/ProfileLoader.js';
 import type { LoadedProfile } from '../../profiles/ProfileLoader.js';
 import { createEmptyProfile, type Profile } from '../../profiles/Profile.js';
@@ -408,16 +413,20 @@ const prepareFirstRunRuntimeOnboarding = (
 
   const syncResult = syncProfileSource(input.homeDirectory, defaultProfilesSource, dependencies.synchronizer);
 
-  /* v8 ignore next -- network/cache failure path is integration-level behavior; setup fallback message is deterministic. */
   if (syncResult.status === 'failed') {
-    throw new Error(
-      `Cannot start Pi-native onboarding because the default profiles source failed to sync: ${syncResult.message}. ` +
-        'Fix the network/git issue or run `outfitter setup` once the source is reachable.',
-    );
+    (dependencies.writeError ?? console.error)(formatDegradedOnboardingWarning(syncResult.message));
+    const builtinProfilesPath = createBuiltinProfilesCachePath(input.homeDirectory);
+    materializeBuiltinProfiles(builtinProfilesPath);
+
+    return { defaultProfilesPath: builtinProfilesPath };
   }
 
   return { defaultProfilesPath: join(syncResult.cachePath, defaultProfilesSource.path) };
 };
+
+const formatDegradedOnboardingWarning = (failureMessage: string): string =>
+  `Warning: could not sync the default profiles source github:${defaultProfilesSource.github} (${failureMessage}). ` +
+  `Continuing with the built-in '${builtinStarterProfileId}' profile; run \`outfitter sync\` to fetch the full catalog once the source is reachable.`;
 
 const shouldUsePiNativeFirstRunOnboarding = (input: RunCommandInput, dependencies: RunCommandDependencies): boolean => {
   if (input.forceRuntimeOnboarding !== true && existsSync(join(input.homeDirectory, '.outfitter', 'settings.yml'))) {

--- a/code/cli/src/cli/commands/SetupCommand.ts
+++ b/code/cli/src/cli/commands/SetupCommand.ts
@@ -9,6 +9,7 @@ import type { Command } from 'commander';
 import spawn from 'cross-spawn';
 import { parse, stringify } from 'yaml';
 
+import { builtinStarterProfileId, materializeBuiltinProfiles } from '../../profiles/BuiltinProfiles.js';
 import {
   createProfileSourceCachePath,
   createRemoteRepositoryCachePath,
@@ -197,12 +198,18 @@ export const executeSetupCommand = async (
     starterLayout?.profilesPath,
     join(input.homeDirectory, '.outfitter', 'profiles'),
   );
-  const rollbackCreatedSettings = createdSettings ? () => rmSync(settingsPath, { force: true }) : () => undefined;
   const syncResult = executeSyncCommand(input, dependencies);
-  failOnInitialDefaultProfileSyncFailure(initialSettingsMissing, rollbackCreatedSettings, syncResult);
-  const selectedDefaultProfileId = shouldSkipInitialDefaultProfilePrompt(initialSettingsMissing, dependencies)
-    ? defaultProfileId
-    : await selectDefaultProfileIfInteractive(input, settingsPath, defaultProfileId, dependencies, starterLayout);
+  const syncFallback = fallBackToBuiltinProfilesOnInitialSyncFailure(
+    join(input.homeDirectory, '.outfitter', 'profiles'),
+    initialSettingsMissing,
+    syncResult,
+  );
+  const selectedDefaultProfileId =
+    syncFallback.degraded && input.setupSourceUri === undefined
+      ? applyDegradedDefaultProfile(settingsPath)
+      : shouldSkipInitialDefaultProfilePrompt(initialSettingsMissing, dependencies)
+        ? defaultProfileId
+        : await selectDefaultProfileIfInteractive(input, settingsPath, defaultProfileId, dependencies, starterLayout);
   const welcomeResult = await runWelcomeAfterInteractiveSetup(input, dependencies);
   const welcomeProfile = persistWelcomeProfileForSetup(input, settingsPath, welcomeResult);
   const finalDefaultProfile = prepareFinalDefaultProfile(input.homeDirectory, selectedDefaultProfileId, welcomeProfile);
@@ -225,6 +232,7 @@ export const executeSetupCommand = async (
       defaultProfilePath: finalDefaultProfile.path,
       createdDefaultProfile: finalDefaultProfile.created,
       syncResult,
+      syncWarningMessages: syncFallback.warnings,
       welcomeProfileMessages: welcomeProfile?.messages ?? [],
       runExampleMessages: input.setupSourceUri === undefined ? [] : [formatRunProfileExample(finalDefaultProfile.id)],
     }),
@@ -232,15 +240,27 @@ export const executeSetupCommand = async (
 };
 /* eslint-enable complexity */
 
+const applyDegradedDefaultProfile = (settingsPath: string): string => {
+  updateSettingsDefaultProfile(settingsPath, builtinStarterProfileId);
+  return builtinStarterProfileId;
+};
+
 const defaultProfilesSourceUri = 'git+https://github.com/ai-outfitter/default-profiles.git:profiles';
 
-const failOnInitialDefaultProfileSyncFailure = (
+interface InitialDefaultProfileSyncFallback {
+  readonly degraded: boolean;
+  readonly warnings: readonly string[];
+}
+
+// Degraded-mode onboarding (OFTR-010.6): when the first-run default catalog sync fails, install
+// the bundled built-in profile and warn instead of failing; `outfitter sync` upgrades later.
+const fallBackToBuiltinProfilesOnInitialSyncFailure = (
+  profilesPath: string,
   initialSettingsMissing: boolean,
-  rollbackCreatedSettings: () => void,
   syncResult: SyncCommandResult,
-): void => {
+): InitialDefaultProfileSyncFallback => {
   if (!initialSettingsMissing) {
-    return;
+    return { degraded: false, warnings: [] };
   }
 
   const failedDefaultProfilesSource = syncResult.sources.find(
@@ -248,15 +268,18 @@ const failOnInitialDefaultProfileSyncFailure = (
   );
 
   if (failedDefaultProfilesSource === undefined) {
-    return;
+    return { degraded: false, warnings: [] };
   }
 
-  rollbackCreatedSettings();
+  materializeBuiltinProfiles(profilesPath);
 
-  throw new Error(
-    `Cannot complete first-run setup because the default profiles source failed to sync: ${failedDefaultProfilesSource.message}. ` +
-      'Fix the network/git issue and rerun `outfitter setup` once the source is reachable.',
-  );
+  return {
+    degraded: true,
+    warnings: [
+      `Warning: the default profiles source ${failedDefaultProfilesSource.uri} failed to sync: ${failedDefaultProfilesSource.message}. ` +
+        `Installed the built-in '${builtinStarterProfileId}' profile instead; run \`outfitter sync\` to fetch the full catalog once the source is reachable.`,
+    ],
+  };
 };
 
 interface InteractiveSetupSourceCommandInput {
@@ -296,15 +319,10 @@ const executeInteractiveSetupSourceCommand = async ({
 }: InteractiveSetupSourceCommandInput): Promise<SetupCommandResult> => {
   const onboarding = await runSetupSourceOnboarding(input, dependencies, starterLayout, currentDefaultProfileId);
   const appliedImport = applySetupSourceImport(input, starterLayout, onboarding);
-  /* v8 ignore next -- setup-source rollback only runs when a home import creates settings and default-profile sync fails. */
-  const rollbackCreatedSettings = appliedImport.createdSettings
-    ? () => rmSync(appliedImport.settingsPath, { force: true })
-    : () => undefined;
   const syncResult = executeSyncCommand(input, dependencies);
-
-  failOnInitialDefaultProfileSyncFailure(
+  const syncFallback = fallBackToBuiltinProfilesOnInitialSyncFailure(
+    appliedImport.profilesPath,
     initialSettingsMissing && appliedImport.settingsPath === homeSettingsPath,
-    rollbackCreatedSettings,
     syncResult,
   );
 
@@ -340,6 +358,7 @@ const executeInteractiveSetupSourceCommand = async ({
       defaultProfilePath,
       createdDefaultProfile,
       syncResult,
+      syncWarningMessages: syncFallback.warnings,
       welcomeProfileMessages:
         appliedImport.selectedProfileConflictMessage === undefined
           ? []
@@ -388,6 +407,7 @@ interface SetupMessageInput {
   readonly defaultProfilePath: string;
   readonly createdDefaultProfile: boolean;
   readonly syncResult: SyncCommandResult;
+  readonly syncWarningMessages: readonly string[];
   readonly welcomeProfileMessages: readonly string[];
   readonly runExampleMessages: readonly string[];
 }
@@ -424,6 +444,7 @@ const buildSetupMessages = (input: SetupMessageInput): readonly string[] => {
 
   messages.push(
     `Selected default profile '${input.defaultProfileId}'.`,
+    ...input.syncWarningMessages,
     ...input.welcomeProfileMessages,
     ...input.runExampleMessages,
     ...input.syncResult.messages,

--- a/code/cli/src/cli/commands/SyncCommand.ts
+++ b/code/cli/src/cli/commands/SyncCommand.ts
@@ -1,8 +1,8 @@
 // Provides the command object for synchronizing URI-backed profile and settings sources.
-import { existsSync, mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { homedir } from 'node:os';
-import { dirname } from 'node:path';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import type { Command } from 'commander';
@@ -21,6 +21,7 @@ import {
   type ProfileSourceReference,
   type RemoteSourceReference,
 } from '../../profiles/ProfileSource.js';
+import { refreshPiExtensionCaches } from '../../agents/pi/PiExtensionCache.js';
 import type { RemoteSettingsReference } from '../../settings/Settings.js';
 import {
   discoverSettingsLoadPlan,
@@ -82,7 +83,7 @@ export const executeSyncCommand = (
     throw new Error(`Cannot sync with invalid settings: ${localSettings.issues.map(formatSettingsIssue).join('; ')}`);
   }
 
-  const synchronizer = dependencies.synchronizer ?? createGitSynchronizer();
+  const synchronizer = dependencies.synchronizer ?? createGitSynchronizer(dependencies.writeLine);
   const repositoryVisibilityClassifier =
     dependencies.repositoryVisibilityClassifier ?? createGitHubRepositoryVisibilityClassifier();
   const privateCatalogGate = createPrivateCatalogGate(
@@ -116,17 +117,22 @@ export const executeSyncCommand = (
     ...profileSourceGateResults.skippedResults,
   ];
   const infoMessages = [...remoteSettingsGateResults.messages, ...profileSourceGateResults.messages];
+  const extensionRefreshMessages = refreshPiExtensionCaches(
+    loadedSettings.settings.cacheDirectory ?? join(input.homeDirectory, '.outfitter', 'cache'),
+    { onProgress: dependencies.writeLine },
+  ).map((result) => `${result.status}: pi extension ${result.source} (${result.message})`);
 
   return {
     sources: sourceResults,
     messages:
-      sourceResults.length === 0
+      sourceResults.length === 0 && extensionRefreshMessages.length === 0
         ? ['No URI profile or remote settings sources configured; nothing to sync.']
         : [
             ...infoMessages,
             ...sourceResults.map(
               (result) => `${result.status}: ${result.uri} -> ${result.cachePath} (${result.message})`,
             ),
+            ...extensionRefreshMessages,
           ],
   };
 };
@@ -140,6 +146,8 @@ export const createSyncCommand = (dependencies: SyncCommandDependencies = {}): C
         .command(command.name)
         .description(command.description)
         .action(() => {
+          /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
+          const writeLine = dependencies.writeLine ?? console.log;
           const result = executeSyncCommand(
             {
               /* v8 ignore next -- default process home is exercised by the direct CLI entrypoint, not unit tests. */
@@ -147,12 +155,11 @@ export const createSyncCommand = (dependencies: SyncCommandDependencies = {}): C
               /* v8 ignore next -- default process cwd is exercised by the direct CLI entrypoint, not unit tests. */
               projectDirectory: dependencies.projectDirectory ?? process.cwd(),
             },
-            dependencies,
+            { ...dependencies, writeLine },
           );
 
           for (const message of result.messages) {
-            /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
-            (dependencies.writeLine ?? console.log)(message);
+            writeLine(message);
           }
         });
     },
@@ -226,11 +233,12 @@ const syncUriSource = (
   }
 };
 
-export const createGitSynchronizer = (): UriProfileSourceSynchronizer => ({
+export const createGitSynchronizer = (progress?: (message: string) => void): UriProfileSourceSynchronizer => ({
   sync(source, cachePath) {
     mkdirSync(dirname(cachePath), { recursive: true });
 
     if (existsSync(cachePath)) {
+      progress?.(`outfitter: updating catalog ${formatDisplayUri(source)}…`);
       runGit(['-C', cachePath, 'fetch', '--all', '--tags']);
       if (source.ref === undefined) {
         runGit(['-C', cachePath, 'pull', '--ff-only']);
@@ -240,11 +248,33 @@ export const createGitSynchronizer = (): UriProfileSourceSynchronizer => ({
       return 'updated';
     }
 
-    runGit(['clone', '--', normalizeGitUri(normalizeRemoteSourceUri(source)), cachePath]);
-    checkoutRefIfPresent(cachePath, source.ref);
+    progress?.(`outfitter: cloning catalog ${formatDisplayUri(source)}…`);
+    cloneCatalogSource(source, cachePath);
     return 'updated';
   },
 });
+
+// Catalog caches are shallow single-branch clones to keep first boot fast on large org catalogs.
+// A ref names the branch or tag to shallow-clone directly; refs that are not remote branch/tag
+// names (for example commit SHAs) fall back to a full clone plus checkout.
+const cloneCatalogSource = (source: RemoteSourceReference, cachePath: string): void => {
+  const cloneUri = normalizeGitUri(normalizeRemoteSourceUri(source));
+
+  if (source.ref === undefined) {
+    runGit(['clone', '--depth', '1', '--single-branch', '--', cloneUri, cachePath]);
+    return;
+  }
+
+  assertSafeGitRef(source.ref);
+
+  if (gitSucceeds(['clone', '--depth', '1', '--single-branch', '--branch', source.ref, '--', cloneUri, cachePath])) {
+    return;
+  }
+
+  rmSync(cachePath, { recursive: true, force: true });
+  runGit(['clone', '--', cloneUri, cachePath]);
+  checkoutRefIfPresent(cachePath, source.ref);
+};
 
 const checkoutRefIfPresent = (cachePath: string, ref: string | undefined): void => {
   if (ref === undefined) {

--- a/code/cli/src/profiles/BuiltinProfiles.ts
+++ b/code/cli/src/profiles/BuiltinProfiles.ts
@@ -1,0 +1,51 @@
+// Provides the built-in fallback profiles bundled inside the npm package. They keep first-run
+// onboarding working offline (degraded mode) when the remote default profile catalog cannot sync.
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+export const builtinStarterProfileId = 'starter';
+
+interface BuiltinProfileFile {
+  readonly relativePath: string;
+  readonly content: string;
+}
+
+// Sane engineering defaults with no remote extensions, so the profile works with no network.
+const builtinProfileFiles: readonly BuiltinProfileFile[] = [
+  {
+    relativePath: join(builtinStarterProfileId, 'profile.yml'),
+    content: [
+      `id: ${builtinStarterProfileId}`,
+      'label: Starter',
+      'description: >-',
+      '  Built-in Outfitter starter profile with sane engineering defaults and no remote',
+      '  extensions. Used when the default profile catalog cannot be synced; run',
+      '  `outfitter sync` to upgrade to the full catalog once the source is reachable.',
+      'controls: {}',
+      '',
+    ].join('\n'),
+  },
+];
+
+export const createBuiltinProfilesCachePath = (homeDirectory: string): string =>
+  join(homeDirectory, '.outfitter', 'cache', 'builtin-profiles');
+
+// Writes the bundled profiles into the target directory without overwriting existing files and
+// returns the number of files written.
+export const materializeBuiltinProfiles = (targetDirectory: string): number => {
+  let writtenFiles = 0;
+
+  for (const file of builtinProfileFiles) {
+    const targetPath = join(targetDirectory, file.relativePath);
+
+    if (existsSync(targetPath)) {
+      continue;
+    }
+
+    mkdirSync(dirname(targetPath), { recursive: true });
+    writeFileSync(targetPath, file.content);
+    writtenFiles += 1;
+  }
+
+  return writtenFiles;
+};

--- a/code/cli/tests/unit/agent-launch.test.ts
+++ b/code/cli/tests/unit/agent-launch.test.ts
@@ -21,7 +21,21 @@ describe('agent launch', () => {
     expect(resolved.command).toBe(process.execPath);
     expect(resolved.args[0]).toMatch(/[\\/]@earendil-works[\\/]pi-coding-agent[\\/].*cli\.js$/u);
     expect(resolved.args.slice(1)).toEqual(piPlan.args);
-    expect(resolved.env).toEqual(piPlan.env);
+    expect(resolved.env).toEqual({ ...piPlan.env, PI_SKIP_VERSION_CHECK: '1' });
+  });
+
+  it('suppresses the bundled pi self-update notice while letting plans override the setting', () => {
+    const resolved = resolveAgentLaunchExecutable(createPiPlan());
+
+    expect(resolved.env.PI_SKIP_VERSION_CHECK).toBe('1');
+
+    const overriddenPlan: AgentLaunchPlan = {
+      command: 'pi',
+      args: [],
+      env: { PI_SKIP_VERSION_CHECK: '' },
+    };
+
+    expect(resolveAgentLaunchExecutable(overriddenPlan).env.PI_SKIP_VERSION_CHECK).toBe('');
   });
 
   it('leaves non-pi launch plans untouched so they resolve from PATH', () => {

--- a/code/cli/tests/unit/builtin-profiles.test.ts
+++ b/code/cli/tests/unit/builtin-profiles.test.ts
@@ -1,0 +1,56 @@
+// Tests the bundled built-in fallback profiles used by degraded offline onboarding.
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  builtinStarterProfileId,
+  createBuiltinProfilesCachePath,
+  materializeBuiltinProfiles,
+} from '../../src/profiles/BuiltinProfiles.js';
+import { loadLocalProfileSource } from '../../src/profiles/ProfileLoader.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-builtin-profiles-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('built-in profiles', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('materializes a valid starter profile without overwriting existing files', () => {
+    const targetDirectory = join(createTemporaryRoot(), 'builtin-profiles');
+
+    expect(materializeBuiltinProfiles(targetDirectory)).toBe(1);
+
+    const loaded = loadLocalProfileSource({ path: targetDirectory });
+
+    expect(loaded.issues).toEqual([]);
+    expect(loaded.profiles.map((profile) => profile.profile.id)).toEqual([builtinStarterProfileId]);
+    expect(loaded.profiles[0]?.profile.template).not.toBe(true);
+    expect(loaded.profiles[0]?.profile.controls).toEqual({});
+
+    const starterProfilePath = join(targetDirectory, builtinStarterProfileId, 'profile.yml');
+    writeFileSync(starterProfilePath, 'id: starter\nlabel: Customized\ncontrols: {}\n');
+
+    expect(materializeBuiltinProfiles(targetDirectory)).toBe(0);
+    expect(readFileSync(starterProfilePath, 'utf8')).toContain('label: Customized');
+  });
+
+  it('derives the built-in profiles cache path from the home directory', () => {
+    expect(createBuiltinProfilesCachePath('/home/user')).toBe(
+      join('/home/user', '.outfitter', 'cache', 'builtin-profiles'),
+    );
+  });
+});

--- a/code/cli/tests/unit/no-hardcoded-model-ids.test.ts
+++ b/code/cli/tests/unit/no-hardcoded-model-ids.test.ts
@@ -1,0 +1,43 @@
+// Guards against reintroducing hardcoded model identifiers into the CLI source tree. Pi owns
+// model defaults; a model ID baked into Outfitter breaks every launch once pi rotates its catalog.
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const sourceRoot = fileURLToPath(new URL('../../src/', import.meta.url));
+
+const modelIdPatterns: readonly RegExp[] = [
+  // Provider-prefixed model IDs such as google/gemini-3.1-pro-preview or anthropic/claude-sonnet-4.
+  /\b(?:google|openai|anthropic|meta-llama|mistralai?|x-ai|xai|deepseek|qwen)\/[a-z0-9][\w.:-]*/giu,
+  // Bare model family IDs with version digits such as gpt-5, gemini-3.1, or claude-4.
+  /\b(?:gpt|gemini|claude|llama|sonnet|opus|haiku|grok)-\d[\w.-]*/giu,
+];
+
+const listSourceFiles = (): readonly string[] =>
+  readdirSync(sourceRoot, { recursive: true, encoding: 'utf8' })
+    .filter((entry) => entry.endsWith('.ts'))
+    .map((entry) => join(sourceRoot, entry));
+
+describe('hardcoded model id gate', () => {
+  it('keeps code/cli/src free of hardcoded model identifiers', () => {
+    const sourceFiles = listSourceFiles();
+
+    expect(sourceFiles.length).toBeGreaterThan(0);
+
+    const offenders: string[] = [];
+
+    for (const filePath of sourceFiles) {
+      const content = readFileSync(filePath, 'utf8');
+
+      for (const pattern of modelIdPatterns) {
+        for (const match of content.matchAll(pattern)) {
+          offenders.push(`${filePath}: ${match[0]}`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/code/cli/tests/unit/pi-extension-cache.test.ts
+++ b/code/cli/tests/unit/pi-extension-cache.test.ts
@@ -1,5 +1,5 @@
 // Tests Pi git extension materialization into the Outfitter cache.
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -7,6 +7,7 @@ import spawn from 'cross-spawn';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { createPiAdapter } from '../../src/agents/pi/PiAdapter.js';
+import { materializePiExtensionSources, refreshPiExtensionCaches } from '../../src/agents/pi/PiExtensionCache.js';
 
 const temporaryPiExtensionCacheTestRoots: string[] = [];
 
@@ -91,6 +92,107 @@ describe('pi extension cache', () => {
 
     expect(() => materializedExtensionPath(`git+file://${remoteRepository}#main`, cacheRoot)).toThrow();
     expect(listCachedExtensions(cacheRoot)).toEqual([]);
+  });
+
+  it('reports per-extension progress while materializing git extensions', () => {
+    const root = createTemporaryRoot();
+    const remoteRepository = createLocalGitExtensionRepository(root, { packageJson: true });
+    const source = `git+file://${remoteRepository}`;
+    const progressLines: string[] = [];
+
+    materializePiExtensionSources([source], {
+      cacheDirectory: join(root, 'cache'),
+      onProgress: (message) => {
+        progressLines.push(message);
+      },
+    });
+
+    expect(progressLines).toEqual([
+      `outfitter: caching extension ${source}…`,
+      `outfitter: installing dependencies for extension ${source}…`,
+    ]);
+  });
+});
+
+describe('pi extension cache refresh', () => {
+  it('refreshes branch-tracking caches and leaves ref-pinned caches immutable', () => {
+    const root = createTemporaryRoot();
+    const remoteRepository = createLocalGitExtensionRepository(root);
+    const cacheDirectory = join(root, 'cache');
+    const branchSource = `git+file://${remoteRepository}`;
+    const pinnedSource = `git+file://${remoteRepository}#main`;
+    const [branchPath] = materializePiExtensionSources([branchSource], { cacheDirectory }) ?? [];
+    const [pinnedPath] = materializePiExtensionSources([pinnedSource], { cacheDirectory }) ?? [];
+
+    const unchangedResults = refreshPiExtensionCaches(cacheDirectory);
+
+    expect(unchangedResults.find((result) => result.cachePath === branchPath)?.status).toBe('unchanged');
+
+    writeFileSync(join(remoteRepository, 'index.ts'), 'export default function updated() {}\n');
+    runGit(['add', 'index.ts'], remoteRepository);
+    runGit(
+      ['-c', 'user.email=test@example.test', '-c', 'user.name=Test User', 'commit', '-m', 'update'],
+      remoteRepository,
+    );
+
+    const progressLines: string[] = [];
+    const refreshedResults = refreshPiExtensionCaches(cacheDirectory, {
+      onProgress: (message) => {
+        progressLines.push(message);
+      },
+    });
+    const branchResult = refreshedResults.find((result) => result.cachePath === branchPath);
+    const pinnedResult = refreshedResults.find((result) => result.cachePath === pinnedPath);
+
+    expect(branchResult?.status).toBe('refreshed');
+    expect(readFileSync(join(branchPath ?? '', 'index.ts'), 'utf8')).toContain('updated');
+    expect(pinnedResult?.status).toBe('pinned');
+    expect(readFileSync(join(pinnedPath ?? '', 'index.ts'), 'utf8')).not.toContain('updated');
+    expect(progressLines.some((line) => line.startsWith('outfitter: refreshing extension '))).toBe(true);
+  });
+
+  it('reports refresh failures without discarding caches and skips unknown entries', () => {
+    const root = createTemporaryRoot();
+    const remoteRepository = createLocalGitExtensionRepository(root);
+    const cacheDirectory = join(root, 'cache');
+    const source = `git+file://${remoteRepository}`;
+    const [cachePath] = materializePiExtensionSources([source], { cacheDirectory }) ?? [];
+    rmSync(remoteRepository, { recursive: true, force: true });
+
+    const gitCacheRoot = join(cacheDirectory, 'extensions', 'git');
+    mkdirSync(join(gitCacheRoot, 'legacy-cache-without-metadata'), { recursive: true });
+    writeFileSync(join(gitCacheRoot, 'broken.source.json'), 'not json\n');
+    writeFileSync(join(gitCacheRoot, 'array.source.json'), '[]\n');
+    writeFileSync(join(gitCacheRoot, 'missing-source-field.source.json'), '{"ref":"main"}\n');
+    writeFileSync(join(gitCacheRoot, 'ghost.source.json'), '{"source":"git+file:///removed"}\n');
+    mkdirSync(join(gitCacheRoot, 'not-a-git-repo'), { recursive: true });
+    writeFileSync(join(gitCacheRoot, 'not-a-git-repo.source.json'), '{"source":"git+file:///not-a-repo"}\n');
+
+    const results = refreshPiExtensionCaches(cacheDirectory);
+
+    expect(results.map((result) => result.status).sort()).toEqual(['failed', 'failed']);
+    expect(results.find((result) => result.cachePath === cachePath)?.status).toBe('failed');
+    expect(existsSync(join(cachePath ?? '', 'index.ts'))).toBe(true);
+    expect(refreshPiExtensionCaches(join(root, 'missing-cache-directory'))).toEqual([]);
+  });
+
+  it('reports dependency install failures after a refreshed cache tip moves', () => {
+    const root = createTemporaryRoot();
+    const remoteRepository = createLocalGitExtensionRepository(root);
+    const cacheDirectory = join(root, 'cache');
+    const source = `git+file://${remoteRepository}`;
+    const [cachePath] = materializePiExtensionSources([source], { cacheDirectory }) ?? [];
+
+    writeFileSync(join(remoteRepository, 'package.json'), '{invalid json}\n');
+    runGit(['add', 'package.json'], remoteRepository);
+    runGit(
+      ['-c', 'user.email=test@example.test', '-c', 'user.name=Test User', 'commit', '-m', 'break package json'],
+      remoteRepository,
+    );
+
+    const results = refreshPiExtensionCaches(cacheDirectory);
+
+    expect(results.find((result) => result.cachePath === cachePath)?.status).toBe('failed');
   });
 });
 

--- a/code/cli/tests/unit/pi-login-launch.test.ts
+++ b/code/cli/tests/unit/pi-login-launch.test.ts
@@ -973,11 +973,7 @@ describe('preparePiLoginLaunchPlan', () => {
     expect(context.submittedInputs).toEqual(['\r']);
     expect(messages.some((message) => message.includes('/outfitter'))).toBe(false);
     expect(readFileSync(join(agentDir, 'settings.json'), 'utf8')).toContain('"quietStartup": true');
-    expect(plan.args).toEqual([
-      '--extension',
-      expect.stringContaining('outfitter-extension.js'),
-      '--model',
-      'google/gemini-3.1-pro-preview',
-    ]);
+    expect(plan.args).toEqual(['--extension', expect.stringContaining('outfitter-extension.js')]);
+    expect(plan.args).not.toContain('--model');
   });
 });

--- a/code/cli/tests/unit/run-command.test.ts
+++ b/code/cli/tests/unit/run-command.test.ts
@@ -211,7 +211,7 @@ describe('run command', () => {
           launch(plan) {
             expect(existsSync(join(homeDirectory, '.outfitter', 'settings.yml'))).toBe(false);
             expect(plan.args).toContain('--extension');
-            expect(plan.args).toContain('google/gemini-3.1-pro-preview');
+            expect(plan.args).not.toContain('--model');
             expect(readFileSync(join(plan.env.PI_CODING_AGENT_DIR, 'settings.json'), 'utf8')).toContain(
               '"quietStartup": true',
             );

--- a/code/cli/tests/unit/run-command.test.ts
+++ b/code/cli/tests/unit/run-command.test.ts
@@ -235,6 +235,48 @@ describe('run command', () => {
     expect(existsSync(join(homeDirectory, '.outfitter', 'settings.yml'))).toBe(false);
   });
 
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('falls back to the built-in starter profile when the default profiles catalog cannot sync', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const builtinProfilesPath = join(homeDirectory, '.outfitter', 'cache', 'builtin-profiles');
+    const warnings: string[] = [];
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        interactive: true,
+        writeLine: () => undefined,
+        writeError: (message) => warnings.push(message),
+        synchronizer: {
+          sync() {
+            throw new Error('network blocked');
+          },
+        },
+        launcher: {
+          launch(plan) {
+            const extensionPath = plan.args[plan.args.indexOf('--extension') + 1] ?? '';
+            expect(readFileSync(extensionPath, 'utf8')).toContain(JSON.stringify(builtinProfilesPath));
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(result.profileId).toBe('outfitter-bootstrap');
+    expect(readFileSync(join(builtinProfilesPath, 'starter', 'profile.yml'), 'utf8')).toContain('id: starter');
+    expect(
+      warnings.some(
+        (message) =>
+          message.includes('github:ai-outfitter/default-profiles') &&
+          message.includes('network blocked') &&
+          message.includes('`outfitter sync`'),
+      ),
+    ).toBe(true);
+  });
+
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.4).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('emits runtime login kickoff guidance when no native login state is configured', async () => {

--- a/code/cli/tests/unit/setup-command.test.ts
+++ b/code/cli/tests/unit/setup-command.test.ts
@@ -168,12 +168,14 @@ describe('setup command', () => {
     expect(readFileSync(defaultProfilePath, 'utf8')).toBe('id: default\nlabel: Custom\n');
   });
 
-  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.1).
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.1, OFTR-010.6).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('fails first-run setup when the default profile source cannot sync', async () => {
+  it('falls back to the built-in starter profile when the default profile source cannot sync on first run', async () => {
     const root = createTemporaryRoot();
     const homeDirectory = join(root, 'home');
     const projectDirectory = join(root, 'project');
+    const settingsPath = join(homeDirectory, '.outfitter', 'settings.yml');
+    const starterProfilePath = join(homeDirectory, '.outfitter', 'profiles', 'starter', 'profile.yml');
 
     const failingDependencies = {
       synchronizer: {
@@ -183,16 +185,23 @@ describe('setup command', () => {
       },
     };
 
-    await expect(executeSetupCommand({ homeDirectory, projectDirectory }, failingDependencies)).rejects.toThrow(
-      'Cannot complete first-run setup because the default profiles source failed to sync',
-    );
-    expect(existsSync(join(homeDirectory, '.outfitter', 'settings.yml'))).toBe(false);
-    await expect(executeSetupCommand({ homeDirectory, projectDirectory }, failingDependencies)).rejects.toThrow(
-      'Cannot complete first-run setup because the default profiles source failed to sync',
-    );
+    const result = await executeSetupCommand({ homeDirectory, projectDirectory }, failingDependencies);
+
+    expect(result.createdSettings).toBe(true);
+    expect(readFileSync(settingsPath, 'utf8')).toContain('default_profile: starter');
+    expect(readFileSync(starterProfilePath, 'utf8')).toContain('id: starter');
+    expect(result.defaultProfilePath).toBe(starterProfilePath);
+    expect(
+      result.messages.some((message) => message.includes('failed to sync') && message.includes('`outfitter sync`')),
+    ).toBe(true);
+
+    const secondResult = await executeSetupCommand({ homeDirectory, projectDirectory }, failingDependencies);
+
+    expect(secondResult.createdSettings).toBe(false);
+    expect(readFileSync(settingsPath, 'utf8')).toContain('default_profile: starter');
   });
 
-  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.1).
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.1, OFTR-010.6).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('does not delete settings created during setup-source synchronization when first-run sync fails', async () => {
     const root = createTemporaryRoot();
@@ -207,27 +216,28 @@ describe('setup command', () => {
       '',
     ].join('\n');
 
-    await expect(
-      executeSetupCommand(
-        { homeDirectory, projectDirectory, setupSourceUri: 'https://example.test/outfitter-config.git' },
-        {
-          setupSourceSynchronizer: {
-            sync(_uri, cachePath) {
-              mkdirSync(cachePath, { recursive: true });
-              mkdirSync(dirname(settingsPath), { recursive: true });
-              writeFileSync(settingsPath, settingsContent);
-            },
-          },
-          synchronizer: {
-            sync() {
-              return 'failed' as const;
-            },
+    const result = await executeSetupCommand(
+      { homeDirectory, projectDirectory, setupSourceUri: 'https://example.test/outfitter-config.git' },
+      {
+        setupSourceSynchronizer: {
+          sync(_uri, cachePath) {
+            mkdirSync(cachePath, { recursive: true });
+            mkdirSync(dirname(settingsPath), { recursive: true });
+            writeFileSync(settingsPath, settingsContent);
           },
         },
-      ),
-    ).rejects.toThrow('Cannot complete first-run setup because the default profiles source failed to sync');
+        synchronizer: {
+          sync() {
+            return 'failed' as const;
+          },
+        },
+      },
+    );
 
     expect(readFileSync(settingsPath, 'utf8')).toBe(settingsContent);
+    expect(
+      result.messages.some((message) => message.includes('failed to sync') && message.includes('`outfitter sync`')),
+    ).toBe(true);
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.1).

--- a/code/cli/tests/unit/sync-command.test.ts
+++ b/code/cli/tests/unit/sync-command.test.ts
@@ -1,11 +1,12 @@
 // Tests sync command and profile source cache behavior.
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { materializePiExtensionSources } from '../../src/agents/pi/PiExtensionCache.js';
 import { executeSyncCommand } from '../../src/cli/commands/SyncCommand.js';
 import {
   createProfileSourceCachePath,
@@ -389,5 +390,79 @@ describe('sync command', () => {
     expect(executeSyncCommand({ homeDirectory, projectDirectory }).messages).toEqual([
       'No URI profile or remote settings sources configured; nothing to sync.',
     ]);
+  });
+
+  it('creates shallow single-branch catalog caches and reports per-source progress', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const repositoryPath = createGitProfileRepository(root);
+    const uri = `git+file://${repositoryPath}`;
+    writeSettings(homeDirectory, `profile_sources:\n  - uri: ${uri}\n`);
+    const progressLines: string[] = [];
+    const writeLine = (message: string): void => {
+      progressLines.push(message);
+    };
+
+    const firstResult = executeSyncCommand({ homeDirectory, projectDirectory }, { writeLine });
+    const cachePath = createProfileSourceCachePath(homeDirectory, uri);
+
+    expect(firstResult.sources[0]?.status).toBe('updated');
+    expect(existsSync(join(cachePath, '.git', 'shallow'))).toBe(true);
+    expect(progressLines.some((line) => line.startsWith('outfitter: cloning catalog '))).toBe(true);
+
+    progressLines.length = 0;
+    const secondResult = executeSyncCommand({ homeDirectory, projectDirectory }, { writeLine });
+
+    expect(secondResult.sources[0]?.status).toBe('updated');
+    expect(progressLines.some((line) => line.startsWith('outfitter: updating catalog '))).toBe(true);
+
+    execFileSync('git', ['checkout', '-b', 'feature'], { cwd: repositoryPath, stdio: 'pipe' });
+    writeFileSync(join(repositoryPath, 'remote', 'profile.yml'), 'id: remote\nlabel: Feature\ncontrols: {}\n');
+    execFileSync('git', ['add', '.'], { cwd: repositoryPath, stdio: 'pipe' });
+    execFileSync(
+      'git',
+      ['-c', 'user.name=Outfitter Test', '-c', 'user.email=outfitter@example.test', 'commit', '-m', 'feature'],
+      { cwd: repositoryPath, stdio: 'pipe' },
+    );
+    writeSettings(homeDirectory, `profile_sources:\n  - uri: ${uri}\n    ref: feature\n    path: .\n`);
+
+    const branchRefResult = executeSyncCommand({ homeDirectory, projectDirectory }, { writeLine });
+    const branchCachePath = createRemoteRepositoryCachePath(homeDirectory, { uri, ref: 'feature' });
+
+    expect(branchRefResult.sources[0]?.status).toBe('updated');
+    expect(existsSync(join(branchCachePath, '.git', 'shallow'))).toBe(true);
+    expect(readFileSync(join(branchCachePath, 'remote', 'profile.yml'), 'utf8')).toContain('label: Feature');
+  });
+
+  it('refreshes branch-tracking pi extension caches during sync and reports the outcome', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const extensionRepository = createGitProfileRepository(root, 'extension-source');
+    const cacheDirectory = join(homeDirectory, '.outfitter', 'cache');
+    writeSettings(homeDirectory, 'default_profile: default\n');
+    materializePiExtensionSources([`git+file://${extensionRepository}`], { cacheDirectory });
+
+    writeFileSync(join(extensionRepository, 'extension.txt'), 'updated extension\n');
+    execFileSync('git', ['add', '.'], { cwd: extensionRepository, stdio: 'pipe' });
+    execFileSync(
+      'git',
+      ['-c', 'user.name=Outfitter Test', '-c', 'user.email=outfitter@example.test', 'commit', '-m', 'update'],
+      { cwd: extensionRepository, stdio: 'pipe' },
+    );
+
+    const progressLines: string[] = [];
+    const result = executeSyncCommand(
+      { homeDirectory, projectDirectory },
+      {
+        writeLine: (message) => {
+          progressLines.push(message);
+        },
+      },
+    );
+
+    expect(result.messages.some((message) => message.startsWith('refreshed: pi extension '))).toBe(true);
+    expect(progressLines.some((line) => line.startsWith('outfitter: refreshing extension '))).toBe(true);
   });
 });

--- a/docs/plans/issues/05-fix-false-update-notice.md
+++ b/docs/plans/issues/05-fix-false-update-notice.md
@@ -22,3 +22,41 @@ During the demo dry run (2026-07-01), an "update available" message appeared rig
 ## References
 
 - Demo dry-run transcript (2026-07-01)
+
+## Investigation (2026-07-01)
+
+**The notice comes from pi itself, not from Outfitter.** Outfitter contains no
+update-check, version-comparison, or notice logic anywhere in `code/cli/src`,
+`bin/`, or `scripts/` (verified by searching for npm dist-tag lookups, semver
+comparisons, registry URLs, and "update available" strings).
+
+Root cause chain:
+
+1. Outfitter always launches its **bundled** pi
+   (`code/cli/src/agents/AgentLaunch.ts`, `resolveAgentLaunchExecutable`
+   resolves `@earendil-works/pi-coding-agent` from Outfitter's own
+   `node_modules` and runs it through the current Node).
+2. On every interactive startup pi runs `checkForNewPiVersion(this.version)`
+   (`dist/modes/interactive/interactive-mode.js` → `dist/utils/version-check.js`
+   in the pi package): it fetches `https://pi.dev/api/latest-version` fresh each
+   launch (no cached result involved) and compares against the running pi's own
+   version. The comparator itself is correct (proper major/minor/patch and
+   prerelease handling).
+3. The bundled pi is version-pinned by Outfitter's dependency (`^0.78.1` at the
+   time of writing). Whenever pi.dev advertises a newer pi than the pinned copy,
+   every Outfitter launch shows "Update Available … run `pi update`" — including
+   immediately after updating Outfitter itself, which is exactly what the demo
+   dry run hit. The instruction is also unactionable: `pi update` updates a
+   global pi install, never the copy bundled inside Outfitter.
+
+**Fix applied in Outfitter:** there is no Outfitter comparator or cache to fix,
+but the false notice is still an Outfitter-context problem, so bundled pi
+launches now set `PI_SKIP_VERSION_CHECK=1` (pi's own documented kill switch for
+this check) in `resolveAgentLaunchExecutable`. Profile-controlled environment
+values still override it. PATH-resolved agents are unaffected. Pi package-update
+notices (`checkForPackageUpdates`, gated by `PI_OFFLINE`) remain enabled because
+those are actionable.
+
+**Upstream note:** the real update channel for the bundled pi is an Outfitter
+release; if pi ever grows a "bundled/embedded" mode notice, this suppression can
+be revisited.

--- a/docs/requirements/OFTR-010-onboarding-welcome.md
+++ b/docs/requirements/OFTR-010-onboarding-welcome.md
@@ -93,3 +93,11 @@ then finish profile setup inside Pi through a native Outfitter extension command
 1. Explicit `outfitter setup` MUST launch Pi-native onboarding rather than terminal setup prompts.
 2. `outfitter setup <source>` MUST pass the provided source into Pi-native onboarding so setup writes happen from inside Pi.
 3. The published `skills/outfitter` fallback MUST remain available as documentation/guidance for environments where the native command is unavailable.
+
+### OFTR-010.6: Degraded Offline Onboarding
+
+1. The npm package MUST bundle a minimal built-in profile with id `starter` that uses sane engineering defaults and requires no network access or remote extensions.
+2. When the first-run sync of the default profile catalog (`ai-outfitter/default-profiles`) fails, onboarding MUST NOT fail. It MUST warn — naming the failed source and explaining that `outfitter sync` retries the catalog once the source is reachable — and MUST fall back to the built-in `starter` profile so the user still reaches a working Pi session (degraded mode).
+3. Degraded-mode fallback applies to both the interactive default `outfitter` launch and setup flows that create initial settings.
+4. When the default catalog sync succeeds, onboarding behavior MUST be identical to non-degraded behavior; the built-in profile MUST NOT shadow or replace catalog profiles.
+5. A later successful `outfitter sync` MUST upgrade a degraded environment to the full default catalog without requiring re-onboarding.


### PR DESCRIPTION
Stacked PR 4/10 — base: `sprint/03-ci-hardening`.

M1 ship-blockers — the first-five-minutes reliability work:
- Bundled offline `starter` profile; catalog sync failure now degrades with a warning instead of dead-ending first run (OFTR-010.6 added).
- Hardcoded `google/gemini-3.1-pro-preview` bootstrap model removed (pi picks its default; `/login` auto-opens when no models exist); grep-gate test prevents recurrence.
- False "update available" notice root-caused to pi's version check against the *bundled, version-pinned* pi; suppressed via `PI_SKIP_VERSION_CHECK=1` for bundled launches only (analysis in docs/plans/issues/05).
- First-boot speed: shallow catalog clones, `.source.json` metadata + `outfitter sync` refresh for branch-tracking git-extension caches (they previously never updated), per-source progress output.

Note: requirement-pinned tests were amended via their escape clause with the OFTR requirements updated first — worth a maintainer look.

Fork issues: [#1](https://github.com/tylerwillis/outfitter/issues/1), [#2](https://github.com/tylerwillis/outfitter/issues/2), [#3](https://github.com/tylerwillis/outfitter/issues/3), [#4](https://github.com/tylerwillis/outfitter/issues/4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


