### PR TITLE
fix(state): clean up composite temp dirs on exit, signals, and startup sweep

### DIFF
--- a/code/cli/src/cli/commands/RunCommand.ts
+++ b/code/cli/src/cli/commands/RunCommand.ts
@@ -30,6 +30,10 @@ import type {
   CompositeProfileStateWritePrompt,
 } from '../../compositeProfile/StatePersistence.js';
 import { watchCompositeProfileInputs } from '../../compositeProfile/CompositeProfileWatcher.js';
+import {
+  registerCompositeProfileDirectoryCleanup,
+  sweepStaleCompositeProfileDirectories,
+} from '../../compositeProfile/CompositeProfileCleanup.js';
 import type { AgentProcessLauncher } from '../../agents/AgentLaunch.js';
 import { launchAgentProcess, resolveAgentLaunchExecutable } from '../../agents/AgentLaunch.js';
 import type { CommandObject } from './CommandObject.js';
@@ -85,12 +89,14 @@ export const executeRunCommand = async (
   input: RunCommandInput,
   dependencies: RunCommandDependencies = {},
 ): Promise<RunCommandResult> => {
+  sweepStaleCompositeProfileDirectories();
   const runtimeOnboarding = prepareFirstRunRuntimeOnboarding(input, dependencies);
   const resolvedProfile =
     runtimeOnboarding === undefined ? loadResolvedProfile(input) : createFirstRunBootstrapProfile(input);
   const adapter =
     dependencies.adapter ?? createAgentAdapter(selectRunAgentId(input.agentId, resolvedProfile.settings.defaultAgent));
   const compositeProfileRootDirectory = createCompositeProfileRootDirectory(resolvedProfile.profile.id, adapter.id);
+  prepareCompositeProfileTeardown(input, compositeProfileRootDirectory, dependencies);
   const compositeProfilePlan = createAdapterCompositeProfilePlan(
     adapter,
     resolvedProfile,
@@ -302,6 +308,27 @@ const createAdapterCompositeProfilePlan = (
     }),
   };
 };
