### PR TITLE
test(conformance): cross-adapter suite with docs drift verification

### DIFF
--- a/code/cli/package.json
+++ b/code/cli/package.json
@@ -33,6 +33,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "vitest --run",
+    "conformance": "vitest --run tests/conformance",
     "coverage": "vitest --run --coverage",
     "check": "npm run lint:fix && npm run coverage",
     "check-ci": "prettier --check . && npm run lint && npm run coverage"

--- a/code/cli/tests/conformance/ConformanceRows.ts
+++ b/code/cli/tests/conformance/ConformanceRows.ts
@@ -1,0 +1,466 @@
+// Declares the conformance rows: for each generic control in the vocabulary, a
+// fixture profile plus the expected outcome per adapter (supported, roadmap, or
+// not applicable). The runner in conformance.test.ts executes every declaration
+// against every registered adapter.
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { delimiter, dirname, join } from 'node:path';
+
+import { expect } from 'vitest';
+
+import {
+  flagValuesOf,
+  type ConformanceFixturePaths,
+  type ConformanceRow,
+  type ConformanceSupportedOutcome,
+} from './ConformanceSpec.js';
+
+const writeFixtureFile = (filePath: string, content: string): void => {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content);
+};
+
+const mcpFragment = JSON.stringify({ mcpServers: { conformance: { command: 'conformance-server' } } });
+
+const setupMcpFragment =
+  (adapterId: string) =>
+  (paths: ConformanceFixturePaths): void => {
+    writeFixtureFile(join(paths.profileFolder, 'cli_specific', adapterId, '.mcp.json'), `${mcpFragment}\n`);
+  };
+
+const assertMergedMcpFile = ({ plan, paths }: ConformanceSupportedOutcome): void => {
+  const mcpFile = plan.compositeProfile.files.find((file) => file.relativePath === '.mcp.json');
+  expect(mcpFile).toBeDefined();
+  expect(mcpFile?.outputPath).toBe(join(paths.compositeRootDirectory, '.mcp.json'));
+  expect(mcpFile?.strategy).toBe('merge');
+  const parsed = JSON.parse(mcpFile?.content ?? '{}') as {
+    mcpServers?: Record<string, { command?: string }>;
+  };
+  expect(parsed.mcpServers?.conformance?.command).toBe('conformance-server');
+};
+
+// Every relative path an adapter declares must materialize as a composite state
+// path; symlink-strategy paths must resolve a concrete source. This assertion is
+// adapter-generic, so any future adapter is held to the same contract.
+const assertDeclaredStatePaths = ({ adapter, plan }: ConformanceSupportedOutcome): void => {
+  const declarations = Object.keys(adapter.statePaths ?? {}).filter((relativePath) => relativePath !== 'unknown');
+  expect(declarations.length).toBeGreaterThan(0);
+
+  for (const relativePath of declarations) {
+    const statePath = plan.compositeProfile.statePaths.find((candidate) => candidate.relativePath === relativePath);
+    expect(statePath, `state path '${relativePath}' missing for adapter '${adapter.id}'`).toBeDefined();
+
+    if (statePath?.strategy === 'symlink') {
+      expect(statePath.sourcePath, `state path '${relativePath}' has no source for '${adapter.id}'`).toBeDefined();
+    }
+  }
+};
+
+export const conformanceRows: readonly ConformanceRow[] = [
+  {
+    id: 'model',
+    description: 'generic model selection maps to the native model flag',
+    expectations: {
+      pi: {
+        status: 'supported',
+        controls: () => ({ model: 'conformance-model' }),
+        assert: ({ launchPlan }) => expect(flagValuesOf(launchPlan.args, '--model')).toEqual(['conformance-model']),
+      },
+      claude: {
+        status: 'supported',
+        controls: () => ({ model: 'conformance-model' }),
+        assert: ({ launchPlan }) => expect(flagValuesOf(launchPlan.args, '--model')).toEqual(['conformance-model']),
+      },
+    },
+  },
+  {
+    id: 'provider',
+    description: 'generic provider selection',
+    expectations: {
+      pi: {
+        status: 'supported',
+        controls: () => ({ provider: 'conformance-provider' }),
+        assert: ({ launchPlan }) =>
+          expect(flagValuesOf(launchPlan.args, '--provider')).toEqual(['conformance-provider']),
+      },
+      claude: { status: 'roadmap', controls: { provider: 'conformance-provider' }, warnsAbout: 'provider' },
+    },
+  },
+  {
+    id: 'thinking',
+    description: 'generic thinking level maps to the native reasoning flag',
+    expectations: {
+      pi: {
+        status: 'supported',
+        controls: () => ({ thinking: 'high' }),
+        assert: ({ launchPlan }) => expect(flagValuesOf(launchPlan.args, '--thinking')).toEqual(['high']),
+      },
+      claude: {
+        status: 'supported',
+        controls: () => ({ thinking: 'medium' }),
+        // The documented table: off/minimal/low → low, medium/high/xhigh/max map
+        // one-to-one, and unknown levels pass through unchanged.
+        assert: ({ adapter, plan, launchPlan }) => {
+          expect(flagValuesOf(launchPlan.args, '--effort')).toEqual(['medium']);
+          const effortFor = (thinking: string): readonly string[] =>
+            flagValuesOf(
+              adapter.createLaunchPlan(plan.compositeProfile, {
+                id: 'conformance-thinking',
+                inherits: [],
+                controls: { thinking },
+              }).args,
+              '--effort',
+            );
+          expect(effortFor('off')).toEqual(['low']);
+          expect(effortFor('minimal')).toEqual(['low']);
+          expect(effortFor('low')).toEqual(['low']);
+          expect(effortFor('high')).toEqual(['high']);
+          expect(effortFor('xhigh')).toEqual(['xhigh']);
+          expect(effortFor('max')).toEqual(['max']);
+          expect(effortFor('claude-native-level')).toEqual(['claude-native-level']);
+        },
+      },
+    },
+  },
+  {
+    id: 'environment',
+    description: 'profile environment variables reach the launch environment',
+    expectations: {
+      pi: {
+        status: 'supported',
+        controls: () => ({ environment: { CONFORMANCE_ENV: 'on' } }),
+        assert: ({ launchPlan }) => expect(launchPlan.env.CONFORMANCE_ENV).toBe('on'),
+      },
+      claude: {
+        status: 'supported',
+        controls: () => ({ environment: { CONFORMANCE_ENV: 'on' } }),
+        assert: ({ launchPlan }) => expect(launchPlan.env.CONFORMANCE_ENV).toBe('on'),
+      },
+    },
+  },
+  {
+    id: 'args',
+    description: 'profile-declared extra CLI arguments are appended to the launch argv',
+    expectations: {
+      pi: {
+        status: 'supported',
+        controls: () => ({ args: ['--no-themes'] }),
+        assert: ({ launchPlan }) => expect(launchPlan.args).toContain('--no-themes'),
+      },
+      claude: {
+        status: 'supported',
+        controls: () => ({ args: ['--permission-mode', 'plan'] }),
+        assert: ({ launchPlan }) => expect(flagValuesOf(launchPlan.args, '--permission-mode')).toEqual(['plan']),
+      },
+    },
+  },
+  {
+    id: 'pass_through_args',
+    description: 'unrecognized CLI arguments are forwarded unmodified after profile args',
+    expectations: {
+      pi: {
+        status: 'supported',
+        passThroughArgs: ['--conformance-pass-through'],
+        assert: ({ launchPlan }) => expect(launchPlan.args.at(-1)).toBe('--conformance-pass-through'),
+      },
+      claude: {
+        status: 'supported',
+        passThroughArgs: ['--conformance-pass-through'],
+        assert: ({ launchPlan }) => expect(launchPlan.args.at(-1)).toBe('--conformance-pass-through'),
+      },
+    },
+  },
+  {
+    id: 'agent_config_directory',
+    description: 'the agent config directory is pointed at the composite profile root',
+    expectations: {
+      pi: {
+        status: 'supported',
+        assert: ({ launchPlan, plan }) =>
+          expect(launchPlan.env.PI_CODING_AGENT_DIR).toBe(plan.compositeProfile.rootDirectory),
+      },
+      claude: {
+        status: 'supported',
+        assert: ({ launchPlan, plan }) =>
+          expect(launchPlan.env.CLAUDE_CONFIG_DIR).toBe(plan.compositeProfile.rootDirectory),
+      },
+    },
+  },
+  {
+    id: 'session_directory',
+    description: 'generic session directory selection places session state',
+    expectations: {
+      pi: {
+        status: 'supported',
+        controls: (paths) => ({ sessionDirectory: join(paths.rootDirectory, 'sessions') }),
+        assert: ({ launchPlan, paths }) =>
+          expect(flagValuesOf(launchPlan.args, '--session-dir')).toEqual([join(paths.rootDirectory, 'sessions')]),
+      },
+      claude: {
+        // Claude has no session-dir flag; session state under `projects/` is
+        // symlinked from the selected directory instead.
+        status: 'supported',
+        controls: (paths) => ({ sessionDirectory: join(paths.rootDirectory, 'sessions') }),
+        assert: ({ plan, paths }) =>
+          expect(
+            plan.compositeProfile.statePaths.find((statePath) => statePath.relativePath === 'projects/'),
+          ).toMatchObject({ strategy: 'symlink', sourcePath: join(paths.rootDirectory, 'sessions') }),
+      },
+    },
+  },
+  {
+    id: 'extensions',
+    description: 'generic extension selections map to the native plugin mechanism',
+    expectations: {
+      pi: {
+        status: 'supported',
+        controls: () => ({ extensions: ['conformance-extension'] }),
+        assert: ({ launchPlan }) =>
+          expect(flagValuesOf(launchPlan.args, '--extension')).toEqual(['conformance-extension']),
+      },
+      claude: {
+        status: 'supported',
+        controls: () => ({ extensions: ['conformance-plugin'] }),
+        assert: ({ launchPlan }) =>
+          expect(flagValuesOf(launchPlan.args, '--plugin-dir')).toEqual(['conformance-plugin']),
+      },
+    },
+  },
+  {
+    id: 'skills',
+    description: 'generic skill selections reach the agent',
+    expectations: {
+      pi: {
+        status: 'supported',
+        setup: (paths) =>
+          writeFixtureFile(join(paths.profileFolder, 'skills', 'conformance-skill', 'SKILL.md'), '# skill\n'),
+        controls: (paths) => ({ skills: [join(paths.profileFolder, 'skills', 'conformance-skill')] }),
+        assert: ({ launchPlan, paths }) =>
+          expect(flagValuesOf(launchPlan.args, '--skill')).toContain(
+            join(paths.profileFolder, 'skills', 'conformance-skill'),
+          ),
+      },
+      claude: {
+        // Claude has no skill flag; skills are materialized as per-skill symlinks
+        // inside the profiled config directory's `skills/`.
+        status: 'supported',
+        setup: (paths) =>
+          writeFixtureFile(join(paths.profileFolder, 'skills', 'conformance-skill', 'SKILL.md'), '# skill\n'),
+        controls: () => ({ skills: ['conformance-skill'] }),
+        assert: ({ plan, paths }) =>
+          expect(
+            plan.compositeProfile.statePaths.find(
+              (statePath) => statePath.relativePath === 'skills/conformance-skill/',
+            ),
+          ).toMatchObject({
+            strategy: 'symlink',
+            sourcePath: join(paths.profileFolder, 'skills', 'conformance-skill'),
+          }),
+      },
+    },
+  },
+  {
+    id: 'prompt_template',
+    description: 'generic prompt template selection',
+    expectations: {
+      pi: {
+        status: 'supported',
+        controls: () => ({ promptTemplate: 'conformance-template' }),
+        assert: ({ launchPlan }) =>
+          expect(flagValuesOf(launchPlan.args, '--prompt-template')).toEqual(['conformance-template']),
+      },
+      claude: {
+        status: 'roadmap',
+        controls: { prompt_template: 'conformance-template' },
+        warnsAbout: 'prompt_template',
+      },
+    },
+  },
+  {
+    id: 'native_commands',
+    description: 'native command/prompt directories are profiled into the config directory',
+    expectations: {
+      pi: {
+        status: 'not-applicable',
+        justification:
+          'Pi selects prompt templates with the native --prompt-template flag (covered by the prompt_template row); it has no commands/ directory inside the agent config dir for Outfitter to profile.',
+      },
+      claude: {
+        status: 'supported',
+        setup: (paths) =>
+          writeFixtureFile(join(paths.profileFolder, 'cli_specific', 'claude', 'commands', 'review.md'), '# review\n'),
+        assert: ({ plan, paths }) =>
+          expect(
+            plan.compositeProfile.statePaths.find((statePath) => statePath.relativePath === 'commands/'),
+          ).toMatchObject({
+            strategy: 'symlink',
+            sourcePath: join(paths.profileFolder, 'cli_specific', 'claude', 'commands'),
+          }),
+      },
+    },
+  },
+  {
+    id: 'system_prompt',
+    description: 'generic system prompt maps to the native flag',
+    expectations: {
+      pi: {
+        status: 'supported',
+        controls: () => ({ systemPrompt: 'conformance system prompt' }),
+        assert: ({ launchPlan }) =>
+          expect(flagValuesOf(launchPlan.args, '--system-prompt')).toEqual(['conformance system prompt']),
+      },
+      claude: {
+        status: 'supported',
+        controls: () => ({ systemPrompt: 'conformance system prompt' }),
+        assert: ({ launchPlan }) =>
+          expect(flagValuesOf(launchPlan.args, '--system-prompt')).toEqual(['conformance system prompt']),
+      },
+    },
+  },
+  {
+    id: 'append_system_prompt',
+    description: 'generic appended system prompt maps to the native flag',
+    expectations: {
+      pi: {
+        status: 'supported',
+        controls: () => ({ appendSystemPrompt: 'conformance appended prompt' }),
+        assert: ({ launchPlan }) =>
+          expect(flagValuesOf(launchPlan.args, '--append-system-prompt')).toEqual(['conformance appended prompt']),
+      },
+      claude: {
+        status: 'supported',
+        controls: () => ({ appendSystemPrompt: 'conformance appended prompt' }),
+        assert: ({ launchPlan }) =>
+          expect(flagValuesOf(launchPlan.args, '--append-system-prompt')).toEqual(['conformance appended prompt']),
+      },
+    },
+  },
+  {
+    id: 'deepwork',
+    description: 'DeepWork job selection is exposed to the agent runtime',
+    expectations: {
+      pi: {
+        status: 'supported',
+        setup: (paths) =>
+          writeFixtureFile(
+            join(paths.rootDirectory, 'profile-source', 'deepwork', 'jobs', 'conformance_triage', 'job.yml'),
+            'name: conformance_triage\n',
+          ),
+        controls: () => ({ deepwork: { jobs: ['conformance_triage'] } }),
+        profileLayers: (paths, profile) => [
+          {
+            profile,
+            profilePath: join(paths.profileFolder, 'profile.yml'),
+            sourceRootPath: join(paths.rootDirectory, 'profile-source'),
+          },
+        ],
+        assert: ({ launchPlan, paths }) =>
+          expect(launchPlan.env.DEEPWORK_ADDITIONAL_JOBS_FOLDERS?.split(delimiter)).toContain(
+            join(paths.rootDirectory, 'profile-source', 'deepwork', 'jobs'),
+          ),
+      },
+      claude: {
+        status: 'roadmap',
+        controls: { deepwork: { jobs: ['conformance_triage'] } },
+        warnsAbout: 'deepwork',
+      },
+    },
+  },
+  {
+    id: 'mcp',
+    description: 'cli_specific MCP config fragments are merged into a composite config',
+    expectations: {
+      pi: {
+        status: 'supported',
+        setup: setupMcpFragment('pi'),
+        // Pi discovers the merged `.mcp.json` inside its profiled agent directory.
+        assert: assertMergedMcpFile,
+      },
+      claude: {
+        status: 'supported',
+        setup: setupMcpFragment('claude'),
+        // Claude does not read `.mcp.json` from CLAUDE_CONFIG_DIR, so the merged
+        // config must also be loaded explicitly through --mcp-config.
+        assert: (outcome) => {
+          assertMergedMcpFile(outcome);
+          expect(flagValuesOf(outcome.launchPlan.args, '--mcp-config')).toEqual([
+            join(outcome.paths.compositeRootDirectory, '.mcp.json'),
+          ]);
+        },
+      },
+    },
+  },
+  {
+    id: 'state_paths',
+    description: 'every adapter-declared state path materializes in the composite profile',
+    expectations: {
+      pi: { status: 'supported', assert: assertDeclaredStatePaths },
+      claude: { status: 'supported', assert: assertDeclaredStatePaths },
+    },
+  },
+  {
+    id: 'tool_availability',
+    description: 'tool enable/disable filtering',
+    expectations: {
+      pi: { status: 'roadmap', controls: { tools: ['Bash'] }, warnsAbout: 'tools' },
+      claude: { status: 'roadmap', controls: { tools: ['Bash'] }, warnsAbout: 'tools' },
+    },
+  },
+  {
+    id: 'context_files',
+    description: 'automatically loaded project/profile context files',
+    expectations: {
+      pi: { status: 'roadmap', controls: { context_files: ['./AGENTS.md'] }, warnsAbout: 'context_files' },
+      claude: { status: 'roadmap', controls: { context_files: ['./AGENTS.md'] }, warnsAbout: 'context_files' },
+    },
+  },
+  {
+    id: 'theme',
+    description: 'terminal UI theme and presentation settings',
+    expectations: {
+      pi: { status: 'roadmap', controls: { theme: 'dark' }, warnsAbout: 'theme' },
+      claude: { status: 'roadmap', controls: { theme: 'dark' }, warnsAbout: 'theme' },
+    },
+  },
+  {
+    id: 'project_override_policy',
+    description: 'whether project-local agent configuration is allowed',
+    expectations: {
+      pi: {
+        status: 'roadmap',
+        controls: { project_override_policy: 'ignore' },
+        warnsAbout: 'project_override_policy',
+      },
+      claude: {
+        status: 'roadmap',
+        controls: { project_override_policy: 'ignore' },
+        warnsAbout: 'project_override_policy',
+      },
+    },
+  },
+  {
+    id: 'working_directory',
+    description: 'the directory the inner agent CLI is launched from',
+    expectations: {
+      pi: { status: 'roadmap', controls: { working_directory: './src' }, warnsAbout: 'working_directory' },
+      claude: { status: 'roadmap', controls: { working_directory: './src' }, warnsAbout: 'working_directory' },
+    },
+  },
+  {
+    id: 'bootstrap_hook',
+    description: 'an early-startup customization hook',
+    expectations: {
+      pi: {
+        // Pi bootstrap behavior is delivered as an explicit bootstrap extension.
+        status: 'supported',
+        controls: () => ({ pi: { extensions: ['conformance-bootstrap-extension'] } }),
+        assert: ({ launchPlan }) =>
+          expect(flagValuesOf(launchPlan.args, '--extension')).toContain('conformance-bootstrap-extension'),
+      },
+      claude: {
+        status: 'roadmap',
+        controls: { bootstrap_hook: 'conformance-bootstrap-extension' },
+        warnsAbout: 'bootstrap_hook',
+      },
+    },
+  },
+];

