### PR TITLE
feat: aggregate profile skills and subagents for Claude Code launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,28 @@ For the full walkthrough, see [Getting started](./docs/documentation/getting-sta
 
 [Profiles](./docs/documentation/profiles.md) compose the context, tools, prompts, skills, extensions, subagents, and DeepWork workflows that shape an agent. Profiles can be shared using [Profile Catalog Repos](./docs/documentation/profile-repository.md).
 
+The simplest useful profile is one YAML file with an appended system prompt. It works unchanged for every supported agent CLI:
+
 ```yaml
 # ~/.outfitter/profiles/home-default.yml
-id: home-default
 label: Home Default
-description: Reusable personal defaults for Outfitter-managed Pi runs.
 controls:
-  provider: openai-codex
-  model: gpt-5.5
+  append_system_prompt: |
+    Use concise, evidence-backed engineering prose.
+    Prefer small, reviewable changes.
+```
+
+```bash
+outfitter run --profile home-default                 # launches pi (default)
+outfitter run --profile home-default --agent claude  # launches Claude Code
+```
+
+Add agent-specific controls only when you need them:
+
+```yaml
+# ~/.outfitter/profiles/home-default.yml
+label: Home Default
+controls:
   thinking: high
   append_system_prompt:
     - |
@@ -44,6 +58,11 @@ controls:
       Prefer small, reviewable changes.
       Keep durable decisions in repo files.
     - repo_file: docs/architecture.md
+  pi:
+    provider: openai-codex
+    model: gpt-5.5
+  claude:
+    model: claude-sonnet-4-6
 ```
 
 ## Documentation

--- a/code/cli/src/agents/claude/ClaudeAdapter.ts
+++ b/code/cli/src/agents/claude/ClaudeAdapter.ts
@@ -11,6 +11,11 @@ import {
   supportedControlNames,
 } from '../AdapterProfileControls.js';
 import { createDeclaredStatePaths, findProfileStateSource } from '../AdapterStatePaths.js';
+import {
+  claudeAggregatedStatePaths,
+  resolveClaudeStateEntrySources,
+  type ClaudeAggregatedStatePath,
+} from './ClaudeProfileResources.js';
 import type { ClaudeProfileControls, Profile, ProfileControls } from '../../profiles/Profile.js';
 import { resolveAppendSystemPromptControl } from '../../profiles/PromptIncludes.js';
 import type { StatePathDeclaration, CompositeProfileStatePath } from '../../compositeProfile/StatePersistence.js';
@@ -142,8 +147,32 @@ const createClaudeStatePaths = (
         directory,
         controls.sessionDirectory,
       ),
-  });
+  }).map((statePath) => withClaudeProfileEntrySources(statePath, input.profileFolders ?? []));
 };
