### PR TITLE
fix(state): handle symlink permission errors with a win32-only fallback via SafeSymlink

### DIFF
--- a/code/cli/src/compositeProfile/StatePersistence.ts
+++ b/code/cli/src/compositeProfile/StatePersistence.ts
@@ -14,6 +14,8 @@ import {
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { sep as posixSeparator } from 'node:path/posix';
 
+import { createSafeSymlink } from '../fs/SafeSymlink.js';
+
 export type StatePersistenceStrategy = 'symlink' | 'discard' | 'warn' | 'error' | 'prompt';
 
 export interface StatePathDeclaration {
@@ -38,16 +40,23 @@ export interface CompositeProfileStateWriteIssue {
   readonly unknown: boolean;
 }
 
+export interface StateMaterializationDependencies {
+  readonly symlink?: typeof symlinkSync;
+  readonly warn?: (message: string) => void;
+  readonly platform?: NodeJS.Platform;
+}
+
 export const materializeCompositeProfileStatePath = (
   rootDirectory: string,
   statePath: CompositeProfileStatePath,
+  dependencies: StateMaterializationDependencies = {},
 ): void => {
   if (statePath.strategy === 'symlink') {
     if (statePath.sourcePath === undefined) {
       throw new Error(`State path '${statePath.relativePath}' uses symlink without a source path.`);
     }
 
-    materializeSymlink(rootDirectory, statePath.relativePath, statePath.sourcePath, statePath.directory);
+    materializeSymlink(rootDirectory, statePath.relativePath, statePath.sourcePath, statePath.directory, dependencies);
     return;
   }
 
@@ -201,6 +210,7 @@ const materializeSymlink = (
   relativePath: string,
   sourcePath: string,
   directory: boolean,
+  dependencies: StateMaterializationDependencies,
 ): void => {
   const outputPath = resolveCompositeProfileStateOutputPath(rootDirectory, relativePath);
   mkdirSync(dirname(outputPath), { recursive: true });
@@ -210,7 +220,7 @@ const materializeSymlink = (
   }
 
   ensureStateSourcePath(sourcePath, directory);
-  symlinkSync(sourcePath, outputPath, directory ? 'dir' : 'file');
+  createSafeSymlink({ sourcePath, outputPath, directory, label: `State path '${relativePath}'` }, dependencies);
 };
 
 const pathLexicallyExists = (path: string): boolean => {

--- a/code/cli/src/fs/SafeSymlink.ts
+++ b/code/cli/src/fs/SafeSymlink.ts
@@ -1,0 +1,74 @@
+// Creates symlinks with a Windows-only fallback for environments that deny symlink creation.
+import { copyFileSync, cpSync, symlinkSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export interface SafeSymlinkInput {
+  readonly sourcePath: string;
+  readonly outputPath: string;
+  readonly directory: boolean;
+  readonly label: string;
+}
+
+export interface SafeSymlinkDependencies {
+  readonly symlink?: typeof symlinkSync;
+  readonly warn?: (message: string) => void;
+  readonly platform?: NodeJS.Platform;
+}
+
+// Windows without Developer Mode rejects symlink creation with EPERM. Directories fall
+// back to junctions, which need no privilege but require an absolute target; files (and
+// directories whose junction also fails) fall back to a one-way copy with a warning
+// because agent writes to the copy cannot persist back to the source. On POSIX platforms
+// a permission error is a real filesystem problem, so it is rethrown instead of being
+// silently downgraded to a copy.
+export const createSafeSymlink = (input: SafeSymlinkInput, dependencies: SafeSymlinkDependencies = {}): void => {
+  const symlink = dependencies.symlink ?? symlinkSync;
+  /* v8 ignore next -- the process platform default is direct runtime behavior; tests inject a platform. */
+  const platform = dependencies.platform ?? process.platform;
+
+  try {
+    symlink(input.sourcePath, input.outputPath, input.directory ? 'dir' : 'file');
+  } catch (error) {
+    if (platform !== 'win32' || !isSymlinkPermissionError(error)) {
+      throw error;
+    }
+
+    createWindowsSafeSymlinkFallback(symlink, input, dependencies.warn);
+  }
+};
+
+const createWindowsSafeSymlinkFallback = (
+  symlink: typeof symlinkSync,
+  input: SafeSymlinkInput,
+  warn: ((message: string) => void) | undefined,
+): void => {
+  if (input.directory) {
+    try {
+      symlink(resolve(input.sourcePath), input.outputPath, 'junction');
+      return;
+    } catch (error) {
+      if (!isSymlinkPermissionError(error)) {
+        throw error;
+      }
+    }
+  }
+
+  copySafeSymlinkFallback(input, warn);
+};
+
+const copySafeSymlinkFallback = (input: SafeSymlinkInput, warn: ((message: string) => void) | undefined): void => {
+  if (input.directory) {
+    cpSync(input.sourcePath, input.outputPath, { recursive: true });
+  } else {
+    copyFileSync(input.sourcePath, input.outputPath);
+  }
+
+  /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a warn writer. */
+  (warn ?? console.error)(
+    `${input.label} could not be symlinked (symlinks are unavailable on this platform); ` +
+      `copied '${input.sourcePath}' instead, so writes to it will not persist back.`,
+  );
+};
+
+const isSymlinkPermissionError = (error: unknown): boolean =>
+  error instanceof Error && 'code' in error && (error.code === 'EPERM' || error.code === 'EACCES');

--- a/code/cli/tests/unit/state-persistence-symlink-fallback.test.ts
+++ b/code/cli/tests/unit/state-persistence-symlink-fallback.test.ts
@@ -1,0 +1,202 @@
+// Tests the Windows-only symlink fallback behavior for environments that deny symlink creation
+// (e.g. Windows without Developer Mode): directories fall back to junctions and files fall
+// back to a copy with a warning, while POSIX permission errors keep failing loudly.
+import {
+  existsSync,
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  ensureStateSourcePath,
+  materializeCompositeProfileStatePath,
+} from '../../src/compositeProfile/StatePersistence.js';
+import { createSafeSymlink } from '../../src/fs/SafeSymlink.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-symlink-fallback-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const createDenyingSymlink = (deniedTypes: readonly (string | undefined)[], symlinkTypes: (string | undefined)[]) =>
+  ((target: string, path: string, type?: string) => {
+    symlinkTypes.push(type);
+
+    if (deniedTypes.includes(type)) {
+      throw Object.assign(new Error(`EPERM: operation not permitted, symlink '${target}' -> '${path}'`), {
+        code: 'EPERM',
+      });
+    }
+
+    symlinkSync(target, path);
+  }) as typeof symlinkSync;
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('state persistence symlink fallback', () => {
+  it('falls back to junctions for directories and copies for files when Windows denies symlink creation', () => {
+    const root = createTemporaryRoot();
+    const sourceFile = ensureStateSourcePath(join(root, 'source', 'settings.json'), false);
+    const sourceDirectory = ensureStateSourcePath(join(root, 'source', 'plugins'), true);
+    writeFileSync(sourceFile, '{"kept":true}\n');
+    const symlinkTypes: (string | undefined)[] = [];
+    const denyingSymlink = ((target: string, path: string, type?: string) => {
+      symlinkTypes.push(type);
+
+      if (type === 'dir') {
+        throw Object.assign(new Error('EPERM: operation not permitted, symlink'), { code: 'EPERM' });
+      }
+
+      if (type === 'file') {
+        throw Object.assign(new Error('EACCES: permission denied, symlink'), { code: 'EACCES' });
+      }
+
+      symlinkSync(target, path);
+    }) as typeof symlinkSync;
+    const warnings: string[] = [];
+    const dependencies = {
+      symlink: denyingSymlink,
+      warn: (message: string) => warnings.push(message),
+      platform: 'win32' as const,
+    };
+
+    materializeCompositeProfileStatePath(
+      root,
+      { relativePath: 'plugins/', strategy: 'symlink', sourcePath: sourceDirectory, directory: true },
+      dependencies,
+    );
+    materializeCompositeProfileStatePath(
+      root,
+      { relativePath: 'settings.json', strategy: 'symlink', sourcePath: sourceFile, directory: false },
+      dependencies,
+    );
+
+    expect(symlinkTypes).toEqual(['dir', 'junction', 'file']);
+    expect(lstatSync(join(root, 'plugins')).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(root, 'plugins'))).toBe(resolve(sourceDirectory));
+    expect(lstatSync(join(root, 'settings.json')).isSymbolicLink()).toBe(false);
+    expect(readFileSync(join(root, 'settings.json'), 'utf8')).toBe('{"kept":true}\n');
+    expect(warnings).toEqual([
+      `State path 'settings.json' could not be symlinked (symlinks are unavailable on this platform); ` +
+        `copied '${sourceFile}' instead, so writes to it will not persist back.`,
+    ]);
+  });
+
+  it('copies directories with a warning when Windows also denies junction creation', () => {
+    const root = createTemporaryRoot();
+    const sourceDirectory = ensureStateSourcePath(join(root, 'source', 'plugins'), true);
+    writeFileSync(join(sourceDirectory, 'plugin.json'), '{"copied":true}\n');
+    const symlinkTypes: (string | undefined)[] = [];
+    const warnings: string[] = [];
+
+    materializeCompositeProfileStatePath(
+      root,
+      { relativePath: 'plugins/', strategy: 'symlink', sourcePath: sourceDirectory, directory: true },
+      {
+        symlink: createDenyingSymlink(['dir', 'junction'], symlinkTypes),
+        warn: (message: string) => warnings.push(message),
+        platform: 'win32',
+      },
+    );
+
+    expect(symlinkTypes).toEqual(['dir', 'junction']);
+    expect(lstatSync(join(root, 'plugins')).isSymbolicLink()).toBe(false);
+    expect(readFileSync(join(root, 'plugins', 'plugin.json'), 'utf8')).toBe('{"copied":true}\n');
+    expect(warnings).toEqual([
+      `State path 'plugins/' could not be symlinked (symlinks are unavailable on this platform); ` +
+        `copied '${sourceDirectory}' instead, so writes to it will not persist back.`,
+    ]);
+  });
+
+  it('rethrows Windows junction failures that are not permission errors', () => {
+    const root = createTemporaryRoot();
+    const sourceDirectory = ensureStateSourcePath(join(root, 'source', 'plugins'), true);
+    const symlinkTypes: (string | undefined)[] = [];
+    const brokenJunctionSymlink = ((target: string, path: string, type?: string) => {
+      symlinkTypes.push(type);
+
+      if (type === 'dir') {
+        throw Object.assign(new Error('EPERM: operation not permitted, symlink'), { code: 'EPERM' });
+      }
+
+      throw Object.assign(new Error(`EEXIST: file already exists, symlink '${target}' -> '${path}'`), {
+        code: 'EEXIST',
+      });
+    }) as typeof symlinkSync;
+
+    expect(() =>
+      materializeCompositeProfileStatePath(
+        root,
+        { relativePath: 'plugins/', strategy: 'symlink', sourcePath: sourceDirectory, directory: true },
+        { symlink: brokenJunctionSymlink, platform: 'win32' },
+      ),
+    ).toThrow('EEXIST: file already exists, symlink');
+    expect(symlinkTypes).toEqual(['dir', 'junction']);
+  });
+
+  it('rethrows permission errors on POSIX platforms instead of copying', () => {
+    const root = createTemporaryRoot();
+    const sourceFile = ensureStateSourcePath(join(root, 'source', 'settings.json'), false);
+    const warnings: string[] = [];
+
+    expect(() =>
+      materializeCompositeProfileStatePath(
+        root,
+        { relativePath: 'settings.json', strategy: 'symlink', sourcePath: sourceFile, directory: false },
+        {
+          symlink: createDenyingSymlink(['file'], []),
+          warn: (message: string) => warnings.push(message),
+          platform: 'linux',
+        },
+      ),
+    ).toThrow('EPERM: operation not permitted, symlink');
+    expect(existsSync(join(root, 'settings.json'))).toBe(false);
+    expect(warnings).toEqual([]);
+  });
+
+  it('rethrows symlink failures that are not permission errors', () => {
+    const root = createTemporaryRoot();
+    const sourceFile = ensureStateSourcePath(join(root, 'source', 'settings.json'), false);
+    const brokenSymlink = (() => {
+      throw Object.assign(new Error('EEXIST: file already exists, symlink'), { code: 'EEXIST' });
+    }) as unknown as typeof symlinkSync;
+
+    expect(() =>
+      materializeCompositeProfileStatePath(
+        root,
+        { relativePath: 'settings.json', strategy: 'symlink', sourcePath: sourceFile, directory: false },
+        { symlink: brokenSymlink, platform: 'win32' },
+      ),
+    ).toThrow('EEXIST: file already exists, symlink');
+  });
+
+  it('creates real symlinks directly through the shared safe symlink helper', () => {
+    const root = createTemporaryRoot();
+    const sourceFile = ensureStateSourcePath(join(root, 'source', 'settings.json'), false);
+
+    createSafeSymlink({
+      sourcePath: sourceFile,
+      outputPath: join(root, 'settings.json'),
+      directory: false,
+      label: `State path 'settings.json'`,
+    });
+
+    expect(readlinkSync(join(root, 'settings.json'))).toBe(sourceFile);
+  });
+});


### PR DESCRIPTION
Split 1/3 of #114 (state-persistence hardening), rebuilt against current main.

State symlink materialization called `symlinkSync` directly, so an EPERM/EACCES (e.g. Windows without Developer Mode) crashed the run unhandled. Symlink creation now goes through a shared `fs/SafeSymlink` helper:

- **win32**: directories fall back to junctions (a junction's own permission failure falls back to a warned directory copy); files fall back to a one-way copy with a warning that writes will not persist back.
- **POSIX**: the error is rethrown — a permission failure there is a real filesystem problem, and a silent copy would lose agent write-back.

The symlink, warn, and platform dependencies are injectable and the fallback matrix is unit-tested.

Provenance: combines the `StatePersistence.ts` slice of `d4f20c4` (#111, which stays focused on CI) with `e657495` (#114) as one reviewable unit. Original commits by Tyler Willis.

Verification: `typecheck`, `eslint`, full vitest suite (283 tests), coverage 99.16% stmts — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)