+
+// Composite directories are removed at process exit and on handled signals. When the agent
+// is launched with --debug the directory is kept for inspection and its path is printed.
+const prepareCompositeProfileTeardown = (
+  input: RunCommandInput,
+  compositeProfileRootDirectory: string,
+  dependencies: RunCommandDependencies,
+): void => {
+  if (isDebugRunLaunch(input.passThroughArgs)) {
+    /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a line writer. */
+    (dependencies.writeLine ?? console.log)(
+      `--debug: keeping composite profile directory ${compositeProfileRootDirectory}`,
+    );
+    return;
+  }
+
+  registerCompositeProfileDirectoryCleanup(compositeProfileRootDirectory);
+};
+
+const isDebugRunLaunch = (passThroughArgs: readonly string[] | undefined): boolean =>
+  (passThroughArgs ?? []).includes('--debug');
 
 interface CompositeProfileStateWriteHandlingInput {
   readonly adapterId: string;

--- a/code/cli/src/compositeProfile/CompositeProfileCleanup.ts
+++ b/code/cli/src/compositeProfile/CompositeProfileCleanup.ts
@@ -1,0 +1,111 @@
+// Removes temporary composite profile directories on process exit and handled signals, and
+// sweeps stale leftovers from earlier crashed runs. Composite directories contain symlinks
+// into real auth/settings state, so removal must delete the links without ever following
+// them to their targets; rmSync satisfies that because it unlinks symlink entries instead of
+// traversing into their targets.
+import { lstatSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const pendingDirectories = new Set<string>();
+const installedProcesses = new WeakSet<NodeJS.Process>();
+const cleanupSignals: readonly NodeJS.Signals[] = ['SIGINT', 'SIGTERM', 'SIGHUP'];
+
+// Cleanup is deferred to process exit (rather than performed inline when a run finishes) so
+// the composite directory stays inspectable for the rest of the process lifetime, and so a
+// single set of handlers covers every registered run.
+export const registerCompositeProfileDirectoryCleanup = (
+  directory: string,
+  processObject: NodeJS.Process = process,
+): void => {
+  pendingDirectories.add(directory);
+  installCompositeProfileCleanupHandlers(processObject);
+};
+
+export const executeCompositeProfileDirectoryCleanup = (): readonly string[] => {
+  const removed: string[] = [];
+
+  for (const directory of pendingDirectories) {
+    try {
+      rmSync(directory, { recursive: true, force: true });
+      removed.push(directory);
+    } catch {
+      // Best-effort teardown: a failed removal must not mask the process's own exit path.
+    }
+  }
+
+  pendingDirectories.clear();
+  return removed;
+};
+
+const installCompositeProfileCleanupHandlers = (processObject: NodeJS.Process): void => {
+  if (installedProcesses.has(processObject)) {
+    return;
+  }
+
+  installedProcesses.add(processObject);
+  processObject.once('exit', () => void executeCompositeProfileDirectoryCleanup());
+
+  for (const signal of cleanupSignals) {
+    processObject.once(signal, () => handleCompositeProfileCleanupSignal(processObject, signal));
+  }
+};
+
+// Session journals are stored under ~/.outfitter/state rather than the composite directory,
+// so signal-time cleanup removes the temporary directory while leaving any crash journal in
+// place to be reported by the next invocation.
+const handleCompositeProfileCleanupSignal = (processObject: NodeJS.Process, signal: NodeJS.Signals): void => {
+  executeCompositeProfileDirectoryCleanup();
+  // The once-registered handler has already been removed, so re-raising terminates the
+  // process with conventional signal semantics unless another handler intervenes.
+  processObject.kill(processObject.pid, signal);
+};
+
+export const defaultCompositeProfileSweepMaxAgeMs = 7 * 24 * 60 * 60 * 1000;
+
+export interface SweepStaleCompositeProfileDirectoriesInput {
+  readonly directory?: string;
+  readonly maxAgeMs?: number;
+  readonly now?: number;
+}
+
+// Best-effort startup sweep of outfitter-* composite directories that crashed runs left in
+// the temporary root. Entries are inspected with lstat and symlink entries are skipped, so
+// the sweep never follows a symlink; stale directories are removed with rmSync, which
+// deletes contained symlinks without touching their targets.
+export const sweepStaleCompositeProfileDirectories = (
+  input: SweepStaleCompositeProfileDirectoriesInput = {},
+): readonly string[] => {
+  const rootDirectory = input.directory ?? tmpdir();
+  const maxAgeMs = input.maxAgeMs ?? defaultCompositeProfileSweepMaxAgeMs;
+  const now = input.now ?? Date.now();
+  const removed: string[] = [];
+
+  for (const entryName of listSweepCandidates(rootDirectory)) {
+    const entryPath = join(rootDirectory, entryName);
+
+    try {
+      const entryStat = lstatSync(entryPath);
+
+      if (!entryStat.isDirectory() || now - entryStat.mtimeMs <= maxAgeMs) {
+        continue;
+      }
+
+      rmSync(entryPath, { recursive: true, force: true });
+      removed.push(entryPath);
+      /* v8 ignore next 3 -- entries can vanish between readdir and lstat; the sweep stays best-effort. */
+    } catch {
+      // Best-effort sweep: unreadable or vanished entries are skipped.
+    }
+  }
+
+  return removed;
+};
+
+const listSweepCandidates = (rootDirectory: string): readonly string[] => {
+  try {
+    return readdirSync(rootDirectory).filter((entryName) => entryName.startsWith('outfitter-'));
+  } catch {
+    return [];
+  }
+};

--- a/code/cli/tests/unit/composite-profile-cleanup.test.ts
+++ b/code/cli/tests/unit/composite-profile-cleanup.test.ts
@@ -1,0 +1,261 @@
+// Tests composite profile temporary directory cleanup: exit/signal teardown, the --debug
+// keep behavior, and the best-effort startup sweep of stale outfitter-* directories.
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { executeRunCommand } from '../../src/cli/commands/RunCommand.js';
+import {
+  defaultCompositeProfileSweepMaxAgeMs,
+  executeCompositeProfileDirectoryCleanup,
+  registerCompositeProfileDirectoryCleanup,
+  sweepStaleCompositeProfileDirectories,
+} from '../../src/compositeProfile/CompositeProfileCleanup.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-cleanup-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+interface FakeProcess {
+  readonly handlers: Map<string, () => void>;
+  readonly killed: { pid: number; signal: string }[];
+  readonly processObject: NodeJS.Process;
+}
+
+const createFakeProcess = (): FakeProcess => {
+  const handlers = new Map<string, () => void>();
+  const killed: { pid: number; signal: string }[] = [];
+  const processObject = {
+    pid: 4242,
+    once(event: string, handler: () => void) {
+      handlers.set(event, handler);
+      return processObject;
+    },
+    kill(pid: number, signal: string) {
+      killed.push({ pid, signal });
+      return true;
+    },
+  } as unknown as NodeJS.Process;
+
+  return { handlers, killed, processObject };
+};
+
+const createCompositeDirectoryWithSymlink = (root: string, name: string): { directory: string; target: string } => {
+  const directory = join(root, name);
+  const target = join(root, `${name}-target.json`);
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(target, '{"durable":true}\n');
+  symlinkSync(target, join(directory, 'auth.json'));
+  return { directory, target };
+};
+
+const writeRunFixture = (root: string): { homeDirectory: string; projectDirectory: string } => {
+  const homeDirectory = join(root, 'home');
+  const projectDirectory = join(root, 'project');
+  mkdirSync(join(homeDirectory, '.outfitter', 'profiles', 'default'), { recursive: true });
+  writeFileSync(
+    join(homeDirectory, '.outfitter', 'settings.yml'),
+    'default_profile: default\nprofile_sources:\n  - path: ./profiles\n',
+  );
+  writeFileSync(join(homeDirectory, '.outfitter', 'profiles', 'default', 'profile.yml'), 'id: default\ncontrols: {}\n');
+  return { homeDirectory, projectDirectory };
+};
+
+afterEach(() => {
+  executeCompositeProfileDirectoryCleanup();
+
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('composite profile directory cleanup', () => {
+  it('removes registered directories without following contained symlinks', () => {
+    const root = createTemporaryRoot();
+    const { directory, target } = createCompositeDirectoryWithSymlink(root, 'outfitter-default-pi-run');
+    registerCompositeProfileDirectoryCleanup(directory, createFakeProcess().processObject);
+
+    const removed = executeCompositeProfileDirectoryCleanup();
+
+    expect(removed).toContain(directory);
+    expect(existsSync(directory)).toBe(false);
+    // The symlinked auth state target must survive cleanup untouched.
+    expect(readFileSync(target, 'utf8')).toBe('{"durable":true}\n');
+  });
+
+  it('cleans registered directories from the process exit handler', () => {
+    const root = createTemporaryRoot();
+    const fakeProcess = createFakeProcess();
+    const { directory, target } = createCompositeDirectoryWithSymlink(root, 'outfitter-default-pi-exit');
+    registerCompositeProfileDirectoryCleanup(directory, fakeProcess.processObject);
+
+    expect([...fakeProcess.handlers.keys()].sort()).toEqual(['SIGHUP', 'SIGINT', 'SIGTERM', 'exit']);
+    fakeProcess.handlers.get('exit')?.();
+
+    expect(existsSync(directory)).toBe(false);
+    expect(existsSync(target)).toBe(true);
+    expect(fakeProcess.killed).toEqual([]);
+  });
+
+  it('cleans registered directories on handled signals, keeps journals, and re-raises', () => {
+    const root = createTemporaryRoot();
+    const fakeProcess = createFakeProcess();
+    const { directory } = createCompositeDirectoryWithSymlink(root, 'outfitter-default-pi-signal');
+    const journalPath = join(root, 'state', 'session-journals', 'outfitter-default-pi-signal.json');
+    mkdirSync(join(root, 'state', 'session-journals'), { recursive: true });
+    writeFileSync(journalPath, '{"undeclaredWrites":["ghost.txt"]}\n');
+    registerCompositeProfileDirectoryCleanup(directory, fakeProcess.processObject);
+
+    fakeProcess.handlers.get('SIGTERM')?.();
+
+    expect(existsSync(directory)).toBe(false);
+    // The crash journal lives outside the composite directory and must survive signal
+    // cleanup so the next invocation can report it.
+    expect(existsSync(journalPath)).toBe(true);
+    expect(fakeProcess.killed).toEqual([{ pid: 4242, signal: 'SIGTERM' }]);
+  });
+
+  it('installs process handlers only once per process object', () => {
+    const root = createTemporaryRoot();
+    const fakeProcess = createFakeProcess();
+    const first = join(root, 'outfitter-first');
+    const second = join(root, 'outfitter-second');
+    mkdirSync(first);
+    mkdirSync(second);
+
+    registerCompositeProfileDirectoryCleanup(first, fakeProcess.processObject);
+    const handlerCount = fakeProcess.handlers.size;
+    registerCompositeProfileDirectoryCleanup(second, fakeProcess.processObject);
+
+    expect(fakeProcess.handlers.size).toBe(handlerCount);
+    fakeProcess.handlers.get('exit')?.();
+    expect(existsSync(first)).toBe(false);
+    expect(existsSync(second)).toBe(false);
+  });
+
+  it('tolerates directories that cannot be removed', () => {
+    const root = createTemporaryRoot();
+    const removable = join(root, 'outfitter-removable');
+    mkdirSync(removable);
+    registerCompositeProfileDirectoryCleanup(join(root, 'invalid\0name'), createFakeProcess().processObject);
+    registerCompositeProfileDirectoryCleanup(removable, createFakeProcess().processObject);
+
+    const removed = executeCompositeProfileDirectoryCleanup();
+
+    expect(removed).toContain(removable);
+    expect(removed).not.toContain(join(root, 'invalid\0name'));
+    expect(existsSync(removable)).toBe(false);
+  });
+});
+
+describe('stale composite profile directory sweep', () => {
+  it('removes only stale outfitter-* directories and never follows symlinks', () => {
+    const root = createTemporaryRoot();
+    const staleAge = new Date(Date.now() - defaultCompositeProfileSweepMaxAgeMs - 60_000);
+    const { directory: staleDirectory, target } = createCompositeDirectoryWithSymlink(root, 'outfitter-stale');
+    utimesSync(staleDirectory, staleAge, staleAge);
+    const freshDirectory = join(root, 'outfitter-fresh');
+    mkdirSync(freshDirectory);
+    const unrelatedDirectory = join(root, 'other-stale');
+    mkdirSync(unrelatedDirectory);
+    utimesSync(unrelatedDirectory, staleAge, staleAge);
+    const linkedDirectory = join(root, 'linked-real-directory');
+    mkdirSync(linkedDirectory);
+    writeFileSync(join(linkedDirectory, 'keep.txt'), 'kept\n');
+    const staleLink = join(root, 'outfitter-symlink-entry');
+    symlinkSync(linkedDirectory, staleLink);
+
+    const removed = sweepStaleCompositeProfileDirectories({ directory: root });
+
+    expect(removed).toEqual([staleDirectory]);
+    expect(existsSync(staleDirectory)).toBe(false);
+    // The stale directory contained a symlink into durable state; the target survives.
+    expect(readFileSync(target, 'utf8')).toBe('{"durable":true}\n');
+    expect(existsSync(freshDirectory)).toBe(true);
+    expect(existsSync(unrelatedDirectory)).toBe(true);
+    // Symlink entries are skipped entirely, even with a stale-looking name.
+    expect(existsSync(staleLink)).toBe(true);
+    expect(readFileSync(join(linkedDirectory, 'keep.txt'), 'utf8')).toBe('kept\n');
+  });
+
+  it('supports injected age thresholds and clocks', () => {
+    const root = createTemporaryRoot();
+    const swept = join(root, 'outfitter-aged');
+    mkdirSync(swept);
+    const cutoff = new Date(Date.now() - 5_000);
+    utimesSync(swept, cutoff, cutoff);
+
+    expect(sweepStaleCompositeProfileDirectories({ directory: root, maxAgeMs: 60_000 })).toEqual([]);
+    expect(sweepStaleCompositeProfileDirectories({ directory: root, maxAgeMs: 1_000 })).toEqual([swept]);
+    expect(existsSync(swept)).toBe(false);
+  });
+
+  it('returns nothing when the sweep root does not exist', () => {
+    expect(sweepStaleCompositeProfileDirectories({ directory: join(createTemporaryRoot(), 'missing') })).toEqual([]);
+  });
+});
+
+describe('run command composite profile teardown', () => {
+  it('registers the composite directory for exit cleanup on normal runs', async () => {
+    const root = createTemporaryRoot();
+    const { homeDirectory, projectDirectory } = writeRunFixture(root);
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        writeError: () => undefined,
+        writeLine: () => undefined,
+        launcher: { launch: () => Promise.resolve(0) },
+      },
+    );
+
+    // The directory stays available after the run and is removed by the deferred cleanup.
+    expect(existsSync(result.compositeProfileDirectory)).toBe(true);
+    const nativeSettingsPath = join(homeDirectory, '.pi', 'agent', 'settings.json');
+    expect(existsSync(nativeSettingsPath)).toBe(true);
+
+    const removed = executeCompositeProfileDirectoryCleanup();
+
+    expect(removed).toContain(result.compositeProfileDirectory);
+    expect(existsSync(result.compositeProfileDirectory)).toBe(false);
+    // Symlinked native state survives the teardown.
+    expect(existsSync(nativeSettingsPath)).toBe(true);
+  });
+
+  it('keeps the composite directory and prints its path when --debug is passed', async () => {
+    const root = createTemporaryRoot();
+    const { homeDirectory, projectDirectory } = writeRunFixture(root);
+    const messages: string[] = [];
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory, passThroughArgs: ['--debug'] },
+      {
+        writeError: () => undefined,
+        writeLine: (message) => messages.push(message),
+        launcher: { launch: () => Promise.resolve(0) },
+      },
+    );
+
+    expect(messages).toContain(`--debug: keeping composite profile directory ${result.compositeProfileDirectory}`);
+
+    const removed = executeCompositeProfileDirectoryCleanup();
+
+    expect(removed).not.toContain(result.compositeProfileDirectory);
+    expect(existsSync(result.compositeProfileDirectory)).toBe(true);
+  });
+});

