### PR TITLE
feat(profiles): generate Pi skills from profiles

### DIFF
--- a/code/cli/src/agents/AgentAdapter.ts
+++ b/code/cli/src/agents/AgentAdapter.ts
@@ -15,6 +15,7 @@ export interface AgentLaunchProfileLayer {
   readonly profilePath: string;
   readonly sourceRootPath?: string;
   readonly resourceRootPath?: string;
+  readonly sourceInputs?: readonly string[];
   readonly layout?: 'directory' | 'flat-file';
 }
 
@@ -25,6 +26,7 @@ export interface AgentLaunchContext {
   readonly cacheDirectory?: string;
   /** Directory of bundled user-facing Outfitter documentation the launched agent may read. */
   readonly outfitterDocsDirectory?: string;
+  readonly generatedSkillProfiles?: readonly AgentLaunchProfileLayer[];
 }
 
 export interface AgentCompositeProfilePlan {
@@ -43,6 +45,7 @@ export interface AgentAdapter {
       readonly profilePaths: readonly string[];
       readonly profileFolders?: readonly string[];
       readonly profileLayers?: readonly AgentLaunchProfileLayer[];
+      readonly generatedSkillProfiles?: readonly AgentLaunchProfileLayer[];
       readonly homeDirectory?: string;
       readonly cacheDirectory?: string;
       readonly settings?: Settings;

--- a/code/cli/src/agents/pi/PiAdapter.ts
+++ b/code/cli/src/agents/pi/PiAdapter.ts
@@ -23,6 +23,8 @@ import type { StatePathDeclaration, CompositeProfileStatePath } from '../../comp
 import { createPiArgs } from './PiArgs.js';
 import { createPiMcpConfigFile } from './PiMcpConfig.js';
 import { materializePiExtensionSources } from './PiExtensionCache.js';
+import { createPiGeneratedSkillFiles, createPiGeneratedSkillSources } from './PiGeneratedSkills.js';
+import { createPiSkillSources } from './PiSkillSources.js';
 
 const piControlNames = new Set([
   ...[...genericControlNames].filter((controlName) => controlName !== 'pi' && controlName !== 'claude'),
@@ -71,6 +73,7 @@ export const createPiAdapter = (): AgentAdapter => ({
           strategy: 'transform',
         }),
         createPiMcpConfigFile(input.rootDirectory, input.profileFolders),
+        ...createPiGeneratedSkillFiles(input.rootDirectory, input.generatedSkillProfiles ?? []),
         transformedSettingsFile,
         transformedKeybindingsFile,
       ].filter((file) => file !== undefined),
@@ -106,7 +109,15 @@ export const createPiAdapter = (): AgentAdapter => ({
       profileFolders,
       context.profileLayers ?? [],
     );
-    const skillSources = createPiSkillSources(controls, profileFolders);
+    const skillSources = createPiSkillSources({
+      builtInOutfitterSkill,
+      controls,
+      profileFolders,
+      generatedSkillSources: createPiGeneratedSkillSources(
+        compositeProfile.rootDirectory,
+        context.generatedSkillProfiles ?? [],
+      ),
+    });
     const appendPrompt = resolveAppendSystemPromptControl({
       fallback: controls.appendSystemPrompt,
       profileLayers: context.profileLayers,
@@ -442,26 +453,6 @@ const resolvePiStateSourcePath = (
 const deepWorkAdditionalJobsFoldersEnv = 'DEEPWORK_ADDITIONAL_JOBS_FOLDERS';
 const packageRootDirectory = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 const builtInOutfitterSkill = join(packageRootDirectory, 'skills', 'outfitter');
-
-const createPiSkillSources = (controls: PiProfileControls, profileFolders: readonly string[]): readonly string[] => [
-  ...new Set([builtInOutfitterSkill, ...(controls.skills ?? []), ...profileFolders.flatMap(skillSourcesForProfile)]),
-];
-
-const skillSourcesForProfile = (profileFolder: string): readonly string[] => [
-  ...skillSourcesForFolder(join(profileFolder, 'skills'), 'profile skills folder'),
-  ...skillSourcesForFolder(join(profileFolder, 'cli_specific', 'pi', 'skills'), 'profile Pi skills folder'),
-];
-
-const skillSourcesForFolder = (skillsFolder: string, description: string): readonly string[] =>
-  readOptionalDirectoryEntries(skillsFolder, description)
-    .filter(isPiSkillEntry(skillsFolder))
-    .map((entry) => join(skillsFolder, entry.name))
-    .sort();
-
-const isPiSkillEntry =
-  (folderPath: string) =>
-  (entry: Dirent): boolean =>
-    entry.isDirectory() && isFile(join(folderPath, entry.name, 'SKILL.md'));
 
 const createDeepWorkAdditionalJobsFolders = (
   controls: PiProfileControls,

--- a/code/cli/src/agents/pi/PiGeneratedSkills.ts
+++ b/code/cli/src/agents/pi/PiGeneratedSkills.ts
@@ -1,0 +1,91 @@
+// Generates native Pi skill definitions from Outfitter profiles.
+import { join } from 'node:path';
+
+import type { AgentLaunchProfileLayer } from '../AgentAdapter.js';
+import { mergeAgentSpecificControls } from '../AdapterProfileControls.js';
+import { createCompositeProfileFile } from '../../compositeProfile/CompositeProfileFile.js';
+import type { AppendSystemPromptEntry, PiProfileControls, Profile } from '../../profiles/Profile.js';
+
+export const createPiGeneratedSkillFiles = (
+  rootDirectory: string,
+  generatedSkillProfiles: readonly AgentLaunchProfileLayer[],
+): ReturnType<typeof createCompositeProfileFile>[] =>
+  generatedSkillProfiles.map((profileLayer) =>
+    createCompositeProfileFile({
+      rootDirectory,
+      relativePath: `skills/${profileLayer.profile.id}/SKILL.md`,
+      content: createPiGeneratedSkillMarkdown(profileLayer.profile),
+      sourceInputs: profileLayer.sourceInputs ?? [profileLayer.profilePath],
+      strategy: 'transform',
+    }),
+  );
+
+export const createPiGeneratedSkillSources = (
+  rootDirectory: string,
+  generatedSkillProfiles: readonly AgentLaunchProfileLayer[],
+): readonly string[] =>
+  generatedSkillProfiles.map((profileLayer) => join(rootDirectory, 'skills', profileLayer.profile.id));
+
+const createPiGeneratedSkillMarkdown = (profile: Profile): string => {
+  const controls = mergePiControls(profile.controls);
+  const promptReferences = createPromptReferences(controls);
+  const runtimeHints = createRuntimeHints(controls);
+
+  return [
+    '---',
+    `name: ${JSON.stringify(profile.id)}`,
+    `description: ${JSON.stringify(profile.description ?? `Adopt the ${profile.label ?? profile.id} Outfitter profile.`)}`,
+    '---',
+    '',
+    `Use this skill when the user asks you to work as, review from, or apply the ${profile.label ?? profile.id} Outfitter profile.`,
+    '',
+    `Adopt the ${profile.label ?? profile.id} profile for the current task. Preserve the user's requested scope; do not restart the agent or shell out to Outfitter unless explicitly asked.`,
+    '',
+    ...(runtimeHints.length === 0 ? [] : ['Profile runtime preferences to honor when possible:', ...runtimeHints, '']),
+    ...(promptReferences.length === 0
+      ? []
+      : [
+          'Before doing substantive work, read and follow these Outfitter prompt files when they are present in the current project or profile source:',
+          ...promptReferences.map((promptReference) => `- ${promptReference}`),
+          '',
+        ]),
+    'Return concise results with changed files, verification evidence, and blockers.',
+    '',
+  ].join('\n');
+};
+
+const createRuntimeHints = (controls: PiProfileControls): readonly string[] => [
+  ...(controls.provider === undefined ? [] : [`- Provider: ${controls.provider}`]),
+  ...(controls.model === undefined ? [] : [`- Model: ${controls.model}`]),
+  ...(controls.thinking === undefined ? [] : [`- Thinking: ${controls.thinking}`]),
+  ...(controls.systemPrompt === undefined ? [] : [`- System prompt file: ${controls.systemPrompt}`]),
+  ...(controls.promptTemplate === undefined ? [] : [`- Prompt template: ${controls.promptTemplate}`]),
+];
+
+const createPromptReferences = (controls: PiProfileControls): readonly string[] => [
+  ...toPromptReferenceArray(controls.appendSystemPrompt),
+  ...(controls.promptTemplate === undefined ? [] : [controls.promptTemplate]),
+];
+
+const toPromptReferenceArray = (value: PiProfileControls['appendSystemPrompt']): readonly string[] => {
+  if (value === undefined) {
+    return [];
+  }
+
+  return (Array.isArray(value) ? value : [value]).map(formatPromptReference);
+};
+
+const formatPromptReference = (entry: AppendSystemPromptEntry): string => {
+  if (typeof entry === 'string') {
+    return entry;
+  }
+
+  if ('file' in entry) {
+    return entry.file;
+  }
+
+  return entry.repo_file;
+};
+
+const mergePiControls = (controls: Profile['controls']): PiProfileControls =>
+  mergeAgentSpecificControls<PiProfileControls>(controls, 'pi');

--- a/code/cli/src/agents/pi/PiSkillSources.ts
+++ b/code/cli/src/agents/pi/PiSkillSources.ts
@@ -1,0 +1,62 @@
+// Resolves Pi skill sources declared by profiles and discovered in profile folders.
+import { readdirSync, statSync, type Dirent } from 'node:fs';
+import { join } from 'node:path';
+
+import type { PiProfileControls } from '../../profiles/Profile.js';
+
+export const createPiSkillSources = (input: {
+  readonly builtInOutfitterSkill: string;
+  readonly controls: PiProfileControls;
+  readonly profileFolders: readonly string[];
+  readonly generatedSkillSources?: readonly string[];
+}): readonly string[] => [
+  ...new Set([
+    input.builtInOutfitterSkill,
+    ...(input.generatedSkillSources ?? []),
+    ...(input.controls.skills ?? []),
+    ...input.profileFolders.flatMap(skillSourcesForProfile),
+  ]),
+];
+
+const skillSourcesForProfile = (profileFolder: string): readonly string[] => [
+  ...skillSourcesForFolder(join(profileFolder, 'skills'), 'profile skills folder'),
+  ...skillSourcesForFolder(join(profileFolder, 'cli_specific', 'pi', 'skills'), 'profile Pi skills folder'),
+];
+
+const skillSourcesForFolder = (skillsFolder: string, description: string): readonly string[] =>
+  readOptionalDirectoryEntries(skillsFolder, description)
+    .filter(isPiSkillEntry(skillsFolder))
+    .map((entry) => join(skillsFolder, entry.name))
+    .sort();
+
+const isPiSkillEntry =
+  (folderPath: string) =>
+  (entry: Dirent): boolean =>
+    entry.isDirectory() && isFile(join(folderPath, entry.name, 'SKILL.md'));
+
+const readOptionalDirectoryEntries = (folderPath: string, description: string): readonly Dirent[] => {
+  try {
+    return readdirSync(folderPath, { withFileTypes: true });
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return [];
+    }
+
+    throw new Error(`Could not read ${description} '${folderPath}': ${String(error)}`, { cause: error });
+  }
+};
+
+const isFile = (path: string): boolean => {
+  try {
+    return statSync(path).isFile();
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return false;
+    }
+
+    throw new Error(`Could not inspect file '${path}': ${String(error)}`, { cause: error });
+  }
+};
+
+const isMissingPathError = (error: unknown): boolean =>
+  error !== null && typeof error === 'object' && 'code' in error && error.code === 'ENOENT';

--- a/code/cli/src/cli/commands/RunCommand.ts
+++ b/code/cli/src/cli/commands/RunCommand.ts
@@ -91,7 +91,7 @@ export const executeRunCommand = async (
     resolvedProfile,
     compositeProfileRootDirectory,
   );
-  const warnings = compositeProfilePlan.warnings;
+  const warnings = [...compositeProfilePlan.warnings, ...resolvedProfile.generatedSkillWarnings];
 
   failStrictOnWarnings(adapter.id, warnings, input.strict);
   emitWarnings(warnings, dependencies.writeError);
@@ -118,6 +118,7 @@ export const executeRunCommand = async (
         {
           profileFolders: resolvedProfile.profileFolders,
           profileLayers: createLaunchProfileLayers(resolvedProfile.profileLayers),
+          generatedSkillProfiles: createLaunchProfileLayers(resolvedProfile.generatedSkillProfiles),
           projectDirectory: input.projectDirectory,
           cacheDirectory: resolvedProfile.cacheDirectory,
           outfitterDocsDirectory: input.outfitterDocsDirectory,
@@ -275,6 +276,7 @@ const createAdapterCompositeProfilePlan = (
     profilePaths: resolvedProfile.profilePaths,
     profileFolders: resolvedProfile.profileFolders,
     profileLayers: createLaunchProfileLayers(resolvedProfile.profileLayers),
+    generatedSkillProfiles: createLaunchProfileLayers(resolvedProfile.generatedSkillProfiles),
     homeDirectory: resolvedProfile.homeDirectory,
     cacheDirectory: resolvedProfile.cacheDirectory,
     settings: resolvedProfile.settings,

--- a/code/cli/src/cli/commands/run/RunProfileResolution.ts
+++ b/code/cli/src/cli/commands/run/RunProfileResolution.ts
@@ -8,8 +8,14 @@ import {
   createRemoteRepositoryCachePath,
   resolveRemoteRepositorySubpath,
 } from '../../../profiles/ProfileCache.js';
+import { findGeneratedSkillProfiles } from '../../../profiles/GeneratedSkillProfiles.js';
 import { loadLocalProfileSource } from '../../../profiles/ProfileLoader.js';
 import type { LoadedProfile } from '../../../profiles/ProfileLoader.js';
+import {
+  findContributingLoadedProfiles,
+  findContributingProfileFolders,
+  findContributingProfilePaths,
+} from '../../../profiles/ProfileContributors.js';
 import { resolveProfile } from '../../../profiles/ProfileMerger.js';
 import type { ProfileSourceReference } from '../../../profiles/ProfileSource.js';
 import { defaultAgentId as registryDefaultAgentId } from '../../../agents/AgentRegistry.js';
@@ -26,6 +32,8 @@ export interface ResolvedRunProfile {
   readonly settings: Settings;
   readonly settingsPaths: readonly string[];
   readonly profileLayers: readonly LoadedProfile[];
+  readonly generatedSkillProfiles: readonly LoadedProfile[];
+  readonly generatedSkillWarnings: readonly string[];
 }
 
 export interface RunProfileResolutionInput {
@@ -48,6 +56,8 @@ export const createFirstRunBootstrapProfile = (input: RunProfileResolutionInput)
   settings: emptySettings(),
   settingsPaths: [],
   profileLayers: [],
+  generatedSkillProfiles: [],
+  generatedSkillWarnings: [],
 });
 
 export const loadResolvedProfile = (input: RunProfileResolutionInput): ResolvedRunProfile => {
@@ -80,9 +90,13 @@ export const loadResolvedProfile = (input: RunProfileResolutionInput): ResolvedR
     throw new Error(`Profile '${profileId}' is a template profile and must be inherited by a runnable profile.`);
   }
 
+  const generatedSkillProfileResolution = findGeneratedSkillProfiles(loadedProfiles.profiles);
+
   return {
     profile: resolution.profile,
     profileLayers: findContributingLoadedProfiles(resolution.profileStack, loadedProfiles.profiles),
+    generatedSkillProfiles: generatedSkillProfileResolution.profiles,
+    generatedSkillWarnings: generatedSkillProfileResolution.warnings,
     profilePaths: findContributingProfilePaths(resolution.profileStack, loadedProfiles.profiles),
     profileFolders: findContributingProfileFolders(resolution.profileStack, loadedProfiles.profiles),
     homeDirectory: input.homeDirectory,
@@ -125,34 +139,15 @@ const selectRunProfileId = (selectedProfileId: string | undefined, defaultProfil
   );
 };
 
-const findContributingProfilePaths = (
-  profileStack: readonly Profile[],
-  loadedProfiles: readonly LoadedProfile[],
-): readonly string[] =>
-  findContributingLoadedProfiles(profileStack, loadedProfiles).map((loadedProfile) => loadedProfile.profilePath);
-
-const findContributingProfileFolders = (
-  profileStack: readonly Profile[],
-  loadedProfiles: readonly LoadedProfile[],
-): readonly string[] =>
-  findContributingLoadedProfiles(profileStack, loadedProfiles).flatMap((loadedProfile) =>
-    loadedProfile.resourceRootPath === undefined ? [] : [loadedProfile.resourceRootPath],
-  );
-
 export const createLaunchProfileLayers = (loadedProfiles: readonly LoadedProfile[]) =>
   loadedProfiles.map((loadedProfile) => ({
     profile: loadedProfile.profile,
     profilePath: loadedProfile.profilePath,
     sourceRootPath: loadedProfile.sourceRootPath,
     resourceRootPath: loadedProfile.resourceRootPath,
+    sourceInputs: loadedProfile.sourceInputs,
     layout: loadedProfile.layout,
   }));
-
-const findContributingLoadedProfiles = (
-  profileStack: readonly Profile[],
-  loadedProfiles: readonly LoadedProfile[],
-): readonly LoadedProfile[] =>
-  profileStack.flatMap((profile) => loadedProfiles.filter((loadedProfile) => loadedProfile.profile.id === profile.id));
 
 export const loadProfileSources = (
   homeDirectory: string,

--- a/code/cli/src/profiles/GeneratedSkillProfiles.ts
+++ b/code/cli/src/profiles/GeneratedSkillProfiles.ts
@@ -1,0 +1,73 @@
+// Resolves profile definitions that should be exposed as generated native Pi skills.
+import { findContributingProfilePaths } from './ProfileContributors.js';
+import type { LoadedProfile } from './ProfileLoader.js';
+import { resolveProfile } from './ProfileMerger.js';
+
+export interface GeneratedSkillProfileResolutionResult {
+  readonly profiles: readonly LoadedProfile[];
+  readonly warnings: readonly string[];
+}
+
+export const findGeneratedSkillProfiles = (
+  loadedProfiles: readonly LoadedProfile[],
+): GeneratedSkillProfileResolutionResult => {
+  const generatedProfiles: LoadedProfile[] = [];
+  const warnings: string[] = [];
+  const profileIds = [...new Set(loadedProfiles.map((loadedProfile) => loadedProfile.profile.id))].filter((profileId) =>
+    mayResolveSkillGeneration(profileId, loadedProfiles),
+  );
+
+  for (const profileId of profileIds) {
+    const resolution = resolveProfile({ profiles: loadedProfiles, profileId });
+
+    if (resolution.profile === undefined || resolution.issues.length > 0) {
+      warnings.push(
+        `Cannot resolve generated skill profile '${profileId}': ${resolution.issues.map(formatIssue).join('; ')}`,
+      );
+      continue;
+    }
+
+    if (resolution.profile.skillGeneration !== true || resolution.profile.template === true) {
+      continue;
+    }
+
+    const sourceProfile = loadedProfiles.findLast((loadedProfile) => loadedProfile.profile.id === profileId);
+
+    /* v8 ignore next -- profile IDs are derived from loadedProfiles, so this guard is defensive. */
+    if (sourceProfile !== undefined) {
+      generatedProfiles.push({
+        ...sourceProfile,
+        profile: resolution.profile,
+        sourceInputs: findContributingProfilePaths(resolution.profileStack, loadedProfiles),
+      });
+    }
+  }
+
+  return { profiles: generatedProfiles, warnings };
+};
+
+const mayResolveSkillGeneration = (
+  profileId: string,
+  loadedProfiles: readonly LoadedProfile[],
+  visitedProfileIds: ReadonlySet<string> = new Set(),
+): boolean => {
+  if (visitedProfileIds.has(profileId)) {
+    return false;
+  }
+
+  const profileLayers = loadedProfiles.filter((loadedProfile) => loadedProfile.profile.id === profileId);
+
+  if (profileLayers.some((loadedProfile) => loadedProfile.profile.skillGeneration === true)) {
+    return true;
+  }
+
+  const nextVisitedProfileIds = new Set([...visitedProfileIds, profileId]);
+  return profileLayers.some((loadedProfile) =>
+    loadedProfile.profile.inherits.some((inheritedProfileId) =>
+      mayResolveSkillGeneration(inheritedProfileId, loadedProfiles, nextVisitedProfileIds),
+    ),
+  );
+};
+
+const formatIssue = (issue: { readonly path: string; readonly message: string }): string =>
+  `${issue.path}: ${issue.message}`;

--- a/code/cli/src/profiles/Profile.ts
+++ b/code/cli/src/profiles/Profile.ts
@@ -45,6 +45,7 @@ export interface Profile {
   readonly label?: string;
   readonly description?: string;
   readonly template?: boolean;
+  readonly skillGeneration?: boolean;
   readonly inherits: readonly string[];
   readonly controls: ProfileControls;
   readonly statePersistence?: StatePersistenceOverrides;

--- a/code/cli/src/profiles/ProfileContributors.ts
+++ b/code/cli/src/profiles/ProfileContributors.ts
@@ -1,0 +1,23 @@
+// Finds loaded profile source files that contribute to a resolved profile stack.
+import type { Profile } from './Profile.js';
+import type { LoadedProfile } from './ProfileLoader.js';
+
+export const findContributingLoadedProfiles = (
+  profileStack: readonly Pick<Profile, 'id'>[],
+  loadedProfiles: readonly LoadedProfile[],
+): readonly LoadedProfile[] =>
+  profileStack.flatMap((profile) => loadedProfiles.filter((loadedProfile) => loadedProfile.profile.id === profile.id));
+
+export const findContributingProfilePaths = (
+  profileStack: readonly Pick<Profile, 'id'>[],
+  loadedProfiles: readonly LoadedProfile[],
+): readonly string[] =>
+  findContributingLoadedProfiles(profileStack, loadedProfiles).map((loadedProfile) => loadedProfile.profilePath);
+
+export const findContributingProfileFolders = (
+  profileStack: readonly Pick<Profile, 'id'>[],
+  loadedProfiles: readonly LoadedProfile[],
+): readonly string[] =>
+  findContributingLoadedProfiles(profileStack, loadedProfiles).flatMap((loadedProfile) =>
+    loadedProfile.resourceRootPath === undefined ? [] : [loadedProfile.resourceRootPath],
+  );

--- a/code/cli/src/profiles/ProfileLoader.ts
+++ b/code/cli/src/profiles/ProfileLoader.ts
@@ -36,6 +36,7 @@ export interface LoadedProfile {
   readonly profile: Profile;
   readonly sourceRootPath?: string;
   readonly resourceRootPath?: string;
+  readonly sourceInputs?: readonly string[];
   readonly layout?: ProfileLayout;
 }
 
@@ -75,6 +76,7 @@ export const parseProfileDocument = (document: unknown, fallbackId: string): Pro
     label: readOptionalString(record.label),
     description: readOptionalString(record.description),
     template: readOptionalBoolean(record.template),
+    skillGeneration: readOptionalBoolean(record.skill_generation),
     inherits: readStringArray(record.inherits),
     controls: readControls(record.controls),
     statePersistence: Object.keys(statePersistence).length > 0 ? statePersistence : undefined,

--- a/code/cli/src/schemas/profile.schema.json
+++ b/code/cli/src/schemas/profile.schema.json
@@ -11,6 +11,7 @@
     "label": { "type": "string" },
     "description": { "type": "string" },
     "template": { "type": "boolean" },
+    "skill_generation": { "type": "boolean" },
     "inherits": {
       "type": "array",
       "items": {

--- a/code/cli/tests/unit/generated-skill-profiles.test.ts
+++ b/code/cli/tests/unit/generated-skill-profiles.test.ts
@@ -1,0 +1,54 @@
+// Tests resolving profile definitions exposed as generated Pi skills.
+import { describe, expect, it } from 'vitest';
+
+import { findGeneratedSkillProfiles } from '../../src/profiles/GeneratedSkillProfiles.js';
+import type { LoadedProfile } from '../../src/profiles/ProfileLoader.js';
+import type { Profile } from '../../src/profiles/Profile.js';
+
+describe('generated skill profiles', () => {
+  it('resolves marked profiles with inherited controls and contributing source inputs', () => {
+    const profiles = [
+      loadedProfile('base', { skillGeneration: true, controls: { thinking: 'high' } }),
+      loadedProfile('reviewer', { inherits: ['base'], controls: { model: 'pi/reviewer' } }),
+    ];
+
+    const result = findGeneratedSkillProfiles(profiles);
+
+    expect(result.warnings).toEqual([]);
+    expect(result.profiles).toHaveLength(2);
+    expect(result.profiles.map((profile) => profile.profile.id)).toEqual(['base', 'reviewer']);
+    expect(result.profiles[1]?.profile.controls).toEqual({ thinking: 'high', model: 'pi/reviewer' });
+    expect(result.profiles[1]?.sourceInputs).toEqual(['/profiles/base/profile.yml', '/profiles/reviewer/profile.yml']);
+  });
+
+  it('skips templates and warns about unresolved marked profiles', () => {
+    const result = findGeneratedSkillProfiles([
+      loadedProfile('template', { skillGeneration: true, template: true }),
+      loadedProfile('broken', { skillGeneration: true, inherits: ['missing'] }),
+      loadedProfile('cycle-a', { skillGeneration: true, inherits: ['cycle-b'] }),
+      loadedProfile('cycle-b', { inherits: ['cycle-a'] }),
+    ]);
+
+    expect(result.profiles).toEqual([]);
+    expect(result.warnings).toEqual([
+      "Cannot resolve generated skill profile 'broken': /profiles/missing: Profile 'missing' was not found.",
+      "Cannot resolve generated skill profile 'cycle-a': /profiles/cycle-a/inherits: Profile inheritance cycle detected: cycle-a -> cycle-b -> cycle-a",
+      "Cannot resolve generated skill profile 'cycle-b': /profiles/cycle-b/inherits: Profile inheritance cycle detected: cycle-b -> cycle-a -> cycle-b",
+    ]);
+  });
+});
+
+const loadedProfile = (id: string, profile: Partial<Profile> = {}): LoadedProfile => ({
+  source: { path: '/profiles' },
+  folderPath: `/profiles/${id}`,
+  profilePath: `/profiles/${id}/profile.yml`,
+  sourceRootPath: '/profiles',
+  resourceRootPath: `/profiles/${id}`,
+  layout: 'directory',
+  profile: {
+    id,
+    inherits: [],
+    controls: {},
+    ...profile,
+  },
+});

--- a/code/cli/tests/unit/pi-adapter-profile-resources.test.ts
+++ b/code/cli/tests/unit/pi-adapter-profile-resources.test.ts
@@ -51,6 +51,65 @@ describe('pi adapter profile resources', () => {
       skillFolder,
     ]);
   });
+
+  it('generates Pi skills from skill-generation profiles and enables them for launch', () => {
+    const root = createTemporaryRoot('outfitter-pi-generated-skills-');
+    const compositeRoot = join(root, 'composite');
+    const profilePath = join(root, 'profiles', 'founder', 'profile.yml');
+    const profile = {
+      id: 'founder',
+      label: 'Founder',
+      description: 'Founder operator review profile',
+      inherits: [],
+      controls: {
+        provider: 'openai-codex',
+        model: 'gpt-5.5',
+        thinking: 'high',
+        systemPrompt: 'prompts/system.md',
+        promptTemplate: 'prompts/template.md',
+        appendSystemPrompt: ['inline guidance', { file: 'prompts/founder.md' }, { repo_file: 'docs/mission.md' }],
+      },
+      skillGeneration: true,
+    } as const;
+
+    const adapter = createPiAdapter();
+    const generatedSkillProfiles = [
+      { profile, profilePath, sourceInputs: [profilePath] },
+      {
+        profile: { id: 'minimal', inherits: [], controls: {}, skillGeneration: true },
+        profilePath: join(root, 'profiles', 'minimal', 'profile.yml'),
+      },
+    ];
+    const compositeProfilePlan = adapter.createCompositeProfile(
+      { id: 'default', inherits: [], controls: {} },
+      { rootDirectory: compositeRoot, profilePaths: [], generatedSkillProfiles },
+    );
+    const launchPlan = adapter.createLaunchPlan(
+      compositeProfilePlan.compositeProfile,
+      { id: 'default', inherits: [], controls: {} },
+      [],
+      { generatedSkillProfiles },
+    );
+
+    const generatedSkillFile = compositeProfilePlan.compositeProfile.files.find(
+      (file) => file.relativePath === 'skills/founder/SKILL.md',
+    );
+
+    expect(generatedSkillFile?.sourceInputs).toEqual([profilePath]);
+    expect(generatedSkillFile?.content).toContain('Adopt the Founder profile');
+    expect(generatedSkillFile?.content).toContain('- Provider: openai-codex');
+    expect(generatedSkillFile?.content).toContain('- inline guidance');
+    expect(generatedSkillFile?.content).toContain('- prompts/founder.md');
+    expect(generatedSkillFile?.content).toContain('- docs/mission.md');
+    expect(launchPlan.args).toEqual([
+      '--skill',
+      builtInOutfitterSkill,
+      '--skill',
+      join(compositeRoot, 'skills', 'founder'),
+      '--skill',
+      join(compositeRoot, 'skills', 'minimal'),
+    ]);
+  });
 });
 
 const createTemporaryRoot = (prefix: string): string => {

--- a/code/cli/tests/unit/profile-loader.test.ts
+++ b/code/cli/tests/unit/profile-loader.test.ts
@@ -81,6 +81,18 @@ describe('profile loading', () => {
     });
   });
 
+  it('parses skill generation marker from profile YAML', () => {
+    const profile = parseProfileYaml('skill_generation: true\nlabel: Reviewer\n', 'reviewer');
+
+    expect(profile).toEqual({
+      id: 'reviewer',
+      label: 'Reviewer',
+      skillGeneration: true,
+      inherits: [],
+      controls: {},
+    });
+  });
+
   it('parses flat profile YAML files with fallback filename identities and no resource root', () => {
     const root = createProfileSourceRoot();
     writeFileSync(join(root, 'engineer.yml'), 'label: Engineer\ncontrols: {}\n');

--- a/docs/documentation/profiles.md
+++ b/docs/documentation/profiles.md
@@ -8,6 +8,7 @@ A profile can compose:
 - model and provider settings
 - Pi extensions
 - skills
+- generated skills
 - subagents
 - DeepWork workflows
 - agent-specific CLI flags and environment variables
@@ -150,6 +151,12 @@ Profile-owned file includes resolve from the source root of the profile layer th
 | Explicit `profile_sources[].path` without `.outfitter/` or `outfitter/` convention | The configured source path |
 
 `repo_file:` resolves from the active project directory where Outfitter launches the agent. This lets a reusable catalog or home profile request project-local governance context such as `docs/mission.md` without copying those docs into the catalog.
+
+### Generated Pi skills
+
+Set `skill_generation: true` on a profile to expose that profile as a generated Pi skill whenever the profile source is loaded. Outfitter resolves the profile, including inherited controls, writes `skills/<profile-id>/SKILL.md` into the temporary composite profile, and launches Pi with that generated skill enabled.
+
+Use generated skills for reusable perspectives that should be available inside another profile's session, such as a product reviewer, founder operator, or documentation editor. The generated skill asks the running agent to adopt the profile's role and honor profile prompt references and runtime preferences where possible; it does not restart the agent or change the selected launch profile.
 
 Run `outfitter profile lint` to report schema and inheritance errors, missing typed include files, and raw string append-prompt entries that look like file paths. Add `--strict` to exit non-zero for warnings, and `--json` for machine-readable diagnostics.
 


### PR DESCRIPTION
## Summary
- add `skill_generation: true` profile support that resolves marked profiles and writes generated Pi `SKILL.md` files into the composite profile
- enable generated profile skills in Pi launch args alongside the built-in Outfitter skill and profile-bundled skills
- document generated profile skills and cover schema parsing, generated profile resolution, and Pi adapter launch behavior in tests

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run coverage -- --coverage.reporter=text-summary`
- `npm run build`
- `/review` requested by user; DeepWork reported no matching review rules for the changed files

## Notes
- Checked subagents PR #92 first. It is still open with passing CI, but GitHub reports it is not currently mergeable because conflicts must be resolved locally before merge.
