### PR TITLE
feat(state): implement the interactive prompt state-persistence strategy

### DIFF
--- a/code/cli/src/agents/AdapterStatePaths.ts
+++ b/code/cli/src/agents/AdapterStatePaths.ts
@@ -27,8 +27,10 @@ export const createDeclaredStatePaths = (input: DeclaredStatePathInput): readonl
       relativePath,
       strategy,
       directory,
+      // Prompt paths resolve a durable source too, so an interactive "persist" choice
+      // after the run has a destination to copy the change to.
       sourcePath:
-        strategy === 'symlink' && relativePath !== 'unknown'
+        (strategy === 'symlink' || strategy === 'prompt') && relativePath !== 'unknown'
           ? input.resolveSourcePath(relativePath, directory)
           : undefined,
     };

--- a/code/cli/src/cli/commands/RunCommand.ts
+++ b/code/cli/src/cli/commands/RunCommand.ts
@@ -19,12 +19,15 @@ import { renderCompositeProfileTemplates } from '../../compositeProfile/Composit
 import {
   createCompositeProfileStateBaseline,
   detectCompositeProfileStateWrites,
+  persistCompositeProfileStateWrite,
+  recordProfileStatePersistenceOverride,
   updateCompositeProfileStateBaselinePaths,
 } from '../../compositeProfile/StatePersistence.js';
 import type {
   CompositeProfileStateBaseline,
   CompositeProfileStatePath,
   CompositeProfileStateWriteIssue,
+  CompositeProfileStateWritePrompt,
 } from '../../compositeProfile/StatePersistence.js';
 import { watchCompositeProfileInputs } from '../../compositeProfile/CompositeProfileWatcher.js';
 import type { AgentProcessLauncher } from '../../agents/AgentLaunch.js';
@@ -34,6 +37,7 @@ import { isNonInteractivePiLaunch, preparePiLoginLaunchPlan } from './PiLoginLau
 import type { SetupCommandDependencies } from './SetupCommand.js';
 import { syncProfileSource, type RemoteProfileSource } from './SyncCommand.js';
 import { emitLaunchSummary } from './run/RunLaunchSummary.js';
