### PR TITLE
fix(launch): suppress pi's false self-update notice for bundled launches

### DIFF
--- a/code/cli/src/agents/AgentLaunch.ts
+++ b/code/cli/src/agents/AgentLaunch.ts
@@ -47,6 +47,11 @@ export const resolveAgentLaunchExecutable = (launchPlan: AgentLaunchPlan): Agent
     ...launchPlan,
     command: bundledPiLaunch.command,
     args: [...bundledPiLaunch.prefixArgs, ...launchPlan.args],
+    // The bundled pi is version-pinned by Outfitter's own dependency, so pi's startup self-update
+    // notice ("Update Available … run pi update") is misleading here: `pi update` cannot update the
+    // bundled copy, and right after updating Outfitter the pinned pi can still lag pi.dev's latest.
+    // Skip pi's self-version check for bundled launches; profiles may override via environment.
+    env: { PI_SKIP_VERSION_CHECK: '1', ...launchPlan.env },
   };
 };
 

--- a/code/cli/tests/unit/agent-launch.test.ts
+++ b/code/cli/tests/unit/agent-launch.test.ts
@@ -21,7 +21,21 @@ describe('agent launch', () => {
     expect(resolved.command).toBe(process.execPath);
     expect(resolved.args[0]).toMatch(/[\\/]@earendil-works[\\/]pi-coding-agent[\\/].*cli\.js$/u);
     expect(resolved.args.slice(1)).toEqual(piPlan.args);
-    expect(resolved.env).toEqual(piPlan.env);
+    expect(resolved.env).toEqual({ ...piPlan.env, PI_SKIP_VERSION_CHECK: '1' });
+  });
+
+  it('suppresses the bundled pi self-update notice while letting plans override the setting', () => {
+    const resolved = resolveAgentLaunchExecutable(createPiPlan());
+
+    expect(resolved.env.PI_SKIP_VERSION_CHECK).toBe('1');
+
+    const overriddenPlan: AgentLaunchPlan = {
+      command: 'pi',
+      args: [],
+      env: { PI_SKIP_VERSION_CHECK: '' },
+    };
+
+    expect(resolveAgentLaunchExecutable(overriddenPlan).env.PI_SKIP_VERSION_CHECK).toBe('');
   });
 
   it('leaves non-pi launch plans untouched so they resolve from PATH', () => {


### PR DESCRIPTION
Cherry-picks a single commit out of #112 (still open, bundling several first-run reliability fixes) so this fix can land on `main` independently.

pi's interactive startup fetches `pi.dev/api/latest-version` and compares it to its own running version — that's upstream pi behavior, not Outfitter code. Because Outfitter always launches its bundled, version-pinned copy of pi, the notice fires whenever pi.dev is ahead of the pinned copy, including right after updating Outfitter itself — and pi's own suggested fix ("run pi update") can't touch the bundled copy anyway.

Sets `PI_SKIP_VERSION_CHECK=1` when resolving bundled pi launches. Profile environment values still override it; PATH-resolved pi is unaffected.

Closes #3.

Note: the original commit also added `docs/plans/issues/05-fix-false-update-notice.md`, but the whole `docs/plans/issues/` directory has since been removed from `main`, so that file was dropped from this cherry-pick — only the code fix and its test are included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)