### PR TITLE
feat(claude): first-run onboarding; deterministic write-notice test; RunCommand decomposition

### DIFF
--- a/code/cli/src/agents/AgentLaunch.ts
+++ b/code/cli/src/agents/AgentLaunch.ts
@@ -60,7 +60,9 @@ const isCommandNotFoundError = (error: unknown): boolean =>
 
 const agentCliInstallHints: Readonly<Record<string, string>> = {
   pi: 'Install Pi with `npm install -g @earendil-works/pi-coding-agent` (see https://pi.dev).',
-  claude: 'Install Claude Code from https://claude.com/claude-code, then rerun with `--agent claude`.',
+  claude:
+    'Install Claude Code with `npm install -g @anthropic-ai/claude-code` (macOS alternative: ' +
+    '`brew install --cask claude-code`), then rerun with `--agent claude`. See https://claude.com/claude-code.',
 };
 
 const formatMissingAgentCliMessage = (agentId: string, command: string): string => {

--- a/code/cli/src/cli/commands/RunCommand.ts
+++ b/code/cli/src/cli/commands/RunCommand.ts
@@ -1,10 +1,9 @@
-/* eslint-disable max-lines */
-// Provides the command object for launching selected profiles.
-import { existsSync, mkdirSync } from 'node:fs';
+// Provides the command object for launching selected profiles: orchestrates first-run
+// onboarding, profile resolution, composite profile assembly, agent launch, and the
+// exit-time state-write pass. The cohesive pieces live in the run/ modules.
 import type { watch } from 'node:fs';
 import { homedir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { createInterface } from 'node:readline/promises';
+import { join } from 'node:path';
 
 import type { ChildProcess } from 'node:child_process';
 import chalk from 'chalk';
@@ -13,19 +12,9 @@ import spawn from 'cross-spawn';
 
 import type { AgentAdapter, AgentLaunchPlan } from '../../agents/AgentAdapter.js';
 import { createAgentAdapter } from '../../agents/AgentRegistry.js';
-import {
-  createProfileSourceCachePath,
-  createRemoteRepositoryCachePath,
-  redactProfileSourceUriCredentials,
-  resolveRemoteRepositorySubpath,
-} from '../../profiles/ProfileCache.js';
-import { loadLocalProfileSource } from '../../profiles/ProfileLoader.js';
+import { redactProfileSourceUriCredentials } from '../../profiles/ProfileCache.js';
 import type { LoadedProfile } from '../../profiles/ProfileLoader.js';
-import { createEmptyProfile, type Profile } from '../../profiles/Profile.js';
-import type { ProfileSourceReference } from '../../profiles/ProfileSource.js';
-import { resolveProfile } from '../../profiles/ProfileMerger.js';
-import { emptySettings, type Settings } from '../../settings/Settings.js';
-import { loadSettingsWithCachedRemoteSettings } from '../../settings/SettingsLoader.js';
+import type { Profile } from '../../profiles/Profile.js';
 import { exportSystemPromptIfEnabled } from '../../prompts/SystemPromptExport.js';
 import {
   createCompositeProfileRootDirectory,
@@ -34,17 +23,9 @@ import {
 import { renderCompositeProfileTemplates } from '../../compositeProfile/CompositeProfileTemplate.js';
 import {
   createCompositeProfileStateBaseline,
-  detectCompositeProfileStateWrites,
-  persistCompositeProfileStateWrite,
-  recordProfileStatePersistenceOverride,
   updateCompositeProfileStateBaselinePaths,
 } from '../../compositeProfile/StatePersistence.js';
-import type {
-  CompositeProfileStateBaseline,
-  CompositeProfileStatePath,
-  CompositeProfileStateWriteIssue,
-  CompositeProfileStateWritePrompt,
-} from '../../compositeProfile/StatePersistence.js';
+import type { CompositeProfileStateWritePrompt } from '../../compositeProfile/StatePersistence.js';
 import {
   watchCompositeProfileInputs,
   watchCompositeProfileStateWrites,
@@ -66,12 +47,22 @@ import type { CommandObject } from './CommandObject.js';
 import { preparePiLoginLaunchPlan } from './PiLoginLaunch.js';
 import {
   emitClaudeLoginHintIfNeeded,
-  isInteractiveRunLaunch,
   prepareFirstRunRuntimeOnboarding,
   resolveRunProgressWriter,
   runClaudeFirstRunOnboardingIfNeeded,
   selectRunAgentId,
 } from './run/FirstRunOnboarding.js';
+import {
+  createFirstRunBootstrapProfile,
+  createLaunchProfileLayers,
+  loadResolvedProfile,
+} from './run/RunProfileResolution.js';
+import type { ResolvedRunProfile } from './run/RunProfileResolution.js';
+import {
+  handleCompositeProfileStateWrites,
+  recordAlwaysStatePersistenceChoice,
+  resolveStateWritePrompt,
+} from './run/StateWriteReporting.js';
 import type { SetupCommandDependencies } from './SetupCommand.js';
 
 export interface RunCommandInput {
@@ -96,6 +87,7 @@ export interface RunCommandResult {
 
 export type { AgentProcessLauncher } from '../../agents/AgentLaunch.js';
 export { resolveAgentLaunchExecutable } from '../../agents/AgentLaunch.js';
+export { createLaunchProfileLayers, loadProfileSources } from './run/RunProfileResolution.js';
 
 export interface RunCommandDependencies extends SetupCommandDependencies {
   readonly adapter?: AgentAdapter;
@@ -322,18 +314,6 @@ const configureRunCommander = (
 
 /* v8 ignore stop */
 
-interface ResolvedRunProfile {
-  readonly profile: Profile;
-  readonly profilePaths: readonly string[];
-  readonly profileFolders: readonly string[];
-  readonly homeDirectory: string;
-  readonly cacheDirectory: string;
-  readonly projectDirectory: string;
-  readonly settings: Settings;
-  readonly settingsPaths: readonly string[];
-  readonly profileLayers: readonly LoadedProfile[];
-}
-
 const failStrictOnWarnings = (adapterId: string, warnings: readonly string[], strict: boolean | undefined): void => {
   if (strict === true && warnings.length > 0) {
     throw new Error(`Strict failed for ${adapterId}: ${warnings.join('; ')}`);
@@ -475,375 +455,10 @@ const reportPreviousSessionJournals = (sessionJournalDirectory: string, dependen
     dependencies.writeError ?? console.error,
   );
 
-interface CompositeProfileStateWriteHandlingInput {
-  readonly adapterId: string;
-  readonly rootDirectory: string;
-  readonly statePaths: readonly CompositeProfileStatePath[];
-  readonly stateBaseline: CompositeProfileStateBaseline;
-  readonly prompt?: CompositeProfileStateWritePrompt;
-  readonly recordAlwaysChoice: (relativePath: string) => string | undefined;
-  readonly notify: (message: string) => void;
-}
-
-const handleCompositeProfileStateWrites = async (
-  input: CompositeProfileStateWriteHandlingInput,
-): Promise<readonly string[]> => {
-  const warnings: string[] = [];
-
-  for (const issue of detectCompositeProfileStateWrites(input.rootDirectory, input.statePaths, input.stateBaseline)) {
-    if (issue.strategy === 'error') {
-      throw new Error(formatCompositeProfileStateWriteIssue(input.adapterId, issue));
-    }
-
-    if (issue.strategy === 'prompt') {
-      warnings.push(...(await handlePromptStateWriteIssue(input, issue)));
-      continue;
-    }
-
-    warnings.push(formatCompositeProfileStateWriteIssue(input.adapterId, issue));
-  }
-
-  return warnings;
-};
-
-const handlePromptStateWriteIssue = async (
-  input: CompositeProfileStateWriteHandlingInput,
-  issue: CompositeProfileStateWriteIssue,
-): Promise<readonly string[]> => {
-  if (issue.unknown) {
-    return [
-      formatCompositeProfileStateWriteIssue(input.adapterId, issue),
-      `state_persistence 'prompt' cannot persist undeclared writes; '${issue.relativePath}' was reported instead.`,
-    ];
-  }
-
-  if (input.prompt === undefined) {
-    return [
-      formatCompositeProfileStateWriteIssue(input.adapterId, issue),
-      `state_persistence prompt for '${issue.relativePath}' skipped: non-interactive session.`,
-    ];
-  }
-
-  const statePath = findDeclaredStatePath(input.statePaths, issue.relativePath);
-  const choice = await input.prompt({
-    agentId: input.adapterId,
-    relativePath: issue.relativePath,
-    sourcePath: statePath.sourcePath,
-  });
-
-  return applyPromptStateWriteChoice(input, statePath, choice);
-};
-
-const applyPromptStateWriteChoice = (
-  input: CompositeProfileStateWriteHandlingInput,
-  statePath: CompositeProfileStatePath,
-  choice: 'persist' | 'discard' | 'always',
-): readonly string[] => {
-  if (choice === 'discard') {
-    input.notify(`Discarded ${input.adapterId} state write to '${statePath.relativePath}'.`);
-    return [];
-  }
-
-  try {
-    persistCompositeProfileStateWrite(input.rootDirectory, statePath);
-  } catch (error) {
-    return [`Could not persist state path '${statePath.relativePath}': ${String(error)}`];
-  }
-
-  input.notify(`Persisted ${input.adapterId} state write '${statePath.relativePath}' to ${statePath.sourcePath}.`);
-
-  if (choice === 'always') {
-    const warning = input.recordAlwaysChoice(statePath.relativePath);
-    return warning === undefined ? [] : [warning];
-  }
-
-  return [];
-};
-
-const findDeclaredStatePath = (
-  statePaths: readonly CompositeProfileStatePath[],
-  relativePath: string,
-): CompositeProfileStatePath => {
-  const statePath = statePaths.find((candidate) => candidate.relativePath === relativePath);
-
-  /* v8 ignore next 3 -- declared prompt issues always originate from a declared state path. */
-  if (statePath === undefined) {
-    throw new Error(`State path '${relativePath}' is not declared by the composite profile.`);
-  }
-
-  return statePath;
-};
-
-// The "always" choice is recorded in the selected profile's own YAML file because profiles
-// are the single source of truth for state_persistence policy; a parallel settings-layer
-// override would create a second precedence system that adapter validation cannot see.
-// Remote/cached profiles are never mutated, so the choice degrades to a one-run persist
-// with an actionable warning.
-const recordAlwaysStatePersistenceChoice = (
-  adapter: AgentAdapter,
-  resolvedProfile: ResolvedRunProfile,
-  relativePath: string,
-): string | undefined => {
-  const declaration = adapter.statePaths?.[relativePath];
-
-  if (declaration === undefined || !declaration.allowedStrategies.includes('symlink')) {
-    return (
-      `Cannot always-persist '${relativePath}': the ${adapter.id} adapter does not allow 'symlink' for it; ` +
-      `the write was persisted once.`
-    );
-  }
-
-  const selectedLayer = [...resolvedProfile.profileLayers]
-    .reverse()
-    .find((layer) => layer.profile.id === resolvedProfile.profile.id);
-
-  if (
-    selectedLayer === undefined ||
-    selectedLayer.source.uri !== undefined ||
-    selectedLayer.source.github !== undefined
-  ) {
-    return (
-      `Cannot record the always-persist choice for '${relativePath}' because profile ` +
-      `'${resolvedProfile.profile.id}' is not a local profile file; the write was persisted once.`
-    );
-  }
-
-  recordProfileStatePersistenceOverride(selectedLayer.profilePath, relativePath, 'symlink');
-  return undefined;
-};
-
-const resolveStateWritePrompt = (
-  dependencies: RunCommandDependencies,
-): CompositeProfileStateWritePrompt | undefined => {
-  if (!isInteractiveRunLaunch(dependencies)) {
-    return undefined;
-  }
-
-  return (
-    dependencies.promptStateWritePersistence ??
-    /* v8 ignore next -- terminal prompting is direct CLI behavior; tests inject a prompt. */
-    createTerminalStateWritePrompt(dependencies.input ?? process.stdin, dependencies.output ?? process.stdout)
-  );
-};
-
-/* v8 ignore start -- readline prompting is direct terminal behavior; tests inject a prompt. */
-const createTerminalStateWritePrompt =
-  (input: NodeJS.ReadableStream, output: NodeJS.WritableStream): CompositeProfileStateWritePrompt =>
-  async (request) => {
-    const readline = createInterface({ input, output });
-
-    try {
-      for (;;) {
-        const answer = (
-          await readline.question(
-            `${request.agentId} wrote state path '${request.relativePath}' (state_persistence 'prompt'). ` +
-              `[p]ersist to ${request.sourcePath ?? 'its durable source'} / [d]iscard / ` +
-              `[a]lways persist for this profile: `,
-          )
-        )
-          .trim()
-          .toLowerCase();
-
-        if (answer === 'p' || answer === 'persist') {
-          return 'persist';
-        }
-
-        if (answer === 'd' || answer === 'discard') {
-          return 'discard';
-        }
-
-        if (answer === 'a' || answer === 'always') {
-          return 'always';
-        }
-      }
-    } finally {
-      readline.close();
-    }
-  };
-/* v8 ignore stop */
-
-const formatCompositeProfileStateWriteIssue = (adapterId: string, issue: CompositeProfileStateWriteIssue): string => {
-  if (issue.unknown) {
-    return `${adapterId} wrote undeclared composite profile state '${issue.relativePath}' and it was not persisted.`;
-  }
-
-  if (issue.strategy === 'symlink') {
-    return `${adapterId} replaced symlinked state path '${issue.relativePath}' and the change was not persisted.`;
-  }
-
-  return `${adapterId} wrote '${issue.relativePath}' with state_persistence '${issue.strategy}' and it was not persisted.`;
-};
-
-const createFirstRunBootstrapProfile = (input: RunCommandInput): ResolvedRunProfile => ({
-  profile: {
-    ...createEmptyProfile('outfitter-bootstrap'),
-    label: 'Outfitter Bootstrap',
-    description: 'Temporary first-run profile that starts Pi before Outfitter settings exist.',
-  },
-  profilePaths: [],
-  profileFolders: [],
-  homeDirectory: input.homeDirectory,
-  cacheDirectory: join(input.homeDirectory, '.outfitter', 'cache'),
-  projectDirectory: input.projectDirectory,
-  settings: emptySettings(),
-  settingsPaths: [],
-  profileLayers: [],
-});
-
-const loadResolvedProfile = (input: RunCommandInput): ResolvedRunProfile => {
-  const loadedSettings = loadSettingsWithCachedRemoteSettings(input);
-
-  if (loadedSettings.issues.length > 0) {
-    throw new Error(`Cannot run with invalid settings: ${loadedSettings.issues.map(formatSettingsIssue).join('; ')}`);
-  }
-
-  ensureConventionalLocalProfileSourceDirectories(loadedSettings.files);
-  const loadedProfiles = loadProfileSources(input.homeDirectory, loadedSettings.settings.profileSources!);
-
-  if (loadedProfiles.issues.length > 0) {
-    throw new Error(`Cannot run with invalid profiles: ${loadedProfiles.issues.map(formatProfileIssue).join('; ')}`);
-  }
-
-  const profileId = selectRunProfileId(input.profileId, loadedSettings.settings.defaultProfile);
-  const resolution = resolveProfile({
-    profiles: loadedProfiles.profiles,
-    profileId,
-  });
-
-  if (resolution.profile === undefined || resolution.issues.length > 0) {
-    throw new Error(`Cannot resolve profile '${profileId}': ${resolution.issues.map(formatProfileIssue).join('; ')}`);
-  }
-
-  const selectedProfile = resolution.profileStack.find((profile) => profile.id === profileId) as Profile;
-
-  if (selectedProfile.template === true) {
-    throw new Error(`Profile '${profileId}' is a template profile and must be inherited by a runnable profile.`);
-  }
-
-  return {
-    profile: resolution.profile,
-    profileLayers: findContributingLoadedProfiles(resolution.profileStack, loadedProfiles.profiles),
-    profilePaths: findContributingProfilePaths(resolution.profileStack, loadedProfiles.profiles),
-    profileFolders: findContributingProfileFolders(resolution.profileStack, loadedProfiles.profiles),
-    homeDirectory: input.homeDirectory,
-    cacheDirectory: loadedSettings.settings.cacheDirectory ?? join(input.homeDirectory, '.outfitter', 'cache'),
-    projectDirectory: input.projectDirectory,
-    settings: loadedSettings.settings,
-    settingsPaths: loadedSettings.files.map((file) => file.location.path),
-  };
-};
-
-const ensureConventionalLocalProfileSourceDirectories = (files: readonly ResolvedRunProfileSettingsFile[]): void => {
-  for (const file of files) {
-    const settingsProfilesPath = join(dirname(file.location.path), 'profiles');
-    const hasConventionalLocalSource = file.settings.profileSources?.some(
-      (source) => source.uri === undefined && source.github === undefined && source.path === settingsProfilesPath,
-    );
-
-    if (hasConventionalLocalSource === true) {
-      mkdirSync(settingsProfilesPath, { recursive: true });
-    }
-  }
-};
-
-type ResolvedRunProfileSettingsFile = ReturnType<typeof loadSettingsWithCachedRemoteSettings>['files'][number];
-
 const withSystemPromptExportPath = (launchPlan: AgentLaunchPlan, outputPath: string | undefined): AgentLaunchPlan =>
   outputPath === undefined
     ? launchPlan
     : { ...launchPlan, env: { ...launchPlan.env, OUTFITTER_SYSTEM_PROMPT_EXPORT_PATH: outputPath } };
-
-const selectRunProfileId = (selectedProfileId: string | undefined, defaultProfileId: string | undefined): string => {
-  if (selectedProfileId !== undefined) {
-    return selectedProfileId;
-  }
-
-  if (defaultProfileId !== undefined) {
-    return defaultProfileId;
-  }
-
-  throw new Error(
-    'Cannot run without a selected profile or default_profile in settings.yml; pass --profile or run `outfitter setup`.',
-  );
-};
-
-const findContributingProfilePaths = (
-  profileStack: readonly Profile[],
-  loadedProfiles: readonly LoadedProfile[],
-): readonly string[] =>
-  findContributingLoadedProfiles(profileStack, loadedProfiles).map((loadedProfile) => loadedProfile.profilePath);
-
-const findContributingProfileFolders = (
-  profileStack: readonly Profile[],
-  loadedProfiles: readonly LoadedProfile[],
-): readonly string[] =>
-  findContributingLoadedProfiles(profileStack, loadedProfiles).flatMap((loadedProfile) =>
-    loadedProfile.resourceRootPath === undefined ? [] : [loadedProfile.resourceRootPath],
-  );
-
-export const createLaunchProfileLayers = (loadedProfiles: readonly LoadedProfile[]) =>
-  loadedProfiles.map((loadedProfile) => ({
-    profile: loadedProfile.profile,
-    profilePath: loadedProfile.profilePath,
-    sourceRootPath: loadedProfile.sourceRootPath,
-    resourceRootPath: loadedProfile.resourceRootPath,
-    layout: loadedProfile.layout,
-  }));
-
-const findContributingLoadedProfiles = (
-  profileStack: readonly Profile[],
-  loadedProfiles: readonly LoadedProfile[],
-): readonly LoadedProfile[] =>
-  profileStack.flatMap((profile) => loadedProfiles.filter((loadedProfile) => loadedProfile.profile.id === profile.id));
-
-export const loadProfileSources = (
-  homeDirectory: string,
-  sources: readonly ProfileSourceReference[],
-): {
-  readonly profiles: readonly LoadedProfile[];
-  readonly issues: readonly { readonly path: string; readonly message: string }[];
-} => {
-  const profiles: LoadedProfile[] = [];
-  const issues: { readonly path: string; readonly message: string }[] = [];
-
-  for (const source of sources) {
-    const materializedSource = materializeSource(homeDirectory, source);
-
-    // A remote source whose cache has never synced (degraded-offline onboarding, blocked
-    // network) contributes no profiles instead of failing the launch; a later successful
-    // `outfitter sync` upgrades it to the full catalog.
-    if (isUnsyncedRemoteProfileSource(source, materializedSource.path)) {
-      continue;
-    }
-
-    const result = loadLocalProfileSource(materializedSource);
-    profiles.push(...result.profiles.map((profile) => ({ ...profile, source })));
-    issues.push(...result.issues);
-  }
-
-  return { profiles, issues };
-};
-
-const isUnsyncedRemoteProfileSource = (source: ProfileSourceReference, materializedPath: string | undefined): boolean =>
-  (source.uri !== undefined || source.github !== undefined) &&
-  materializedPath !== undefined &&
-  !existsSync(materializedPath);
-
-const materializeSource = (homeDirectory: string, source: ProfileSourceReference): ProfileSourceReference => {
-  if (source.uri === undefined && source.github === undefined) {
-    return source;
-  }
-
-  if (source.uri !== undefined && source.ref === undefined && source.path === undefined) {
-    return { path: createProfileSourceCachePath(homeDirectory, source.uri), only: source.only, except: source.except };
-  }
-
-  return {
-    path: resolveRemoteRepositorySubpath(createRemoteRepositoryCachePath(homeDirectory, source), source.path),
-    only: source.only,
-    except: source.except,
-  };
-};
 
 /* v8 ignore start -- the real child-process launcher is direct runtime behavior; tests inject a launcher. */
 const createSpawnLauncher = (): AgentProcessLauncher => ({
@@ -879,12 +494,3 @@ const signalNumbers: Readonly<Partial<Record<NodeJS.Signals, number>>> = {
   SIGINT: 2,
   SIGTERM: 15,
 };
-
-const formatSettingsIssue = (issue: {
-  readonly filePath: string;
-  readonly path: string;
-  readonly message: string;
-}): string => `${issue.filePath}#${issue.path} ${issue.message}`;
-
-const formatProfileIssue = (issue: { readonly path: string; readonly message: string }): string =>
-  `${issue.path} ${issue.message}`;

--- a/code/cli/src/cli/commands/RunCommand.ts
+++ b/code/cli/src/cli/commands/RunCommand.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines */
 // Provides the command object for launching selected profiles.
 import { existsSync, mkdirSync } from 'node:fs';
+import type { watch } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { createInterface } from 'node:readline/promises';
@@ -48,10 +49,13 @@ import {
   watchCompositeProfileInputs,
   watchCompositeProfileStateWrites,
 } from '../../compositeProfile/CompositeProfileWatcher.js';
+import type { StateWriteNoticeTimers } from '../../compositeProfile/CompositeProfileWatcher.js';
 import {
   createCompositeProfileSessionJournal,
   reportAndClearCompositeProfileSessionJournals,
 } from '../../compositeProfile/CompositeProfileSessionJournal.js';
+import type { CompositeProfileSessionJournal } from '../../compositeProfile/CompositeProfileSessionJournal.js';
+import type { CompositeProfile } from '../../compositeProfile/CompositeProfile.js';
 import {
   registerCompositeProfileDirectoryCleanup,
   sweepStaleCompositeProfileDirectories,
@@ -98,6 +102,12 @@ export interface RunCommandDependencies extends SetupCommandDependencies {
   readonly launcher?: AgentProcessLauncher;
   readonly writeError?: (message: string) => void;
   readonly promptStateWritePersistence?: CompositeProfileStateWritePrompt;
+  // Deterministic overrides for the live state-write monitor (tests inject a fake
+  // fs.watch and a manual notice-flush clock instead of racing platform timing).
+  readonly stateWriteMonitor?: {
+    readonly watchFactory?: typeof watch;
+    readonly timers?: StateWriteNoticeTimers;
+  };
 }
 
 export const executeRunCommand = async (
@@ -216,14 +226,12 @@ export const executeRunCommand = async (
     compositeProfileDirectory: compositeProfilePlan.compositeProfile.rootDirectory,
     baseline: stateBaseline,
   });
-  const stateWriteWatcher = watchCompositeProfileStateWrites({
-    compositeProfile: compositeProfilePlan.compositeProfile,
-    agentId: adapter.id,
-    journal: sessionJournal,
-    /* v8 ignore next 2 -- console fallbacks are direct CLI behavior; tests inject writers. */
-    notify: (message) => (dependencies.writeError ?? console.error)(message),
-    warn: (message) => (dependencies.writeError ?? console.error)(message),
-  });
+  const stateWriteWatcher = createRunStateWriteWatcher(
+    compositeProfilePlan.compositeProfile,
+    adapter.id,
+    sessionJournal,
+    dependencies,
+  );
 
   try {
     const launcher =
@@ -442,6 +450,23 @@ const prepareCompositeProfileTeardown = (
 
 const isDebugRunLaunch = (passThroughArgs: readonly string[] | undefined): boolean =>
   (passThroughArgs ?? []).includes('--debug');
+
+const createRunStateWriteWatcher = (
+  compositeProfile: CompositeProfile,
+  agentId: string,
+  journal: CompositeProfileSessionJournal,
+  dependencies: RunCommandDependencies,
+) =>
+  watchCompositeProfileStateWrites({
+    compositeProfile,
+    agentId,
+    journal,
+    watchFactory: dependencies.stateWriteMonitor?.watchFactory,
+    timers: dependencies.stateWriteMonitor?.timers,
+    /* v8 ignore next 2 -- console fallbacks are direct CLI behavior; tests inject writers. */
+    notify: (message) => (dependencies.writeError ?? console.error)(message),
+    warn: (message) => (dependencies.writeError ?? console.error)(message),
+  });
 
 const reportPreviousSessionJournals = (sessionJournalDirectory: string, dependencies: RunCommandDependencies): void =>
   reportAndClearCompositeProfileSessionJournals(

--- a/code/cli/src/cli/commands/RunCommand.ts
+++ b/code/cli/src/cli/commands/RunCommand.ts
@@ -11,18 +11,13 @@ import type { Command } from 'commander';
 import spawn from 'cross-spawn';
 
 import type { AgentAdapter, AgentLaunchPlan } from '../../agents/AgentAdapter.js';
-import { createAgentAdapter, defaultAgentId as registryDefaultAgentId } from '../../agents/AgentRegistry.js';
+import { createAgentAdapter } from '../../agents/AgentRegistry.js';
 import {
   createProfileSourceCachePath,
   createRemoteRepositoryCachePath,
   redactProfileSourceUriCredentials,
   resolveRemoteRepositorySubpath,
 } from '../../profiles/ProfileCache.js';
-import {
-  builtinStarterProfileId,
-  createBuiltinProfilesCachePath,
-  materializeBuiltinProfiles,
-} from '../../profiles/BuiltinProfiles.js';
 import { loadLocalProfileSource } from '../../profiles/ProfileLoader.js';
 import type { LoadedProfile } from '../../profiles/ProfileLoader.js';
 import { createEmptyProfile, type Profile } from '../../profiles/Profile.js';
@@ -64,9 +59,16 @@ import {
 import type { AgentProcessLauncher } from '../../agents/AgentLaunch.js';
 import { launchAgentProcess, resolveAgentLaunchExecutable } from '../../agents/AgentLaunch.js';
 import type { CommandObject } from './CommandObject.js';
-import { isNonInteractivePiLaunch, preparePiLoginLaunchPlan } from './PiLoginLaunch.js';
+import { preparePiLoginLaunchPlan } from './PiLoginLaunch.js';
+import {
+  emitClaudeLoginHintIfNeeded,
+  isInteractiveRunLaunch,
+  prepareFirstRunRuntimeOnboarding,
+  resolveRunProgressWriter,
+  runClaudeFirstRunOnboardingIfNeeded,
+  selectRunAgentId,
+} from './run/FirstRunOnboarding.js';
 import type { SetupCommandDependencies } from './SetupCommand.js';
-import { createGitSynchronizer, syncProfileSource, type RemoteProfileSource } from './SyncCommand.js';
 
 export interface RunCommandInput {
   readonly homeDirectory: string;
@@ -107,6 +109,9 @@ export const executeRunCommand = async (
   // ~/.outfitter/state rather than the tmp root, so the sweep can never delete one.
   reportPreviousSessionJournals(sessionJournalDirectory, dependencies);
   sweepStaleCompositeProfileDirectories();
+  // First runs with `--agent claude` finish profile setup through a terminal-side picker
+  // that writes settings before the normal profile resolution below runs.
+  await runClaudeFirstRunOnboardingIfNeeded(input, dependencies);
   const runtimeOnboarding = prepareFirstRunRuntimeOnboarding(input, dependencies);
   const resolvedProfile =
     runtimeOnboarding === undefined ? loadResolvedProfile(input) : createFirstRunBootstrapProfile(input);
@@ -171,6 +176,14 @@ export const executeRunCommand = async (
     compositeProfilePlan.compositeProfile.rootDirectory,
     dependencies.writeLine,
   );
+  // Claude owns its login flow; Outfitter only hints at `/login` when no prior claude
+  // login state is cheaply detectable, and never touches credentials itself.
+  emitClaudeLoginHintIfNeeded({
+    adapterId: adapter.id,
+    homeDirectory: input.homeDirectory,
+    passThroughArgs: input.passThroughArgs,
+    dependencies,
+  });
   const watcher = watchCompositeProfileInputs({
     compositeProfile: compositeProfilePlan.compositeProfile,
     refreshCompositeProfile: () => {
@@ -636,82 +649,6 @@ const formatCompositeProfileStateWriteIssue = (adapterId: string, issue: Composi
   return `${adapterId} wrote '${issue.relativePath}' with state_persistence '${issue.strategy}' and it was not persisted.`;
 };
 
-interface FirstRunRuntimeOnboarding {
-  readonly defaultProfilesPath: string;
-}
-
-const defaultProfilesSource = {
-  github: 'ai-outfitter/default-profiles',
-  path: 'profiles',
-} as const satisfies RemoteProfileSource;
-
-const prepareFirstRunRuntimeOnboarding = (
-  input: RunCommandInput,
-  dependencies: RunCommandDependencies,
-): FirstRunRuntimeOnboarding | undefined => {
-  if (!shouldUsePiNativeFirstRunOnboarding(input, dependencies)) {
-    return undefined;
-  }
-
-  const syncResult = syncProfileSource(
-    input.homeDirectory,
-    defaultProfilesSource,
-    dependencies.synchronizer ?? createGitSynchronizer(resolveRunProgressWriter(dependencies)),
-  );
-
-  if (syncResult.status === 'failed') {
-    (dependencies.writeError ?? console.error)(formatDegradedOnboardingWarning(syncResult.message));
-    const builtinProfilesPath = createBuiltinProfilesCachePath(input.homeDirectory);
-    materializeBuiltinProfiles(builtinProfilesPath);
-
-    return { defaultProfilesPath: builtinProfilesPath };
-  }
-
-  return { defaultProfilesPath: join(syncResult.cachePath, defaultProfilesSource.path) };
-};
-
-const formatDegradedOnboardingWarning = (failureMessage: string): string =>
-  `Warning: could not sync the default profiles source github:${defaultProfilesSource.github} (${failureMessage}). ` +
-  `Continuing with the built-in '${builtinStarterProfileId}' profile; run \`outfitter sync\` to fetch the full catalog once the source is reachable.`;
-
-const shouldUsePiNativeFirstRunOnboarding = (input: RunCommandInput, dependencies: RunCommandDependencies): boolean => {
-  if (input.forceRuntimeOnboarding !== true && existsSync(join(input.homeDirectory, '.outfitter', 'settings.yml'))) {
-    return false;
-  }
-
-  const selectedAgentId = dependencies.adapter?.id ?? selectRunAgentId(input.agentId, undefined);
-
-  /* v8 ignore next -- explicit profile/non-pi paths are covered by normal run command selection tests. */
-  if (input.profileId !== undefined || selectedAgentId !== 'pi') {
-    return false;
-  }
-
-  if (isNonInteractivePiLaunch(input.passThroughArgs ?? [])) {
-    return false;
-  }
-
-  return isInteractiveRunLaunch(dependencies);
-};
-
-// Network/build steps (catalog clones, extension caching) report per-source progress through this
-// writer so first boot never stalls silently before launch.
-const resolveRunProgressWriter = (dependencies: RunCommandDependencies): ((message: string) => void) =>
-  /* v8 ignore next -- console fallback is direct CLI behavior; tests inject writeLine. */
-  dependencies.writeLine ?? console.log;
-
-const isInteractiveRunLaunch = (dependencies: RunCommandDependencies): boolean => {
-  if (dependencies.interactive !== undefined) {
-    return dependencies.interactive;
-  }
-
-  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
-  const inputIsTty = (dependencies.input ?? process.stdin).isTTY === true;
-  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
-  const outputIsTty = (dependencies.output ?? process.stdout).isTTY === true;
-
-  return inputIsTty && outputIsTty;
-};
-
 const createFirstRunBootstrapProfile = (input: RunCommandInput): ResolvedRunProfile => ({
   profile: {
     ...createEmptyProfile('outfitter-bootstrap'),
@@ -791,9 +728,6 @@ const withSystemPromptExportPath = (launchPlan: AgentLaunchPlan, outputPath: str
     ? launchPlan
     : { ...launchPlan, env: { ...launchPlan.env, OUTFITTER_SYSTEM_PROMPT_EXPORT_PATH: outputPath } };
 
-const selectRunAgentId = (selectedAgentId: string | undefined, defaultAgentId: string | undefined): string =>
-  selectedAgentId ?? defaultAgentId ?? registryDefaultAgentId;
-
 const selectRunProfileId = (selectedProfileId: string | undefined, defaultProfileId: string | undefined): string => {
   if (selectedProfileId !== undefined) {
     return selectedProfileId;
@@ -849,6 +783,14 @@ export const loadProfileSources = (
 
   for (const source of sources) {
     const materializedSource = materializeSource(homeDirectory, source);
+
+    // A remote source whose cache has never synced (degraded-offline onboarding, blocked
+    // network) contributes no profiles instead of failing the launch; a later successful
+    // `outfitter sync` upgrades it to the full catalog.
+    if (isUnsyncedRemoteProfileSource(source, materializedSource.path)) {
+      continue;
+    }
+
     const result = loadLocalProfileSource(materializedSource);
     profiles.push(...result.profiles.map((profile) => ({ ...profile, source })));
     issues.push(...result.issues);
@@ -856,6 +798,11 @@ export const loadProfileSources = (
 
   return { profiles, issues };
 };
+
+const isUnsyncedRemoteProfileSource = (source: ProfileSourceReference, materializedPath: string | undefined): boolean =>
+  (source.uri !== undefined || source.github !== undefined) &&
+  materializedPath !== undefined &&
+  !existsSync(materializedPath);
 
 const materializeSource = (homeDirectory: string, source: ProfileSourceReference): ProfileSourceReference => {
   if (source.uri === undefined && source.github === undefined) {

--- a/code/cli/src/cli/commands/run/FirstRunOnboarding.ts
+++ b/code/cli/src/cli/commands/run/FirstRunOnboarding.ts
@@ -1,0 +1,297 @@
+// First-run onboarding for `outfitter run`: routes fresh machines into the pi-native
+// bootstrap flow or the terminal-side claude profile picker, sharing the default-catalog
+// sync and the degraded-offline builtin fallback between both paths.
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { createInterface } from 'node:readline/promises';
+import { join } from 'node:path';
+
+import { defaultAgentId as registryDefaultAgentId } from '../../../agents/AgentRegistry.js';
+import {
+  builtinStarterProfileId,
+  createBuiltinProfilesCachePath,
+  materializeBuiltinProfiles,
+} from '../../../profiles/BuiltinProfiles.js';
+import { loadLocalProfileSource } from '../../../profiles/ProfileLoader.js';
+import { isNonInteractivePiLaunch } from '../PiLoginLaunch.js';
+import { createDefaultSettingsContent } from '../SetupCommand.js';
+import { assertValidDefaultProfileId, chooseSetupPromptDefault } from '../setup/SetupProfileDiscovery.js';
+import { promptForSetupProfileWithReadline, resolvePromptOutput } from '../setup/SetupPrompts.js';
+import type { SetupProfileChoice } from '../setup/SetupTypes.js';
+import { createGitSynchronizer, syncProfileSource, type RemoteProfileSource } from '../SyncCommand.js';
+import { writeWelcomeIntro } from '../WelcomeCommand.js';
+import type { RunCommandDependencies, RunCommandInput } from '../RunCommand.js';
+
+export interface FirstRunRuntimeOnboarding {
+  readonly defaultProfilesPath: string;
+}
+
+export const defaultProfilesSource = {
+  github: 'ai-outfitter/default-profiles',
+  path: 'profiles',
+} as const satisfies RemoteProfileSource;
+
+// Network/build steps (catalog clones, extension caching) report per-source progress through this
+// writer so first boot never stalls silently before launch.
+export const resolveRunProgressWriter = (dependencies: RunCommandDependencies): ((message: string) => void) =>
+  /* v8 ignore next -- console fallback is direct CLI behavior; tests inject writeLine. */
+  dependencies.writeLine ?? console.log;
+
+export const selectRunAgentId = (selectedAgentId: string | undefined, defaultAgentId: string | undefined): string =>
+  selectedAgentId ?? defaultAgentId ?? registryDefaultAgentId;
+
+export const isInteractiveRunLaunch = (dependencies: RunCommandDependencies): boolean => {
+  if (dependencies.interactive !== undefined) {
+    return dependencies.interactive;
+  }
+
+  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
+  const inputIsTty = (dependencies.input ?? process.stdin).isTTY === true;
+  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
+  const outputIsTty = (dependencies.output ?? process.stdout).isTTY === true;
+
+  return inputIsTty && outputIsTty;
+};
+
+export const prepareFirstRunRuntimeOnboarding = (
+  input: RunCommandInput,
+  dependencies: RunCommandDependencies,
+): FirstRunRuntimeOnboarding | undefined => {
+  if (!shouldUsePiNativeFirstRunOnboarding(input, dependencies)) {
+    return undefined;
+  }
+
+  const syncResult = syncProfileSource(
+    input.homeDirectory,
+    defaultProfilesSource,
+    dependencies.synchronizer ?? createGitSynchronizer(resolveRunProgressWriter(dependencies)),
+  );
+
+  if (syncResult.status === 'failed') {
+    (dependencies.writeError ?? console.error)(formatDegradedOnboardingWarning(syncResult.message));
+    const builtinProfilesPath = createBuiltinProfilesCachePath(input.homeDirectory);
+    materializeBuiltinProfiles(builtinProfilesPath);
+
+    return { defaultProfilesPath: builtinProfilesPath };
+  }
+
+  return { defaultProfilesPath: join(syncResult.cachePath, defaultProfilesSource.path) };
+};
+
+const formatDegradedOnboardingWarning = (failureMessage: string): string =>
+  `Warning: could not sync the default profiles source github:${defaultProfilesSource.github} (${failureMessage}). ` +
+  `Continuing with the built-in '${builtinStarterProfileId}' profile; run \`outfitter sync\` to fetch the full catalog once the source is reachable.`;
+
+const shouldUsePiNativeFirstRunOnboarding = (input: RunCommandInput, dependencies: RunCommandDependencies): boolean => {
+  if (input.forceRuntimeOnboarding !== true && hasUserSettings(input.homeDirectory)) {
+    return false;
+  }
+
+  const selectedAgentId = dependencies.adapter?.id ?? selectRunAgentId(input.agentId, undefined);
+
+  /* v8 ignore next -- explicit profile/non-pi paths are covered by normal run command selection tests. */
+  if (input.profileId !== undefined || selectedAgentId !== 'pi') {
+    return false;
+  }
+
+  if (isNonInteractivePiLaunch(input.passThroughArgs ?? [])) {
+    return false;
+  }
+
+  return isInteractiveRunLaunch(dependencies);
+};
+
+const hasUserSettings = (homeDirectory: string): boolean =>
+  existsSync(join(homeDirectory, '.outfitter', 'settings.yml'));
+
+// Claude Code has no pi-tui equivalent for embedded onboarding UI, so first runs with
+// `--agent claude` finish profile setup with a terminal-side picker before launching claude.
+export const runClaudeFirstRunOnboardingIfNeeded = async (
+  input: RunCommandInput,
+  dependencies: RunCommandDependencies,
+): Promise<void> => {
+  if (!shouldUseClaudeFirstRunOnboarding(input, dependencies)) {
+    return;
+  }
+
+  const catalog = syncClaudeFirstRunProfileCatalog(input, dependencies);
+  const profiles = discoverClaudeFirstRunProfileChoices(catalog.profilesPath);
+  const promptDefault = chooseSetupPromptDefault(profiles, 'founder', builtinStarterProfileId);
+  const selectedProfileId = await selectClaudeFirstRunProfile(profiles, promptDefault, dependencies);
+  assertValidSelectedClaudeProfile(selectedProfileId, profiles);
+  writeClaudeFirstRunSettings(input.homeDirectory, selectedProfileId);
+  resolveRunProgressWriter(dependencies)(
+    `Saved ~/.outfitter/settings.yml with default profile '${selectedProfileId}' and default agent 'claude'.`,
+  );
+};
+
+const shouldUseClaudeFirstRunOnboarding = (input: RunCommandInput, dependencies: RunCommandDependencies): boolean => {
+  if (hasUserSettings(input.homeDirectory)) {
+    return false;
+  }
+
+  const selectedAgentId = dependencies.adapter?.id ?? selectRunAgentId(input.agentId, undefined);
+
+  if (input.profileId !== undefined || selectedAgentId !== 'claude') {
+    return false;
+  }
+
+  if (isNonInteractiveClaudeLaunch(input.passThroughArgs ?? [])) {
+    return false;
+  }
+
+  return isInteractiveRunLaunch(dependencies);
+};
+
+// `--print`/`-p` launches are claude's non-interactive mode: no picker, no settings writes.
+const isNonInteractiveClaudeLaunch = (args: readonly string[]): boolean =>
+  args.some((arg) => arg === '--print' || arg === '-p');
+
+interface ClaudeFirstRunProfileCatalog {
+  readonly profilesPath: string;
+}
+
+const syncClaudeFirstRunProfileCatalog = (
+  input: RunCommandInput,
+  dependencies: RunCommandDependencies,
+): ClaudeFirstRunProfileCatalog => {
+  const syncResult = syncProfileSource(
+    input.homeDirectory,
+    defaultProfilesSource,
+    dependencies.synchronizer ?? createGitSynchronizer(resolveRunProgressWriter(dependencies)),
+  );
+
+  if (syncResult.status === 'failed') {
+    (dependencies.writeError ?? console.error)(formatDegradedOnboardingWarning(syncResult.message));
+    // The written settings reference `./profiles` next to settings.yml, so the degraded
+    // builtin starter materializes there (mirrors the setup command's degraded fallback).
+    const localProfilesPath = join(input.homeDirectory, '.outfitter', 'profiles');
+    materializeBuiltinProfiles(localProfilesPath);
+
+    return { profilesPath: localProfilesPath };
+  }
+
+  return { profilesPath: join(syncResult.cachePath, defaultProfilesSource.path) };
+};
+
+const discoverClaudeFirstRunProfileChoices = (profilesPath: string): readonly SetupProfileChoice[] =>
+  loadLocalProfileSource({ path: profilesPath })
+    .profiles.filter((loadedProfile) => loadedProfile.profile.template !== true)
+    .map((loadedProfile) => ({
+      id: loadedProfile.profile.id,
+      label: loadedProfile.profile.label,
+      description: loadedProfile.profile.description,
+    }))
+    .sort((left, right) => left.id.localeCompare(right.id));
+
+const selectClaudeFirstRunProfile = async (
+  profiles: readonly SetupProfileChoice[],
+  promptDefault: string,
+  dependencies: RunCommandDependencies,
+): Promise<string> => {
+  if (dependencies.selectDefaultProfile !== undefined) {
+    return dependencies.selectDefaultProfile(profiles, promptDefault);
+  }
+
+  return promptForClaudeFirstRunProfile(profiles, promptDefault, dependencies);
+};
+
+const promptForClaudeFirstRunProfile = async (
+  profiles: readonly SetupProfileChoice[],
+  promptDefault: string,
+  dependencies: RunCommandDependencies,
+): Promise<string> => {
+  const output = resolvePromptOutput(dependencies);
+  /* v8 ignore next 2 -- default process streams are direct terminal behavior; tests inject streams. */
+  const readline = createInterface({
+    input: dependencies.input ?? process.stdin,
+    output: resolveClaudeReadlineOutput(dependencies),
+  });
+
+  try {
+    writeWelcomeIntro(output);
+    output.write("\nYou're setting up Outfitter for Claude Code.\n");
+    return await promptForSetupProfileWithReadline(
+      readline,
+      output,
+      profiles,
+      promptDefault,
+      'Choose the default profile for your sessions:',
+    );
+  } finally {
+    readline.close();
+  }
+};
+
+/* v8 ignore next 2 -- default process stdout is direct terminal behavior; tests inject writable streams. */
+const resolveClaudeReadlineOutput = (dependencies: RunCommandDependencies): NodeJS.WritableStream =>
+  typeof dependencies.output?.write === 'function' ? dependencies.output : process.stdout;
+
+const assertValidSelectedClaudeProfile = (selectedProfileId: string, profiles: readonly SetupProfileChoice[]): void => {
+  assertValidDefaultProfileId(selectedProfileId);
+
+  if (profiles.length > 0 && profiles.every((profile) => profile.id !== selectedProfileId)) {
+    throw new Error(`Selected default profile '${selectedProfileId}' was not one of the available setup profiles.`);
+  }
+};
+
+// The claude-first user keeps `outfitter` working without flags on later runs: the picker
+// persists both the chosen default profile and `default_agent: claude`.
+const writeClaudeFirstRunSettings = (homeDirectory: string, selectedProfileId: string): void => {
+  const settingsPath = join(homeDirectory, '.outfitter', 'settings.yml');
+  mkdirSync(join(homeDirectory, '.outfitter'), { recursive: true });
+  writeFileSync(settingsPath, `default_agent: claude\n${createDefaultSettingsContent(selectedProfileId)}`);
+};
+
+export interface ClaudeLoginHintInput {
+  readonly adapterId: string;
+  readonly homeDirectory: string;
+  readonly passThroughArgs?: readonly string[];
+  readonly dependencies: RunCommandDependencies;
+}
+
+const claudeLoginHintMessage =
+  'Claude Code manages its own credentials; if it reports that you are not logged in, run `/login` inside ' +
+  'Claude Code. Outfitter never reads or stores Claude credentials.';
+
+// Credentials never touch Outfitter: claude's own `/login` flow owns authentication. When no
+// prior claude login state is cheaply detectable on disk, interactive launches get a one-line
+// hint so a fresh user knows what to do if claude starts logged out.
+export const emitClaudeLoginHintIfNeeded = (input: ClaudeLoginHintInput): void => {
+  if (input.adapterId !== 'claude' || isNonInteractiveClaudeLaunch(input.passThroughArgs ?? [])) {
+    return;
+  }
+
+  if (!isInteractiveRunLaunch(input.dependencies) || hasConfiguredClaudeLoginState(input.homeDirectory)) {
+    return;
+  }
+
+  resolveRunProgressWriter(input.dependencies)(claudeLoginHintMessage);
+};
+
+// Filesystem-only pre-start guidance (never authoritative): claude stores OAuth/API-key state
+// in `~/.claude/.credentials.json` (Linux) or records the account in `~/.claude.json` (macOS
+// keeps the secret itself in the Keychain).
+const hasConfiguredClaudeLoginState = (homeDirectory: string): boolean => {
+  if (existsSync(join(homeDirectory, '.claude', '.credentials.json'))) {
+    return true;
+  }
+
+  const claudeConfigPath = join(homeDirectory, '.claude.json');
+
+  if (!existsSync(claudeConfigPath)) {
+    return false;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(claudeConfigPath, 'utf8'));
+
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return false;
+    }
+
+    const record = parsed as Readonly<Record<string, unknown>>;
+    return record.oauthAccount !== undefined || record.primaryApiKey !== undefined;
+  } catch {
+    return false;
+  }
+};

--- a/code/cli/src/cli/commands/run/RunProfileResolution.ts
+++ b/code/cli/src/cli/commands/run/RunProfileResolution.ts
@@ -1,0 +1,205 @@
+// Resolves the profile a run launches: loads settings and profile sources, resolves the
+// selected profile stack, and materializes remote source caches into local paths.
+import { existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import {
+  createProfileSourceCachePath,
+  createRemoteRepositoryCachePath,
+  resolveRemoteRepositorySubpath,
+} from '../../../profiles/ProfileCache.js';
+import { loadLocalProfileSource } from '../../../profiles/ProfileLoader.js';
+import type { LoadedProfile } from '../../../profiles/ProfileLoader.js';
+import { createEmptyProfile, type Profile } from '../../../profiles/Profile.js';
+import type { ProfileSourceReference } from '../../../profiles/ProfileSource.js';
+import { resolveProfile } from '../../../profiles/ProfileMerger.js';
+import { emptySettings, type Settings } from '../../../settings/Settings.js';
+import { loadSettingsWithCachedRemoteSettings } from '../../../settings/SettingsLoader.js';
+import type { RunCommandInput } from '../RunCommand.js';
+
+export interface ResolvedRunProfile {
+  readonly profile: Profile;
+  readonly profilePaths: readonly string[];
+  readonly profileFolders: readonly string[];
+  readonly homeDirectory: string;
+  readonly cacheDirectory: string;
+  readonly projectDirectory: string;
+  readonly settings: Settings;
+  readonly settingsPaths: readonly string[];
+  readonly profileLayers: readonly LoadedProfile[];
+}
+
+export const createFirstRunBootstrapProfile = (input: RunCommandInput): ResolvedRunProfile => ({
+  profile: {
+    ...createEmptyProfile('outfitter-bootstrap'),
+    label: 'Outfitter Bootstrap',
+    description: 'Temporary first-run profile that starts Pi before Outfitter settings exist.',
+  },
+  profilePaths: [],
+  profileFolders: [],
+  homeDirectory: input.homeDirectory,
+  cacheDirectory: join(input.homeDirectory, '.outfitter', 'cache'),
+  projectDirectory: input.projectDirectory,
+  settings: emptySettings(),
+  settingsPaths: [],
+  profileLayers: [],
+});
+
+export const loadResolvedProfile = (input: RunCommandInput): ResolvedRunProfile => {
+  const loadedSettings = loadSettingsWithCachedRemoteSettings(input);
+
+  if (loadedSettings.issues.length > 0) {
+    throw new Error(`Cannot run with invalid settings: ${loadedSettings.issues.map(formatSettingsIssue).join('; ')}`);
+  }
+
+  ensureConventionalLocalProfileSourceDirectories(loadedSettings.files);
+  const loadedProfiles = loadProfileSources(input.homeDirectory, loadedSettings.settings.profileSources!);
+
+  if (loadedProfiles.issues.length > 0) {
+    throw new Error(`Cannot run with invalid profiles: ${loadedProfiles.issues.map(formatProfileIssue).join('; ')}`);
+  }
+
+  const profileId = selectRunProfileId(input.profileId, loadedSettings.settings.defaultProfile);
+  const resolution = resolveProfile({
+    profiles: loadedProfiles.profiles,
+    profileId,
+  });
+
+  if (resolution.profile === undefined || resolution.issues.length > 0) {
+    throw new Error(`Cannot resolve profile '${profileId}': ${resolution.issues.map(formatProfileIssue).join('; ')}`);
+  }
+
+  const selectedProfile = resolution.profileStack.find((profile) => profile.id === profileId) as Profile;
+
+  if (selectedProfile.template === true) {
+    throw new Error(`Profile '${profileId}' is a template profile and must be inherited by a runnable profile.`);
+  }
+
+  return {
+    profile: resolution.profile,
+    profileLayers: findContributingLoadedProfiles(resolution.profileStack, loadedProfiles.profiles),
+    profilePaths: findContributingProfilePaths(resolution.profileStack, loadedProfiles.profiles),
+    profileFolders: findContributingProfileFolders(resolution.profileStack, loadedProfiles.profiles),
+    homeDirectory: input.homeDirectory,
+    cacheDirectory: loadedSettings.settings.cacheDirectory ?? join(input.homeDirectory, '.outfitter', 'cache'),
+    projectDirectory: input.projectDirectory,
+    settings: loadedSettings.settings,
+    settingsPaths: loadedSettings.files.map((file) => file.location.path),
+  };
+};
+
+const ensureConventionalLocalProfileSourceDirectories = (files: readonly ResolvedRunProfileSettingsFile[]): void => {
+  for (const file of files) {
+    const settingsProfilesPath = join(dirname(file.location.path), 'profiles');
+    const hasConventionalLocalSource = file.settings.profileSources?.some(
+      (source) => source.uri === undefined && source.github === undefined && source.path === settingsProfilesPath,
+    );
+
+    if (hasConventionalLocalSource === true) {
+      mkdirSync(settingsProfilesPath, { recursive: true });
+    }
+  }
+};
+
+type ResolvedRunProfileSettingsFile = ReturnType<typeof loadSettingsWithCachedRemoteSettings>['files'][number];
+
+const selectRunProfileId = (selectedProfileId: string | undefined, defaultProfileId: string | undefined): string => {
+  if (selectedProfileId !== undefined) {
+    return selectedProfileId;
+  }
+
+  if (defaultProfileId !== undefined) {
+    return defaultProfileId;
+  }
+
+  throw new Error(
+    'Cannot run without a selected profile or default_profile in settings.yml; pass --profile or run `outfitter setup`.',
+  );
+};
+
+const findContributingProfilePaths = (
+  profileStack: readonly Profile[],
+  loadedProfiles: readonly LoadedProfile[],
+): readonly string[] =>
+  findContributingLoadedProfiles(profileStack, loadedProfiles).map((loadedProfile) => loadedProfile.profilePath);
+
+const findContributingProfileFolders = (
+  profileStack: readonly Profile[],
+  loadedProfiles: readonly LoadedProfile[],
+): readonly string[] =>
+  findContributingLoadedProfiles(profileStack, loadedProfiles).flatMap((loadedProfile) =>
+    loadedProfile.resourceRootPath === undefined ? [] : [loadedProfile.resourceRootPath],
+  );
+
+export const createLaunchProfileLayers = (loadedProfiles: readonly LoadedProfile[]) =>
+  loadedProfiles.map((loadedProfile) => ({
+    profile: loadedProfile.profile,
+    profilePath: loadedProfile.profilePath,
+    sourceRootPath: loadedProfile.sourceRootPath,
+    resourceRootPath: loadedProfile.resourceRootPath,
+    layout: loadedProfile.layout,
+  }));
+
+const findContributingLoadedProfiles = (
+  profileStack: readonly Profile[],
+  loadedProfiles: readonly LoadedProfile[],
+): readonly LoadedProfile[] =>
+  profileStack.flatMap((profile) => loadedProfiles.filter((loadedProfile) => loadedProfile.profile.id === profile.id));
+
+export const loadProfileSources = (
+  homeDirectory: string,
+  sources: readonly ProfileSourceReference[],
+): {
+  readonly profiles: readonly LoadedProfile[];
+  readonly issues: readonly { readonly path: string; readonly message: string }[];
+} => {
+  const profiles: LoadedProfile[] = [];
+  const issues: { readonly path: string; readonly message: string }[] = [];
+
+  for (const source of sources) {
+    const materializedSource = materializeSource(homeDirectory, source);
+
+    // A remote source whose cache has never synced (degraded-offline onboarding, blocked
+    // network) contributes no profiles instead of failing the launch; a later successful
+    // `outfitter sync` upgrades it to the full catalog.
+    if (isUnsyncedRemoteProfileSource(source, materializedSource.path)) {
+      continue;
+    }
+
+    const result = loadLocalProfileSource(materializedSource);
+    profiles.push(...result.profiles.map((profile) => ({ ...profile, source })));
+    issues.push(...result.issues);
+  }
+
+  return { profiles, issues };
+};
+
+const isUnsyncedRemoteProfileSource = (source: ProfileSourceReference, materializedPath: string | undefined): boolean =>
+  (source.uri !== undefined || source.github !== undefined) &&
+  materializedPath !== undefined &&
+  !existsSync(materializedPath);
+
+const materializeSource = (homeDirectory: string, source: ProfileSourceReference): ProfileSourceReference => {
+  if (source.uri === undefined && source.github === undefined) {
+    return source;
+  }
+
+  if (source.uri !== undefined && source.ref === undefined && source.path === undefined) {
+    return { path: createProfileSourceCachePath(homeDirectory, source.uri), only: source.only, except: source.except };
+  }
+
+  return {
+    path: resolveRemoteRepositorySubpath(createRemoteRepositoryCachePath(homeDirectory, source), source.path),
+    only: source.only,
+    except: source.except,
+  };
+};
+
+const formatSettingsIssue = (issue: {
+  readonly filePath: string;
+  readonly path: string;
+  readonly message: string;
+}): string => `${issue.filePath}#${issue.path} ${issue.message}`;
+
+const formatProfileIssue = (issue: { readonly path: string; readonly message: string }): string =>
+  `${issue.path} ${issue.message}`;

--- a/code/cli/src/cli/commands/run/StateWriteReporting.ts
+++ b/code/cli/src/cli/commands/run/StateWriteReporting.ts
@@ -1,0 +1,218 @@
+// Handles the exit-time composite profile state-write diff for a run: formatting issues,
+// prompting for state_persistence 'prompt' paths, and recording always-persist choices.
+import { createInterface } from 'node:readline/promises';
+
+import type { AgentAdapter } from '../../../agents/AgentAdapter.js';
+import {
+  detectCompositeProfileStateWrites,
+  persistCompositeProfileStateWrite,
+  recordProfileStatePersistenceOverride,
+} from '../../../compositeProfile/StatePersistence.js';
+import type {
+  CompositeProfileStateBaseline,
+  CompositeProfileStatePath,
+  CompositeProfileStateWriteIssue,
+  CompositeProfileStateWritePrompt,
+} from '../../../compositeProfile/StatePersistence.js';
+import { isInteractiveRunLaunch } from './FirstRunOnboarding.js';
+import type { ResolvedRunProfile } from './RunProfileResolution.js';
+import type { RunCommandDependencies } from '../RunCommand.js';
+
+export interface CompositeProfileStateWriteHandlingInput {
+  readonly adapterId: string;
+  readonly rootDirectory: string;
+  readonly statePaths: readonly CompositeProfileStatePath[];
+  readonly stateBaseline: CompositeProfileStateBaseline;
+  readonly prompt?: CompositeProfileStateWritePrompt;
+  readonly recordAlwaysChoice: (relativePath: string) => string | undefined;
+  readonly notify: (message: string) => void;
+}
+
+export const handleCompositeProfileStateWrites = async (
+  input: CompositeProfileStateWriteHandlingInput,
+): Promise<readonly string[]> => {
+  const warnings: string[] = [];
+
+  for (const issue of detectCompositeProfileStateWrites(input.rootDirectory, input.statePaths, input.stateBaseline)) {
+    if (issue.strategy === 'error') {
+      throw new Error(formatCompositeProfileStateWriteIssue(input.adapterId, issue));
+    }
+
+    if (issue.strategy === 'prompt') {
+      warnings.push(...(await handlePromptStateWriteIssue(input, issue)));
+      continue;
+    }
+
+    warnings.push(formatCompositeProfileStateWriteIssue(input.adapterId, issue));
+  }
+
+  return warnings;
+};
+
+const handlePromptStateWriteIssue = async (
+  input: CompositeProfileStateWriteHandlingInput,
+  issue: CompositeProfileStateWriteIssue,
+): Promise<readonly string[]> => {
+  if (issue.unknown) {
+    return [
+      formatCompositeProfileStateWriteIssue(input.adapterId, issue),
+      `state_persistence 'prompt' cannot persist undeclared writes; '${issue.relativePath}' was reported instead.`,
+    ];
+  }
+
+  if (input.prompt === undefined) {
+    return [
+      formatCompositeProfileStateWriteIssue(input.adapterId, issue),
+      `state_persistence prompt for '${issue.relativePath}' skipped: non-interactive session.`,
+    ];
+  }
+
+  const statePath = findDeclaredStatePath(input.statePaths, issue.relativePath);
+  const choice = await input.prompt({
+    agentId: input.adapterId,
+    relativePath: issue.relativePath,
+    sourcePath: statePath.sourcePath,
+  });
+
+  return applyPromptStateWriteChoice(input, statePath, choice);
+};
+
+const applyPromptStateWriteChoice = (
+  input: CompositeProfileStateWriteHandlingInput,
+  statePath: CompositeProfileStatePath,
+  choice: 'persist' | 'discard' | 'always',
+): readonly string[] => {
+  if (choice === 'discard') {
+    input.notify(`Discarded ${input.adapterId} state write to '${statePath.relativePath}'.`);
+    return [];
+  }
+
+  try {
+    persistCompositeProfileStateWrite(input.rootDirectory, statePath);
+  } catch (error) {
+    return [`Could not persist state path '${statePath.relativePath}': ${String(error)}`];
+  }
+
+  input.notify(`Persisted ${input.adapterId} state write '${statePath.relativePath}' to ${statePath.sourcePath}.`);
+
+  if (choice === 'always') {
+    const warning = input.recordAlwaysChoice(statePath.relativePath);
+    return warning === undefined ? [] : [warning];
+  }
+
+  return [];
+};
+
+const findDeclaredStatePath = (
+  statePaths: readonly CompositeProfileStatePath[],
+  relativePath: string,
+): CompositeProfileStatePath => {
+  const statePath = statePaths.find((candidate) => candidate.relativePath === relativePath);
+
+  /* v8 ignore next 3 -- declared prompt issues always originate from a declared state path. */
+  if (statePath === undefined) {
+    throw new Error(`State path '${relativePath}' is not declared by the composite profile.`);
+  }
+
+  return statePath;
+};
+
+// The "always" choice is recorded in the selected profile's own YAML file because profiles
+// are the single source of truth for state_persistence policy; a parallel settings-layer
+// override would create a second precedence system that adapter validation cannot see.
+// Remote/cached profiles are never mutated, so the choice degrades to a one-run persist
+// with an actionable warning.
+export const recordAlwaysStatePersistenceChoice = (
+  adapter: AgentAdapter,
+  resolvedProfile: ResolvedRunProfile,
+  relativePath: string,
+): string | undefined => {
+  const declaration = adapter.statePaths?.[relativePath];
+
+  if (declaration === undefined || !declaration.allowedStrategies.includes('symlink')) {
+    return (
+      `Cannot always-persist '${relativePath}': the ${adapter.id} adapter does not allow 'symlink' for it; ` +
+      `the write was persisted once.`
+    );
+  }
+
+  const selectedLayer = [...resolvedProfile.profileLayers]
+    .reverse()
+    .find((layer) => layer.profile.id === resolvedProfile.profile.id);
+
+  if (
+    selectedLayer === undefined ||
+    selectedLayer.source.uri !== undefined ||
+    selectedLayer.source.github !== undefined
+  ) {
+    return (
+      `Cannot record the always-persist choice for '${relativePath}' because profile ` +
+      `'${resolvedProfile.profile.id}' is not a local profile file; the write was persisted once.`
+    );
+  }
+
+  recordProfileStatePersistenceOverride(selectedLayer.profilePath, relativePath, 'symlink');
+  return undefined;
+};
+
+export const resolveStateWritePrompt = (
+  dependencies: RunCommandDependencies,
+): CompositeProfileStateWritePrompt | undefined => {
+  if (!isInteractiveRunLaunch(dependencies)) {
+    return undefined;
+  }
+
+  return (
+    dependencies.promptStateWritePersistence ??
+    /* v8 ignore next -- terminal prompting is direct CLI behavior; tests inject a prompt. */
+    createTerminalStateWritePrompt(dependencies.input ?? process.stdin, dependencies.output ?? process.stdout)
+  );
+};
+
+/* v8 ignore start -- readline prompting is direct terminal behavior; tests inject a prompt. */
+const createTerminalStateWritePrompt =
+  (input: NodeJS.ReadableStream, output: NodeJS.WritableStream): CompositeProfileStateWritePrompt =>
+  async (request) => {
+    const readline = createInterface({ input, output });
+
+    try {
+      for (;;) {
+        const answer = (
+          await readline.question(
+            `${request.agentId} wrote state path '${request.relativePath}' (state_persistence 'prompt'). ` +
+              `[p]ersist to ${request.sourcePath ?? 'its durable source'} / [d]iscard / ` +
+              `[a]lways persist for this profile: `,
+          )
+        )
+          .trim()
+          .toLowerCase();
+
+        if (answer === 'p' || answer === 'persist') {
+          return 'persist';
+        }
+
+        if (answer === 'd' || answer === 'discard') {
+          return 'discard';
+        }
+
+        if (answer === 'a' || answer === 'always') {
+          return 'always';
+        }
+      }
+    } finally {
+      readline.close();
+    }
+  };
+/* v8 ignore stop */
+
+const formatCompositeProfileStateWriteIssue = (adapterId: string, issue: CompositeProfileStateWriteIssue): string => {
+  if (issue.unknown) {
+    return `${adapterId} wrote undeclared composite profile state '${issue.relativePath}' and it was not persisted.`;
+  }
+
+  if (issue.strategy === 'symlink') {
+    return `${adapterId} replaced symlinked state path '${issue.relativePath}' and the change was not persisted.`;
+  }
+
+  return `${adapterId} wrote '${issue.relativePath}' with state_persistence '${issue.strategy}' and it was not persisted.`;
+};

--- a/code/cli/src/compositeProfile/CompositeProfileWatcher.ts
+++ b/code/cli/src/compositeProfile/CompositeProfileWatcher.ts
@@ -68,9 +68,24 @@ export interface WatchCompositeProfileStateWritesInput {
   readonly journal?: Pick<CompositeProfileSessionJournal, 'recordUndeclaredWrites'>;
   readonly throttleMs?: number;
   readonly watchFactory?: typeof watch;
+  readonly timers?: StateWriteNoticeTimers;
+}
+
+// Injectable clock for the notice throttle so callers (and tests) can flush notices
+// deterministically instead of racing real timers. `setTimeout` must return a non-null
+// handle that `clearTimeout` accepts.
+export interface StateWriteNoticeTimers {
+  setTimeout(callback: () => void, delayMs: number): object;
+  clearTimeout(handle: object): void;
 }
 
 export const defaultStateWriteNoticeThrottleMs = 1000;
+
+// Real timers never keep the process alive just to print a throttled notice.
+const defaultStateWriteNoticeTimers: StateWriteNoticeTimers = {
+  setTimeout: (callback, delayMs) => setTimeout(callback, delayMs).unref(),
+  clearTimeout: (handle) => clearTimeout(handle as NodeJS.Timeout),
+};
 
 // Watches the composite profile root while the agent runs and surfaces undeclared writes in
 // near real time. Notices are deduplicated per path and flushed on a throttle interval;
@@ -110,9 +125,10 @@ export const watchCompositeProfileStateWrites = (
 
 const createStateWriteMonitor = (input: WatchCompositeProfileStateWritesInput) => {
   const generatedFilePaths = input.compositeProfile.files.map((file) => file.relativePath);
+  const timers = input.timers ?? defaultStateWriteNoticeTimers;
   const observedPaths = new Set<string>();
   const pendingNotices: string[] = [];
-  let flushTimer: NodeJS.Timeout | undefined;
+  let flushTimer: object | undefined;
   let closed = false;
 
   const flush = (): void => {
@@ -144,13 +160,13 @@ const createStateWriteMonitor = (input: WatchCompositeProfileStateWritesInput) =
       observedPaths.add(relativePath);
       input.journal?.recordUndeclaredWrites([relativePath]);
       pendingNotices.push(relativePath);
-      flushTimer ??= setTimeout(flush, input.throttleMs ?? defaultStateWriteNoticeThrottleMs).unref();
+      flushTimer ??= timers.setTimeout(flush, input.throttleMs ?? defaultStateWriteNoticeThrottleMs);
     },
     close(): void {
       closed = true;
 
       if (flushTimer !== undefined) {
-        clearTimeout(flushTimer);
+        timers.clearTimeout(flushTimer);
         flushTimer = undefined;
       }
     },

--- a/code/cli/tests/unit/agent-launch.test.ts
+++ b/code/cli/tests/unit/agent-launch.test.ts
@@ -77,6 +77,8 @@ describe('agent launch', () => {
     ).catch((error: unknown) => error);
 
     expect((thrownError as Error).message).toContain("Could not launch the 'claude' agent CLI");
+    expect((thrownError as Error).message).toContain('npm install -g @anthropic-ai/claude-code');
+    expect((thrownError as Error).message).toContain('brew install --cask claude-code');
     expect((thrownError as Error).message).toContain('https://claude.com/claude-code');
   });
 

--- a/code/cli/tests/unit/claude-onboarding.test.ts
+++ b/code/cli/tests/unit/claude-onboarding.test.ts
@@ -1,0 +1,390 @@
+// Tests the claude first-run terminal onboarding: install guidance, the terminal-side
+// profile picker with degraded-offline fallback, and the /login hint boundary.
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { AgentLaunchPlan } from '../../src/agents/AgentAdapter.js';
+import { executeRunCommand } from '../../src/cli/commands/RunCommand.js';
+import type { RunCommandDependencies } from '../../src/cli/commands/RunCommand.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-claude-onboarding-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+const claudeLoginHint =
+  'Claude Code manages its own credentials; if it reports that you are not logged in, run `/login` inside ' +
+  'Claude Code. Outfitter never reads or stores Claude credentials.';
+
+const createCatalogSynchronizer = (
+  syncedSources: unknown[] = [],
+): NonNullable<RunCommandDependencies['synchronizer']> => ({
+  sync(source, cachePath) {
+    syncedSources.push(source);
+    for (const profileId of ['founder', 'engineer', 'data_analyst']) {
+      mkdirSync(join(cachePath, 'profiles', profileId), { recursive: true });
+      writeFileSync(
+        join(cachePath, 'profiles', profileId, 'profile.yml'),
+        `id: ${profileId}\nlabel: ${profileId}\ncontrols: {}\n`,
+      );
+    }
+    return 'updated';
+  },
+});
+
+const writeExistingClaudeSettings = (homeDirectory: string): void => {
+  mkdirSync(join(homeDirectory, '.outfitter', 'profiles', 'engineer'), { recursive: true });
+  writeFileSync(
+    join(homeDirectory, '.outfitter', 'settings.yml'),
+    'default_agent: claude\ndefault_profile: engineer\nprofile_sources:\n  - path: ./profiles\n',
+  );
+  writeFileSync(
+    join(homeDirectory, '.outfitter', 'profiles', 'engineer', 'profile.yml'),
+    'id: engineer\ncontrols: {}\n',
+  );
+};
+
+describe('claude first-run onboarding', () => {
+  it('syncs the default catalog, picks a profile in the terminal, writes settings, and launches claude', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const messages: string[] = [];
+    const syncedSources: unknown[] = [];
+    const offeredChoices: string[][] = [];
+    const offeredDefaults: string[] = [];
+    const launches: AgentLaunchPlan[] = [];
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory, agentId: 'claude' },
+      {
+        interactive: true,
+        writeLine: (message) => messages.push(message),
+        writeError: () => undefined,
+        synchronizer: createCatalogSynchronizer(syncedSources),
+        selectDefaultProfile: (profiles, currentDefault) => {
+          offeredChoices.push(profiles.map((profile) => profile.id));
+          offeredDefaults.push(currentDefault);
+          return Promise.resolve('engineer');
+        },
+        launcher: {
+          launch(plan) {
+            launches.push(plan);
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(syncedSources).toEqual([{ github: 'ai-outfitter/default-profiles', path: 'profiles' }]);
+    expect(offeredChoices).toEqual([['data_analyst', 'engineer', 'founder']]);
+    expect(offeredDefaults).toEqual(['founder']);
+    const settingsContent = readFileSync(join(homeDirectory, '.outfitter', 'settings.yml'), 'utf8');
+    expect(settingsContent).toContain('default_agent: claude');
+    expect(settingsContent).toContain('default_profile: engineer');
+    expect(settingsContent).toContain('github: ai-outfitter/default-profiles');
+    expect(result.profileId).toBe('engineer');
+    expect(result.agentId).toBe('claude');
+    expect(launches).toHaveLength(1);
+    expect(launches[0]?.command).toBe('claude');
+    expect(launches[0]?.env.CLAUDE_CONFIG_DIR).toBe(result.compositeProfileDirectory);
+    expect(messages).toContain(
+      "Saved ~/.outfitter/settings.yml with default profile 'engineer' and default agent 'claude'.",
+    );
+    // No claude login state exists in the fixture home, so the /login hint is shown.
+    expect(messages).toContain(claudeLoginHint);
+  });
+
+  it('prompts through the terminal readline picker when no picker dependency is injected', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const input = Object.assign(new PassThrough(), { isTTY: true });
+    const output = Object.assign(new PassThrough(), { isTTY: true });
+    let outputText = '';
+    output.on('data', (chunk: Buffer | string) => {
+      outputText += chunk.toString();
+    });
+
+    const resultPromise = executeRunCommand(
+      { homeDirectory, projectDirectory, agentId: 'claude' },
+      {
+        input,
+        output,
+        writeLine: () => undefined,
+        writeError: () => undefined,
+        synchronizer: createCatalogSynchronizer(),
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+    setImmediate(() => input.end('\n'));
+    const result = await resultPromise;
+
+    expect(outputText).toContain("You're setting up Outfitter for Claude Code.");
+    expect(outputText).toContain('Choose the default profile for your sessions:');
+    expect(outputText).toContain('founder');
+    // Enter accepts the recommended founder default.
+    expect(result.profileId).toBe('founder');
+    expect(readFileSync(join(homeDirectory, '.outfitter', 'settings.yml'), 'utf8')).toContain(
+      'default_profile: founder',
+    );
+  });
+
+  it('falls back to the built-in starter profile when the default catalog cannot sync', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const warnings: string[] = [];
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory, agentId: 'claude' },
+      {
+        interactive: true,
+        writeLine: () => undefined,
+        writeError: (message) => warnings.push(message),
+        synchronizer: {
+          sync() {
+            throw new Error('network blocked');
+          },
+        },
+        selectDefaultProfile: (profiles, currentDefault) => {
+          expect(profiles.map((profile) => profile.id)).toEqual(['starter']);
+          return Promise.resolve(currentDefault);
+        },
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(result.profileId).toBe('starter');
+    expect(result.agentId).toBe('claude');
+    expect(readFileSync(join(homeDirectory, '.outfitter', 'profiles', 'starter', 'profile.yml'), 'utf8')).toContain(
+      'id: starter',
+    );
+    expect(readFileSync(join(homeDirectory, '.outfitter', 'settings.yml'), 'utf8')).toContain(
+      'default_profile: starter',
+    );
+    expect(
+      warnings.some(
+        (message) =>
+          message.includes('github:ai-outfitter/default-profiles') &&
+          message.includes('network blocked') &&
+          message.includes('`outfitter sync`'),
+      ),
+    ).toBe(true);
+
+    // Later runs keep working offline: the unsynced catalog source contributes no
+    // profiles until `outfitter sync` succeeds, and the starter default still resolves.
+    const secondResult = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        interactive: true,
+        writeLine: () => undefined,
+        writeError: () => undefined,
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+    expect(secondResult.profileId).toBe('starter');
+    expect(secondResult.agentId).toBe('claude');
+  });
+
+  it('rejects a picker selection that is not one of the offered profiles', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+
+    await expect(
+      executeRunCommand(
+        { homeDirectory, projectDirectory, agentId: 'claude' },
+        {
+          interactive: true,
+          writeLine: () => undefined,
+          writeError: () => undefined,
+          synchronizer: createCatalogSynchronizer(),
+          selectDefaultProfile: () => Promise.resolve('not-offered'),
+          launcher: {
+            launch() {
+              throw new Error('must not launch after an invalid picker selection');
+            },
+          },
+        },
+      ),
+    ).rejects.toThrow("Selected default profile 'not-offered' was not one of the available setup profiles.");
+
+    expect(existsSync(join(homeDirectory, '.outfitter', 'settings.yml'))).toBe(false);
+  });
+
+  it('does not show the picker or mutate settings for non-interactive claude first runs', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+
+    await expect(
+      executeRunCommand(
+        { homeDirectory, projectDirectory, agentId: 'claude' },
+        {
+          interactive: false,
+          writeLine: () => undefined,
+          synchronizer: {
+            sync() {
+              throw new Error('non-interactive first runs must not sync onboarding sources');
+            },
+          },
+          launcher: {
+            launch() {
+              throw new Error('non-interactive first runs must not launch without settings');
+            },
+          },
+        },
+      ),
+    ).rejects.toThrow('Cannot run without a selected profile or default_profile');
+
+    expect(existsSync(join(homeDirectory, '.outfitter', 'settings.yml'))).toBe(false);
+  });
+
+  it('skips onboarding for print-mode claude launches and explicit profile selections', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const failingDependencies = {
+      interactive: true,
+      writeLine: () => undefined,
+      selectDefaultProfile: () => Promise.reject(new Error('the picker must not open')),
+      synchronizer: {
+        sync: () => {
+          throw new Error('onboarding sources must not sync');
+        },
+      },
+    } as const;
+
+    for (const printFlag of ['--print', '-p']) {
+      await expect(
+        executeRunCommand(
+          { homeDirectory, projectDirectory, agentId: 'claude', passThroughArgs: [printFlag] },
+          failingDependencies,
+        ),
+      ).rejects.toThrow('Cannot run without a selected profile or default_profile');
+    }
+
+    await expect(
+      executeRunCommand(
+        { homeDirectory, projectDirectory, agentId: 'claude', profileId: 'engineer' },
+        failingDependencies,
+      ),
+    ).rejects.toThrow("Cannot resolve profile 'engineer'");
+
+    expect(existsSync(join(homeDirectory, '.outfitter', 'settings.yml'))).toBe(false);
+  });
+});
+
+describe('claude login hint', () => {
+  const runWithExistingSettings = async (
+    homeDirectory: string,
+    projectDirectory: string,
+    overrides: Partial<Parameters<typeof executeRunCommand>[0]> = {},
+  ): Promise<string[]> => {
+    const messages: string[] = [];
+
+    await executeRunCommand(
+      { homeDirectory, projectDirectory, ...overrides },
+      {
+        interactive: true,
+        writeLine: (message) => messages.push(message),
+        writeError: () => undefined,
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    return messages;
+  };
+
+  it('hints at /login when no claude login state is detectable and stays quiet once it is', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    writeExistingClaudeSettings(homeDirectory);
+
+    expect(await runWithExistingSettings(homeDirectory, projectDirectory)).toContain(claudeLoginHint);
+
+    // A malformed ~/.claude.json is not evidence of a configured login.
+    writeFileSync(join(homeDirectory, '.claude.json'), 'not json\n');
+    expect(await runWithExistingSettings(homeDirectory, projectDirectory)).toContain(claudeLoginHint);
+
+    writeFileSync(join(homeDirectory, '.claude.json'), '[]\n');
+    expect(await runWithExistingSettings(homeDirectory, projectDirectory)).toContain(claudeLoginHint);
+
+    writeFileSync(join(homeDirectory, '.claude.json'), '{"oauthAccount":{"emailAddress":"user@example.com"}}\n');
+    expect(await runWithExistingSettings(homeDirectory, projectDirectory)).not.toContain(claudeLoginHint);
+
+    rmSync(join(homeDirectory, '.claude.json'));
+    mkdirSync(join(homeDirectory, '.claude'), { recursive: true });
+    writeFileSync(join(homeDirectory, '.claude', '.credentials.json'), '{}\n');
+    expect(await runWithExistingSettings(homeDirectory, projectDirectory)).not.toContain(claudeLoginHint);
+  });
+
+  it('does not hint for print-mode claude launches or non-claude agents', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    writeExistingClaudeSettings(homeDirectory);
+
+    expect(
+      await runWithExistingSettings(homeDirectory, projectDirectory, { passThroughArgs: ['--print', 'prompt'] }),
+    ).not.toContain(claudeLoginHint);
+    expect(await runWithExistingSettings(homeDirectory, projectDirectory, { agentId: 'pi' })).not.toContain(
+      claudeLoginHint,
+    );
+  });
+
+  it('translates a missing claude binary into actionable npm and brew install guidance', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    writeExistingClaudeSettings(homeDirectory);
+
+    const thrownError = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        interactive: true,
+        writeLine: () => undefined,
+        launcher: {
+          launch: () => Promise.reject(Object.assign(new Error('spawn claude ENOENT'), { code: 'ENOENT' })),
+        },
+      },
+    ).catch((error: unknown) => error);
+
+    expect(thrownError).toBeInstanceOf(Error);
+    const message = (thrownError as Error).message;
+    expect(message).toContain("Could not launch the 'claude' agent CLI");
+    expect(message).toContain('npm install -g @anthropic-ai/claude-code');
+    expect(message).toContain('brew install --cask claude-code');
+  });
+});

--- a/code/cli/tests/unit/state-write-monitor.test.ts
+++ b/code/cli/tests/unit/state-write-monitor.test.ts
@@ -362,22 +362,35 @@ describe('run command crash coverage', () => {
     const errors: string[] = [];
     const liveNotice =
       "pi is writing undeclared composite profile state 'unexpected.txt' (undeclared writes are not persisted).";
+    // A deterministic monitor: the fake watch delivers the event and the manual clock
+    // flushes the throttled notice, so nothing races platform fs.watch or real timers.
+    const fakeWatch = createFakeWatch();
+    const scheduledFlushes: (() => void)[] = [];
 
     const result = await executeRunCommand(
       { homeDirectory, projectDirectory },
       {
         writeError: (message) => errors.push(message),
         writeLine: () => undefined,
+        stateWriteMonitor: {
+          watchFactory: fakeWatch.factory,
+          timers: {
+            setTimeout: (callback) => {
+              scheduledFlushes.push(callback);
+              return callback;
+            },
+            clearTimeout: () => undefined,
+          },
+        },
         launcher: {
-          async launch(plan) {
+          launch(plan) {
             writeFileSync(join(plan.env.PI_CODING_AGENT_DIR, 'unexpected.txt'), 'live write\n');
+            fakeWatch.emit('unexpected.txt');
 
-            const deadline = Date.now() + 8000;
-            while (!errors.includes(liveNotice) && Date.now() < deadline) {
-              await sleep(25);
-            }
-
-            expect(errors).toContain(liveNotice);
+            // The notice is throttled until the injected clock fires; the journal
+            // record is immediate so crashes lose as little accounting as possible.
+            expect(errors).toEqual([]);
+            expect(scheduledFlushes).toHaveLength(1);
             const journalFiles = readdirSync(journalDirectory);
             expect(journalFiles).toHaveLength(1);
             const journal = JSON.parse(readFileSync(join(journalDirectory, journalFiles[0] ?? ''), 'utf8')) as Record<
@@ -385,7 +398,10 @@ describe('run command crash coverage', () => {
               unknown
             >;
             expect(journal.undeclaredWrites).toEqual(['unexpected.txt']);
-            return 0;
+
+            scheduledFlushes[0]?.();
+            expect(errors).toContain(liveNotice);
+            return Promise.resolve(0);
           },
         },
       },
@@ -397,5 +413,5 @@ describe('run command crash coverage', () => {
     );
     // The clean exit discards this session's journal.
     expect(readdirSync(journalDirectory)).toEqual([]);
-  }, 15000);
+  });
 });

--- a/docs/documentation/getting-started.md
+++ b/docs/documentation/getting-started.md
@@ -22,6 +22,18 @@ If you are new to Claude Code, Codex, Pi, and agent CLIs, start with [First-time
 
 Learn how shared setup sources work in [Profile repositories](./profile-repository.md), then see [Profiles](./profiles.md) for profile composition, inheritance, and prompt examples.
 
+### Using Claude Code
+
+Claude Code is a peer adapter with its own first-run flow. On a fresh machine:
+
+```bash
+outfitter run --agent claude
+```
+
+- **First run** — with no Outfitter settings yet, a terminal-side profile picker syncs the default profile catalog, lets you choose a default profile, and writes `~/.outfitter/settings.yml` with `default_agent: claude` before launching Claude Code. If the catalog cannot be reached, onboarding continues offline with the built-in `starter` profile; `outfitter sync` upgrades to the full catalog later.
+- **Claude Code not installed** — Outfitter prints install guidance (`npm install -g @anthropic-ai/claude-code`, or `brew install --cask claude-code` on macOS) instead of a bare launch error.
+- **Login** — Claude Code owns its own login: launch it and run `/login` inside the session if it reports you are not logged in. Outfitter never reads or stores Claude credentials; it only prints a `/login` hint when no prior login state is detectable.
+
 ## Common commands
 
 ```bash

--- a/project-log.md
+++ b/project-log.md
@@ -2,6 +2,21 @@
 
 Chronological log of development activities, changes, and lessons learned. Append new entries; never remove old ones.
 
+## 2026-07-01 (evening) — Fork execution sprint: 29 of 32 plan issues shipped (Claude session)
+
+**What was done:**
+
+- Forked to `tylerwillis/outfitter`, filed all 32 plan issues there (mapping in docs/plans/issues/README.md), then executed autonomously with parallel agents in git worktrees, merging in issue order with gates green at every merge.
+- **Shipped (all on fork main):** M1 ship-blockers (bundled offline `starter` profile + degraded sync, hardcoded bootstrap model removed, pi's false update notice suppressed via PI_SKIP_VERSION_CHECK for bundled launches, shallow catalog clones + extension-cache refresh policy + progress output); CI hardening (packaged E2E smoke script+job, ubuntu/macos/windows matrix with visible-warning windows leg, GHCR Docker publish gated on npm publish); docs front door (architecture/organization path typos fixed with hygiene test, philosophy rewritten, AGENTS.md reconciled, catalog trust model, concepts + CLI reference, support matrix); Claude parity (MCP composition via --mcp-config + shared McpConfigMerge, skills materialization, thinking→effort table, terminal first-run onboarding with /login hint); state persistence (interactive `prompt` strategy writing back to profile YAML, live undeclared-write notices + crash journals, composite temp-dir cleanup + sweep); tech debt (pi extension extracted to typed code/pi-extension workspace with esbuild bundle + config-file injection, SetupCommand 1612→496 and PiLoginLaunch 945→243 and RunCommand decomposed with all eslint-disable headers deleted, dead deps removed via OFTR-001.5 amendment); cross-adapter conformance suite (104 tests, registry-driven, docs drift verifier, `npm run conformance`); doc site now renders docs/documentation via sync script (fictional landing-page details replaced); SEO tagline + keywords; licensing section (MIT vs enterprise BSL); persona-reviews and federated-context example catalogs (lint clean).
+- **High-effort code review mid-sprint found 10 confirmed defects** (silent state-loss copy fallback, uncaught junction retry, ungated Docker publish, prerelease latest-tag bug, hidden windows CI failures, symlink-fragile hygiene test, --only parser crash, unguarded setup symlink, homedir() crash on passwd-less UIDs, inflated smoke timings) — all 10 fixed.
+- **Final state:** 465 CLI tests + 61 pi-extension tests + docs build + packaged smoke all green. 30/33 fork issues closed. Open: #6 (record demo video — script ready in docs/plans/demo-video-script.md), #28 (ecosystem listings — copy ready in docs/plans/launch/ecosystem-listings.md), #31 (publish personas to default-profiles — example catalog ready in examples/persona-reviews/).
+
+**Lessons:**
+
+- Agent worktrees were created from stale HEADs repeatedly; every agent needed an explicit fetch/reset-to-canonical-main instruction.
+- The requirement-pinned-test system worked as designed: agents amended requirements (OFTR-001.5, OFTR-006.5.8-10, OFTR-010.6, OFTR-005.6) before touching pinned tests, leaving a clean trace.
+- Two genuine product bugs surfaced by doc/example work: `only:` filters break profile inheritance when they exclude the base (docs now use `template: true`), and unsynced remote sources used to fail launches instead of degrading.
+
 ## 2026-07-01 (later) — Cross-adapter conformance suite (Claude session, wave2/conformance)
 
 **What was done:**


### PR DESCRIPTION
Stacked PR 10/10 — base: `sprint/09-extraction`. Merging this makes origin main identical to the fully-integrated, fully-green `sprint/2026-07-full`.

- **Claude first-run onboarding**: terminal profile picker for `--agent claude` (reuses the setup prompt modules; founder recommended), same degraded-offline starter fallback as pi, `default_agent: claude` written to settings, actionable install guidance when the binary is missing, one-line `/login` hint only when no login state is detectable — credentials never touch Outfitter. Supporting fix: unsynced remote sources now contribute zero profiles instead of failing launches.
- **Flake fix**: the live state-write-notice test raced FSEvents + the real 1s throttle; watcher throttle now takes an injectable clock; 20/20 consecutive runs green.
- **RunCommand decomposition follow-up**: `run/` modules extracted, the last `eslint-disable max-lines` header in cli/commands deleted.
- Project log entry for the sprint.

Final integrated state: 465 CLI + 61 pi-extension + 104 conformance tests, docs build, packaged smoke — all green.

Fork issues: [#17](https://github.com/tylerwillis/outfitter/issues/17), [#33](https://github.com/tylerwillis/outfitter/issues/33)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