--- a/code/cli/tests/conformance/ConformanceSpec.ts
+++ b/code/cli/tests/conformance/ConformanceSpec.ts
@@ -1,0 +1,270 @@
+// Defines the cross-adapter conformance vocabulary: row/expectation types, shared
+// assertion helpers, and the mapping from conformance rows onto the published
+// support-matrix tables so the docs cannot drift from adapter behavior.
+import type {
+  AgentAdapter,
+  AgentCompositeProfilePlan,
+  AgentLaunchPlan,
+  AgentLaunchProfileLayer,
+} from '../../src/agents/AgentAdapter.js';
+import type { Profile, ProfileControls } from '../../src/profiles/Profile.js';
+
+/** Temporary directories a fixture may populate before the adapter runs. */
+export interface ConformanceFixturePaths {
+  /** Root of the per-expectation temporary directory tree. */
+  readonly rootDirectory: string;
+  /** Stand-in home directory passed to the adapter. */
+  readonly homeDirectory: string;
+  /** Stand-in project directory passed to the adapter. */
+  readonly projectDirectory: string;
+  /** A profile folder registered in `profileFolders` for the adapter run. */
+  readonly profileFolder: string;
+  /** Composite profile root directory passed to `createCompositeProfile`. */
+  readonly compositeRootDirectory: string;
+}
+
+/** Everything a supported-row assertion may inspect. */
+export interface ConformanceSupportedOutcome {
+  readonly adapter: AgentAdapter;
+  readonly profile: Profile;
+  readonly plan: AgentCompositeProfilePlan;
+  readonly launchPlan: AgentLaunchPlan;
+  readonly paths: ConformanceFixturePaths;
+}
+
+/** The adapter translates the control: the composite output/launch flags are asserted. */
+export interface SupportedExpectation {
+  readonly status: 'supported';
+  readonly controls?: (paths: ConformanceFixturePaths) => ProfileControls;
+  readonly setup?: (paths: ConformanceFixturePaths) => void;
+  readonly passThroughArgs?: readonly string[];
+  readonly profileLayers?: (paths: ConformanceFixturePaths, profile: Profile) => readonly AgentLaunchProfileLayer[];
+  readonly assert: (outcome: ConformanceSupportedOutcome) => void;
+}
+
+/**
+ * The adapter cannot translate the control yet: requesting it must produce the
+ * exact untranslatable-control warning, and `--strict` must escalate to failure.
+ * `controls` must be JSON-serializable (it is embedded into a profile.yml) and
+ * use the snake_case spelling users write in profiles.
+ */
+export interface RoadmapExpectation {
+  readonly status: 'roadmap';
+  readonly controls: ProfileControls;
+  /** The control name the warning must reference. */
+  readonly warnsAbout: string;
+}
+
+/** The concept has no meaningful translation for this adapter; a justification is required. */
+export interface NotApplicableExpectation {
+  readonly status: 'not-applicable';
+  readonly justification: string;
+}
+
+export type ConformanceExpectation = SupportedExpectation | RoadmapExpectation | NotApplicableExpectation;
+
+export interface ConformanceRow {
+  readonly id: string;
+  readonly description: string;
+  /** Keyed by adapter id; every registered adapter must declare every row. */
+  readonly expectations: Readonly<Record<string, ConformanceExpectation>>;
+}
+
+export const untranslatableControlWarning = (adapterId: string, controlName: string): string =>
+  `${adapterId} adapter cannot translate requested control '${controlName}'.`;
+
+/** Returns the values following each occurrence of a repeatable `--flag value` pair. */
+export const flagValuesOf = (args: readonly string[], flag: string): readonly string[] =>
+  args.flatMap((arg, index) => {
+    const value = args[index + 1];
+    return arg === flag && value !== undefined ? [value] : [];
+  });
+
+// --- Documentation matrix mapping -------------------------------------------
+
+export type DocSupportStatus = 'Supported' | 'Partial' | 'Roadmap';
+
+export interface DocMatrixFileSpec {
+  readonly key: string;
+  readonly repoRelativePath: string;
+  /** Table column header used for each adapter id; a new adapter must add its column. */
+  readonly adapterColumns: Readonly<Record<string, string>>;
+  /**
+   * `fine` renders Partial as-is; `coarse` renders Partial as Supported. The
+   * architecture matrix is restricted to Supported/Roadmap/Unsupported by
+   * OFTR-007.2 and defines Supported as "at least one native mechanism", so a
+   * partially-translated concept reads as Supported there.
+   */
+  readonly statusVocabulary: 'fine' | 'coarse';
+}
+
+export const docMatrixFiles: readonly DocMatrixFileSpec[] = [
+  {
+    key: 'support-matrix',
+    repoRelativePath: 'docs/documentation/support-matrix.md',
+    adapterColumns: { pi: 'Pi', claude: 'Claude Code' },
+    statusVocabulary: 'fine',
+  },
+  {
+    key: 'controllable-elements',
+    repoRelativePath: 'docs/architecture/controllable-elements.md',
+    adapterColumns: { pi: 'Pi', claude: 'Claude' },
+    statusVocabulary: 'coarse',
+  },
+];
+
+export interface DocMatrixRow {
+  /** Conformance row ids aggregated into this documentation table row. */
+  readonly rowIds: readonly string[];
+  /** Exact table-cell label per doc file key; omit when the file's table has no such row. */
+  readonly labels: Readonly<Record<string, string | undefined>>;
+}
+
+export const docMatrixRows: readonly DocMatrixRow[] = [
+  {
+    rowIds: ['agent_config_directory'],
+    labels: { 'support-matrix': 'Agent config directory', 'controllable-elements': 'Agent Config Directory' },
+  },
+  {
+    rowIds: ['session_directory'],
+    labels: {
+      'support-matrix': 'Session directory (`session_directory`)',
+      'controllable-elements': 'Session Directory',
+    },
+  },
+  {
+    rowIds: ['extensions'],
+    labels: { 'support-matrix': 'Extensions / plugins (`extensions`)', 'controllable-elements': 'Extensions' },
+  },
+  {
+    rowIds: ['skills'],
+    labels: { 'support-matrix': 'Skills (`skills`)', 'controllable-elements': 'Skills' },
+  },
+  {
+    rowIds: ['prompt_template', 'native_commands'],
+    labels: {
+      'support-matrix': 'Prompt templates / commands (`prompt_template`)',
+      'controllable-elements': 'Prompt Templates',
+    },
+  },
+  {
+    rowIds: ['system_prompt'],
+    labels: { 'support-matrix': 'System prompt (`system_prompt`)', 'controllable-elements': 'System Prompt' },
+  },
+  {
+    rowIds: ['append_system_prompt'],
+    labels: {
+      'support-matrix': 'Appended system prompt (`append_system_prompt`)',
+      'controllable-elements': 'Appended System Prompt',
+    },
+  },
+  {
+    rowIds: ['model', 'provider', 'thinking'],
+    labels: {
+      'support-matrix': 'Model selection (`model`, `provider`, `thinking`)',
+      'controllable-elements': 'Model Selection',
+    },
+  },
+  {
+    rowIds: ['environment'],
+    labels: {
+      'support-matrix': 'Credentials and environment (`environment`)',
+      'controllable-elements': 'Credentials and Environment',
+    },
+  },
+  {
+    rowIds: ['mcp'],
+    labels: { 'support-matrix': 'MCP servers (`cli_specific/<agent>/.mcp.json`)' },
+  },
+  {
+    rowIds: ['deepwork'],
+    labels: { 'support-matrix': 'DeepWork job selection (`deepwork`)' },
+  },
+  {
+    rowIds: ['tool_availability'],
+    labels: { 'support-matrix': 'Tool availability', 'controllable-elements': 'Tool Availability' },
+  },
+  {
+    rowIds: ['context_files'],
+    labels: { 'support-matrix': 'Context files', 'controllable-elements': 'Context Files' },
+  },
+  {
+    rowIds: ['theme'],
+    labels: { 'support-matrix': 'Theme / UI presentation', 'controllable-elements': 'Theme / UI Presentation' },
+  },
+  {
+    rowIds: ['project_override_policy'],
+    labels: { 'support-matrix': 'Project override policy', 'controllable-elements': 'Project Override Policy' },
+  },
+  {
+    rowIds: ['working_directory'],
+    labels: { 'support-matrix': 'Working directory', 'controllable-elements': 'Working Directory' },
+  },
+  {
+    rowIds: ['pass_through_args', 'args'],
+    labels: { 'support-matrix': 'Pass-through arguments', 'controllable-elements': 'Pass-through Arguments' },
+  },
+  {
+    rowIds: ['bootstrap_hook'],
+    labels: { 'support-matrix': 'Bootstrap hook', 'controllable-elements': 'Bootstrap Hook' },
+  },
+];
+
+/** Conformance rows intentionally absent from the documentation tables. */
+export const undocumentedRowIds: readonly { readonly id: string; readonly reason: string }[] = [
+  {
+    id: 'state_paths',
+    reason:
+      'State persistence is an adapter-internal mechanism documented in docs/documentation/state.md; the matrix covers it through the config/session directory rows.',
+  },
+];
+
+/**
+ * Computes the documentation status for a table row from the declared per-control
+ * statuses: everything supported → Supported, everything roadmap → Roadmap, a mix
+ * → Partial. Not-applicable declarations are excluded from the aggregate.
+ */
+export const expectedDocStatus = (
+  docRow: DocMatrixRow,
+  conformanceRows: readonly ConformanceRow[],
+  adapterId: string,
+  statusVocabulary: DocMatrixFileSpec['statusVocabulary'],
+): DocSupportStatus => {
+  const statuses = docRow.rowIds
+    .map((rowId) => statusOfRow(rowId, conformanceRows, adapterId))
+    .filter((status) => status !== 'not-applicable');
+
+  if (statuses.length === 0) {
+    throw new Error(`doc matrix row [${docRow.rowIds.join(', ')}] has no applicable status for '${adapterId}'`);
+  }
+
+  if (statuses.every((status) => status === 'supported')) {
+    return 'Supported';
+  }
+
+  if (statuses.every((status) => status === 'roadmap')) {
+    return 'Roadmap';
+  }
+
+  return statusVocabulary === 'coarse' ? 'Supported' : 'Partial';
+};
+
+const statusOfRow = (
+  rowId: string,
+  conformanceRows: readonly ConformanceRow[],
+  adapterId: string,
+): ConformanceExpectation['status'] => {
+  const row = conformanceRows.find((candidate) => candidate.id === rowId);
+
+  if (row === undefined) {
+    throw new Error(`doc matrix references unknown conformance row '${rowId}'`);
+  }
+
+  const expectation = row.expectations[adapterId];
+
+  if (expectation === undefined) {
+    throw new Error(`conformance row '${rowId}' declares no expectation for adapter '${adapterId}'`);
+  }
+
+  return expectation.status;
+};

