### PR TITLE
Resolve shared profile skill paths for Pi

### DIFF
--- a/code/cli/src/agents/pi/PiAdapter.ts
+++ b/code/cli/src/agents/pi/PiAdapter.ts
@@ -23,6 +23,7 @@ import type { StatePathDeclaration, CompositeProfileStatePath } from '../../comp
 import { createPiArgs } from './PiArgs.js';
 import { createPiMcpConfigFile } from './PiMcpConfig.js';
 import { materializePiExtensionSources } from './PiExtensionCache.js';
+import { createPiSkillSources } from './PiSkillSources.js';
 
 const piControlNames = new Set([
   ...[...genericControlNames].filter((controlName) => controlName !== 'pi' && controlName !== 'claude'),
@@ -106,7 +107,12 @@ export const createPiAdapter = (): AgentAdapter => ({
       profileFolders,
       context.profileLayers ?? [],
     );
-    const skillSources = createPiSkillSources(controls, profileFolders);
+    const skillSources = createPiSkillSources({
+      builtInOutfitterSkill,
+      controls,
+      profileFolders,
+      profileLayers: context.profileLayers ?? [],
+    });
     const appendPrompt = resolveAppendSystemPromptControl({
       fallback: controls.appendSystemPrompt,
       profileLayers: context.profileLayers,
@@ -442,26 +448,6 @@ const resolvePiStateSourcePath = (
 const deepWorkAdditionalJobsFoldersEnv = 'DEEPWORK_ADDITIONAL_JOBS_FOLDERS';
 const packageRootDirectory = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 const builtInOutfitterSkill = join(packageRootDirectory, 'skills', 'outfitter');
-
-const createPiSkillSources = (controls: PiProfileControls, profileFolders: readonly string[]): readonly string[] => [
-  ...new Set([builtInOutfitterSkill, ...(controls.skills ?? []), ...profileFolders.flatMap(skillSourcesForProfile)]),
-];
-
-const skillSourcesForProfile = (profileFolder: string): readonly string[] => [
-  ...skillSourcesForFolder(join(profileFolder, 'skills'), 'profile skills folder'),
-  ...skillSourcesForFolder(join(profileFolder, 'cli_specific', 'pi', 'skills'), 'profile Pi skills folder'),
-];
-
-const skillSourcesForFolder = (skillsFolder: string, description: string): readonly string[] =>
-  readOptionalDirectoryEntries(skillsFolder, description)
-    .filter(isPiSkillEntry(skillsFolder))
-    .map((entry) => join(skillsFolder, entry.name))
-    .sort();
-
-const isPiSkillEntry =
-  (folderPath: string) =>
-  (entry: Dirent): boolean =>
-    entry.isDirectory() && isFile(join(folderPath, entry.name, 'SKILL.md'));
 
 const createDeepWorkAdditionalJobsFolders = (
   controls: PiProfileControls,

--- a/code/cli/src/agents/pi/PiSkillSources.ts
+++ b/code/cli/src/agents/pi/PiSkillSources.ts
@@ -52,8 +52,7 @@ const sharedSkillRootsForLayer = (profileLayer: AgentLaunchProfileLayer): readon
   return roots;
 };
 
-const isPiSkillSource = (sourcePath: string): boolean =>
-  isFile(sourcePath) || isFile(join(sourcePath, 'SKILL.md'));
+const isPiSkillSource = (sourcePath: string): boolean => isFile(sourcePath) || isFile(join(sourcePath, 'SKILL.md'));
 
 const skillSourcesForProfile = (profileFolder: string): readonly string[] => [
   ...skillSourcesForFolder(join(profileFolder, 'skills'), 'profile skills folder'),

--- a/code/cli/src/agents/pi/PiSkillSources.ts
+++ b/code/cli/src/agents/pi/PiSkillSources.ts
@@ -1,0 +1,99 @@
+// Resolves Pi skill sources declared by profiles and discovered in profile folders.
+import { readdirSync, statSync, type Dirent } from 'node:fs';
+import { dirname, isAbsolute, join } from 'node:path';
+
+import type { AgentLaunchProfileLayer } from '../AgentAdapter.js';
+import type { PiProfileControls } from '../../profiles/Profile.js';
+
+export const createPiSkillSources = (input: {
+  readonly builtInOutfitterSkill: string;
+  readonly controls: PiProfileControls;
+  readonly profileFolders: readonly string[];
+  readonly profileLayers: readonly AgentLaunchProfileLayer[];
+}): readonly string[] => [
+  ...new Set([
+    input.builtInOutfitterSkill,
+    ...(input.controls.skills ?? []).map((source) => resolveProfileSkillSource(source, input.profileLayers)),
+    ...input.profileFolders.flatMap(skillSourcesForProfile),
+  ]),
+];
+
+const resolveProfileSkillSource = (source: string, profileLayers: readonly AgentLaunchProfileLayer[]): string => {
+  if (isAbsolute(source)) {
+    return source;
+  }
+
+  for (const root of sharedSkillRootsForLayers(profileLayers)) {
+    const resolvedSource = join(root, source);
+
+    if (isPiSkillSource(resolvedSource)) {
+      return resolvedSource;
+    }
+  }
+
+  return source;
+};
+
+const sharedSkillRootsForLayers = (profileLayers: readonly AgentLaunchProfileLayer[]): readonly string[] => [
+  ...new Set(profileLayers.flatMap(sharedSkillRootsForLayer)),
+];
+
+const sharedSkillRootsForLayer = (profileLayer: AgentLaunchProfileLayer): readonly string[] => {
+  const roots: string[] = [];
+
+  if (profileLayer.sourceRootPath !== undefined) {
+    roots.push(dirname(profileLayer.sourceRootPath), profileLayer.sourceRootPath);
+  }
+
+  if (profileLayer.resourceRootPath !== undefined) {
+    roots.push(profileLayer.resourceRootPath);
+  }
+
+  return roots;
+};
+
+const isPiSkillSource = (sourcePath: string): boolean =>
+  isFile(sourcePath) || isFile(join(sourcePath, 'SKILL.md'));
+
+const skillSourcesForProfile = (profileFolder: string): readonly string[] => [
+  ...skillSourcesForFolder(join(profileFolder, 'skills'), 'profile skills folder'),
+  ...skillSourcesForFolder(join(profileFolder, 'cli_specific', 'pi', 'skills'), 'profile Pi skills folder'),
+];
+
+const skillSourcesForFolder = (skillsFolder: string, description: string): readonly string[] =>
+  readOptionalDirectoryEntries(skillsFolder, description)
+    .filter(isPiSkillEntry(skillsFolder))
+    .map((entry) => join(skillsFolder, entry.name))
+    .sort();
+
+const isPiSkillEntry =
+  (folderPath: string) =>
+  (entry: Dirent): boolean =>
+    entry.isDirectory() && isFile(join(folderPath, entry.name, 'SKILL.md'));
+
+const readOptionalDirectoryEntries = (folderPath: string, description: string): readonly Dirent[] => {
+  try {
+    return readdirSync(folderPath, { withFileTypes: true });
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return [];
+    }
+
+    throw new Error(`Could not read ${description} '${folderPath}': ${String(error)}`, { cause: error });
+  }
+};
+
+const isFile = (path: string): boolean => {
+  try {
+    return statSync(path).isFile();
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return false;
+    }
+
+    throw new Error(`Could not inspect file '${path}': ${String(error)}`, { cause: error });
+  }
+};
+
+const isMissingPathError = (error: unknown): boolean =>
+  error !== null && typeof error === 'object' && 'code' in error && error.code === 'ENOENT';

--- a/code/cli/tests/unit/pi-adapter-profile-resources.test.ts
+++ b/code/cli/tests/unit/pi-adapter-profile-resources.test.ts
@@ -19,6 +19,41 @@ afterEach(() => {
 });
 
 describe('pi adapter profile resources', () => {
+  it('resolves profile-declared Pi skills from a shared profile source skills folder', () => {
+    const root = createTemporaryRoot('outfitter-pi-shared-skills-');
+    const profilesRoot = join(root, 'profiles');
+    const profileFolder = join(profilesRoot, 'founder');
+    const skillFolder = join(root, 'skills', 'pyramid-principle');
+    mkdirSync(profileFolder, { recursive: true });
+    mkdirSync(skillFolder, { recursive: true });
+    writeFileSync(join(skillFolder, 'SKILL.md'), '---\nname: pyramid-principle\ndescription: Structure prose\n---\n');
+
+    const adapter = createPiAdapter();
+    const compositeProfilePlan = adapter.createCompositeProfile(
+      { id: 'founder', inherits: [], controls: {} },
+      { rootDirectory: join(root, 'composite'), profilePaths: [], profileFolders: [profileFolder] },
+    );
+    const launchPlan = adapter.createLaunchPlan(
+      compositeProfilePlan.compositeProfile,
+      { id: 'founder', inherits: [], controls: { pi: { skills: ['skills/pyramid-principle'] } } },
+      [],
+      {
+        profileFolders: [profileFolder],
+        profileLayers: [
+          {
+            profile: { id: 'founder', inherits: [], controls: { pi: { skills: ['skills/pyramid-principle'] } } },
+            profilePath: join(profileFolder, 'profile.yml'),
+            sourceRootPath: profilesRoot,
+            resourceRootPath: profileFolder,
+            layout: 'directory',
+          },
+        ],
+      },
+    );
+
+    expect(launchPlan.args).toEqual(['--skill', builtInOutfitterSkill, '--skill', skillFolder]);
+  });
+
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.3).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('adds profile-bundled Pi skills to the launch args', () => {

--- a/code/cli/tests/unit/run-command-deepwork-jobs.test.ts
+++ b/code/cli/tests/unit/run-command-deepwork-jobs.test.ts
@@ -129,6 +129,42 @@ describe('run command profile-bundled Pi resource exposure', () => {
     expect(result.launchPlan.args).not.toContain(unrelatedSkillFolder);
   });
 
+  it('resolves profile-declared Pi skills from sibling source skills when launching pi', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const sourceRoot = join(projectDirectory, '.outfitter');
+    const profilesDirectory = join(sourceRoot, 'profiles');
+    writeProfile(
+      profilesDirectory,
+      'founder',
+      ['id: founder', 'controls:', '  pi:', '    skills:', '      - skills/pyramid-principle', ''].join('\n'),
+    );
+    const skillFolder = join(sourceRoot, 'skills', 'pyramid-principle');
+    mkdirSync(skillFolder, { recursive: true });
+    writeFileSync(join(skillFolder, 'SKILL.md'), '---\nname: pyramid-principle\ndescription: Structure prose\n---\n');
+    writeSettings(
+      homeDirectory,
+      'default_profile: founder\nprofile_sources:\n  - path: ../../project/.outfitter/profiles\n',
+    );
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+        writeLine: () => undefined,
+      },
+    );
+
+    expect(result.launchPlan.args).toContain('--skill');
+    expect(result.launchPlan.args).toContain(skillFolder);
+    expect(result.launchPlan.args).not.toContain('skills/pyramid-principle');
+  });
+
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.3).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('resolves flat profile named DeepWork jobs from sibling source jobs without exposing flat profile resources', async () => {


### PR DESCRIPTION
## Summary
- Resolve profile-declared Pi skill paths against contributing profile source roots before passing them to Pi.
- Preserve existing automatic profile-bundled skill discovery.
- Cover the default-profiles-style layout where profiles live under `profiles/` and shared skills live in sibling `skills/`.

## Validation
- `npm run lint`
- `npx vitest --run tests/unit/pi-adapter-profile-resources.test.ts tests/unit/run-command-deepwork-jobs.test.ts`
- `npm run typecheck`
- `npm run build`
- `/review`: no configured review rules matched these files.