+import { createTerminalStateWritePrompt } from './run/RunStateWritePrompt.js';
 import {
   createFirstRunBootstrapProfile,
   createLaunchProfileLayers,
@@ -74,6 +78,7 @@ export interface RunCommandDependencies extends SetupCommandDependencies {
   readonly adapter?: AgentAdapter;
   readonly launcher?: AgentProcessLauncher;
   readonly writeError?: (message: string) => void;
+  readonly promptStateWritePersistence?: CompositeProfileStateWritePrompt;
 }
 
 export const executeRunCommand = async (
@@ -174,12 +179,16 @@ export const executeRunCommand = async (
       dependencies.launcher ??
       /* v8 ignore next -- tests inject launchers instead of spawning pi. */ createSpawnLauncher();
     const exitCode = await launchAgentProcess(launcher, launchPlan, adapter.id);
-    const stateWriteWarnings = handleCompositeProfileStateWrites(
-      adapter.id,
-      compositeProfilePlan.compositeProfile.rootDirectory,
-      compositeProfilePlan.compositeProfile.statePaths,
+    const stateWriteWarnings = await handleCompositeProfileStateWrites({
+      adapterId: adapter.id,
+      rootDirectory: compositeProfilePlan.compositeProfile.rootDirectory,
+      statePaths: compositeProfilePlan.compositeProfile.statePaths,
       stateBaseline,
-    );
+      prompt: resolveStateWritePrompt(dependencies),
+      recordAlwaysChoice: (relativePath) => recordAlwaysStatePersistenceChoice(adapter, resolvedProfile, relativePath),
+      /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a line writer. */
+      notify: dependencies.writeLine ?? console.log,
+    });
 
     failStrictOnWarnings(adapter.id, stateWriteWarnings, input.strict);
     emitWarnings(stateWriteWarnings, dependencies.writeError);
@@ -294,23 +303,155 @@ const createAdapterCompositeProfilePlan = (
   };
 };
 
-const handleCompositeProfileStateWrites = (
-  adapterId: string,
-  compositeProfileRootDirectory: string,
-  statePaths: readonly CompositeProfileStatePath[],
-  stateBaseline: CompositeProfileStateBaseline,
-): readonly string[] => {
+interface CompositeProfileStateWriteHandlingInput {
+  readonly adapterId: string;
+  readonly rootDirectory: string;
+  readonly statePaths: readonly CompositeProfileStatePath[];
+  readonly stateBaseline: CompositeProfileStateBaseline;
+  readonly prompt?: CompositeProfileStateWritePrompt;
+  readonly recordAlwaysChoice: (relativePath: string) => string | undefined;
+  readonly notify: (message: string) => void;
+}
+
+const handleCompositeProfileStateWrites = async (
+  input: CompositeProfileStateWriteHandlingInput,
+): Promise<readonly string[]> => {
   const warnings: string[] = [];
 
-  for (const issue of detectCompositeProfileStateWrites(compositeProfileRootDirectory, statePaths, stateBaseline)) {
+  for (const issue of detectCompositeProfileStateWrites(input.rootDirectory, input.statePaths, input.stateBaseline)) {
     if (issue.strategy === 'error') {
-      throw new Error(formatCompositeProfileStateWriteIssue(adapterId, issue));
+      throw new Error(formatCompositeProfileStateWriteIssue(input.adapterId, issue));
     }
 
-    warnings.push(formatCompositeProfileStateWriteIssue(adapterId, issue));
+    if (issue.strategy === 'prompt') {
+      warnings.push(...(await handlePromptStateWriteIssue(input, issue)));
+      continue;
+    }
+
+    warnings.push(formatCompositeProfileStateWriteIssue(input.adapterId, issue));
   }
 
   return warnings;
+};
+
+const handlePromptStateWriteIssue = async (
+  input: CompositeProfileStateWriteHandlingInput,
+  issue: CompositeProfileStateWriteIssue,
+): Promise<readonly string[]> => {
+  if (issue.unknown) {
+    return [
+      formatCompositeProfileStateWriteIssue(input.adapterId, issue),
+      `state_persistence 'prompt' cannot persist undeclared writes; '${issue.relativePath}' was reported instead.`,
+    ];
+  }
+
+  if (input.prompt === undefined) {
+    return [
+      formatCompositeProfileStateWriteIssue(input.adapterId, issue),
+      `state_persistence prompt for '${issue.relativePath}' skipped: non-interactive session.`,
+    ];
+  }
+
+  const statePath = findDeclaredStatePath(input.statePaths, issue.relativePath);
+  const choice = await input.prompt({
+    agentId: input.adapterId,
+    relativePath: issue.relativePath,
+    sourcePath: statePath.sourcePath,
+  });
+
+  return applyPromptStateWriteChoice(input, statePath, choice);
+};
+
+const applyPromptStateWriteChoice = (
+  input: CompositeProfileStateWriteHandlingInput,
+  statePath: CompositeProfileStatePath,
+  choice: 'persist' | 'discard' | 'always',
+): readonly string[] => {
+  if (choice === 'discard') {
+    input.notify(`Discarded ${input.adapterId} state write to '${statePath.relativePath}'.`);
+    return [];
+  }
+
+  try {
+    persistCompositeProfileStateWrite(input.rootDirectory, statePath);
+  } catch (error) {
+    return [`Could not persist state path '${statePath.relativePath}': ${String(error)}`];
+  }
+
+  input.notify(`Persisted ${input.adapterId} state write '${statePath.relativePath}' to ${statePath.sourcePath}.`);
+
+  if (choice === 'always') {
+    const warning = input.recordAlwaysChoice(statePath.relativePath);
+    return warning === undefined ? [] : [warning];
+  }
+
+  return [];
+};
+
+const findDeclaredStatePath = (
+  statePaths: readonly CompositeProfileStatePath[],
+  relativePath: string,
+): CompositeProfileStatePath => {
+  const statePath = statePaths.find((candidate) => candidate.relativePath === relativePath);
+
+  /* v8 ignore next 3 -- declared prompt issues always originate from a declared state path. */
+  if (statePath === undefined) {
+    throw new Error(`State path '${relativePath}' is not declared by the composite profile.`);
+  }
+
+  return statePath;
+};
+
+// The "always" choice is recorded in the selected profile's own YAML file because profiles
+// are the single source of truth for state_persistence policy; a parallel settings-layer
+// override would create a second precedence system that adapter validation cannot see.
+// Remote/cached profiles are never mutated, so the choice degrades to a one-run persist
+// with an actionable warning.
+const recordAlwaysStatePersistenceChoice = (
+  adapter: AgentAdapter,
+  resolvedProfile: ResolvedRunProfile,
+  relativePath: string,
+): string | undefined => {
+  const declaration = adapter.statePaths?.[relativePath];
+
+  if (declaration === undefined || !declaration.allowedStrategies.includes('symlink')) {
+    return (
+      `Cannot always-persist '${relativePath}': the ${adapter.id} adapter does not allow 'symlink' for it; ` +
+      `the write was persisted once.`
+    );
+  }
+
+  const selectedLayer = [...resolvedProfile.profileLayers]
+    .reverse()
+    .find((layer) => layer.profile.id === resolvedProfile.profile.id);
+
+  if (
+    selectedLayer === undefined ||
+    selectedLayer.source.uri !== undefined ||
+    selectedLayer.source.github !== undefined
+  ) {
+    return (
+      `Cannot record the always-persist choice for '${relativePath}' because profile ` +
+      `'${resolvedProfile.profile.id}' is not a local profile file; the write was persisted once.`
+    );
+  }
+
+  recordProfileStatePersistenceOverride(selectedLayer.profilePath, relativePath, 'symlink');
+  return undefined;
+};
+
+const resolveStateWritePrompt = (
+  dependencies: RunCommandDependencies,
+): CompositeProfileStateWritePrompt | undefined => {
+  if (!isInteractiveRunLaunch(dependencies)) {
+    return undefined;
+  }
+
+  return (
+    dependencies.promptStateWritePersistence ??
+    /* v8 ignore next -- terminal prompting is direct CLI behavior; tests inject a prompt. */
+    createTerminalStateWritePrompt(dependencies.input ?? process.stdin, dependencies.output ?? process.stdout)
+  );
 };
 
 const formatCompositeProfileStateWriteIssue = (adapterId: string, issue: CompositeProfileStateWriteIssue): string => {

--- a/code/cli/src/cli/commands/run/RunStateWritePrompt.ts
+++ b/code/cli/src/cli/commands/run/RunStateWritePrompt.ts
@@ -1,0 +1,40 @@
+// Provides the readline-based terminal prompt for state_persistence 'prompt' decisions.
+import { createInterface } from 'node:readline/promises';
+
+import type { CompositeProfileStateWritePrompt } from '../../../compositeProfile/StatePersistence.js';
+
+/* v8 ignore start -- readline prompting is direct terminal behavior; tests inject a prompt. */
+export const createTerminalStateWritePrompt =
+  (input: NodeJS.ReadableStream, output: NodeJS.WritableStream): CompositeProfileStateWritePrompt =>
+  async (request) => {
+    const readline = createInterface({ input, output });
+
+    try {
+      for (;;) {
+        const answer = (
+          await readline.question(
+            `${request.agentId} wrote state path '${request.relativePath}' (state_persistence 'prompt'). ` +
+              `[p]ersist to ${request.sourcePath ?? 'its durable source'} / [d]iscard / ` +
+              `[a]lways persist for this profile: `,
+          )
+        )
+          .trim()
+          .toLowerCase();
+
+        if (answer === 'p' || answer === 'persist') {
+          return 'persist';
+        }
+
+        if (answer === 'd' || answer === 'discard') {
+          return 'discard';
+        }
+
+        if (answer === 'a' || answer === 'always') {
+          return 'always';
+        }
+      }
+    } finally {
+      readline.close();
+    }
+  };
+/* v8 ignore stop */

--- a/code/cli/src/compositeProfile/StatePersistence.ts
+++ b/code/cli/src/compositeProfile/StatePersistence.ts
@@ -1,5 +1,6 @@
 // Defines composite profile state persistence declarations, strategies, and write detection helpers.
 import {
+  cpSync,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -13,6 +14,8 @@ import {
 } from 'node:fs';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { sep as posixSeparator } from 'node:path/posix';
+
+import { parseDocument } from 'yaml';
 
 import { createSafeSymlink } from '../fs/SafeSymlink.js';
 
@@ -126,6 +129,52 @@ export const detectCompositeProfileStateWrites = (
   }
 
   return [...issues.values()].sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+};
+
+export type CompositeProfileStateWritePromptChoice = 'persist' | 'discard' | 'always';
+
+export interface CompositeProfileStateWritePromptRequest {
+  readonly agentId: string;
+  readonly relativePath: string;
+  readonly sourcePath?: string;
+}
+
+export type CompositeProfileStateWritePrompt = (
+  request: CompositeProfileStateWritePromptRequest,
+) => Promise<CompositeProfileStateWritePromptChoice>;
+
+// Copies an agent's change to a prompt-strategy state path from the composite profile back
+// to the durable source path, so an interactive "persist" choice survives the run.
+export const persistCompositeProfileStateWrite = (
+  rootDirectory: string,
+  statePath: CompositeProfileStatePath,
+): void => {
+  if (statePath.sourcePath === undefined) {
+    throw new Error(`State path '${statePath.relativePath}' cannot be persisted without a durable source path.`);
+  }
+
+  const outputPath = resolveCompositeProfileStateOutputPath(rootDirectory, statePath.relativePath);
+
+  if (!pathLexicallyExists(outputPath)) {
+    throw new Error(
+      `State path '${statePath.relativePath}' no longer exists in the composite profile, so it cannot be persisted.`,
+    );
+  }
+
+  ensureStateSourcePath(statePath.sourcePath, statePath.directory);
+  cpSync(outputPath, statePath.sourcePath, { recursive: true, force: true });
+};
+
+// Records a durable state_persistence override in a profile YAML file, preserving the
+// existing document structure and comments.
+export const recordProfileStatePersistenceOverride = (
+  profilePath: string,
+  relativePath: string,
+  strategy: StatePersistenceStrategy,
+): void => {
+  const profileDocument = parseDocument(readFileSync(profilePath, 'utf8'));
+  profileDocument.setIn(['state_persistence', relativePath], strategy);
+  writeFileSync(profilePath, profileDocument.toString());
 };
 
 export const ensureStateSourcePath = (sourcePath: string, directory: boolean): string => {

--- a/code/cli/tests/unit/state-persistence-prompt.test.ts
+++ b/code/cli/tests/unit/state-persistence-prompt.test.ts
@@ -1,0 +1,404 @@
+// Tests the interactive `prompt` state-persistence strategy: persist/discard/always choices,
+// non-interactive fallback, and undeclared-write handling.
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { executeRunCommand } from '../../src/cli/commands/RunCommand.js';
+import { createCompositeProfile } from '../../src/compositeProfile/CompositeProfile.js';
+import {
+  persistCompositeProfileStateWrite,
+  recordProfileStatePersistenceOverride,
+} from '../../src/compositeProfile/StatePersistence.js';
+import type { CompositeProfileStateWritePromptRequest } from '../../src/compositeProfile/StatePersistence.js';
+import { createProfileSourceCachePath } from '../../src/profiles/ProfileCache.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-state-prompt-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const writeSettings = (homeDirectory: string, content: string): void => {
+  mkdirSync(join(homeDirectory, '.outfitter'), { recursive: true });
+  writeFileSync(join(homeDirectory, '.outfitter', 'settings.yml'), content);
+};
+
+const writeProfile = (profilesRoot: string, id: string, content: string): string => {
+  const profileDirectory = join(profilesRoot, id);
+  mkdirSync(profileDirectory, { recursive: true });
+  const profilePath = join(profileDirectory, 'profile.yml');
+  writeFileSync(profilePath, content);
+  return profilePath;
+};
+
+const createPromptRunRoot = (
+  profileContent: string,
+): { root: string; homeDirectory: string; projectDirectory: string; profilePath: string } => {
+  const root = createTemporaryRoot();
+  const homeDirectory = join(root, 'home');
+  const projectDirectory = join(root, 'project');
+  writeSettings(homeDirectory, 'default_profile: default\nprofile_sources:\n  - path: ./profiles\n');
+  const profilePath = writeProfile(join(homeDirectory, '.outfitter', 'profiles'), 'default', profileContent);
+  return { root, homeDirectory, projectDirectory, profilePath };
+};
+
+const promptProfileContent = [
+  'id: default',
+  '# durable policy comment',
+  'state_persistence:',
+  '  mcp.json: prompt',
+  'controls: {}',
+  '',
+].join('\n');
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('prompt state persistence strategy', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('persists a prompt-strategy write to its durable source when the user chooses persist', async () => {
+    const { homeDirectory, projectDirectory } = createPromptRunRoot(promptProfileContent);
+    const requests: CompositeProfileStateWritePromptRequest[] = [];
+    const messages: string[] = [];
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        interactive: true,
+        writeError: () => undefined,
+        writeLine: (message) => messages.push(message),
+        promptStateWritePersistence: (request) => {
+          requests.push(request);
+          return Promise.resolve('persist');
+        },
+        launcher: {
+          launch(plan) {
+            writeFileSync(join(plan.env.PI_CODING_AGENT_DIR, 'mcp.json'), '{"servers":{"kept":true}}\n');
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    const nativeMcpPath = join(homeDirectory, '.pi', 'agent', 'mcp.json');
+    expect(requests).toEqual([{ agentId: 'pi', relativePath: 'mcp.json', sourcePath: nativeMcpPath }]);
+    expect(readFileSync(nativeMcpPath, 'utf8')).toBe('{"servers":{"kept":true}}\n');
+    expect(result.warnings).toEqual([]);
+    expect(messages).toContain(`Persisted pi state write 'mcp.json' to ${nativeMcpPath}.`);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('discards a prompt-strategy write when the user chooses discard', async () => {
+    const { homeDirectory, projectDirectory } = createPromptRunRoot(promptProfileContent);
+    const messages: string[] = [];
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        interactive: true,
+        writeError: () => undefined,
+        writeLine: (message) => messages.push(message),
+        promptStateWritePersistence: () => Promise.resolve('discard'),
+        launcher: {
+          launch(plan) {
+            writeFileSync(join(plan.env.PI_CODING_AGENT_DIR, 'mcp.json'), '{"servers":{"dropped":true}}\n');
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(existsSync(join(homeDirectory, '.pi', 'agent', 'mcp.json'))).toBe(false);
+    expect(result.warnings).toEqual([]);
+    expect(messages).toContain(`Discarded pi state write to 'mcp.json'.`);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('records an always-persist choice as a symlink override in the selected local profile', async () => {
+    const { homeDirectory, projectDirectory, profilePath } = createPromptRunRoot(promptProfileContent);
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        interactive: true,
+        writeError: () => undefined,
+        writeLine: () => undefined,
+        promptStateWritePersistence: () => Promise.resolve('always'),
+        launcher: {
+          launch(plan) {
+            writeFileSync(join(plan.env.PI_CODING_AGENT_DIR, 'mcp.json'), '{"servers":{"always":true}}\n');
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(readFileSync(join(homeDirectory, '.pi', 'agent', 'mcp.json'), 'utf8')).toBe('{"servers":{"always":true}}\n');
+    expect(result.warnings).toEqual([]);
+    const updatedProfile = readFileSync(profilePath, 'utf8');
+    expect(updatedProfile).toContain('mcp.json: symlink');
+    expect(updatedProfile).not.toContain('mcp.json: prompt');
+    expect(updatedProfile).toContain('# durable policy comment');
+
+    // The recorded override materializes as a symlink on the next run.
+    const secondRun = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        interactive: true,
+        writeError: () => undefined,
+        writeLine: () => undefined,
+        launcher: {
+          launch(plan) {
+            expect(readFileSync(join(plan.env.PI_CODING_AGENT_DIR, 'mcp.json'), 'utf8')).toBe(
+              '{"servers":{"always":true}}\n',
+            );
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+    expect(secondRun.warnings).toEqual([]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('persists once and warns when the always choice cannot be recorded for a remote profile', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const sourceUri = 'https://example.com/team-profiles.git';
+    writeSettings(homeDirectory, `default_profile: default\nprofile_sources:\n  - uri: ${sourceUri}\n`);
+    const cachePath = createProfileSourceCachePath(homeDirectory, sourceUri);
+    writeProfile(cachePath, 'default', promptProfileContent);
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        interactive: true,
+        writeError: () => undefined,
+        writeLine: () => undefined,
+        promptStateWritePersistence: () => Promise.resolve('always'),
+        launcher: {
+          launch(plan) {
+            writeFileSync(join(plan.env.PI_CODING_AGENT_DIR, 'mcp.json'), '{"servers":{"remote":true}}\n');
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(readFileSync(join(homeDirectory, '.pi', 'agent', 'mcp.json'), 'utf8')).toBe('{"servers":{"remote":true}}\n');
+    expect(result.warnings).toEqual([
+      "Cannot record the always-persist choice for 'mcp.json' because profile 'default' is not a local profile file; " +
+        'the write was persisted once.',
+    ]);
+    expect(readFileSync(join(cachePath, 'default', 'profile.yml'), 'utf8')).toBe(promptProfileContent);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('falls back to a warning with an explicit notice when the session is not interactive', async () => {
+    const { homeDirectory, projectDirectory } = createPromptRunRoot(promptProfileContent);
+    let prompted = false;
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        interactive: false,
+        writeError: () => undefined,
+        writeLine: () => undefined,
+        promptStateWritePersistence: () => {
+          prompted = true;
+          return Promise.resolve('persist');
+        },
+        launcher: {
+          launch(plan) {
+            writeFileSync(join(plan.env.PI_CODING_AGENT_DIR, 'mcp.json'), '{"servers":{}}\n');
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(prompted).toBe(false);
+    expect(existsSync(join(homeDirectory, '.pi', 'agent', 'mcp.json'))).toBe(false);
+    expect(result.warnings).toEqual([
+      "pi wrote 'mcp.json' with state_persistence 'prompt' and it was not persisted.",
+      "state_persistence prompt for 'mcp.json' skipped: non-interactive session.",
+    ]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('reports undeclared writes under an unknown prompt strategy instead of prompting', async () => {
+    const { homeDirectory, projectDirectory } = createPromptRunRoot(
+      ['id: default', 'state_persistence:', '  unknown: prompt', 'controls: {}', ''].join('\n'),
+    );
+    let prompted = false;
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        interactive: true,
+        writeError: () => undefined,
+        writeLine: () => undefined,
+        promptStateWritePersistence: () => {
+          prompted = true;
+          return Promise.resolve('persist');
+        },
+        launcher: {
+          launch(plan) {
+            writeFileSync(join(plan.env.PI_CODING_AGENT_DIR, 'surprise.txt'), 'unexpected\n');
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(prompted).toBe(false);
+    expect(result.warnings).toEqual([
+      "pi wrote undeclared composite profile state 'surprise.txt' and it was not persisted.",
+      "state_persistence 'prompt' cannot persist undeclared writes; 'surprise.txt' was reported instead.",
+    ]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('persists prompt-strategy directories recursively when the user chooses persist', async () => {
+    const { homeDirectory, projectDirectory } = createPromptRunRoot(
+      ['id: default', 'state_persistence:', '  plugins/: prompt', 'controls: {}', ''].join('\n'),
+    );
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        interactive: true,
+        writeError: () => undefined,
+        writeLine: () => undefined,
+        promptStateWritePersistence: () => Promise.resolve('persist'),
+        launcher: {
+          launch(plan) {
+            writeFileSync(join(plan.env.PI_CODING_AGENT_DIR, 'plugins', 'installed.json'), '{"plugin":true}\n');
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(readFileSync(join(homeDirectory, '.pi', 'agent', 'plugins', 'installed.json'), 'utf8')).toBe(
+      '{"plugin":true}\n',
+    );
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('warns when a persist choice cannot be applied because the composite path disappeared', async () => {
+    const { homeDirectory, projectDirectory } = createPromptRunRoot(
+      ['id: default', 'state_persistence:', '  plugins/: prompt', 'controls: {}', ''].join('\n'),
+    );
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        interactive: true,
+        writeError: () => undefined,
+        writeLine: () => undefined,
+        promptStateWritePersistence: () => Promise.resolve('persist'),
+        launcher: {
+          launch(plan) {
+            rmSync(join(plan.env.PI_CODING_AGENT_DIR, 'plugins'), { recursive: true, force: true });
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(result.warnings).toEqual([
+      "Could not persist state path 'plugins/': Error: State path 'plugins/' no longer exists in the composite " +
+        'profile, so it cannot be persisted.',
+    ]);
+  });
+
+  it('warns when an adapter does not allow the symlink strategy for an always choice', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    writeSettings(homeDirectory, 'default_profile: default\nprofile_sources:\n  - path: ./profiles\n');
+    writeProfile(join(homeDirectory, '.outfitter', 'profiles'), 'default', 'id: default\ncontrols: {}\n');
+    const durablePath = join(root, 'durable', 'state.json');
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        interactive: true,
+        writeError: () => undefined,
+        writeLine: () => undefined,
+        promptStateWritePersistence: () => Promise.resolve('always'),
+        adapter: {
+          id: 'mock-agent',
+          supportedControls: [],
+          createCompositeProfile(_profile, compositeProfileInput) {
+            return {
+              compositeProfile: createCompositeProfile(
+                compositeProfileInput.rootDirectory,
+                [],
+                [{ relativePath: 'state.json', strategy: 'prompt', directory: false, sourcePath: durablePath }],
+              ),
+              warnings: [],
+            };
+          },
+          createLaunchPlan(compositeProfile) {
+            return { command: 'mock-agent', args: [], env: { MOCK_AGENT_DIR: compositeProfile.rootDirectory } };
+          },
+          getUnsupportedControls() {
+            return [];
+          },
+        },
+        launcher: {
+          launch(plan) {
+            writeFileSync(join(plan.env.MOCK_AGENT_DIR, 'state.json'), '{"mock":true}\n');
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(readFileSync(durablePath, 'utf8')).toBe('{"mock":true}\n');
+    expect(result.warnings).toEqual([
+      "Cannot always-persist 'state.json': the mock-agent adapter does not allow 'symlink' for it; " +
+        'the write was persisted once.',
+    ]);
+  });
+
+  it('rejects persisting state paths that have no durable source path', () => {
+    const root = createTemporaryRoot();
+
+    expect(() =>
+      persistCompositeProfileStateWrite(root, { relativePath: 'state.json', strategy: 'prompt', directory: false }),
+    ).toThrow("State path 'state.json' cannot be persisted without a durable source path.");
+  });
+
+  it('creates a state_persistence block when recording an override in a profile without one', () => {
+    const root = createTemporaryRoot();
+    const profilePath = join(root, 'profile.yml');
+    writeFileSync(profilePath, 'id: default\n# retained comment\ncontrols: {}\n');
+
+    recordProfileStatePersistenceOverride(profilePath, 'mcp.json', 'symlink');
+
+    const content = readFileSync(profilePath, 'utf8');
+    expect(content).toContain('# retained comment');
+    expect(content).toContain('state_persistence:');
+    expect(content).toContain('mcp.json: symlink');
+  });
+});

--- a/docs/documentation/state.md
+++ b/docs/documentation/state.md
@@ -64,10 +64,24 @@ state_persistence:
   cache/: discard # Allow writes, then throw them away when the run ends.
   plugins/: warn # Allow writes, discard them, and report them after the run.
   settings.json: error # Allow the run, then fail if this path changed.
-  mcp.json: prompt # Reserved for future interactive handling; currently diagnostic where allowed.
+  mcp.json: prompt # Ask after the run: persist, discard, or always persist for this profile.
 ```
 
-Use `symlink` for state you want to keep, such as login state, durable settings, MCP config, or plugin installs. Use `discard`, `warn`, or `error` for state that should not become part of the durable profile.
+Use `symlink` for state you want to keep, such as login state, durable settings, MCP config, or plugin installs. Use `discard`, `warn`, or `error` for state that should not become part of the durable profile. Use `prompt` when you want to decide interactively after each run.
+
+## Prompt strategy
+
+When a `prompt` path changed during a run and both stdin and stdout are interactive terminals, Outfitter asks what to do with the change after the agent exits:
+
+- **persist** — copy the change to the path's durable source (the profile-managed file or the native CLI location) for this run only.
+- **discard** — throw the change away with the rest of the composite profile.
+- **always** — persist the change and record a `state_persistence: <path>: symlink` override in the selected profile's own YAML file, so future runs persist writes to that path automatically.
+
+The "always" choice is written into the selected profile's `profile.yml` because profiles are the single source of truth for `state_persistence` policy. If the selected profile comes from a remote or cached source, Outfitter never mutates the cache: the change is persisted once and a warning explains that the choice could not be recorded.
+
+In non-interactive sessions (CI, scripts, piped stdio), `prompt` falls back to `warn` and Outfitter prints an explicit `prompt skipped: non-interactive` notice.
+
+Undeclared writes governed by `unknown: prompt` cannot be persisted because they have no durable destination; Outfitter reports them as warnings and says so.
 
 ## User stories
 

--- a/docs/requirements/OFTR-005-run-and-composite-profile.md
+++ b/docs/requirements/OFTR-005-run-and-composite-profile.md
@@ -55,9 +55,13 @@ The `run` command assembles a temporary agent-specific configuration directory c
 6. For `symlink` strategy paths, Outfitter MUST materialize the composite profile path as a symlink to the resolved profile or native CLI source path.
 7. For non-persistent strategies, Outfitter MUST materialize normal temporary composite profile paths and detect writes after the child agent exits.
 8. Unknown writes MUST be governed by the adapter's `unknown` pseudo-path strategy and MUST NOT be persisted by symlink.
-9. Outfitter MUST warn for `warn`, `prompt`, and symlink-replacement state write issues, fail for `error` state write issues, and ignore `discard` state writes.
+9. Outfitter MUST warn for `warn`, non-interactive `prompt`, and symlink-replacement state write issues, fail for `error` state write issues, and ignore `discard` state writes.
 10. State path materialization MUST reject paths that escape the composite profile root.
 11. During live composite profile updates, Outfitter MUST update generated composite profile files without re-materializing declared state paths so post-launch write detection can still observe agent changes to those paths.
+12. When a declared `prompt` strategy path changed and the session is interactive (stdin and stdout are terminals), Outfitter MUST prompt after the agent exits with persist, discard, and always-persist-for-this-profile choices.
+13. The persist choice MUST copy the composite profile change to the path's resolved durable source; the always choice MUST additionally record a `symlink` override in the selected local profile's `state_persistence`, and Outfitter MUST persist once and warn when the choice cannot be recorded (non-local selected profile or `symlink` not allowed for the path).
+14. When the session is not interactive, changed `prompt` strategy paths MUST fall back to `warn` behavior with an explicit "prompt skipped: non-interactive" notice.
+15. Undeclared writes governed by an `unknown: prompt` strategy MUST be reported as warnings with an explicit notice that undeclared writes cannot be persisted.
 
 ### OFTR-005.7: Generated Pi Prompt Export
 


### PR DESCRIPTION
Split 2/3 of #114 — stacked on #133 (merge that first; GitHub will retarget).

The `prompt` state-persistence strategy was a silent no-op: profiles could configure it, but it degraded to a post-exit warning. After the agent exits, each changed declared prompt path now asks (when stdin/stdout are TTYs) whether to **persist** the change to its durable source, **discard** it, or **always** persist it for this profile:

- "always" records a `state_persistence` symlink override in the selected profile's own YAML — the profile is the single source of truth for state policy; remote/cached profiles are never mutated and instead persist once with a warning.
- Non-interactive sessions fall back to warn with an explicit `prompt skipped: non-interactive` notice.
- Undeclared prompt-governed writes are reported with a notice that they cannot be persisted.

The prompt UI is injectable through `RunCommandDependencies`; the readline default lives in `run/RunStateWritePrompt.ts` following the existing `run/` module pattern (this also keeps `RunCommand.ts` within the max-lines budget). Documents the behavior in `docs/documentation/state.md` and amends OFTR-005.6 — the requirement amendment deserves a maintainer look.

Provenance: cherry-pick of `a98c9dc` (#114) by Tyler Willis, with the prompt-module extraction adapted to main's post-#127 layout.

Verification: `typecheck`, `eslint`, full vitest suite (294 tests), coverage 99.16% stmts — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)