### PR TITLE
feat: point launched agents at bundled Outfitter user docs

### DIFF
--- a/code/cli/scripts/sync-package-assets.mjs
+++ b/code/cli/scripts/sync-package-assets.mjs
@@ -26,6 +26,9 @@ const copies = [
   ['LICENSE.md', 'LICENSE.md', false],
   [join('code', 'enterprise'), join('code', 'enterprise'), true],
   [join('code', 'pi-extension', 'src'), join('code', 'pi-extension', 'src'), true],
+  [join('docs', 'documentation'), join('doc', 'documentation'), true],
+  // The documentation README links ../philosophy.md; keep that link working in the package.
+  [join('docs', 'philosophy.md'), join('doc', 'philosophy.md'), false],
 ];
 
 for (const [from, to, recursive] of copies) {

--- a/code/cli/scripts/sync-package-assets.mjs
+++ b/code/cli/scripts/sync-package-assets.mjs
@@ -27,8 +27,14 @@ const copies = [
   [join('code', 'enterprise'), join('code', 'enterprise'), true],
   [join('code', 'pi-extension', 'src'), join('code', 'pi-extension', 'src'), true],
   [join('docs', 'documentation'), join('doc', 'documentation'), true],
-  // The documentation README links ../philosophy.md; keep that link working in the package.
+  // Keep cross-references from the shipped documentation working in the package:
+  // README.md links ../philosophy.md and state.md links ../architecture/state_writeback_strategy.md.
   [join('docs', 'philosophy.md'), join('doc', 'philosophy.md'), false],
+  [
+    join('docs', 'architecture', 'state_writeback_strategy.md'),
+    join('doc', 'architecture', 'state_writeback_strategy.md'),
+    false,
+  ],
 ];
 
 for (const [from, to, recursive] of copies) {

--- a/code/cli/src/agents/AgentAdapter.ts
+++ b/code/cli/src/agents/AgentAdapter.ts
@@ -23,6 +23,8 @@ export interface AgentLaunchContext {
   readonly profileLayers?: readonly AgentLaunchProfileLayer[];
   readonly projectDirectory?: string;
   readonly cacheDirectory?: string;
+  /** Directory of bundled user-facing Outfitter documentation the launched agent may read. */
+  readonly outfitterDocsDirectory?: string;
 }
 
 export interface AgentCompositeProfilePlan {

--- a/code/cli/src/agents/OutfitterDocs.ts
+++ b/code/cli/src/agents/OutfitterDocs.ts
@@ -1,0 +1,43 @@
+// Points launched agents at the bundled user-facing Outfitter documentation.
+//
+// This mirrors pi's own self-documentation mechanism: pi's default system prompt
+// lists absolute paths to the docs shipped inside the pi package with guidance to
+// read them only when the user asks about pi itself. Outfitter appends the same
+// kind of section for its own documentation so an Outfitter-managed agent can
+// explain Outfitter features and iterate on its own profiles.
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageRootDirectory = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+// The docs live at <repo>/docs/documentation in the repository layout and are
+// staged to <package>/doc/documentation by scripts/sync-package-assets.mjs for
+// the published npm package.
+export const resolveOutfitterDocsDirectory = (): string | undefined => {
+  const repositoryDocsPath = join(packageRootDirectory, '..', '..', 'docs', 'documentation');
+  const packageDocsPath = join(packageRootDirectory, 'doc', 'documentation');
+
+  /* v8 ignore else -- packaged npm layout is exercised after pack, not unit tests. */
+  if (existsSync(repositoryDocsPath)) {
+    return repositoryDocsPath;
+  }
+
+  /* v8 ignore next 3 -- packaged npm layout is exercised after pack, not unit tests. */
+  if (existsSync(packageDocsPath)) {
+    return packageDocsPath;
+  }
+
+  /* v8 ignore next -- defensive fallback for installs that exclude documentation assets. */
+  return undefined;
+};
+
+export const createOutfitterDocsSystemPrompt = (docsDirectory: string): string => {
+  return [
+    'Outfitter documentation (read only when the user asks about Outfitter itself — profiles, settings, profile catalogs, setup sources, state persistence, or how to inspect or change this launch configuration):',
+    `- Documentation index: ${join(docsDirectory, 'README.md')}`,
+    `- Additional docs: ${docsDirectory}`,
+    '- When asked about: getting started (getting-started.md), profiles and profile layouts (profiles.md), shared profile repositories and catalogs (profile-repository.md), state persistence (state.md), switching from another agent CLI (switching-to-outfitter.md), first-time CLI agent users (first-time-cli-agent-users.md), iterating on a local or worktree profile — including improving your own active profile (iterating-on-profiles.md)',
+    '- When reading Outfitter docs, resolve relative links against the documentation directory, read the referenced .md files completely, and follow cross-references before answering or editing profiles.',
+  ].join('\n');
+};

--- a/code/cli/src/agents/pi/PiAdapter.ts
+++ b/code/cli/src/agents/pi/PiAdapter.ts
@@ -11,6 +11,7 @@ import type {
   AgentLaunchProfileLayer,
 } from '../AgentAdapter.js';
 import { genericControlNames, mergeAgentSpecificControls, supportedControlNames } from '../AdapterProfileControls.js';
+import { createOutfitterDocsSystemPrompt } from '../OutfitterDocs.js';
 import { createDeclaredStatePaths, findProfileStateSource } from '../AdapterStatePaths.js';
 import { filterPiSettingsPackagesDuplicatingExtensions } from './PiSettingsMergePolicy.js';
 import type { PiProfileControls, Profile, ProfileControls } from '../../profiles/Profile.js';
@@ -120,7 +121,12 @@ export const createPiAdapter = (): AgentAdapter => ({
           ...controls,
           extensions: materializePiExtensionSources(controls.extensions, { cacheDirectory: context.cacheDirectory }),
           skills: skillSources,
-          appendSystemPrompt: appendPrompt.prompts,
+          appendSystemPrompt: [
+            ...appendPrompt.prompts,
+            // Mirrors pi's own docs section in the default system prompt: point the
+            // agent at the bundled Outfitter user documentation by absolute path.
+            ...toOutfitterDocsPrompts(context.outfitterDocsDirectory),
+          ],
         }),
         ...passThroughArgs,
       ],
@@ -559,6 +565,9 @@ const formatFilesystemError = (error: unknown): string => String(error);
 
 const splitPathList = (value: string | undefined): readonly string[] =>
   value === undefined || value === '' ? [] : value.split(delimiter).filter((entry) => entry !== '');
+
+const toOutfitterDocsPrompts = (docsDirectory: string | undefined): readonly string[] =>
+  docsDirectory === undefined ? [] : [createOutfitterDocsSystemPrompt(docsDirectory)];
 
 const mergePiControls = (controls: ProfileControls): PiProfileControls =>
   mergeAgentSpecificControls<PiProfileControls>(controls, 'pi');

--- a/code/cli/src/cli/OutfitterCli.ts
+++ b/code/cli/src/cli/OutfitterCli.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 
 import { Command } from 'commander';
 
+import { resolveOutfitterDocsDirectory } from '../agents/OutfitterDocs.js';
 import type { CommandObject } from './commands/CommandObject.js';
 import { createProfileCommands } from './commands/profile/Command.js';
 import { createRunCommand, executeRunCommand } from './commands/RunCommand.js';
@@ -13,9 +14,13 @@ import { createWelcomeCommand } from './commands/WelcomeCommand.js';
 export const createDefaultCommands = (): CommandObject[] => [
   createRunCommand(),
   createSetupCommand({
-    /* v8 ignore next -- covered by end-to-end CLI smoke usage; unit tests inject this dependency. */
+    /* v8 ignore next 2 -- covered by end-to-end CLI smoke usage; unit tests inject this dependency. */
     async launchSetupSourceProfile(input) {
-      await executeRunCommand({ ...input, profileId: input.profileId });
+      await executeRunCommand({
+        ...input,
+        profileId: input.profileId,
+        outfitterDocsDirectory: resolveOutfitterDocsDirectory(),
+      });
     },
   }),
   createSyncCommand(),

--- a/code/cli/src/cli/commands/RunCommand.ts
+++ b/code/cli/src/cli/commands/RunCommand.ts
@@ -11,6 +11,7 @@ import spawn from 'cross-spawn';
 
 import type { AgentAdapter, AgentLaunchPlan } from '../../agents/AgentAdapter.js';
 import { createAgentAdapter, defaultAgentId as registryDefaultAgentId } from '../../agents/AgentRegistry.js';
+import { resolveOutfitterDocsDirectory } from '../../agents/OutfitterDocs.js';
 import {
   createProfileSourceCachePath,
   createRemoteRepositoryCachePath,
@@ -57,6 +58,8 @@ export interface RunCommandInput {
   readonly passThroughArgs?: readonly string[];
   readonly forceRuntimeOnboarding?: boolean;
   readonly setupSourceUri?: string;
+  /** Bundled user-facing Outfitter docs to expose to the launched agent's system prompt. */
+  readonly outfitterDocsDirectory?: string;
 }
 
 export interface RunCommandResult {
@@ -121,6 +124,7 @@ export const executeRunCommand = async (
           profileLayers: createLaunchProfileLayers(resolvedProfile.profileLayers),
           projectDirectory: input.projectDirectory,
           cacheDirectory: resolvedProfile.cacheDirectory,
+          outfitterDocsDirectory: input.outfitterDocsDirectory,
         },
       ),
       systemPromptExport.outputPath,
@@ -215,6 +219,7 @@ export const createRunCommand = (dependencies: RunCommandDependencies = {}): Com
             agentId: options.agent,
             strict: options.strict,
             passThroughArgs: args,
+            outfitterDocsDirectory: resolveOutfitterDocsDirectory(),
           },
           dependencies,
         );

--- a/code/cli/tests/unit/outfitter-docs.test.ts
+++ b/code/cli/tests/unit/outfitter-docs.test.ts
@@ -1,0 +1,63 @@
+// Tests the agent-readable Outfitter documentation prompt, mirroring pi's own docs mechanism.
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { createOutfitterDocsSystemPrompt, resolveOutfitterDocsDirectory } from '../../src/agents/OutfitterDocs.js';
+import { createPiAdapter } from '../../src/agents/pi/PiAdapter.js';
+
+const repositoryDocsDirectory = fileURLToPath(new URL('../../../../docs/documentation', import.meta.url));
+
+describe('outfitter docs prompt', () => {
+  it('resolves the repository documentation directory in the source layout', () => {
+    expect(resolveOutfitterDocsDirectory()).toBe(repositoryDocsDirectory);
+  });
+
+  it('builds guidance that points at the documentation index by absolute path', () => {
+    const prompt = createOutfitterDocsSystemPrompt('/opt/outfitter/doc/documentation');
+
+    expect(prompt).toContain('read only when the user asks about Outfitter itself');
+    expect(prompt).toContain(`- Documentation index: ${join('/opt/outfitter/doc/documentation', 'README.md')}`);
+    expect(prompt).toContain('- Additional docs: /opt/outfitter/doc/documentation');
+    expect(prompt).toContain('profiles and profile layouts (profiles.md)');
+    expect(prompt).toContain('improving your own active profile (iterating-on-profiles.md)');
+    expect(prompt).toContain('read the referenced .md files completely');
+  });
+
+  it('appends the docs prompt to pi launch plans when the launch context provides a docs directory', () => {
+    const adapter = createPiAdapter();
+    const compositeProfilePlan = adapter.createCompositeProfile(
+      { id: 'engineering', inherits: [], controls: {} },
+      { rootDirectory: '/tmp/outfitter-engineering-pi-docs-prompt', profilePaths: [] },
+    );
+    const launchPlan = adapter.createLaunchPlan(
+      compositeProfilePlan.compositeProfile,
+      { id: 'engineering', inherits: [], controls: { appendSystemPrompt: 'profile prompt' } },
+      [],
+      { outfitterDocsDirectory: repositoryDocsDirectory },
+    );
+
+    const appendPrompts = launchPlan.args.filter(
+      (_arg, index) => launchPlan.args[index - 1] === '--append-system-prompt',
+    );
+    expect(appendPrompts[0]).toBe('profile prompt');
+    expect(appendPrompts[1]).toContain(`- Additional docs: ${repositoryDocsDirectory}`);
+    expect(appendPrompts).toHaveLength(2);
+  });
+
+  it('keeps pi launch plans untouched when no docs directory is provided', () => {
+    const adapter = createPiAdapter();
+    const compositeProfilePlan = adapter.createCompositeProfile(
+      { id: 'engineering', inherits: [], controls: {} },
+      { rootDirectory: '/tmp/outfitter-engineering-pi-docs-absent', profilePaths: [] },
+    );
+    const launchPlan = adapter.createLaunchPlan(compositeProfilePlan.compositeProfile, {
+      id: 'engineering',
+      inherits: [],
+      controls: {},
+    });
+
+    expect(launchPlan.args).not.toContain('--append-system-prompt');
+  });
+});

--- a/docs/documentation/README.md
+++ b/docs/documentation/README.md
@@ -7,6 +7,7 @@ User-facing Outfitter documentation.
 - [Switching to Outfitter](./switching-to-outfitter.md)
 - [Profiles](./profiles.md)
 - [Profile repositories](./profile-repository.md)
+- [Iterating on local and worktree profiles](./iterating-on-profiles.md)
 - [State persistence](./state.md)
 - [Philosophy](../philosophy.md)
 

--- a/docs/documentation/iterating-on-profiles.md
+++ b/docs/documentation/iterating-on-profiles.md
@@ -1,0 +1,109 @@
+# Iterating on local and worktree profiles
+
+This guide covers the edit-run-inspect loop for profiles: switching to a profile you can edit, iterating on it locally or in a git worktree of a profile catalog, and verifying the result.
+It is written for people and for Outfitter-managed agents — if you are an agent reading this, the "Improving your own profile" section describes how to modify the profile you were launched with.
+
+## Where editable profiles live
+
+Outfitter resolves profiles from every configured `profile_sources` entry.
+Three scopes are directly editable on the current machine:
+
+| Scope         | Profiles                               | Settings                                  | Use for                                   |
+| ------------- | -------------------------------------- | ----------------------------------------- | ----------------------------------------- |
+| user          | `~/.outfitter/profiles/`               | `~/.outfitter/settings.yml`               | Personal defaults shared across projects  |
+| project       | `<project>/.outfitter/profiles/`       | `<project>/.outfitter/settings.yml`       | Checked-in behavior the whole team gets   |
+| project-local | `<project>/.outfitter/local/profiles/` | `<project>/.outfitter/local/settings.yml` | Machine-private overrides and experiments |
+
+Profiles synced from a remote catalog (`github:` or `uri:` profile sources) land in the Outfitter cache.
+Do not edit the cache — `outfitter sync` overwrites it.
+To iterate on a catalog profile, work in a local checkout of the catalog instead (see the worktree section below).
+
+## Switching profiles
+
+- One launch: `outfitter run --profile <id> [-- <agent args>]`
+- Future launches: set `default_profile: <id>` in the settings scope you want it to apply to.
+- List what is resolvable right now: `outfitter profile list` (add `--all` to include inheritance-only templates).
+
+Profile changes apply on the next launch.
+A running session keeps the composite profile it started with, so after editing a profile you must restart `outfitter` to load the result.
+
+## The iteration loop
+
+1. Create or locate an editable profile:
+
+   ```sh
+   outfitter profile create my_experiment --scope project-local
+   ```
+
+To iterate on an existing profile without touching it, create a new profile that inherits from it:
+
+```yaml
+# .outfitter/local/profiles/my_experiment/profile.yml
+id: my_experiment
+label: My Experiment
+inherits:
+  - engineer
+controls:
+  append_system_prompt:
+    - |
+      <the behavior you are trying out>
+```
+
+2. Point your next launch at it, either with `outfitter run --profile my_experiment` or by setting `default_profile: my_experiment` in `.outfitter/local/settings.yml`.
+
+3. Validate before launching:
+
+   ```sh
+   outfitter profile lint --strict
+   ```
+
+This reports schema and inheritance errors, missing typed prompt include files, and raw append-prompt strings that look like file paths.
+
+4. Inspect what the agent actually received.
+   With `profile_export: true` in the active settings, Outfitter writes the composed system prompt next to the profile (`generated-system-prompt.md` in a directory profile, `<id>.generated-system-prompt.md` beside a flat profile).
+   Diff it between iterations to confirm a change landed.
+
+5. Restart and test the behavior, then fold the settled changes back into the profile the experiment inherited from.
+
+## Iterating on a catalog profile in a git worktree
+
+Shared profiles usually come from a catalog repository (see [Profile repositories](./profile-repository.md)) referenced as a `github:` source.
+To change one:
+
+1. Clone the catalog, or add a worktree to an existing clone so the iteration branch stays isolated:
+
+   ```sh
+   cd ~/repos/acme/profile-catalog/main
+   git worktree add ../worktrees/feat/sharper-review-prompts -b feat/sharper-review-prompts
+   ```
+
+2. Point a machine-private profile source at the worktree in `.outfitter/local/settings.yml` (or `~/.outfitter/settings.yml`).
+   Local `path:` sources take the same layout as the catalog:
+
+   ```yaml
+   # .outfitter/local/settings.yml
+   profile_sources:
+     - path: ~/repos/acme/profile-catalog/worktrees/feat/sharper-review-prompts/profiles
+   ```
+
+3. Iterate with the loop above: edit in the worktree, `outfitter profile lint --strict`, relaunch, inspect the prompt export.
+
+4. Commit in the worktree, push, and open a pull request against the catalog.
+   After it merges, remove the local `path:` override, run `outfitter sync` to refresh the cached catalog, and remove the worktree.
+
+Because the override lives in project-local settings, teammates and CI keep resolving the published catalog while you iterate.
+
+## Improving your own profile (for Outfitter-managed agents)
+
+If you are an agent launched by Outfitter, your instructions, tools, skills, and extensions came from a profile, and you can improve that profile the same way you improve code — but the change only takes effect for future sessions, never the current one.
+
+1. Identify your active profile.
+   The launch header and `outfitter profile list` show profile ids; your composite profile directory contains `outfitter/profile.json` with the id, label, and merged controls you were launched with.
+2. Find the editable source for that profile with the scope table above.
+   If the profile comes from a remote catalog, do not edit the cache — use the worktree flow above, or create a local profile that `inherits` from it and layer the improvement on top.
+3. Make the smallest change that captures the improvement: a new `append_system_prompt` entry for a behavior correction, a `skills` entry for a reusable procedure, or a control override (model, thinking level, environment) for launch mechanics.
+4. Validate with `outfitter profile lint --strict`, and review the `profile_export` prompt output when prompt text changed.
+5. Tell the user what you changed and why, and that the change applies when they restart `outfitter` (or launch `outfitter run --profile <id>`).
+   You cannot reload your own profile mid-session.
+
+Prefer durable, reviewable improvements: put team-relevant changes in the project or catalog profile through a pull request, and keep personal or experimental changes in user or project-local scope.


### PR DESCRIPTION
## Summary

Recreates pi's self-documentation mechanism for Outfitter's own user-facing docs. Pi's default system prompt lists absolute paths to the docs bundled in the pi package, with guidance to read them only when the user asks about pi itself. This PR gives Outfitter-managed agents the same capability for `docs/documentation`:

- **New `src/agents/OutfitterDocs.ts`** resolves the documentation directory in both the repository layout (`docs/documentation`) and the packaged npm layout (`doc/documentation`, staged by `sync-package-assets.mjs`), and builds a pi-style guidance section: docs index path, topic → file hints, and read-only-when-asked framing.
- **The pi adapter appends that section as an extra `--append-system-prompt`** when the launch context provides `outfitterDocsDirectory`. The real CLI entry points (`outfitter run` and the post-setup launch) resolve it; direct `executeRunCommand` / `createLaunchPlan` callers — including the protected OFTR requirement tests — are unaffected unless they opt in.
- **`docs/documentation` ships in the npm package** (plus the `philosophy.md` the docs index links to), so installed agents can read the docs by absolute path.
- **New doc: [Iterating on local and worktree profiles](docs/documentation/iterating-on-profiles.md)** — switching profiles, the local edit-run-inspect loop, iterating on a catalog profile in a git worktree, and an explicit section telling Outfitter-managed agents how to improve their own active profile (find the editable source, layer changes via `inherits`, validate with `outfitter profile lint --strict`, restart to apply).

## Testing

- New unit tests in `code/cli/tests/unit/outfitter-docs.test.ts` cover docs-directory resolution, the guidance prompt content, launch plans with and without a docs directory.
- `npm run lint`, `npm run typecheck`, `npm run coverage` in `code/cli`: 274/274 tests pass, coverage thresholds intact; all protected requirement tests unmodified.
- `prettier --check .` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)