--- a/code/cli/tests/conformance/conformance.test.ts
+++ b/code/cli/tests/conformance/conformance.test.ts
@@ -1,0 +1,189 @@
+// Runs the cross-adapter conformance suite: every adapter in the registry must
+// declare an expectation for every conformance row, and each declaration is
+// verified against real adapter behavior (supported ⇒ correct composite output
+// and launch flags; roadmap ⇒ exact warning text and --strict escalation;
+// not applicable ⇒ recorded justification).
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { AgentAdapter } from '../../src/agents/AgentAdapter.js';
+import { createAgentAdapter, supportedAgentIds } from '../../src/agents/AgentRegistry.js';
+import { executeRunCommand } from '../../src/cli/commands/RunCommand.js';
+import type { Profile } from '../../src/profiles/Profile.js';
+import { conformanceRows } from './ConformanceRows.js';
+import {
+  untranslatableControlWarning,
+  type ConformanceFixturePaths,
+  type ConformanceRow,
+  type RoadmapExpectation,
+  type SupportedExpectation,
+} from './ConformanceSpec.js';
+
+const temporaryRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+const createFixturePaths = (): ConformanceFixturePaths => {
+  const rootDirectory = mkdtempSync(join(tmpdir(), 'outfitter-conformance-'));
+  temporaryRoots.push(rootDirectory);
+  const paths = {
+    rootDirectory,
+    homeDirectory: join(rootDirectory, 'home'),
+    projectDirectory: join(rootDirectory, 'project'),
+    profileFolder: join(rootDirectory, 'profile'),
+    compositeRootDirectory: join(rootDirectory, 'composite'),
+  };
+  mkdirSync(paths.homeDirectory, { recursive: true });
+  mkdirSync(paths.projectDirectory, { recursive: true });
+  mkdirSync(paths.profileFolder, { recursive: true });
+  return paths;
+};
+
+const runSupportedExpectation = (
+  adapter: AgentAdapter,
+  row: ConformanceRow,
+  expectation: SupportedExpectation,
+): void => {
+  const paths = createFixturePaths();
+  expectation.setup?.(paths);
+  const profile: Profile = { id: `conformance-${row.id}`, inherits: [], controls: expectation.controls?.(paths) ?? {} };
+  const profileLayers = expectation.profileLayers?.(paths, profile);
+
+  const plan = adapter.createCompositeProfile(profile, {
+    rootDirectory: paths.compositeRootDirectory,
+    profilePaths: [join(paths.profileFolder, 'profile.yml')],
+    profileFolders: [paths.profileFolder],
+    profileLayers,
+    homeDirectory: paths.homeDirectory,
+    projectDirectory: paths.projectDirectory,
+  });
+  // A supported control must translate silently: no untranslatable-control or
+  // resolution warnings are acceptable for the row's fixture.
+  expect(plan.warnings).toEqual([]);
+
+  const launchPlan = adapter.createLaunchPlan(plan.compositeProfile, profile, expectation.passThroughArgs ?? [], {
+    profileFolders: [paths.profileFolder],
+    profileLayers,
+    projectDirectory: paths.projectDirectory,
+  });
+
+  expectation.assert({ adapter, profile, plan, launchPlan, paths });
+};
+
+const runRoadmapWarningExpectation = (
+  adapter: AgentAdapter,
+  row: ConformanceRow,
+  expectation: RoadmapExpectation,
+): void => {
+  const paths = createFixturePaths();
+  const profile: Profile = { id: `conformance-${row.id}`, inherits: [], controls: expectation.controls };
+
+  const plan = adapter.createCompositeProfile(profile, {
+    rootDirectory: paths.compositeRootDirectory,
+    profilePaths: [],
+    profileFolders: [paths.profileFolder],
+    homeDirectory: paths.homeDirectory,
+    projectDirectory: paths.projectDirectory,
+  });
+
+  expect(plan.warnings).toEqual([untranslatableControlWarning(adapter.id, expectation.warnsAbout)]);
+};
+
+const runStrictEscalationExpectation = async (agentId: string, expectation: RoadmapExpectation): Promise<void> => {
+  const paths = createFixturePaths();
+  const profileDirectory = join(paths.homeDirectory, '.outfitter', 'profiles', 'default');
+  mkdirSync(profileDirectory, { recursive: true });
+  writeFileSync(
+    join(paths.homeDirectory, '.outfitter', 'settings.yml'),
+    'default_profile: default\nprofile_sources:\n  - path: ./profiles\n',
+  );
+  writeFileSync(
+    join(profileDirectory, 'profile.yml'),
+    `id: default\ncontrols: ${JSON.stringify(expectation.controls)}\n`,
+  );
+
+  await expect(
+    executeRunCommand(
+      { homeDirectory: paths.homeDirectory, projectDirectory: paths.projectDirectory, agentId, strict: true },
+      {
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    ),
+  ).rejects.toThrow(`Strict failed for ${agentId}: ${untranslatableControlWarning(agentId, expectation.warnsAbout)}`);
+};
+
+const registerRowTests = (adapter: AgentAdapter, row: ConformanceRow): void => {
+  const expectation = row.expectations[adapter.id];
+
+  // Missing declarations are reported by the completeness test.
+  if (expectation === undefined) {
+    return;
+  }
+
+  if (expectation.status === 'supported') {
+    it(`${row.id}: supported — ${row.description}`, () => {
+      runSupportedExpectation(adapter, row, expectation);
+    });
+    return;
+  }
+
+  if (expectation.status === 'roadmap') {
+    it(`${row.id}: roadmap — warns with exact text`, () => {
+      runRoadmapWarningExpectation(adapter, row, expectation);
+    });
+    it(`${row.id}: roadmap — --strict escalates the warning to a failure`, async () => {
+      await runStrictEscalationExpectation(adapter.id, expectation);
+    });
+    return;
+  }
+
+  it(`${row.id}: not applicable — justification recorded`, () => {
+    expect(expectation.justification.trim().length).toBeGreaterThan(0);
+  });
+};
+
+for (const agentId of supportedAgentIds) {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.5, OFTR-006.3, OFTR-006.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  describe(`conformance (${agentId})`, () => {
+    const adapter = createAgentAdapter(agentId);
+
+    // Adding an adapter to the registry forces a declaration for every row.
+    it('declares an expectation for every conformance row', () => {
+      const undeclaredRows = conformanceRows
+        .filter((row) => row.expectations[agentId] === undefined)
+        .map((row) => row.id);
+      expect(undeclaredRows, `adapter '${agentId}' must declare every conformance row`).toEqual([]);
+    });
+
+    for (const row of conformanceRows) {
+      registerRowTests(adapter, row);
+    }
+  });
+}
+
+describe('conformance vocabulary', () => {
+  it('has unique row ids', () => {
+    const rowIds = conformanceRows.map((row) => row.id);
+    expect(new Set(rowIds).size).toBe(rowIds.length);
+  });
+
+  it('declares expectations only for registered adapters', () => {
+    const registeredAgentIds = new Set<string>(supportedAgentIds);
+    const unknownAdapterIds = conformanceRows.flatMap((row) =>
+      Object.keys(row.expectations).filter((adapterId) => !registeredAgentIds.has(adapterId)),
+    );
+    expect(unknownAdapterIds).toEqual([]);
+  });
+});

--- a/code/cli/tests/conformance/support-matrix-drift.test.ts
+++ b/code/cli/tests/conformance/support-matrix-drift.test.ts
@@ -1,0 +1,115 @@
+// Verifies the published support matrices agree with the declared conformance
+// statuses, so the user-facing docs cannot drift from adapter behavior. The
+// tables stay hand-written prose; this suite parses them and cross-checks every
+// row and adapter column against the conformance declarations that the
+// behavioral suite (conformance.test.ts) enforces.
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { supportedAgentIds } from '../../src/agents/AgentRegistry.js';
+import { conformanceRows } from './ConformanceRows.js';
+import {
+  docMatrixFiles,
+  docMatrixRows,
+  expectedDocStatus,
+  undocumentedRowIds,
+  type DocMatrixFileSpec,
+} from './ConformanceSpec.js';
+
+const repoRoot = fileURLToPath(new URL('../../../..', import.meta.url));
+
+interface ParsedMatrixTable {
+  readonly header: readonly string[];
+  readonly rows: readonly (readonly string[])[];
+}
+
+const isSeparatorRow = (cells: readonly string[]): boolean => cells.every((cell) => /^:?-+:?$/.test(cell));
+
+const parseMatrixTable = (docFile: DocMatrixFileSpec): ParsedMatrixTable => {
+  const markdown = readFileSync(join(repoRoot, docFile.repoRelativePath), 'utf8');
+  const cellRows = markdown
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('|') && line.endsWith('|'))
+    .map((line) =>
+      line
+        .split('|')
+        .slice(1, -1)
+        .map((cell) => cell.trim()),
+    )
+    .filter((cells) => !isSeparatorRow(cells));
+  const [header, ...rows] = cellRows;
+
+  if (header === undefined) {
+    throw new Error(`no markdown table found in ${docFile.repoRelativePath}`);
+  }
+
+  return { header, rows };
+};
+
+const mappedDocRowsFor = (docFile: DocMatrixFileSpec) =>
+  docMatrixRows.flatMap((docRow) => {
+    const label = docRow.labels[docFile.key];
+    return label === undefined ? [] : [{ docRow, label }];
+  });
+
+for (const docFile of docMatrixFiles) {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-007.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  describe(`support matrix drift (${docFile.repoRelativePath})`, () => {
+    const table = parseMatrixTable(docFile);
+
+    it('has a status column for every registered adapter', () => {
+      for (const agentId of supportedAgentIds) {
+        const columnLabel = docFile.adapterColumns[agentId];
+        expect(columnLabel, `adapter '${agentId}' has no documented matrix column`).toBeDefined();
+        expect(table.header, `column '${columnLabel ?? agentId}' missing`).toContain(columnLabel);
+      }
+    });
+
+    it('documents exactly the conformance-mapped rows', () => {
+      const documentedLabels = table.rows.map((cells) => cells[0]).sort();
+      const mappedLabels = mappedDocRowsFor(docFile)
+        .map((mapped) => mapped.label)
+        .sort();
+      expect(documentedLabels).toEqual(mappedLabels);
+    });
+
+    for (const { docRow, label } of mappedDocRowsFor(docFile)) {
+      it(`row '${label}' matches the declared conformance statuses`, () => {
+        const tableRow = table.rows.find((cells) => cells[0] === label);
+        expect(tableRow, `table row '${label}' missing`).toBeDefined();
+
+        for (const agentId of supportedAgentIds) {
+          const columnIndex = table.header.indexOf(docFile.adapterColumns[agentId] ?? '');
+          expect(columnIndex).toBeGreaterThan(0);
+          expect(tableRow?.[columnIndex], `status for '${agentId}' in row '${label}'`).toBe(
+            expectedDocStatus(docRow, conformanceRows, agentId, docFile.statusVocabulary),
+          );
+        }
+      });
+    }
+  });
+}
+
+describe('support matrix mapping completeness', () => {
+  it('maps every conformance row to a documentation row or an explicit exemption', () => {
+    const mappedRowIds = docMatrixRows.flatMap((docRow) => docRow.rowIds);
+    const exemptRowIds = undocumentedRowIds.map((exemption) => exemption.id);
+    const referencedRowIds = [...mappedRowIds, ...exemptRowIds];
+
+    expect(new Set(referencedRowIds).size, 'conformance rows must be referenced exactly once').toBe(
+      referencedRowIds.length,
+    );
+    expect([...referencedRowIds].sort()).toEqual(conformanceRows.map((row) => row.id).sort());
+  });
+
+  it('gives every exempt row a justification', () => {
+    for (const exemption of undocumentedRowIds) {
+      expect(exemption.reason.trim().length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/docs/architecture/file_structure.md
+++ b/docs/architecture/file_structure.md
@@ -70,6 +70,7 @@ The CLI package root is `code/cli`, but the npm package must still include repos
 
 Integration fixtures should live under `code/cli/tests/fixtures/integration/` with full `home/`, `project/`, and optional `expected/` trees.
 Fixture-backed integration tests and shared harness helpers should live under `code/cli/tests/integration/`.
+The cross-adapter conformance suite (per-control declarations, the adapter runner, and the support-matrix drift check) lives under `code/cli/tests/conformance/` and runs standalone via `npm run conformance`.
 
 Scenario fixtures should live under `code/cli/tests/fixtures/scenarios/`, for example:
 

--- a/docs/documentation/support-matrix.md
+++ b/docs/documentation/support-matrix.md
@@ -10,6 +10,8 @@ Status values:
 
 When a profile requests a control an adapter cannot translate, Outfitter warns to stderr; `--strict` makes those warnings fatal.
 
+This matrix is checked against the cross-adapter conformance suite (`code/cli/tests/conformance/`): `npm run conformance` verifies every row below against real adapter behavior and fails when the table disagrees with the code.
+
 | What you can control                              | Pi        | Claude Code |
 | ------------------------------------------------- | --------- | ----------- |
 | Agent config directory                            | Supported | Supported   |
@@ -21,6 +23,8 @@ When a profile requests a control an adapter cannot translate, Outfitter warns t
 | Appended system prompt (`append_system_prompt`)   | Supported | Supported   |
 | Model selection (`model`, `provider`, `thinking`) | Supported | Partial     |
 | Credentials and environment (`environment`)       | Supported | Supported   |
+| MCP servers (`cli_specific/<agent>/.mcp.json`)    | Supported | Supported   |
+| DeepWork job selection (`deepwork`)               | Supported | Roadmap     |
 | Tool availability                                 | Roadmap   | Roadmap     |
 | Context files                                     | Roadmap   | Roadmap     |
 | Theme / UI presentation                           | Roadmap   | Roadmap     |
@@ -42,6 +46,7 @@ When a profile requests a control an adapter cannot translate, Outfitter warns t
 ## Pi notes
 
 - Pi translates the full generic control set: `provider`, `model`, `thinking`, `system_prompt`, `append_system_prompt`, `extensions` (`--extension`), `skills` (`--skill`), `prompt_template` (`--prompt-template`), `environment`, `args`, `session_directory`, and DeepWork job selection.
+- **MCP servers** — `cli_specific/pi/.mcp.json` fragments are merged across contributing profile layers into a composite `.mcp.json` inside the profiled agent directory.
 - Bootstrap behavior (for example the onboarding flow) uses an explicit Pi bootstrap extension via `--extension`.
 
 For the architecture-level definitions behind each row, see [Controllable elements](../architecture/controllable-elements.md).

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint": "npm run lint --workspace @ai-outfitter/outfitter",
     "lint:fix": "npm run lint:fix --workspace @ai-outfitter/outfitter",
     "test": "npm test --workspace @ai-outfitter/outfitter",
+    "conformance": "npm run conformance --workspace @ai-outfitter/outfitter",
     "coverage": "npm run coverage --workspace @ai-outfitter/outfitter",
     "snapper:format": "node scripts/run-snapper.mjs --git-md -i",
     "check": "npm run snapper:format && prettier --write . && npm run lint:fix && npm run coverage",

--- a/project-log.md
+++ b/project-log.md
@@ -2,6 +2,21 @@
 
 Chronological log of development activities, changes, and lessons learned. Append new entries; never remove old ones.
 
+## 2026-07-01 (later) — Cross-adapter conformance suite (Claude session, wave2/conformance)
+
+**What was done:**
+
+- Implemented the cross-adapter conformance test suite (issue #19 / plan issue 21) under `code/cli/tests/conformance/`: a declaration module (`ConformanceSpec.ts` types + doc mapping, `ConformanceRows.ts` with 23 rows covering model, provider, thinking, environment, args, pass-through args, agent config dir, session dir, extensions, skills, prompt_template, native commands, system/append prompts, deepwork, MCP fragments, state paths, and the roadmap concepts), a registry-driven runner (`conformance.test.ts`) and a docs drift verifier (`support-matrix-drift.test.ts`).
+- Every adapter in `AgentRegistry.supportedAgentIds` must declare Supported (behavior asserted), Roadmap (exact warning text + `--strict` escalation via `executeRunCommand`), or Not Applicable (justification) for every row; a new adapter fails the suite until it declares all rows.
+- Docs drift prevention: chose a verifier over a generator — the matrices live inside hand-written prose docs, so the tests parse both tables (`docs/documentation/support-matrix.md` fine-grained with Partial; `docs/architecture/controllable-elements.md` coarse per OFTR-007.2's Supported/Roadmap/Unsupported vocabulary) and assert every row/column agrees with the aggregated conformance declarations. Added `npm run conformance` as the one-command proof.
+- Docs: added MCP servers and DeepWork job selection rows to the support matrix (previously undocumented in the table), an MCP note in the Pi notes, the conformance-suite pointer, and the new tests directory in `file_structure.md`.
+
+**Key findings / lessons:**
+
+- No genuine status mismatches existed between the current matrices and adapter behavior; the gaps were missing rows (MCP, DeepWork) rather than wrong cells.
+- OFTR-007.2.4 restricts the architecture matrix cells to `Unsupported|Supported|Roadmap`, so "Partial" must not be introduced there; the doc's own "How to Read This Matrix" prose justifies coarsening Partial→Supported for that file only.
+- The two matrices intentionally differ in vocabulary; the conformance spec encodes that with a per-file `statusVocabulary` so both stay verified without contradiction.
+
 ## 2026-07-01 (later) — Update plan drafted as local issue queue (Claude session)
 
 **What was done:**

--- a/project-plan.md
+++ b/project-plan.md
@@ -23,7 +23,7 @@ Strategy stair-steps: individual → team → enterprise; TUI → GUI; open → 
 - `code/pi-extension/` — placeholder; the real Pi onboarding extension is currently a ~750-line JS string in `PiLoginLaunch.ts` (known debt).
 - `code/doc_site/` — Nextra site, 2 pages so far.
 - `docs/` — user docs (`documentation/`), architecture (`architecture/`, typo fixed 2026-07-01), formal requirements OFTR-001..010, plans, specs.
-- Testing: vitest, 254 tests, ~99% coverage with 98% thresholds enforced in CI; golden-tree integration fixtures; requirement-pinning "do not modify" tests. CI: ubuntu-only; release-please + npm publish workflows; Dockerfile exists but image not published.
+- Testing: vitest, 254 tests, ~99% coverage with 98% thresholds enforced in CI; golden-tree integration fixtures; requirement-pinning "do not modify" tests; cross-adapter conformance suite (`code/cli/tests/conformance/`, `npm run conformance`) that forces every registered adapter to declare Supported/Roadmap/N-A per generic control and verifies the docs support matrices against those declarations. CI: ubuntu-only; release-please + npm publish workflows; Dockerfile exists but image not published.
 
 ## How it works (core flow)
 


### PR DESCRIPTION
Stacked PR 8/10 — base: `sprint/07-polish`.

Cross-adapter conformance suite (`code/cli/tests/conformance/`, `npm run conformance`, 104 tests): 23 rows covering the full generic-control vocabulary; iterates the adapter registry so any future adapter must declare every row; Supported rows assert composite output/flags, Roadmap rows assert exact warning text **and** `--strict` escalation. A drift verifier parses both published support matrices and fails CI if any cell disagrees with declared conformance — docs can no longer drift from code. Two missing rows added to `support-matrix.md`; no wrong cells found.

Fork issue: [#19](https://github.com/tylerwillis/outfitter/issues/19)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