--- a/docs/documentation/state.md
+++ b/docs/documentation/state.md
@@ -83,6 +83,12 @@ In non-interactive sessions (CI, scripts, piped stdio), `prompt` falls back to `
 
 Undeclared writes governed by `unknown: prompt` cannot be persisted because they have no durable destination; Outfitter reports them as warnings and says so.
 
+## Temporary directory cleanup
+
+Composite profile directories are created under the system temporary directory and removed automatically when the Outfitter process exits or receives a handled signal. Removal deletes symlink entries without following them, so the durable auth/settings state the links point at is never touched. Pass `--debug` to keep the directory for inspection; Outfitter prints its path.
+
+Each startup also best-effort sweeps `outfitter-*` directories older than seven days from the temporary root. The sweep never follows symlinks, so a stale directory's links are removed while their targets survive.
+
 ## User stories
 
 ### Keep login working


### PR DESCRIPTION
Split 3/3 of #114 — stacked on #133 and the prompt-strategy PR (merge in order; GitHub will retarget).

Composite profile directories were created with `mkdtemp` but never removed, so every run leaked a tmp directory full of **symlinks into real auth/settings state**. Now:

- Directories register for deferred cleanup that runs on process exit and handled signals (SIGINT/SIGTERM/SIGHUP re-raise after cleaning).
- Removal uses `rmSync`, which deletes symlink entries without following them — link targets survive.
- `--debug` keeps the directory and prints its path.
- Startup best-effort sweeps `outfitter-*` directories older than seven days from the tmp root, inspecting entries with `lstat` and skipping symlinks so the sweep never follows one.

Provenance: cherry-pick of `7ccc74c` (#114) by Tyler Willis, with the session-journal interactions omitted because live undeclared-write detection (`40e9fe9`) is deliberately not part of this split — it remains available for a future PR.

Verification: `typecheck`, `eslint`, full vitest suite (300 tests), coverage 99.18% stmts — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)