+
+const withClaudeProfileEntrySources = (
+  statePath: CompositeProfileStatePath,
+  profileFolders: readonly string[],
+): CompositeProfileStatePath => {
+  if (
+    statePath.strategy !== 'symlink' ||
+    statePath.sourcePath === undefined ||
+    !isClaudeAggregatedStatePath(statePath.relativePath)
+  ) {
+    return statePath;
+  }
+
+  const entrySources = resolveClaudeStateEntrySources({
+    relativePath: statePath.relativePath,
+    profileFolders,
+    baseSourcePath: statePath.sourcePath,
+  });
+
+  return entrySources === undefined ? statePath : { ...statePath, sourcePath: undefined, entrySources };
+};
+
+const isClaudeAggregatedStatePath = (relativePath: string): relativePath is ClaudeAggregatedStatePath =>
+  (claudeAggregatedStatePaths as readonly string[]).includes(relativePath);
 
 const resolveClaudeStateSourcePath = (
   profileFolders: readonly string[],

--- a/code/cli/src/agents/claude/ClaudeProfileResources.ts
+++ b/code/cli/src/agents/claude/ClaudeProfileResources.ts
@@ -1,0 +1,108 @@
+// Aggregates profile-provided Claude skills and subagents into merged composite state directories.
+import { readdirSync, statSync, type Dirent } from 'node:fs';
+import { join } from 'node:path';
+
+import type { CompositeProfileStateEntrySource } from '../../compositeProfile/StatePersistence.js';
+
+export type ClaudeAggregatedStatePath = 'skills/' | 'agents/';
+
+export const claudeAggregatedStatePaths: readonly ClaudeAggregatedStatePath[] = ['skills/', 'agents/'];
+
+/**
+ * Resolves per-entry symlink sources for the composite `skills/` or `agents/` directory.
+ * Returns undefined when no contributing profile folder ships generic entries, so the
+ * adapter keeps the existing whole-directory symlink behavior.
+ */
+export const resolveClaudeStateEntrySources = (input: {
+  readonly relativePath: ClaudeAggregatedStatePath;
+  readonly profileFolders: readonly string[];
+  readonly baseSourcePath: string;
+}): readonly CompositeProfileStateEntrySource[] | undefined => {
+  const profileEntries = input.profileFolders.flatMap((profileFolder) =>
+    profileEntrySourcesForFolder(input.relativePath, profileFolder),
+  );
+
+  if (profileEntries.length === 0) {
+    return undefined;
+  }
+
+  const mergedEntries = new Map<string, CompositeProfileStateEntrySource>();
+
+  for (const entry of baseEntrySources(input.baseSourcePath, input.relativePath)) {
+    mergedEntries.set(entry.name, entry);
+  }
+
+  for (const entry of profileEntries) {
+    mergedEntries.set(entry.name, entry);
+  }
+
+  return [...mergedEntries.values()].sort((left, right) => left.name.localeCompare(right.name));
+};
+
+const profileEntrySourcesForFolder = (
+  relativePath: ClaudeAggregatedStatePath,
+  profileFolder: string,
+): readonly CompositeProfileStateEntrySource[] =>
+  relativePath === 'skills/'
+    ? skillEntrySourcesForFolder(join(profileFolder, 'skills'), 'profile skills folder')
+    : subagentEntrySourcesForFolder(join(profileFolder, 'agents'), 'profile agents folder');
+
+const skillEntrySourcesForFolder = (
+  skillsFolder: string,
+  description: string,
+): readonly CompositeProfileStateEntrySource[] =>
+  readOptionalDirectoryEntries(skillsFolder, description)
+    .filter((entry) => entry.isDirectory() && isFile(join(skillsFolder, entry.name, 'SKILL.md')))
+    .map((entry) => ({ name: entry.name, sourcePath: join(skillsFolder, entry.name), directory: true }))
+    .sort(byEntryName);
+
+const subagentEntrySourcesForFolder = (
+  agentsFolder: string,
+  description: string,
+): readonly CompositeProfileStateEntrySource[] =>
+  readOptionalDirectoryEntries(agentsFolder, description)
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+    .map((entry) => ({ name: entry.name, sourcePath: join(agentsFolder, entry.name), directory: false }))
+    .sort(byEntryName);
+
+const baseEntrySources = (
+  baseSourcePath: string,
+  relativePath: ClaudeAggregatedStatePath,
+): readonly CompositeProfileStateEntrySource[] =>
+  readOptionalDirectoryEntries(baseSourcePath, `claude ${relativePath} state directory`)
+    .map((entry) => ({
+      name: entry.name,
+      sourcePath: join(baseSourcePath, entry.name),
+      directory: entry.isDirectory(),
+    }))
+    .sort(byEntryName);
+
+const byEntryName = (left: CompositeProfileStateEntrySource, right: CompositeProfileStateEntrySource): number =>
+  left.name.localeCompare(right.name);
+
+const readOptionalDirectoryEntries = (folderPath: string, description: string): readonly Dirent[] => {
+  try {
+    return readdirSync(folderPath, { withFileTypes: true });
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return [];
+    }
+
+    throw new Error(`Could not read ${description} '${folderPath}': ${String(error)}`, { cause: error });
+  }
+};
+
+const isFile = (path: string): boolean => {
+  try {
+    return statSync(path).isFile();
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return false;
+    }
+
+    throw new Error(`Could not inspect file '${path}': ${String(error)}`, { cause: error });
+  }
+};
+
+const isMissingPathError = (error: unknown): boolean =>
+  error !== null && typeof error === 'object' && 'code' in error && error.code === 'ENOENT';

--- a/code/cli/src/compositeProfile/StatePersistence.ts
+++ b/code/cli/src/compositeProfile/StatePersistence.ts
@@ -21,11 +21,19 @@ export interface StatePathDeclaration {
   readonly allowedStrategies: readonly StatePersistenceStrategy[];
 }
 
