### PR TITLE
fix(onboarding): remove hardcoded bootstrap model from first-run pi launch

### DIFF
--- a/code/cli/src/cli/commands/PiLoginLaunch.ts
+++ b/code/cli/src/cli/commands/PiLoginLaunch.ts
@@ -46,9 +46,11 @@ export const preparePiLoginLaunchPlan = (input: PiLoginLaunchPlanInput): AgentLa
     return launchPlan;
   }
 
+  // First-run onboarding intentionally passes no `--model`: pi applies its own default from the
+  // models it knows about, and the runtime extension opens `/login` when no model is available.
+  // Injecting a hardcoded model ID here would break every new user when pi rotates its catalog.
   if (input.runtimeOnboarding?.autoOpenOutfitter === true) {
     writeQuietPiStartupSettings(piConfigDirectory);
-    launchPlan = addFirstRunBootstrapModelIfNeeded(launchPlan);
   }
 
   writePiOutfitterEnterpriseSupportFiles(piConfigDirectory);
@@ -73,18 +75,6 @@ export const preparePiLoginLaunchPlan = (input: PiLoginLaunchPlanInput): AgentLa
 
   return launchPlan;
 };
-
-const addFirstRunBootstrapModelIfNeeded = (launchPlan: AgentLaunchPlan): AgentLaunchPlan => {
-  if (hasPiModelArg(launchPlan.args)) {
-    return launchPlan;
-  }
-
-  return { ...launchPlan, args: ['--model', 'google/gemini-3.1-pro-preview', ...launchPlan.args] };
-};
-
-/* v8 ignore next -- arg parser supports both spellings; integration smoke covers explicit --model passthrough. */
-const hasPiModelArg = (args: readonly string[]): boolean =>
-  args.some((arg) => arg === '--model' || arg.startsWith('--model='));
 
 const writeQuietPiStartupSettings = (piConfigDirectory: string): void => {
   const settingsPath = join(piConfigDirectory, 'settings.json');

--- a/code/cli/tests/unit/no-hardcoded-model-ids.test.ts
+++ b/code/cli/tests/unit/no-hardcoded-model-ids.test.ts
@@ -1,0 +1,43 @@
+// Guards against reintroducing hardcoded model identifiers into the CLI source tree. Pi owns
+// model defaults; a model ID baked into Outfitter breaks every launch once pi rotates its catalog.
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const sourceRoot = fileURLToPath(new URL('../../src/', import.meta.url));
+
+const modelIdPatterns: readonly RegExp[] = [
+  // Provider-prefixed model IDs such as google/gemini-3.1-pro-preview or anthropic/claude-sonnet-4.
+  /\b(?:google|openai|anthropic|meta-llama|mistralai?|x-ai|xai|deepseek|qwen)\/[a-z0-9][\w.:-]*/giu,
+  // Bare model family IDs with version digits such as gpt-5, gemini-3.1, or claude-4.
+  /\b(?:gpt|gemini|claude|llama|sonnet|opus|haiku|grok)-\d[\w.-]*/giu,
+];
+
+const listSourceFiles = (): readonly string[] =>
+  readdirSync(sourceRoot, { recursive: true, encoding: 'utf8' })
+    .filter((entry) => entry.endsWith('.ts'))
+    .map((entry) => join(sourceRoot, entry));
+
+describe('hardcoded model id gate', () => {
+  it('keeps code/cli/src free of hardcoded model identifiers', () => {
+    const sourceFiles = listSourceFiles();
+
+    expect(sourceFiles.length).toBeGreaterThan(0);
+
+    const offenders: string[] = [];
+
+    for (const filePath of sourceFiles) {
+      const content = readFileSync(filePath, 'utf8');
+
+      for (const pattern of modelIdPatterns) {
+        for (const match of content.matchAll(pattern)) {
+          offenders.push(`${filePath}: ${match[0]}`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/code/cli/tests/unit/pi-login-launch.test.ts
+++ b/code/cli/tests/unit/pi-login-launch.test.ts
@@ -973,11 +973,7 @@ describe('preparePiLoginLaunchPlan', () => {
     expect(context.submittedInputs).toEqual(['\r']);
     expect(messages.some((message) => message.includes('/outfitter'))).toBe(false);
     expect(readFileSync(join(agentDir, 'settings.json'), 'utf8')).toContain('"quietStartup": true');
-    expect(plan.args).toEqual([
-      '--extension',
-      expect.stringContaining('outfitter-extension.js'),
-      '--model',
-      'google/gemini-3.1-pro-preview',
-    ]);
+    expect(plan.args).toEqual(['--extension', expect.stringContaining('outfitter-extension.js')]);
+    expect(plan.args).not.toContain('--model');
   });
 });

--- a/code/cli/tests/unit/run-command.test.ts
+++ b/code/cli/tests/unit/run-command.test.ts
@@ -211,7 +211,7 @@ describe('run command', () => {
           launch(plan) {
             expect(existsSync(join(homeDirectory, '.outfitter', 'settings.yml'))).toBe(false);
             expect(plan.args).toContain('--extension');
-            expect(plan.args).toContain('google/gemini-3.1-pro-preview');
+            expect(plan.args).not.toContain('--model');
             expect(readFileSync(join(plan.env.PI_CODING_AGENT_DIR, 'settings.json'), 'utf8')).toContain(
               '"quietStartup": true',
             );


### PR DESCRIPTION
Cherry-picked from closed #112 (`7ecf3dd`, authored by Tyler Willis) — that PR was closed with this fix unmerged.

**User-visible symptom on main today:** every first-run pi launch is forced to `--model google/gemini-3.1-pro-preview` (PiLoginLaunch.ts), regardless of which provider the user logs into. Anyone not on that provider gets a wrong or unusable default in their first five minutes.

- pi now picks its own default model; `/login` auto-opens when no models exist.
- A grep-gate test (`no-hardcoded-model-ids.test.ts`) prevents hardcoded model ids from reappearing in `src/`.

Verification: prettier, typecheck, eslint, full vitest suite (284 tests) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)