### PR TITLE
fix(onboarding): complete first-run project setup handoff

### DIFF
--- a/code/cli/src/cli/commands/PiLoginLaunch.ts
+++ b/code/cli/src/cli/commands/PiLoginLaunch.ts
@@ -386,8 +386,14 @@ export default function outfitter(pi) {
     const questionUi = createQuestionUi(ctx);
 
     if (OUTFITTER_SETUP_SOURCE_URI !== undefined) {
-      await runProvidedSourceOnboarding({ mkdirSync, writeFileSync, dirname }, paths, questionUi, OUTFITTER_SETUP_SOURCE_URI);
-      await openLoginIfNoModels(ctx);
+      const installed = await runProvidedSourceOnboarding(
+        { existsSync, mkdirSync, readFileSync, writeFileSync, dirname },
+        paths,
+        questionUi,
+        ctx,
+        OUTFITTER_SETUP_SOURCE_URI,
+      );
+      if (!installed) await openLoginIfNoModels(ctx);
       return;
     }
 
@@ -400,23 +406,34 @@ export default function outfitter(pi) {
     }
 
     if (setupMode === "catalog") {
-      await runRemoteSettingsOnboarding({ existsSync, mkdirSync, readFileSync, writeFileSync, dirname }, paths, questionUi);
-      await openLoginIfNoModels(ctx);
+      const installed = await runRemoteSettingsOnboarding(
+        { existsSync, mkdirSync, readFileSync, writeFileSync, dirname },
+        paths,
+        questionUi,
+        ctx,
+      );
+      if (!installed) await openLoginIfNoModels(ctx);
       return;
     }
 
     if (setupMode === "create") {
-      await runCreateProfileOnboarding({ existsSync, mkdirSync, readFileSync, writeFileSync, dirname, join }, paths, questionUi);
-      await openLoginIfNoModels(ctx);
+      const installed = await runCreateProfileOnboarding(
+        { existsSync, mkdirSync, readFileSync, writeFileSync, dirname, join },
+        paths,
+        questionUi,
+        ctx,
+      );
+      if (!installed) await openLoginIfNoModels(ctx);
       return;
     }
 
-    await runDefaultCatalogOnboarding(
+    const installed = await runDefaultCatalogOnboarding(
       { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync, dirname, join },
       paths,
       questionUi,
+      ctx,
     );
-    await openLoginIfNoModels(ctx);
+    if (!installed) await openLoginIfNoModels(ctx);
   };
 
   pi.registerCommand("outfitter", {
@@ -532,9 +549,10 @@ const createOutfitterPaths = (join) => ({
   projectSettingsPath: join(OUTFITTER_PROJECT, ".outfitter", "settings.yml"),
   projectProfilesPath: join(OUTFITTER_PROJECT, ".outfitter", "profiles"),
   defaultProfilesPath: OUTFITTER_DEFAULT_PROFILES_PATH,
+  restartMarkerPath: join(OUTFITTER_HOME, ".outfitter", "runtime-onboarding-complete.json"),
 });
 
-const runDefaultCatalogOnboarding = async (fs, paths, questionUi) => {
+const runDefaultCatalogOnboarding = async (fs, paths, questionUi, ctx) => {
   const currentDefault = readCurrentDefaultProfile(paths.homeSettingsPath, fs.existsSync, fs.readFileSync);
   const profiles = discoverProfileChoices(fs, paths, currentDefault);
   if (profiles.length === 0) {
@@ -542,24 +560,24 @@ const runDefaultCatalogOnboarding = async (fs, paths, questionUi) => {
       "No profiles were found in the default Outfitter profile catalog. Fix the catalog sync or provide a different catalog.",
       "error",
     );
-    return;
+    return false;
   }
 
   const selectedProfile = await questionUi.selectProfile(profiles, currentDefault);
   if (selectedProfile === undefined) {
     questionUi.notify("Outfitter setup cancelled; no settings were changed.", "warning");
-    return;
+    return false;
   }
 
   if (!OUTFITTER_PROFILE_ID_PATTERN.test(selectedProfile.id)) {
     questionUi.notify("Selected profile id is not filesystem-safe; no settings were changed.", "error");
-    return;
+    return false;
   }
 
   const installTarget = await questionUi.selectInstallTarget(paths);
   if (installTarget === undefined) {
     questionUi.notify("Outfitter setup cancelled; no settings were changed.", "warning");
-    return;
+    return false;
   }
 
   fs.mkdirSync(fs.dirname(installTarget.settingsPath), { recursive: true });
@@ -575,23 +593,24 @@ const runDefaultCatalogOnboarding = async (fs, paths, questionUi) => {
     [
       "Outfitter saved default profile '" + selectedProfile.id + "' to " + installTarget.settingsPath + ".",
       "Profile choices were loaded from the default Outfitter profile catalog, not generated locally.",
-      "It applies on the next 'outfitter' launch; restart Outfitter to load the selected profile.",
+      "It applies on the next 'outfitter' launch; Outfitter will restart automatically to load the selected profile.",
     ].join("\n"),
     "info",
   );
+  return completeProfileInstall(fs, paths, questionUi, ctx);
 };
 
-const runCreateProfileOnboarding = async (fs, paths, questionUi) => {
+const runCreateProfileOnboarding = async (fs, paths, questionUi, ctx) => {
   const profileId = normalizeInputValue(await questionUi.input("Profile id", "my_profile"));
   if (!profileId || !OUTFITTER_PROFILE_ID_PATTERN.test(profileId)) {
     questionUi.notify("Profile id is not filesystem-safe; no settings were changed.", "error");
-    return;
+    return false;
   }
   const label = normalizeInputValue(await questionUi.input("Profile label", profileId));
   const installTarget = await questionUi.selectInstallTarget(paths);
   if (installTarget === undefined) {
     questionUi.notify("Outfitter setup cancelled; no settings were changed.", "warning");
-    return;
+    return false;
   }
 
   fs.mkdirSync(fs.dirname(installTarget.settingsPath), { recursive: true });
@@ -611,23 +630,24 @@ const runCreateProfileOnboarding = async (fs, paths, questionUi) => {
     [
       "Outfitter created profile '" + profileId + "' at " + profilePath + ".",
       "Outfitter saved settings to " + installTarget.settingsPath + ".",
-      "It applies on the next 'outfitter' launch; restart Outfitter to load the selected profile.",
+      "It applies on the next 'outfitter' launch; Outfitter will restart automatically to load the selected profile.",
     ].join("\n"),
     "info",
   );
+  return completeProfileInstall(fs, paths, questionUi, ctx);
 };
 
-const runRemoteSettingsOnboarding = async (fs, paths, questionUi) => {
+const runRemoteSettingsOnboarding = async (fs, paths, questionUi, ctx) => {
   const github = normalizeInputValue(await questionUi.input("GitHub catalog repo (owner/repo)", "my_account/outfitter_config"));
   const ref = normalizeInputValue(await questionUi.input("Catalog ref", "main")) || "main";
   const settingsPath = normalizeInputValue(await questionUi.input("Catalog settings path", "settings.yml")) || "settings.yml";
   if (!github || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(github)) {
     questionUi.notify("Catalog repo must use owner/repo syntax; no settings were changed.", "error");
-    return;
+    return false;
   }
   if (settingsPath.startsWith("/") || settingsPath.includes("..")) {
     questionUi.notify("Catalog settings path must stay inside the repository; no settings were changed.", "error");
-    return;
+    return false;
   }
 
   const privateCatalogOnboarding = await loadPrivateCatalogOnboarding();
@@ -637,7 +657,7 @@ const runRemoteSettingsOnboarding = async (fs, paths, questionUi) => {
     const accepted = await questionUi.confirmPrivateCatalog(github);
     if (!accepted) {
       questionUi.notify("Private catalog setup was cancelled; no settings were changed.", "warning");
-      return;
+      return false;
     }
 
     privateCatalogAccepted = true;
@@ -646,7 +666,7 @@ const runRemoteSettingsOnboarding = async (fs, paths, questionUi) => {
   const installTarget = await questionUi.selectInstallTarget(paths);
   if (installTarget === undefined) {
     questionUi.notify("Outfitter setup cancelled; no settings were changed.", "warning");
-    return;
+    return false;
   }
 
   if (privateCatalogAccepted) {
@@ -661,17 +681,18 @@ const runRemoteSettingsOnboarding = async (fs, paths, questionUi) => {
       ? "Outfitter enabled private profile catalogs in ~/.outfitter/settings.yml and saved this catalog."
       : [
           "Outfitter saved remote settings catalog to " + installTarget.settingsPath + ".",
-          "Run 'outfitter sync' or restart Outfitter after the catalog is reachable.",
+          "Outfitter will sync profiles and restart automatically after the catalog is installed.",
         ].join("\n"),
     "info",
   );
+  return completeProfileInstall(fs, paths, questionUi, ctx);
 };
 
-const runProvidedSourceOnboarding = async (fs, paths, questionUi, sourceUri) => {
+const runProvidedSourceOnboarding = async (fs, paths, questionUi, ctx, sourceUri) => {
   const installTarget = await questionUi.selectInstallTarget(paths);
   if (installTarget === undefined) {
     questionUi.notify("Outfitter setup cancelled; no settings were changed.", "warning");
-    return;
+    return false;
   }
 
   fs.mkdirSync(fs.dirname(installTarget.settingsPath), { recursive: true });
@@ -679,10 +700,42 @@ const runProvidedSourceOnboarding = async (fs, paths, questionUi, sourceUri) => 
   questionUi.notify(
     [
       "Outfitter saved setup source to " + installTarget.settingsPath + ".",
-      "Run 'outfitter sync' or restart Outfitter after the source is reachable.",
+      "Outfitter will sync profiles and restart automatically after the source is installed.",
     ].join("\n"),
     "info",
   );
+  return completeProfileInstall(fs, paths, questionUi, ctx);
+};
+
+const completeProfileInstall = (fs, paths, questionUi, ctx) => {
+  ensureHomeSetupExists(fs, paths);
+  fs.mkdirSync(fs.dirname(paths.restartMarkerPath), { recursive: true });
+  fs.writeFileSync(
+    paths.restartMarkerPath,
+    JSON.stringify({ completedAt: new Date().toISOString(), projectDirectory: OUTFITTER_PROJECT }, null, 2) + "\n",
+  );
+  questionUi.notify("Outfitter will sync profiles and restart automatically to apply the installed profile.", "info");
+  if (typeof ctx.shutdown === "function") ctx.shutdown();
+  return true;
+};
+
+const ensureHomeSetupExists = (fs, paths) => {
+  fs.mkdirSync(fs.dirname(paths.homeSettingsPath), { recursive: true });
+  fs.mkdirSync(paths.homeProfilesPath, { recursive: true });
+
+  if (!fs.existsSync(paths.homeSettingsPath)) {
+    fs.writeFileSync(paths.homeSettingsPath, createDefaultSettingsContent("engineer"));
+    return;
+  }
+
+  let content = fs.readFileSync(paths.homeSettingsPath, "utf8");
+  if (!/^default_profile:/mu.test(content)) {
+    content = content.replace(/\s*$/u, "\n") + "default_profile: engineer\n";
+  }
+  if (!/^profile_sources:/mu.test(content)) {
+    content = content.replace(/\s*$/u, "\n") + "profile_sources:\n  - github: ai-outfitter/default-profiles\n    path: profiles\n  - path: ./profiles\n";
+  }
+  fs.writeFileSync(paths.homeSettingsPath, content);
 };
 
 const normalizeInputValue = (value) => typeof value === "string" ? value.trim() : undefined;

--- a/code/cli/src/cli/commands/RunCommand.ts
+++ b/code/cli/src/cli/commands/RunCommand.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 // Provides the command object for launching selected profiles.
-import { existsSync, mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
@@ -46,7 +46,7 @@ import { launchAgentProcess, resolveAgentLaunchExecutable } from '../../agents/A
 import type { CommandObject } from './CommandObject.js';
 import { isNonInteractivePiLaunch, preparePiLoginLaunchPlan } from './PiLoginLaunch.js';
 import type { SetupCommandDependencies } from './SetupCommand.js';
-import { syncProfileSource, type RemoteProfileSource } from './SyncCommand.js';
+import { executeSyncCommand, syncProfileSource, type RemoteProfileSource } from './SyncCommand.js';
 
 export interface RunCommandInput {
   readonly homeDirectory: string;
@@ -174,6 +174,17 @@ export const executeRunCommand = async (
       dependencies.launcher ??
       /* v8 ignore next -- tests inject launchers instead of spawning pi. */ createSpawnLauncher();
     const exitCode = await launchAgentProcess(launcher, launchPlan, adapter.id);
+
+    const restartedResult = await relaunchAfterRuntimeOnboardingIfComplete(
+      input,
+      dependencies,
+      runtimeOnboarding,
+      watcher,
+    );
+    if (restartedResult !== undefined) {
+      return restartedResult;
+    }
+
     const stateWriteWarnings = handleCompositeProfileStateWrites(
       adapter.id,
       compositeProfilePlan.compositeProfile.rootDirectory,
@@ -449,6 +460,32 @@ const isInteractiveRunLaunch = (dependencies: RunCommandDependencies): boolean =
   const outputIsTty = (dependencies.output ?? process.stdout).isTTY === true;
 
   return inputIsTty && outputIsTty;
+};
+
+const relaunchAfterRuntimeOnboardingIfComplete = async (
+  input: RunCommandInput,
+  dependencies: RunCommandDependencies,
+  runtimeOnboarding: FirstRunRuntimeOnboarding | undefined,
+  watcher: { close(): void },
+): Promise<RunCommandResult | undefined> => {
+  if (runtimeOnboarding === undefined || !consumeRuntimeOnboardingRestartMarker(input)) {
+    return undefined;
+  }
+
+  executeSyncCommand(input, dependencies);
+  watcher.close();
+  return executeRunCommand({ ...input, forceRuntimeOnboarding: false, setupSourceUri: undefined }, dependencies);
+};
+
+const consumeRuntimeOnboardingRestartMarker = (input: RunCommandInput): boolean => {
+  const markerPath = join(input.homeDirectory, '.outfitter', 'runtime-onboarding-complete.json');
+
+  if (!existsSync(markerPath)) {
+    return false;
+  }
+
+  rmSync(markerPath, { force: true });
+  return true;
 };
 
 const createFirstRunBootstrapProfile = (input: RunCommandInput): ResolvedRunProfile => ({

--- a/code/cli/src/cli/commands/SetupCommand.ts
+++ b/code/cli/src/cli/commands/SetupCommand.ts
@@ -296,6 +296,12 @@ const executeInteractiveSetupSourceCommand = async ({
 }: InteractiveSetupSourceCommandInput): Promise<SetupCommandResult> => {
   const onboarding = await runSetupSourceOnboarding(input, dependencies, starterLayout, currentDefaultProfileId);
   const appliedImport = applySetupSourceImport(input, starterLayout, onboarding);
+  const homeSetupMessage = ensureHomeSetupAfterProjectSetupSourceImport(
+    input,
+    homeSettingsPath,
+    initialSettingsMissing,
+    onboarding.importTarget,
+  );
   /* v8 ignore next -- setup-source rollback only runs when a home import creates settings and default-profile sync fails. */
   const rollbackCreatedSettings = appliedImport.createdSettings
     ? () => rmSync(appliedImport.settingsPath, { force: true })
@@ -340,10 +346,12 @@ const executeInteractiveSetupSourceCommand = async ({
       defaultProfilePath,
       createdDefaultProfile,
       syncResult,
-      welcomeProfileMessages:
-        appliedImport.selectedProfileConflictMessage === undefined
+      welcomeProfileMessages: [
+        ...(homeSetupMessage === undefined ? [] : [homeSetupMessage]),
+        ...(appliedImport.selectedProfileConflictMessage === undefined
           ? []
-          : [appliedImport.selectedProfileConflictMessage],
+          : [appliedImport.selectedProfileConflictMessage]),
+      ],
       runExampleMessages:
         postImportAction === 'exit'
           ? formatSetupSourceExitMessages(
@@ -355,6 +363,24 @@ const executeInteractiveSetupSourceCommand = async ({
           : [],
     }),
   };
+};
+
+const ensureHomeSetupAfterProjectSetupSourceImport = (
+  input: SetupCommandInput,
+  homeSettingsPath: string,
+  initialSettingsMissing: boolean,
+  importTarget: SetupSourceImportTarget,
+): string | undefined => {
+  if (!initialSettingsMissing || importTarget !== 'project') {
+    return undefined;
+  }
+
+  const createdHomeSettings = createInitialSettingsIfMissing(homeSettingsPath);
+  mkdirSync(join(input.homeDirectory, '.outfitter', 'profiles'), { recursive: true });
+
+  return createdHomeSettings
+    ? `Created user settings at ${homeSettingsPath} so later Outfitter launches do not repeat first-run setup.`
+    : undefined;
 };
 
 interface FinalDefaultProfile {

--- a/code/cli/src/cli/commands/SyncCommand.ts
+++ b/code/cli/src/cli/commands/SyncCommand.ts
@@ -26,6 +26,7 @@ import {
   discoverSettingsLoadPlan,
   loadSettings,
   loadSettingsWithCachedRemoteSettings,
+  resolveCachedRemoteSettingsPath,
 } from '../../settings/SettingsLoader.js';
 import type { CommandObject } from './CommandObject.js';
 
@@ -170,8 +171,8 @@ const syncRemoteSettingsSource = (
   const displayUri = formatDisplayUri(source);
 
   try {
-    const settingsPath = resolveRemoteRepositorySubpath(cachePath, source.path);
     const status = synchronizer.sync(source, cachePath);
+    const settingsPath = resolveCachedRemoteSettingsPath(homeDirectory, source);
 
     if (!existsSync(settingsPath)) {
       return {

--- a/code/cli/src/settings/SettingsLoader.ts
+++ b/code/cli/src/settings/SettingsLoader.ts
@@ -94,6 +94,18 @@ export const discoverRemoteSettingsLoadPlan = (
   remoteSettings: readonly RemoteSettingsReference[],
 ): SettingsLoadPlan => discoverRemoteSettingsLocations(homeDirectory, remoteSettings).plan;
 
+export const resolveCachedRemoteSettingsPath = (homeDirectory: string, source: RemoteSettingsReference): string => {
+  const repositoryPath = createRemoteRepositoryCachePath(homeDirectory, source);
+  const configuredPath = resolveRemoteRepositorySubpath(repositoryPath, source.path);
+
+  if (existsSync(configuredPath) || source.path !== 'settings.yml') {
+    return configuredPath;
+  }
+
+  const nestedOutfitterSettingsPath = resolveRemoteRepositorySubpath(repositoryPath, '.outfitter/settings.yml');
+  return existsSync(nestedOutfitterSettingsPath) ? nestedOutfitterSettingsPath : configuredPath;
+};
+
 export const loadSettingsFiles = (plan: SettingsLoadPlan): SettingsLoadResult => {
   const files: LoadedSettingsFile[] = [];
   const issues: SettingsLoadIssue[] = [];
@@ -151,7 +163,7 @@ const discoverRemoteSettingsLocations = (
     try {
       locations.push({
         scope: 'remote',
-        path: resolveRemoteRepositorySubpath(createRemoteRepositoryCachePath(homeDirectory, source), source.path),
+        path: resolveCachedRemoteSettingsPath(homeDirectory, source),
       });
     } catch (error) {
       issues.push({

--- a/code/cli/tests/unit/pi-login-launch.test.ts
+++ b/code/cli/tests/unit/pi-login-launch.test.ts
@@ -215,6 +215,7 @@ const createMockContext = (
   const headerRenders: string[][] = [];
   const customRenders: string[][] = [];
   const submittedInputs: string[] = [];
+  let shutdowns = 0;
   const selectedOptions = [...(options.selectedOptions ?? [])];
   const inputValues = [...(options.inputValues ?? [])];
   const nextSelectedOption = (fallback: string): string | undefined =>
@@ -235,6 +236,9 @@ const createMockContext = (
     inputCalls,
     selectCalls,
     submittedInputs,
+    get shutdowns() {
+      return shutdowns;
+    },
     get terminalInputHandler() {
       return terminalInputHandler;
     },
@@ -327,6 +331,9 @@ const createMockContext = (
         bold: (text: string) => text,
         fg: (_color: string, text: string) => text,
       },
+    },
+    shutdown: () => {
+      shutdowns += 1;
     },
   };
 };
@@ -801,7 +808,15 @@ describe('preparePiLoginLaunchPlan', () => {
         '',
       ].join('\n'),
     );
-    expect(existsSync(join(homeDirectory, '.outfitter', 'settings.yml'))).toBe(false);
+    expect(readFileSync(join(homeDirectory, '.outfitter', 'settings.yml'), 'utf8')).toContain(
+      'default_profile: engineer',
+    );
+    expect(readFileSync(join(homeDirectory, '.outfitter', 'settings.yml'), 'utf8')).toContain(
+      'github: ai-outfitter/default-profiles',
+    );
+    expect(existsSync(join(homeDirectory, '.outfitter', 'runtime-onboarding-complete.json'))).toBe(true);
+    expect(context.shutdowns).toBe(1);
+    expect(context.notifications.join('\n')).toContain('restart automatically');
     expect(context.customRenders[1]?.join('\n')).toContain('→ Current project directory (.outfitter)');
     expect(context.customRenders[1]?.join('\n')).toContain(
       'These profiles will only be available in the current project directory and',

--- a/code/cli/tests/unit/profile-command.test.ts
+++ b/code/cli/tests/unit/profile-command.test.ts
@@ -13,7 +13,7 @@ import {
   executeProfileLintCommand,
 } from '../../src/cli/commands/profile/Command.js';
 import { createSetupCommand } from '../../src/cli/commands/SetupCommand.js';
-import { createSyncCommand } from '../../src/cli/commands/SyncCommand.js';
+import { createSyncCommand, executeSyncCommand } from '../../src/cli/commands/SyncCommand.js';
 import { createProfileSourceCachePath, createRemoteRepositoryCachePath } from '../../src/profiles/ProfileCache.js';
 
 const temporaryRoots: string[] = [];
@@ -184,6 +184,39 @@ describe('profile command', () => {
         setupSourceUri: 'https://example.test/catalog.git',
       },
     ]);
+  });
+
+  it('resolves remote settings from nested .outfitter/settings.yml when root settings.yml is absent', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const setupSourceUri = join(root, 'link');
+    writeSettings(
+      homeDirectory,
+      ['remote_settings:', `  - uri: ${JSON.stringify(setupSourceUri)}`, '    path: settings.yml', ''].join('\n'),
+    );
+
+    const result = executeSyncCommand(
+      { homeDirectory, projectDirectory },
+      {
+        repositoryVisibilityClassifier: { classify: () => 'unknown' },
+        synchronizer: {
+          sync(_source, cachePath) {
+            mkdirSync(join(cachePath, '.outfitter'), { recursive: true });
+            writeFileSync(
+              join(cachePath, '.outfitter', 'settings.yml'),
+              'profile_sources:\n  - github: ai-outfitter/default-profiles\n    path: profiles\n',
+            );
+            mkdirSync(join(cachePath, 'profiles'), { recursive: true });
+            return 'updated';
+          },
+        },
+      },
+    );
+
+    expect(result.messages.join('\n')).toContain('.outfitter/settings.yml');
+    expect(result.sources[0]?.status).toBe('updated');
+    expect(result.sources[0]?.message).toContain('Remote settings file available');
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.7, OFTR-004.5).

--- a/code/cli/tests/unit/run-command.test.ts
+++ b/code/cli/tests/unit/run-command.test.ts
@@ -235,6 +235,58 @@ describe('run command', () => {
     expect(existsSync(join(homeDirectory, '.outfitter', 'settings.yml'))).toBe(false);
   });
 
+  it('syncs configured sources and relaunches after Pi-native runtime onboarding completes', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const launches: unknown[] = [];
+    const syncedSources: unknown[] = [];
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        interactive: true,
+        writeLine: () => undefined,
+        synchronizer: {
+          sync(source, cachePath) {
+            syncedSources.push(source);
+            writeProfile(join(cachePath, 'profiles'), 'founder', 'id: founder\ncontrols: {}\n');
+            return 'updated';
+          },
+        },
+        launcher: {
+          launch(plan) {
+            launches.push(plan);
+            if (launches.length === 1) {
+              mkdirSync(join(homeDirectory, '.outfitter'), { recursive: true });
+              writeFileSync(
+                join(homeDirectory, '.outfitter', 'settings.yml'),
+                [
+                  'default_profile: founder',
+                  'profile_sources:',
+                  '  - github: ai-outfitter/default-profiles',
+                  '    path: profiles',
+                  '  - path: ./profiles',
+                  '',
+                ].join('\n'),
+              );
+              writeFileSync(join(homeDirectory, '.outfitter', 'runtime-onboarding-complete.json'), '{}\n');
+            }
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(launches).toHaveLength(2);
+    expect(result.profileId).toBe('founder');
+    expect(existsSync(join(homeDirectory, '.outfitter', 'runtime-onboarding-complete.json'))).toBe(false);
+    expect(syncedSources).toEqual([
+      { github: 'ai-outfitter/default-profiles', path: 'profiles' },
+      { github: 'ai-outfitter/default-profiles', path: 'profiles' },
+    ]);
+  });
+
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.4).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('emits runtime login kickoff guidance when no native login state is configured', async () => {

--- a/code/cli/tests/unit/setup-command.test.ts
+++ b/code/cli/tests/unit/setup-command.test.ts
@@ -791,6 +791,52 @@ describe('setup command', () => {
     }
   });
 
+  it('creates home setup state when first-run setup-source import targets the project', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+
+    const result = await executeSetupCommand(
+      { homeDirectory, projectDirectory, setupSourceUri: 'https://example.test/link-profiles' },
+      {
+        interactive: true,
+        input: { isTTY: true } as NodeJS.ReadableStream & { isTTY: true },
+        output: { isTTY: true } as NodeJS.WritableStream & { isTTY: true },
+        writeLine: () => undefined,
+        setupSourceSynchronizer: {
+          sync(_uri, cachePath) {
+            const outfitterDirectory = join(cachePath, '.outfitter');
+            mkdirSync(join(outfitterDirectory, 'profiles', 'founder'), { recursive: true });
+            writeFileSync(join(outfitterDirectory, 'settings.yml'), 'default_profile: founder\n');
+            writeFileSync(
+              join(outfitterDirectory, 'profiles', 'founder', 'profile.yml'),
+              'id: founder\ncontrols: {}\n',
+            );
+          },
+        },
+        selectSetupSourceImportTarget() {
+          return Promise.resolve('project');
+        },
+        selectSetupSourceImportMode() {
+          return Promise.resolve('copy');
+        },
+        selectDefaultProfile() {
+          return Promise.resolve('founder');
+        },
+        selectSetupSourceLaunchAction() {
+          return Promise.resolve('exit');
+        },
+      },
+    );
+
+    expect(result.settingsPath).toBe(join(projectDirectory, '.outfitter', 'settings.yml'));
+    expect(readFileSync(join(homeDirectory, '.outfitter', 'settings.yml'), 'utf8')).toContain(
+      'github: ai-outfitter/default-profiles',
+    );
+    expect(existsSync(join(homeDirectory, '.outfitter', 'profiles'))).toBe(true);
+    expect(result.messages.join('\n')).toContain('so later Outfitter launches do not repeat first-run setup');
+  });
+
   it('imports setup-source profiles into the project without changing the user default', async () => {
     const root = createTemporaryRoot();
     const homeDirectory = join(root, 'home');

--- a/docs/archtecture/onboarding.md
+++ b/docs/archtecture/onboarding.md
@@ -53,8 +53,10 @@ flowchart TD
   Q --> T{Install target}
   T -- Home --> U[Write ~/.outfitter/settings.yml]
   T -- Project --> V[Write <project>/.outfitter/settings.yml]
-  U --> W[Notify restart required for selected profile]
+  U --> W[Write completion marker]
   V --> W
+  W --> X[Sync configured sources]
+  X --> Y[Restart/relaunch with installed profile]
 ```
 
 ## Native Command and Agent-Turn Boundary
@@ -145,7 +147,7 @@ Private catalog setup was cancelled; no settings were changed.
 
 If the home setting is already enabled, onboarding skips the private-catalog enterprise prompt and saves the catalog normally. Outfitter does not collect, echo, persist, synthesize, or validate provider credentials.
 
-The final install target question writes either `~/.outfitter/settings.yml` or `<project>/.outfitter/settings.yml`. Profile changes selected after Pi has already started apply to the next `outfitter` launch, so onboarding must communicate that restart boundary.
+The final install target question writes either `~/.outfitter/settings.yml` or `<project>/.outfitter/settings.yml`. If a first-run user chooses the project target while home settings are missing, onboarding also creates valid home setup state so later launches do not repeat first-run onboarding. Profile changes selected after Pi has already started apply to the next `outfitter` launch, so completed onboarding writes a restart marker, shuts down the bootstrap Pi process, lets the CLI run `outfitter sync`, and relaunches with the installed profile.
 
 The install target prompt SHOULD also use `selectDescribedOption`, because the distinction between user-wide and project-local settings is semantic, not just locational. Required copy:
 

--- a/docs/milestones/M1-initial-release/README.md
+++ b/docs/milestones/M1-initial-release/README.md
@@ -1,0 +1,130 @@
+# M1: Initial Release
+
+## Tracker
+
+- Provider: GitHub
+- Provider milestone: [Initial Release](https://github.com/ai-outfitter/outfitter/milestone/1)
+- Provider ID: `1`
+- Milestone key: `M1-initial-release`
+- Branch: `milestone/M1-initial-release`
+- Worktree: `/home/ncrmro/repos/unsupervised/worktrees/outfitter/milestone/M1-initial-release`
+- Status: planned
+
+## Customer deliverable
+
+Outfitter's initial release gets a new user from first install to a useful Pi session without configuration spelunking. The release centers on two business/user requirements:
+
+1. **Easy onboarding:** a new user SHOULD be able to start Outfitter, choose the recommended founder/default catalog path inside Pi, and reach a useful Pi session without profile/source/extension spelunking.
+2. **Welcome flow:** a new user MUST see guided Outfitter/Pi onboarding before setup decisions, and provider credential entry MUST remain inside Pi.
+
+The merged Pi-native welcome/onboarding PR belongs to M1 onboarding scope. PR #94 / commit `65037fc` is assigned to the GitHub `Initial Release` milestone and is mapped in `evidence/onboarding-pr-94.md`.
+
+## Requirements in scope
+
+- `docs/requirements/OFTR-004-sync-and-setup.md`
+  - OFTR-004.1.1-6: setup launches Pi-native onboarding, preserves `setup <source>`, and creates home setup state for first-run project installs.
+  - OFTR-004.2.1-18: sync validates settings, synchronizes remote settings/profile sources, redacts credentials, gates private catalogs, and resolves nested `.outfitter/settings.yml` for setup-style sources.
+- `docs/requirements/OFTR-010-onboarding-welcome.md`
+  - OFTR-010.1: default interactive first-run launches Pi with a bootstrap extension, registers native `/outfitter`, avoids agent/model turns, and does not mutate settings in non-interactive launches.
+  - OFTR-010.2: Pi-native onboarding asks setup mode, reads catalog profiles from the synced default source, selects install target, creates home setup state for project installs, syncs, and restarts/relaunches after install.
+  - OFTR-010.3: onboarding UI keeps credential collection outside Outfitter prompts and explains profiles/settings/catalogs with Outfitter branding.
+  - OFTR-010.4: Pi login setup MUST be delegated to Pi without Outfitter collecting provider credentials.
+  - OFTR-010.5: explicit terminal setup compatibility remains through Pi-native setup launch behavior and published fallback guidance.
+
+## Requirements out of scope
+
+- Organization profile catalog management beyond what the founder profile and default Outfitter skill require.
+- Container launch backends, trusted publishing, release provenance, and other platform-only work unless needed to unblock the initial release.
+- Setup-source symlink mode refinements beyond preserving the already specified behavior.
+- New remote provider integrations or provider credential collection.
+- Target conformance reports.
+
+## Press release
+
+Outfitter's initial release turns Pi setup into a guided first run. Start Outfitter, complete native `/outfitter` onboarding inside Pi, and Pi restarts with the selected profile/catalog instead of asking new users to assemble profiles, extensions, and login steps manually. Provider credential entry stays in Pi's `/login` flow.
+
+## Internal FAQ
+
+**Who is this for?** New Pi users, founder-operators, and engineers who want a productive agentic coding setup without manually composing profiles and extensions.
+
+**What is the default path?** Choose the default Outfitter profile catalog, select the recommended founder profile when present, pick the install target, and let Outfitter sync/restart so Pi loads the installed profile.
+
+**What if the user chooses project install on a fresh machine?** Outfitter writes the project settings and also creates a valid home setup state so later launches do not repeat first-run onboarding.
+
+**Does Outfitter collect API keys?** No. Outfitter may detect missing Pi login state and open Pi's `/login` flow, but credential entry stays inside Pi.
+
+**Can support tell users to rerun setup?** Yes, but support MUST distinguish first-run welcome onboarding from later setup/profile management. Later customization happens through `/outfitter` or `outfitter profile list`.
+
+**What should engineering preserve?** Pi-native `/outfitter` onboarding, default-catalog profile choices loaded from synchronized catalog data, deterministic founder recommendation when available, no provider credential collection, home setup state for first-run project installs, and automatic sync/restart after install.
+
+## ASCII mockup
+
+```text
+  ____        _    __ _ _   _
+ / __ \      | |  / _(_) | | |
+| |  | |_   _| |_| |_ _| |_| |_ ___ _ __
+| |  | | | | | __|  _| | __| __/ _ \ '__|
+| |__| | |_| | |_| | | | |_| ||  __/ |
+ \____/ \__,_|\__|_| |_|\__|\__\___|_|
+
+Pi is a fully extensible agentic coding harness.
+The founder profile brings Pi to feature parity with dedicated agentic coding tools.
+Run /outfitter inside Pi at any time to customize your profile.
+
+How would you like to set up Outfitter?
+→ Use the default Outfitter profile catalog
+  Create your own profile
+  Provide a different catalog to import
+```
+
+## Expected KPI movement
+
+Outfitter does not yet have a dedicated `docs/mission.md` KPI table. M1 will therefore record initial-release measurements in the milestone evidence before close:
+
+- `M1-KPI-1` — First-run happy-path completion: target 100% pass rate for the automated fresh-home onboarding scenario before release handoff; measurement window: release-candidate validation.
+- `M1-KPI-2` — Prompt count on recommended path: target only the required Pi-native setup decisions before restart/relaunch, excluding Pi-native `/login`; measurement window: release-candidate validation.
+- `M1-KPI-3` — Welcome requirement coverage: target tests or captured session evidence proving branded welcome text, accept path, decline path, and Pi login handoff; measurement window: release-candidate validation.
+
+Follow-up governance SHOULD add durable project KPIs to `docs/mission.md`; that work is not required to ship M1.
+
+## E2E happy-path test
+
+1. Start from a fresh temporary home with no existing `~/.outfitter` and no Pi auth/model state.
+2. Run the default interactive `outfitter` entry point.
+3. Confirm Pi launches with the Outfitter bootstrap extension and auto-opens native `/outfitter` without sending an agent/model message.
+4. Choose the default Outfitter profile catalog and the recommended founder profile when present.
+5. Confirm Outfitter writes `~/.outfitter/settings.yml`, synchronizes configured sources, and automatically restarts/relaunches with the installed profile.
+6. Confirm project-target first-run setup also creates home setup state so later launches do not repeat onboarding.
+7. Confirm missing Pi login state is delegated to Pi's `/login` flow without Outfitter collecting credentials.
+
+## Post-release test plan
+
+- **Immediately after release candidate build:** run unit, lint, typecheck, and fresh-home onboarding tests. Roll back if the accepted path asks for extra profile/loadout decisions or fails to launch Pi.
+- **Dogfood within 24 hours:** run the published package or release artifact in a clean temp home and capture the prompt transcript. Roll back if welcome text is missing, the founder path is not default, or `/login` handling leaks credentials into Outfitter.
+- **After first external user or dogfood install:** record whether the user reached Pi from the default path without operator intervention. Roll back or patch if onboarding requires undocumented setup steps.
+
+## Feature flags and rollout plan
+
+- Feature flag: Not needed — M1 is the initial release onboarding surface, and hiding it would remove the release's primary customer value.
+- Preview cohort: maintainer dogfood from clean temporary homes and local packaged builds.
+- Rollout cohort: first public initial-release users.
+- Full release: publish once automated validation and one dogfood transcript pass.
+- Rollback path: hold or deprecate the release artifact; patch the setup/welcome command path; keep credential/login handling inside Pi.
+
+## Acceptance criteria
+
+- A fresh user CAN complete Pi-native onboarding without profile/source/extension spelunking.
+- The recommended path SHOULD select founder when the synced default catalog contains it.
+- Interactive first-run/setup paths in M1 scope MUST run guided native `/outfitter` onboarding before setup writes.
+- Project-target first-run installs SHOULD create home setup state to avoid repeated onboarding on later launches.
+- Completed onboarding SHOULD synchronize configured sources and restart/relaunch so the installed profile is active.
+- Missing Pi login state MUST be handled by Pi's `/login` flow, not by Outfitter credential collection.
+- Requirement 2's merged welcome-flow work MUST be associated with M1 onboarding scope through GitHub milestone metadata or a follow-up governance commit.
+- Release handoff MUST include automated validation evidence and at least one dogfood transcript or equivalent session log.
+
+## Risks and open questions
+
+- **Merged PR scope drift:** The welcome-flow PR was merged before this milestone dossier; mitigate by amending metadata where safe or adding a follow-up governance commit.
+- **Prompt regression:** Setup-source and first-run setup paths can diverge; mitigate with tests covering accepted, declined, and setup-source paths.
+- **Credential boundary:** Login convenience can accidentally become credential handling; keep `/login` inside Pi and test non-interactive output streams.
+- **Missing durable KPIs:** Outfitter has requirements but no mission KPI table; add project KPIs after M1 planning if governance needs release-over-release measurement.

--- a/docs/milestones/M1-initial-release/evidence/onboarding-pr-94.md
+++ b/docs/milestones/M1-initial-release/evidence/onboarding-pr-94.md
@@ -1,0 +1,47 @@
+# M1 onboarding evidence: PR #94
+
+## Provider metadata
+
+- GitHub PR: <https://github.com/ai-outfitter/outfitter/pull/94>
+- PR title: `feat(onboarding): add pi-native first-run setup`
+- Merge commit: `65037fc3399826871768bd594340caee217a74e4`
+- Merged: 2026-06-30
+- GitHub milestone action: assigned PR #94 to milestone `Initial Release` on 2026-07-02 through `gh pr edit 94 --milestone "Initial Release"`.
+- History action: no commit was amended and no published history was rewritten.
+
+## M1 requirement coverage
+
+### Requirement 1 — Easy onboarding
+
+PR #94 moved first-run setup into Pi-native `/outfitter` onboarding. The implementation launches Pi with a bootstrap extension when interactive first-run settings are absent, synchronizes the default profile catalog, presents catalog/profile/install-target choices, and keeps non-interactive launches from prompting or mutating settings.
+
+Follow-up work in this branch tightens the first-run project-install path: when a fresh user chooses a project install, Outfitter also creates valid home setup state, then syncs and relaunches after install so the selected profile can become active without a manual second command.
+
+### Requirement 2 — Welcome flow and credential boundary
+
+PR #94 registers a native Pi command with `pi.registerCommand("outfitter", ...)`, opens it without sending an agent/model message, renders Outfitter-branded startup/onboarding copy, and delegates missing provider setup to Pi's `/login` flow. Outfitter does not collect, echo, or persist provider credentials.
+
+## Requirement traceability
+
+- `docs/requirements/OFTR-010-onboarding-welcome.md`
+  - OFTR-010.1: native Pi first-run entry, extension command dispatch, non-interactive no-mutation boundary, exact project trust.
+  - OFTR-010.2: setup mode, synced default catalog, profile picker, install target, project/home persistence, home setup state for first-run project installs, sync/restart after install.
+  - OFTR-010.3: Pi UI surface and credential-prompt boundary.
+  - OFTR-010.4: Pi `/login` handoff and no Outfitter credential handling.
+  - OFTR-010.5: explicit terminal setup compatibility through Pi-native setup launch behavior.
+- `docs/requirements/OFTR-004-sync-and-setup.md`
+  - OFTR-004.1: `setup` launches Pi-native onboarding and preserves `setup <source>`.
+  - OFTR-004.1.6: first-run project setup-source installs create home setup state.
+  - OFTR-004.2.18: sync resolves setup-style cached `.outfitter/settings.yml` when `path: settings.yml` is configured and no root file exists.
+
+## Validation evidence from this branch
+
+- `npm test --workspace @ai-outfitter/outfitter -- tests/unit/pi-login-launch.test.ts tests/unit/run-command.test.ts tests/unit/setup-command.test.ts tests/unit/setup-sources.test.ts tests/unit/profile-command.test.ts` — 5 files, 76 tests passed.
+- `npm run typecheck` — passed.
+- `npm run lint` — passed.
+
+## Scope caveats
+
+- GitHub fetch through the configured SSH remote failed with `Permission denied (publickey)`; latest `main` was fetched through a one-off HTTPS fetch without changing remotes.
+- No target conformance report was generated.
+- Release creation, publishing, tagging, and pushing were not performed.

--- a/docs/milestones/M1-initial-release/plan.md
+++ b/docs/milestones/M1-initial-release/plan.md
@@ -1,0 +1,201 @@
+> **Execution**: Before starting implementation, complete the DeepPlan
+> workflow by calling `deepwork_finished_step` on the `present_plan` step, then
+> call `deepwork_start_workflow` with job_name=`<session_job_name>`, workflow_name=`main`.
+
+# M1 Initial Release Implementation Plan
+
+## Goal
+
+Ship Outfitter M1 Initial Release readiness by completing the enterprise/business-license boundary work. Onboarding and welcome-flow implementation are considered complete; M1 release creation will be handled by release-please/release automation, not by a manual release PR in this plan.
+
+## Execution note: 2026-07-02 onboarding maintenance
+
+After this plan was written, maintainer/user direction added urgent M1 onboarding requirements: project-target first-run setup must create home setup state, installed profiles should auto-sync, and Outfitter should restart/relaunch after install. Those requirements are tracked in `docs/requirements/OFTR-004-sync-and-setup.md`, `docs/requirements/OFTR-010-onboarding-welcome.md`, and `evidence/onboarding-pr-94.md`; they do not reopen the older terminal-only welcome direction.
+
+## Scope correction from maintainer feedback
+
+Maintainer direction supersedes the earlier onboarding-heavy draft:
+
+- Do **not** plan more onboarding implementation for M1; it is done.
+- Do **not** plan manual release creation; release-please owns release generation.
+- Focus M1 execution on enterprise business-license changes.
+- The `code/enterprise` subtree must carry a different restrictive license.
+- Use the Panopticon licensing pattern from `https://github.com/Unsupervisedcom/panopticon/blob/main/LICENSE`.
+
+The referenced Panopticon root license pattern says, in substance:
+
+- content under the enterprise directory is licensed under that directory's license;
+- content outside that restricted directory remains under the root open license.
+
+## Current repository observations
+
+- Current root license file: `LICENSE.md`
+- Current package metadata: `package.json` has `"license": "BUSL-1.1"`
+- Current npm package files include `LICENSE.md`, but do not include a `code/enterprise` entry.
+- No `code/enterprise` directory currently exists in the M1 worktree.
+- The currently checked-in `LICENSE.md` is already a Business Source License 1.1 for Outfitter.
+
+## Product/legal implementation decision
+
+M1 should establish a clear split-license layout:
+
+1. Root project files and non-enterprise code use the primary project license declared at the repository root.
+2. `code/enterprise/**` uses its own restrictive enterprise license from `code/enterprise/LICENSE`.
+3. Root license text must conspicuously point readers to the enterprise carve-out, following the Panopticon root-license pattern.
+4. Package metadata and published package contents must not accidentally hide or misrepresent the enterprise license boundary.
+
+Because the public Panopticon repository currently exposes the root split-license notice but does not expose an `enterprise/LICENSE` file, implementation should use the root notice pattern exactly and place Outfitter's restrictive Business Source License terms in `code/enterprise/LICENSE` unless maintainers provide a different enterprise license text before execution.
+
+## PR plan and expected commits
+
+### PR 1 — Split-license governance and repository metadata
+
+**Branch:** `chore/m1-enterprise-license-boundary`  
+**Title:** `chore(license): define enterprise license boundary`
+
+Expected commits:
+
+- `chore(license): define enterprise license boundary`
+
+Likely affected files:
+
+- `LICENSE.md`
+- `code/enterprise/LICENSE` (new)
+- `code/enterprise/README.md` (new, if needed for discoverability)
+- `package.json`
+- `README.md` or docs license page if one exists
+
+Implementation checklist:
+
+- Update root `LICENSE.md` to use the Panopticon-style split-license notice:
+  - enterprise subtree: `code/enterprise/**` is licensed under `code/enterprise/LICENSE`;
+  - everything outside that subtree is licensed under the root license terms.
+- Create `code/enterprise/LICENSE` with the restrictive enterprise/business license text.
+  - Default license text: current Outfitter Business Source License 1.1 terms from existing `LICENSE.md`.
+  - If legal/maintainers provide a different enterprise license, use that exact text instead.
+- Add `code/enterprise/README.md` only if helpful to make the boundary obvious to package consumers and contributors.
+- Update `package.json` license metadata to avoid falsely describing the whole package as a single uniform license if root code becomes open while enterprise remains restricted.
+  - Preferred SPDX expression if compatible with final root license: `MIT AND LicenseRef-Outfitter-Enterprise` or similar.
+  - If the project remains all-BUSL outside enterprise, keep `BUSL-1.1` but still include the enterprise carve-out.
+- Update package `files` only if `code/enterprise` is intended to be published.
+  - If enterprise code should be published, include `code/enterprise` and its license.
+  - If enterprise code should not be published, explicitly document that and ensure package contents do not include it accidentally.
+
+Acceptance criteria:
+
+- A reader can determine the license for `code/enterprise/**` without ambiguity.
+- A reader can determine the license for all non-enterprise repository content without ambiguity.
+- Root license file follows the Panopticon-style enterprise carve-out.
+- The restrictive enterprise license is present in `code/enterprise/LICENSE`.
+- Package metadata and package contents reflect the split-license model.
+- No onboarding code changes are included in this PR.
+
+Validation evidence:
+
+```bash
+npm run typecheck
+npm run lint
+npm test
+npm pack --dry-run
+```
+
+Manual validation:
+
+- Inspect `npm pack --dry-run` output and confirm the intended license files are included.
+- Confirm `LICENSE.md` and `code/enterprise/LICENSE` are both present where expected.
+- Confirm package metadata does not claim a misleading single license for differently licensed content.
+
+### PR 2 — Enterprise subtree scaffolding/package safeguards, if needed
+
+**Branch:** `chore/m1-enterprise-package-safeguards`  
+**Title:** `chore(enterprise): guard licensed package boundaries`
+
+Expected commits:
+
+- `chore(enterprise): guard licensed package boundaries`
+
+Likely affected files:
+
+- `code/enterprise/**`
+- `.npmignore` or `package.json` `files`
+- `scripts/*` if a packaging/license verification script is added
+- `tests/*` only if the repo has package-manifest tests
+
+Implementation checklist:
+
+- Decide whether `code/enterprise` is included in the public npm package.
+- Add a lightweight package/license verification check if current tooling has no coverage.
+- Ensure future enterprise code added under `code/enterprise` cannot be published without its license notice.
+- Ensure generated artifacts do not copy enterprise code into a differently licensed path without preserving notice.
+
+Acceptance criteria:
+
+- `npm pack --dry-run` proves the intended inclusion/exclusion of `code/enterprise`.
+- If enterprise files are included, their restrictive license file is included.
+- If enterprise files are excluded, the root docs still explain where enterprise code lives in source and why it is not in the package.
+- CI or documented release validation includes a package license-boundary check.
+
+Validation evidence:
+
+```bash
+npm pack --dry-run
+npm run check-ci
+```
+
+If `check-ci` is unavailable or too broad for the branch, run:
+
+```bash
+npm run typecheck
+npm run lint
+npm test
+```
+
+## Onboarding / welcome-flow disposition
+
+No new onboarding work is planned. Existing M1 onboarding and welcome-flow work remains associated with M1 as already merged. If metadata can be edited safely in GitHub, add the relevant merged PR/commit to the `Initial Release` milestone. Do not rewrite published history solely to amend commit metadata.
+
+## Release automation disposition
+
+No manual release PR is planned. Release-please should create release artifacts after the M1 branch has the required license-boundary commits and validation passes.
+
+Release validation before allowing release-please to proceed should include:
+
+```bash
+npm run typecheck
+npm run lint
+npm test
+npm pack --dry-run
+```
+
+## KPI expectations
+
+The maintainer-confirmed M1 implementation focus is licensing/release readiness, while onboarding implementation is already complete. KPI evidence should therefore be recorded as follows:
+
+- `M1-KPI-1` — First-run happy-path completion: use existing onboarding validation evidence from the merged welcome/onboarding work; no new onboarding implementation required.
+- `M1-KPI-2` — Prompt count on accepted path: use existing welcome/onboarding validation evidence; no new onboarding implementation required.
+- `M1-KPI-3` — Welcome requirement coverage: use existing test/session evidence from merged onboarding work; no new onboarding implementation required.
+- `M1-KPI-4` — Enterprise license boundary readiness: `code/enterprise/LICENSE`, root carve-out notice, package metadata, and package dry-run evidence are complete before release automation.
+
+## E2E / release-readiness test plan
+
+1. Run existing onboarding validation/tests to confirm no regression from license-only changes.
+2. Run `npm pack --dry-run`.
+3. Inspect package contents for license files and `code/enterprise` inclusion/exclusion.
+4. Confirm root `LICENSE.md` points to `code/enterprise/LICENSE` for enterprise code.
+5. Confirm release-please sees only the intended commits and can generate the release without manual release-file edits.
+
+## Feature flag and rollout
+
+- Feature flag: not needed. License-boundary changes are repository/package governance, not runtime behavior.
+- Rollout path: merge license-boundary PR(s) into the M1 milestone branch, validate package contents, then allow release-please to create the release.
+- Rollback path: revert the license-boundary commit(s) before release if legal/package validation fails. If already released, publish a corrected patch release and update repository license notices immediately.
+
+## Dependencies
+
+No new runtime dependencies are planned. No new product libraries are needed.
+
+## Open questions for execution
+
+- What is the intended root non-enterprise license after adopting the Panopticon pattern: MIT like Panopticon, current BUSL-1.1, or another license?
+- Should `code/enterprise` be included in the npm package or kept source-only?
+- Is current Outfitter `LICENSE.md` the desired restrictive enterprise license text, or will legal provide a different `code/enterprise/LICENSE`?

--- a/docs/requirements/OFTR-004-sync-and-setup.md
+++ b/docs/requirements/OFTR-004-sync-and-setup.md
@@ -13,6 +13,7 @@ Outfitter provides setup and maintenance commands that launch Pi-native onboardi
 3. The `setup` command MUST force Pi-native onboarding even when existing Outfitter settings are present.
 4. The `setup <source>` command MUST preserve the provided source and hand it to Pi-native onboarding.
 5. Setup writes MUST happen from the Pi-native `/outfitter` flow after Pi starts.
+6. When first-run `setup <source>` onboarding installs settings in the current project while `~/.outfitter/settings.yml` is missing, Outfitter SHOULD create a valid home-folder setup state so later launches do not repeat first-run onboarding.
 
 ### OFTR-004.2: Sync Command
 
@@ -58,6 +59,7 @@ Outfitter provides setup and maintenance commands that launch Pi-native onboardi
 
 16. GitHub privacy detection MUST only treat an HTTP 200 GitHub API response with JSON `private: true` as private. Public responses, unknown responses, HTTP 403/404, network failures, malformed responses, and non-GitHub sources MUST NOT warn, error, or block.
 17. Private catalog enablement MUST remain informational commercial governance and MUST NOT collect, echo, persist, synthesize, or validate provider credentials.
+18. When a cached remote settings repository is configured with `path: settings.yml` and lacks a root `settings.yml` but contains `.outfitter/settings.yml`, `sync` and cached settings loading SHOULD resolve the nested `.outfitter/settings.yml` file.
 
 ### OFTR-004.3: Create Profile Command
 

--- a/docs/requirements/OFTR-010-onboarding-welcome.md
+++ b/docs/requirements/OFTR-010-onboarding-welcome.md
@@ -37,8 +37,11 @@ then finish profile setup inside Pi through a native Outfitter extension command
 8. The final onboarding question MUST choose whether to install settings in the home folder or current project directory.
 9. The Pi-native onboarding flow MUST persist selected home settings to `~/.outfitter/settings.yml` and selected project settings to `<project>/.outfitter/settings.yml`.
 10. The onboarding UI MUST clearly communicate that profile/loadout changes made after Pi starts apply to the next `outfitter` launch.
-11. When Pi-native onboarding imports a GitHub catalog and detects an HTTP 200 GitHub API response with `private: true`, it SHOULD ask before saving the catalog unless `enterprise.private_profile_catalogs: true` is already enabled in `~/.outfitter/settings.yml`.
-12. The Pi-native private catalog prompt MUST use this text:
+11. When first-run Pi-native onboarding persists project settings while `~/.outfitter/settings.yml` is missing, Outfitter SHOULD create a valid home-folder setup state so later launches do not repeat first-run onboarding.
+12. After a Pi-native onboarding install completes, Outfitter SHOULD synchronize configured remote settings/profile sources before relaunching with the installed profile.
+13. After a Pi-native onboarding install completes, Outfitter SHOULD automatically restart or relaunch so the installed profile is active without requiring a manual second command.
+14. When Pi-native onboarding imports a GitHub catalog and detects an HTTP 200 GitHub API response with `private: true`, it SHOULD ask before saving the catalog unless `enterprise.private_profile_catalogs: true` is already enabled in `~/.outfitter/settings.yml`.
+15. The Pi-native private catalog prompt MUST use this text:
 
     ```text
     Private GitHub profile catalog detected: OWNER/REPO.
@@ -49,27 +52,27 @@ then finish profile setup inside Pi through a native Outfitter extension command
     Enable private profile catalogs in ~/.outfitter/settings.yml and use this catalog?
     ```
 
-13. The Pi-native choices MUST be:
+16. The Pi-native choices MUST be:
 
     ```text
     Enable and continue
     Cancel private catalog setup
     ```
 
-14. If the user accepts, Pi-native onboarding MUST write `enterprise.private_profile_catalogs: true` to `~/.outfitter/settings.yml`, save the catalog, and show:
+17. If the user accepts, Pi-native onboarding MUST write `enterprise.private_profile_catalogs: true` to `~/.outfitter/settings.yml`, save the catalog, and show:
 
     ```text
     Outfitter enabled private profile catalogs in ~/.outfitter/settings.yml and saved this catalog.
     ```
 
-15. If the user declines, Pi-native onboarding MUST leave settings unchanged, not save the catalog, and show:
+18. If the user declines, Pi-native onboarding MUST leave settings unchanged, not save the catalog, and show:
 
     ```text
     Private catalog setup was cancelled; no settings were changed.
     ```
 
-16. If `enterprise.private_profile_catalogs: true` is already enabled in `~/.outfitter/settings.yml`, Pi-native onboarding MUST NOT show private-catalog enterprise information or prompts.
-17. Pi-native onboarding MUST NOT collect, echo, persist, synthesize, or validate provider credentials for private catalogs.
+19. If `enterprise.private_profile_catalogs: true` is already enabled in `~/.outfitter/settings.yml`, Pi-native onboarding MUST NOT show private-catalog enterprise information or prompts.
+20. Pi-native onboarding MUST NOT collect, echo, persist, synthesize, or validate provider credentials for private catalogs.
 
 ### OFTR-010.3: Onboarding UI Surface
 


### PR DESCRIPTION
## Summary

- resolve setup-style remote settings caches that store `.outfitter/settings.yml` while configured as `path: settings.yml`
- complete first-run project setup handoff by creating home setup state, syncing, and relaunching after Pi-native install
- associate PR #94 / commit `65037fc` with M1 Initial Release evidence and update requirements/architecture docs

## Validation

- `npm test --workspace @ai-outfitter/outfitter -- tests/unit/pi-login-launch.test.ts tests/unit/run-command.test.ts tests/unit/setup-command.test.ts tests/unit/setup-sources.test.ts tests/unit/profile-command.test.ts`
- `npm run typecheck`
- `npm run lint`

## Notes

- PR #94 is assigned to the `Initial Release` milestone.
- No release, tag, publish, merge, force-push, credential handling, or target conformance report.