+export interface CompositeProfileStateEntrySource {
+  readonly name: string;
+  readonly sourcePath: string;
+  readonly directory: boolean;
+}
+
 export interface CompositeProfileStatePath {
   readonly relativePath: string;
   readonly strategy: StatePersistenceStrategy;
   readonly sourcePath?: string;
   readonly directory: boolean;
+  /** When set, the state directory is materialized as a real directory of per-entry symlinks. */
+  readonly entrySources?: readonly CompositeProfileStateEntrySource[];
 }
 
 export interface CompositeProfileStateBaseline {
@@ -43,6 +51,11 @@ export const materializeCompositeProfileStatePath = (
   statePath: CompositeProfileStatePath,
 ): void => {
   if (statePath.strategy === 'symlink') {
+    if (statePath.entrySources !== undefined) {
+      materializeEntrySymlinks(rootDirectory, statePath.relativePath, statePath.entrySources);
+      return;
+    }
+
     if (statePath.sourcePath === undefined) {
       throw new Error(`State path '${statePath.relativePath}' uses symlink without a source path.`);
     }
@@ -193,6 +206,29 @@ const getExistingSourceType = (sourcePath: string): 'file' | 'directory' | undef
 
     /* v8 ignore next -- non-ENOENT stat failures should surface as actionable filesystem errors. */
     throw error;
+  }
+};
+
+const materializeEntrySymlinks = (
+  rootDirectory: string,
+  relativePath: string,
+  entrySources: readonly CompositeProfileStateEntrySource[],
+): void => {
+  const outputPath = resolveCompositeProfileStateOutputPath(rootDirectory, relativePath);
+  mkdirSync(outputPath, { recursive: true });
+
+  for (const entrySource of entrySources) {
+    const entryOutputPath = resolveCompositeProfileRelativePath(
+      outputPath,
+      entrySource.name,
+      `State entry '${relativePath}${entrySource.name}'`,
+    );
+
+    if (pathLexicallyExists(entryOutputPath)) {
+      unlinkSync(entryOutputPath);
+    }
+
+    symlinkSync(entrySource.sourcePath, entryOutputPath, entrySource.directory ? 'dir' : 'file');
   }
 };
 

--- a/code/cli/tests/unit/claude-adapter-profile-resources.test.ts
+++ b/code/cli/tests/unit/claude-adapter-profile-resources.test.ts
@@ -1,0 +1,230 @@
+// Tests profile-bundled Claude skills and subagents aggregated into the composite profile.
+import { lstatSync, mkdirSync, mkdtempSync, readFileSync, readlinkSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createClaudeAdapter } from '../../src/agents/claude/ClaudeAdapter.js';
+import { resolveClaudeStateEntrySources } from '../../src/agents/claude/ClaudeProfileResources.js';
+import { writeCompositeProfile } from '../../src/compositeProfile/CompositeProfileAssembler.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (prefix: string): string => {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const writeSkill = (skillsFolder: string, name: string): string => {
+  const skillFolder = join(skillsFolder, name);
+  mkdirSync(skillFolder, { recursive: true });
+  writeFileSync(join(skillFolder, 'SKILL.md'), `---\nname: ${name}\ndescription: ${name} skill\n---\n`);
+  return skillFolder;
+};
+
+const writeSubagent = (agentsFolder: string, fileName: string, content: string): string => {
+  mkdirSync(agentsFolder, { recursive: true });
+  const agentPath = join(agentsFolder, fileName);
+  writeFileSync(agentPath, content);
+  return agentPath;
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('claude adapter profile resources', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.5.8, OFTR-006.5.10, OFTR-006.5.11).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('aggregates profile-bundled skills with home skills into a merged composite skills directory', () => {
+    const root = createTemporaryRoot('outfitter-claude-profile-skills-');
+    const homeDirectory = join(root, 'home');
+    const profileFolder = join(root, 'profiles', 'reviewer');
+    const homeSkillFolder = writeSkill(join(homeDirectory, '.claude', 'skills'), 'personal-skill');
+    writeSkill(join(homeDirectory, '.claude', 'skills'), 'review');
+    const profileSkillFolder = writeSkill(join(profileFolder, 'skills'), 'review');
+    mkdirSync(join(profileFolder, 'skills', 'not-a-skill'), { recursive: true });
+    writeFileSync(join(profileFolder, 'skills', 'stray-file.md'), 'not a skill directory\n');
+
+    const adapter = createClaudeAdapter();
+    const compositeRoot = join(root, 'composite');
+    const compositeProfilePlan = adapter.createCompositeProfile(
+      { id: 'reviewer', inherits: [], controls: {} },
+      { rootDirectory: compositeRoot, profilePaths: [], profileFolders: [profileFolder], homeDirectory },
+    );
+
+    const skillsStatePath = compositeProfilePlan.compositeProfile.statePaths.find(
+      (statePath) => statePath.relativePath === 'skills/',
+    );
+    expect(skillsStatePath).toMatchObject({ strategy: 'symlink', sourcePath: undefined });
+    expect(skillsStatePath?.entrySources).toEqual([
+      { name: 'personal-skill', sourcePath: homeSkillFolder, directory: true },
+      { name: 'review', sourcePath: profileSkillFolder, directory: true },
+    ]);
+
+    writeCompositeProfile(compositeProfilePlan.compositeProfile);
+
+    expect(lstatSync(join(compositeRoot, 'skills')).isDirectory()).toBe(true);
+    expect(lstatSync(join(compositeRoot, 'skills')).isSymbolicLink()).toBe(false);
+    expect(readlinkSync(join(compositeRoot, 'skills', 'review'))).toBe(profileSkillFolder);
+    expect(readlinkSync(join(compositeRoot, 'skills', 'personal-skill'))).toBe(homeSkillFolder);
+
+    writeFileSync(join(compositeRoot, 'skills', 'review', 'SKILL.md'), 'updated skill\n');
+    expect(readFileSync(join(profileSkillFolder, 'SKILL.md'), 'utf8')).toBe('updated skill\n');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.5.9, OFTR-006.5.10).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('aggregates profile-bundled subagents with home subagents and lets later profile layers win', () => {
+    const root = createTemporaryRoot('outfitter-claude-profile-agents-');
+    const homeDirectory = join(root, 'home');
+    const baseFolder = join(root, 'profiles', 'team-base');
+    const profileFolder = join(root, 'profiles', 'reviewer');
+    const homeAgentPath = writeSubagent(join(homeDirectory, '.claude', 'agents'), 'personal.md', '# Personal agent\n');
+    writeSubagent(join(homeDirectory, '.claude', 'agents'), 'reviewer.md', '# Home reviewer\n');
+    writeSubagent(join(baseFolder, 'agents'), 'reviewer.md', '# Base reviewer\n');
+    const profileAgentPath = writeSubagent(join(profileFolder, 'agents'), 'reviewer.md', '# Profile reviewer\n');
+    mkdirSync(join(profileFolder, 'agents', 'not-an-agent'), { recursive: true });
+    writeSubagent(join(profileFolder, 'agents'), 'notes.txt', 'not markdown\n');
+
+    const adapter = createClaudeAdapter();
+    const compositeRoot = join(root, 'composite');
+    const compositeProfilePlan = adapter.createCompositeProfile(
+      { id: 'reviewer', inherits: ['team-base'], controls: {} },
+      { rootDirectory: compositeRoot, profilePaths: [], profileFolders: [baseFolder, profileFolder], homeDirectory },
+    );
+
+    const agentsStatePath = compositeProfilePlan.compositeProfile.statePaths.find(
+      (statePath) => statePath.relativePath === 'agents/',
+    );
+    expect(agentsStatePath?.entrySources).toEqual([
+      { name: 'personal.md', sourcePath: homeAgentPath, directory: false },
+      { name: 'reviewer.md', sourcePath: profileAgentPath, directory: false },
+    ]);
+
+    writeCompositeProfile(compositeProfilePlan.compositeProfile);
+
+    expect(readFileSync(join(compositeRoot, 'agents', 'reviewer.md'), 'utf8')).toBe('# Profile reviewer\n');
+    expect(readFileSync(join(compositeRoot, 'agents', 'personal.md'), 'utf8')).toBe('# Personal agent\n');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.5.8, OFTR-006.5.10).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('keeps whole-directory symlinks when no contributing profile ships generic skills or subagents', () => {
+    const root = createTemporaryRoot('outfitter-claude-no-resources-');
+    const homeDirectory = join(root, 'home');
+    const profileFolder = join(root, 'profiles', 'plain');
+    mkdirSync(profileFolder, { recursive: true });
+
+    const adapter = createClaudeAdapter();
+    const compositeProfilePlan = adapter.createCompositeProfile(
+      { id: 'plain', inherits: [], controls: {} },
+      { rootDirectory: join(root, 'composite'), profilePaths: [], profileFolders: [profileFolder], homeDirectory },
+    );
+
+    for (const relativePath of ['skills/', 'agents/']) {
+      const statePath = compositeProfilePlan.compositeProfile.statePaths.find(
+        (candidate) => candidate.relativePath === relativePath,
+      );
+      expect(statePath).toMatchObject({
+        strategy: 'symlink',
+        sourcePath: join(homeDirectory, '.claude', relativePath.slice(0, -1)),
+      });
+      expect(statePath?.entrySources).toBeUndefined();
+    }
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.5.10).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('merges generic profile skills with claude-specific profile skill state instead of home state', () => {
+    const root = createTemporaryRoot('outfitter-claude-cli-specific-skills-');
+    const homeDirectory = join(root, 'home');
+    const profileFolder = join(root, 'profiles', 'owner');
+    const cliSpecificSkillFolder = writeSkill(join(profileFolder, 'cli_specific', 'claude', 'skills'), 'owned-skill');
+    const genericSkillFolder = writeSkill(join(profileFolder, 'skills'), 'shared-skill');
+    writeSkill(join(homeDirectory, '.claude', 'skills'), 'hidden-home-skill');
+
+    const adapter = createClaudeAdapter();
+    const compositeProfilePlan = adapter.createCompositeProfile(
+      { id: 'owner', inherits: [], controls: {} },
+      { rootDirectory: join(root, 'composite'), profilePaths: [], profileFolders: [profileFolder], homeDirectory },
+    );
+
+    const skillsStatePath = compositeProfilePlan.compositeProfile.statePaths.find(
+      (statePath) => statePath.relativePath === 'skills/',
+    );
+    expect(skillsStatePath?.entrySources).toEqual([
+      { name: 'owned-skill', sourcePath: cliSpecificSkillFolder, directory: true },
+      { name: 'shared-skill', sourcePath: genericSkillFolder, directory: true },
+    ]);
+  });
+
+  it('respects state_persistence overrides for aggregated skill and agent directories', () => {
+    const root = createTemporaryRoot('outfitter-claude-discarded-skills-');
+    const homeDirectory = join(root, 'home');
+    const profileFolder = join(root, 'profiles', 'discarding');
+    writeSkill(join(profileFolder, 'skills'), 'ignored-skill');
+
+    const adapter = createClaudeAdapter();
+    const compositeProfilePlan = adapter.createCompositeProfile(
+      { id: 'discarding', inherits: [], controls: {}, statePersistence: { 'skills/': 'discard' } },
+      { rootDirectory: join(root, 'composite'), profilePaths: [], profileFolders: [profileFolder], homeDirectory },
+    );
+
+    const skillsStatePath = compositeProfilePlan.compositeProfile.statePaths.find(
+      (statePath) => statePath.relativePath === 'skills/',
+    );
+    expect(skillsStatePath).toMatchObject({ strategy: 'discard', sourcePath: undefined });
+    expect(skillsStatePath?.entrySources).toBeUndefined();
+  });
+
+  it('surfaces append_system_prompt include diagnostics as composite profile warnings', () => {
+    const root = createTemporaryRoot('outfitter-claude-prompt-include-');
+    const profileFolder = join(root, 'profiles', 'prompted');
+    mkdirSync(profileFolder, { recursive: true });
+    const profile = {
+      id: 'prompted',
+      inherits: [],
+      controls: { appendSystemPrompt: { file: 'prompts/missing.md' } },
+    };
+
+    const adapter = createClaudeAdapter();
+    const compositeProfilePlan = adapter.createCompositeProfile(profile, {
+      rootDirectory: join(root, 'composite'),
+      profilePaths: [],
+      profileFolders: [profileFolder],
+      profileLayers: [
+        {
+          profile,
+          profilePath: join(profileFolder, 'profile.yml'),
+          sourceRootPath: join(root, 'profiles'),
+          resourceRootPath: profileFolder,
+          layout: 'directory',
+        },
+      ],
+    });
+
+    expect(compositeProfilePlan.warnings).toEqual([
+      expect.stringContaining("claude Prompt file include 'prompts/missing.md' was not found."),
+    ]);
+  });
+
+  it('reports unreadable profile resource folders with an actionable error', () => {
+    const root = createTemporaryRoot('outfitter-claude-unreadable-skills-');
+    const profileFolder = join(root, 'profiles', 'broken');
+    mkdirSync(profileFolder, { recursive: true });
+    writeFileSync(join(profileFolder, 'skills'), 'a file where the skills folder should be\n');
+
+    expect(() =>
+      resolveClaudeStateEntrySources({
+        relativePath: 'skills/',
+        profileFolders: [profileFolder],
+        baseSourcePath: join(root, 'home', '.claude', 'skills'),
+      }),
+    ).toThrow('Could not read profile skills folder');
+  });
+});

--- a/code/cli/tests/unit/claude-adapter.test.ts
+++ b/code/cli/tests/unit/claude-adapter.test.ts
@@ -312,6 +312,41 @@ describe('Claude Code adapter support', () => {
     expect(messages).toContain('↳ launching claude …');
   });
 
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.5.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('appends layered profile append_system_prompt entries as repeated Claude flags', () => {
+    const root = createTemporaryRoot();
+    const adapter = createClaudeAdapter();
+    const homeLayerProfile = {
+      id: 'home-default',
+      inherits: [],
+      controls: { appendSystemPrompt: 'Home prompt.' },
+    };
+    const projectLayerProfile = {
+      id: 'project',
+      inherits: ['home-default'],
+      controls: { claude: { appendSystemPrompt: 'Project prompt for Claude.' } },
+    };
+    const compositeProfilePlan = adapter.createCompositeProfile(projectLayerProfile, {
+      rootDirectory: join(root, 'composite'),
+      profilePaths: [],
+    });
+
+    const launchPlan = adapter.createLaunchPlan(compositeProfilePlan.compositeProfile, projectLayerProfile, [], {
+      profileLayers: [
+        { profile: homeLayerProfile, profilePath: join(root, 'profiles', 'home-default.yml') },
+        { profile: projectLayerProfile, profilePath: join(root, 'profiles', 'project.yml') },
+      ],
+    });
+
+    expect(launchPlan.args).toEqual([
+      '--append-system-prompt',
+      'Project prompt for Claude.',
+      '--append-system-prompt',
+      'Home prompt.',
+    ]);
+  });
+
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.5, OFTR-006.5).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('makes Claude Code unsupported control warnings fatal when strict is enabled', async () => {

--- a/docs/architecture/controllable-elements.md
+++ b/docs/architecture/controllable-elements.md
@@ -46,8 +46,15 @@ Executable/plugin modules that add tools, providers, hooks, or runtime behavior.
 
 Reusable task instructions, workflows, or resource bundles exposed to the agent.
 
-- Pi name: skills, `--skill`
-- Claude name: skills under the Claude config directory; Outfitter can profile native Claude skills through `cli_specific/claude/skills`, but generic `skills` selection is not mapped yet
+- Pi name: skills, `--skill`; profile `skills/<name>/SKILL.md` folders are passed automatically
+- Claude name: skills under the Claude config directory; Outfitter aggregates profile `skills/` folders and `cli_specific/claude/skills` into the profiled `skills/` directory, but the generic `controls.skills` selector is not mapped yet
+
+### Subagents
+
+Named agent definitions the primary agent can delegate focused tasks to.
+
+- Pi name: not consumed yet
+- Claude name: subagents under the Claude config directory `agents/`; Outfitter aggregates profile `agents/<name>.md` files and `cli_specific/claude/agents` into the profiled `agents/` directory
 
 ### Prompt Templates
 
@@ -141,6 +148,7 @@ An early-startup customization used to register providers, tools, hooks, or addi
 | Session Directory           | Supported | Supported |
 | Extensions                  | Supported | Supported |
 | Skills                      | Supported | Supported |
+| Subagents                   | Roadmap   | Supported |
 | Prompt Templates            | Supported | Supported |
 | System Prompt               | Supported | Supported |
 | Appended System Prompt      | Supported | Supported |
@@ -159,4 +167,4 @@ An early-startup customization used to register providers, tools, hooks, or addi
 For v1, a Outfitter profile may describe all defined terms generically.
 The Pi adapter is the first implementation, and pi remains the default adapter.
 Adapter-specific overrides live under `controls.pi` and `controls.claude`; unsupported controls warn at runtime, and `--strict` makes those warnings fatal.
-For Claude Code, `skills/` and `commands/` are supported as native configuration directories inside the profiled `CLAUDE_CONFIG_DIR`; the generic `controls.skills` and `controls.prompt_template` selectors remain unmapped and warn if requested.
+For Claude Code, `skills/`, `agents/`, and `commands/` are supported as native configuration directories inside the profiled `CLAUDE_CONFIG_DIR`, with profile `skills/` and `agents/` folders aggregated into them; the generic `controls.skills` and `controls.prompt_template` selectors remain unmapped and warn if requested.

--- a/docs/documentation/profiles.md
+++ b/docs/documentation/profiles.md
@@ -14,6 +14,39 @@ A profile can compose:
 
 Profiles can be local to a user or project, inherited from other profiles, or loaded from a shared profile repository. See [Profile repositories](./profile-repository.md) for shared setup sources.
 
+## The simplest profile
+
+A profile needs nothing more than a label and one control. This profile works unchanged with every supported agent CLI:
+
+```yaml
+# ~/.outfitter/profiles/reviewer.yml
+label: Reviewer
+controls:
+  append_system_prompt: |
+    Review changes for correctness first, style second.
+    Cite the file and line for every finding.
+```
+
+```bash
+outfitter run --profile reviewer                 # pi (default agent)
+outfitter run --profile reviewer --agent claude  # Claude Code
+```
+
+Generic controls translate to whichever agent launches: for Pi the appended prompt becomes `--append-system-prompt`, and for Claude Code the same flag on the `claude` CLI. Set `default_agent: claude` in `~/.outfitter/settings.yml` to make Claude Code the default. When one agent needs a different value, nest it under the agent key:
+
+```yaml
+# ~/.outfitter/profiles/reviewer.yml
+label: Reviewer
+controls:
+  append_system_prompt: |
+    Review changes for correctness first, style second.
+  pi:
+    provider: openai-codex
+    model: gpt-5.5
+  claude:
+    model: claude-sonnet-4-6
+```
+
 ## Profile layouts
 
 Outfitter supports two profile layouts inside any configured `profile_sources` directory.
@@ -51,11 +84,13 @@ The original layout is one folder per profile with a required `profile.yml`. Use
     prompts/
       system.md
     skills/
+    agents/
     extensions/
     deepwork/
       jobs/
     cli_specific/
       pi/
+      claude/
 ```
 
 ```yaml
@@ -69,6 +104,16 @@ controls:
 ```
 
 Directory profiles keep bundled resources close to the profile that references them. Generated Pi prompt exports for directory profiles are written as `generated-system-prompt.md` inside the profile directory when `profile_export` is enabled.
+
+### Skills and subagents
+
+Directory profiles ship skills and subagents as plain folders:
+
+- `skills/<name>/SKILL.md` — Agent Skills shared across agent CLIs. Pi receives each valid skill as a `--skill` argument; Claude Code sees the same skills inside its profiled config directory.
+- `agents/<name>.md` — subagent definitions. Claude Code loads them from the profiled config directory `agents/` folder; Pi does not consume them yet.
+- `cli_specific/pi/skills/` and `cli_specific/claude/{skills,agents}/` — CLI-specific variants when a skill or subagent should only apply to one agent.
+
+For Claude Code, profile-shipped skills and subagents are merged with the entries the launch would otherwise see (profile `cli_specific/claude/` state when present, else `~/.claude/skills` and `~/.claude/agents`). Profile entries win name conflicts, and each merged entry is a symlink, so editing an existing skill or subagent writes through to its source. Skills or subagents newly created during a merged session live only in the temporary composite profile; move them into a profile or `~/.claude` to keep them.
 
 ## Home and project example
 

--- a/docs/documentation/support-matrix.md
+++ b/docs/documentation/support-matrix.md
@@ -15,7 +15,9 @@ When a profile requests a control an adapter cannot translate, Outfitter warns t
 | Agent config directory                            | Supported | Supported   |
 | Session directory (`session_directory`)           | Supported | Supported   |
 | Extensions / plugins (`extensions`)               | Supported | Supported   |
-| Skills (`skills`)                                 | Supported | Partial     |
+| Skills (profile `skills/` folders)                | Supported | Supported   |
+| Skills (`controls.skills` selector)               | Supported | Roadmap     |
+| Subagents (profile `agents/` folders)             | Roadmap   | Supported   |
 | Prompt templates / commands (`prompt_template`)   | Supported | Partial     |
 | System prompt (`system_prompt`)                   | Supported | Supported   |
 | Appended system prompt (`append_system_prompt`)   | Supported | Supported   |
@@ -32,7 +34,8 @@ When a profile requests a control an adapter cannot translate, Outfitter warns t
 ## Claude Code notes
 
 - **Config and session state** — Outfitter points `CLAUDE_CONFIG_DIR` at the composite profile, declares Claude state paths (`settings.json`, `agents/`, `skills/`, `commands/`, `plugins/`, `projects/`) for persistence, and lets `session_directory` choose where `projects/` session state is symlinked from. There is no standalone session-dir flag.
-- **Skills (Partial)** — native Claude skills work when a profile ships them as `cli_specific/claude/skills/` directories, which Outfitter places in the profiled config directory. The generic `controls.skills` selector is not translated for Claude and warns if requested.
+- **Skills** — Claude loads skills from the composite profile `skills/` directory. Profiles contribute skills two ways: shared `skills/<name>/SKILL.md` folders (the same folders Pi picks up as `--skill` arguments) and Claude-specific `cli_specific/claude/skills/` state. When any contributing profile ships shared skills, Outfitter materializes `skills/` as a merged directory of per-skill symlinks — profile skills plus the entries of the otherwise-selected skill state (profile `cli_specific/claude/skills/` if present, else `~/.claude/skills`) — with profile skills winning name conflicts. Edits to existing skills write through to their sources; skills newly created during a merged session are not persisted. The generic `controls.skills` selector is still not translated for Claude and warns if requested.
+- **Subagents** — same shape as skills: profiles contribute subagents as `agents/<name>.md` files, merged with `cli_specific/claude/agents/` state or `~/.claude/agents`. When no profile ships shared subagents, `agents/` stays a whole-directory symlink so writes persist to the owning source.
 - **Prompt templates (Partial)** — same shape: native `cli_specific/claude/commands/` directories work, but the generic `controls.prompt_template` selector is not translated and warns.
 - **Model selection (Partial)** — `model` maps to `--model` and `thinking` maps to `--effort`, but `provider` is not translated for Claude and warns if requested.
 - **Extensions** — `controls.extensions` entries are passed as repeated `--plugin-dir` flags.

--- a/docs/requirements/OFTR-006-agent-adapters.md
+++ b/docs/requirements/OFTR-006-agent-adapters.md
@@ -60,6 +60,10 @@ Pi is the default and primary supported adapter; Claude Code is also supported t
 5. The Claude Code adapter SHOULD support `--model`, `--effort`, `--system-prompt`, `--append-system-prompt`, and `--plugin-dir` where native Claude Code flags exist.
 6. The Claude Code adapter SHOULD support `controls.session_directory` and `controls.claude.session_directory` by routing Claude `projects/` session state through Outfitter state persistence.
 7. The Claude Code adapter MUST return unsupported-control warnings for requested generic or `controls.claude` controls that it cannot translate.
+8. The Claude Code adapter MUST expose valid Agent Skills from contributing profile `skills/` folders as entries of the composite profile `skills/` directory, and MAY also expose Claude-specific skills from `cli_specific/claude/skills/`.
+9. The Claude Code adapter MUST expose Claude subagent definitions from contributing profile `agents/` folders as entries of the composite profile `agents/` directory, and MAY also expose Claude-specific subagents from `cli_specific/claude/agents/`.
+10. When profile skills or subagents are aggregated, the Claude Code adapter MUST keep entries from the otherwise-selected state source (profile `cli_specific/claude/` state or the user's `~/.claude` state) available alongside the profile entries, and profile entries MUST take precedence on name conflicts.
+11. Aggregated `skills/` and `agents/` composite directories MUST link each entry to its source so edits to existing entries write through, and MAY treat entries newly created inside the composite directory during a session as non-durable.
 
 ### OFTR-006.6: Pi Settings Reconciliation
 


### PR DESCRIPTION
## What

Makes the `claude` adapter a first-class target for wrapped profile launches, on par with `pi` for the profile concepts that matter day to day:

- **Appended system prompts per profile** — already translated (`--append-system-prompt`, layered across inherited profiles with agent-specific `controls.claude.append_system_prompt` overrides); now pinned by a dedicated requirement-traced test, and prompt-include diagnostics surface as composite-profile warnings.
- **Skills** — profiles that ship shared `skills/<name>/SKILL.md` folders (the same folders Pi passes as `--skill`) now reach Claude Code: the adapter aggregates them into the composite `CLAUDE_CONFIG_DIR/skills/` directory.
- **Subagents** — new profile convention `agents/<name>.md`; aggregated the same way into `CLAUDE_CONFIG_DIR/agents/`.

## Design

Claude Code discovers skills and subagents only from directories under `CLAUDE_CONFIG_DIR`, and Outfitter previously materialized `skills/` and `agents/` as a single whole-directory symlink (profile `cli_specific/claude/` state if present, else `~/.claude`). That leaves no way to combine profile-shipped resources with the user's own.

This PR adds an opt-in merged mode:

- When any contributing profile folder ships generic `skills/` or `agents/` entries, that state path is materialized as a **real directory of per-entry symlinks** (`CompositeProfileStatePath.entrySources`), merging the entries of the otherwise-selected source with the profile entries. Profile entries win name conflicts; later profile layers win over earlier ones.
- When no profile ships generic entries — including every existing profile today — behavior is **byte-identical to before**: one whole-directory symlink with full write-through. No protected OFTR test was modified; new behavior is reachable only via profile content those tests don't ship.

### Known limitations (documented in `docs/documentation/profiles.md` and the support matrix)

- Edits to *existing* merged entries write through their symlinks, but a skill or subagent **newly created during a merged session** lands in the temporary composite directory and is discarded at exit.
- The generic `controls.skills` selector is still not translated for Claude (it keeps warning, per OFTR-006.5.7 and the pinned fixture expectations); folder-based shipping is the supported path.
- Pi does not consume `agents/` folders yet (marked Roadmap in the matrix).

## Requirements & docs

- OFTR-006.5 gains clauses 8–11 covering skill/subagent aggregation, merge precedence, and write-through semantics; new tests carry the traceability comments.
- `docs/documentation/profiles.md` opens with a "simplest profile" example — one YAML file with an `append_system_prompt` that launches unchanged via `outfitter run --profile reviewer` (pi) or `--agent claude`, plus the minimal per-agent override shape. README shows the same minimal-first progression.
- Support matrix and `docs/architecture/controllable-elements.md` updated (skills split into folder vs selector rows; new subagents row).

## Testing

- `code/cli`: lint, typecheck, full vitest suite (285 passing), coverage 99.1% stmts / 98.1% branches (≥98% threshold), root `prettier --check`, `docs:ci` build — all green.
- New unit tests cover merged skills (incl. write-through and invalid-entry filtering), subagent layering precedence, `cli_specific` + generic merging, `state_persistence` overrides, unreadable-folder errors, layered Claude append prompts, and prompt-include warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)