### PR TITLE
fix(sync): refresh branch-tracking extension caches and speed up first boot

### DIFF
--- a/code/cli/src/agents/AgentAdapter.ts
+++ b/code/cli/src/agents/AgentAdapter.ts
@@ -25,6 +25,7 @@ export interface AgentLaunchContext {
   readonly cacheDirectory?: string;
   /** Directory of bundled user-facing Outfitter documentation the launched agent may read. */
   readonly outfitterDocsDirectory?: string;
+  readonly onProgress?: (message: string) => void;
 }
 
 export interface AgentCompositeProfilePlan {

--- a/code/cli/src/agents/pi/PiAdapter.ts
+++ b/code/cli/src/agents/pi/PiAdapter.ts
@@ -125,7 +125,10 @@ export const createPiAdapter = (): AgentAdapter => ({
       args: [
         ...createPiArgs({
           ...controls,
-          extensions: materializePiExtensionSources(controls.extensions, { cacheDirectory: context.cacheDirectory }),
+          extensions: materializePiExtensionSources(controls.extensions, {
+            cacheDirectory: context.cacheDirectory,
+            onProgress: context.onProgress,
+          }),
           skills: skillSources,
           appendSystemPrompt: [
             ...appendPrompt.prompts,

--- a/code/cli/src/agents/pi/PiExtensionCache.ts
+++ b/code/cli/src/agents/pi/PiExtensionCache.ts
@@ -1,12 +1,18 @@
 // Caches remote Pi extension packages as local directories before launch.
+//
+// Refresh policy: caches for `#ref`-pinned sources are immutable once created. Caches for
+// branch-tracking (ref-less) sources are refreshed by `outfitter sync` through
+// refreshPiExtensionCaches, which fast-forwards the shallow clone and reinstalls dependencies
+// when the tip moved. Launch-time materialization never refreshes an existing cache.
 import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 import spawn from 'cross-spawn';
 
 export interface PiExtensionCacheOptions {
   readonly cacheDirectory?: string;
+  readonly onProgress?: (message: string) => void;
 }
 
 interface GitExtensionSource {
@@ -23,10 +29,14 @@ export const materializePiExtensionSources = (
   }
 
   const { cacheDirectory } = options;
-  return sources.map((source) => materializePiExtensionSource(source, cacheDirectory));
+  return sources.map((source) => materializePiExtensionSource(source, cacheDirectory, options.onProgress));
 };
 
-const materializePiExtensionSource = (source: string, cacheDirectory: string): string => {
+const materializePiExtensionSource = (
+  source: string,
+  cacheDirectory: string,
+  onProgress?: (message: string) => void,
+): string => {
   const gitSource = parseGitExtensionSource(source);
 
   if (gitSource === undefined) {
@@ -37,15 +47,139 @@ const materializePiExtensionSource = (source: string, cacheDirectory: string): s
 
   if (!existsSync(cachePath)) {
     try {
+      onProgress?.(`outfitter: caching extension ${source}…`);
       cloneGitExtension(gitSource, cachePath);
-      installGitExtensionDependencies(cachePath);
+      installGitExtensionDependencies(cachePath, source, onProgress);
+      writeCacheSourceMetadata(cachePath, source, gitSource.ref);
     } catch (error) {
       rmSync(cachePath, { recursive: true, force: true });
+      rmSync(cacheSourceMetadataPath(cachePath), { force: true });
       throw error;
     }
   }
 
   return cachePath;
+};
+
+export interface PiExtensionCacheRefreshResult {
+  readonly source: string;
+  readonly cachePath: string;
+  readonly status: 'refreshed' | 'unchanged' | 'pinned' | 'failed';
+  readonly message: string;
+}
+
+// Refreshes branch-tracking git-extension caches under `<cacheDirectory>/extensions/git`.
+// `#ref`-pinned entries are reported as pinned and left untouched. Entries without source
+// metadata (created before metadata existed) are skipped silently.
+export const refreshPiExtensionCaches = (
+  cacheDirectory: string,
+  options: Pick<PiExtensionCacheOptions, 'onProgress'> = {},
+): readonly PiExtensionCacheRefreshResult[] => {
+  const gitCacheRoot = join(cacheDirectory, 'extensions', 'git');
+
+  if (!existsSync(gitCacheRoot)) {
+    return [];
+  }
+
+  return readdirSync(gitCacheRoot)
+    .filter((entryName) => entryName.endsWith(cacheSourceMetadataSuffix))
+    .sort()
+    .flatMap((entryName) => {
+      const result = refreshPiExtensionCache(gitCacheRoot, entryName, options.onProgress);
+      return result === undefined ? [] : [result];
+    });
+};
+
+const refreshPiExtensionCache = (
+  gitCacheRoot: string,
+  metadataFileName: string,
+  onProgress?: (message: string) => void,
+): PiExtensionCacheRefreshResult | undefined => {
+  const cachePath = join(gitCacheRoot, metadataFileName.slice(0, -cacheSourceMetadataSuffix.length));
+  const metadata = readCacheSourceMetadata(join(gitCacheRoot, metadataFileName));
+
+  if (metadata === undefined || !existsSync(cachePath)) {
+    return undefined;
+  }
+
+  if (metadata.ref !== undefined) {
+    return {
+      source: metadata.source,
+      cachePath,
+      status: 'pinned',
+      message: `pinned to #${metadata.ref}; cache left unchanged`,
+    };
+  }
+
+  onProgress?.(`outfitter: refreshing extension ${metadata.source}…`);
+  return pullBranchTrackingExtensionCache(metadata.source, cachePath, onProgress);
+};
+
+const pullBranchTrackingExtensionCache = (
+  source: string,
+  cachePath: string,
+  onProgress?: (message: string) => void,
+): PiExtensionCacheRefreshResult => {
+  const headBeforePull = readCacheHead(cachePath);
+  const pullResult = runCommand('git', ['pull', '--ff-only'], cachePath);
+
+  if (pullResult.status !== 0) {
+    return {
+      source,
+      cachePath,
+      status: 'failed',
+      message: commandError('git', ['pull', '--ff-only'], pullResult).message,
+    };
+  }
+
+  const headAfterPull = readCacheHead(cachePath);
+
+  if (headAfterPull === headBeforePull) {
+    return { source, cachePath, status: 'unchanged', message: 'already up to date' };
+  }
+
+  try {
+    installGitExtensionDependencies(cachePath, source, onProgress);
+  } catch (error) {
+    return { source, cachePath, status: 'failed', message: error instanceof Error ? error.message : String(error) };
+  }
+
+  return { source, cachePath, status: 'refreshed', message: `updated to ${headAfterPull}` };
+};
+
+const cacheSourceMetadataSuffix = '.source.json';
+
+const cacheSourceMetadataPath = (cachePath: string): string => `${cachePath}${cacheSourceMetadataSuffix}`;
+
+const writeCacheSourceMetadata = (cachePath: string, source: string, ref: string | undefined): void => {
+  writeFileSync(cacheSourceMetadataPath(cachePath), `${JSON.stringify({ source, ref }, null, 2)}\n`);
+};
+
+const readCacheSourceMetadata = (
+  metadataPath: string,
+): { readonly source: string; readonly ref?: string } | undefined => {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(metadataPath, 'utf8'));
+
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return undefined;
+    }
+
+    const record = parsed as { readonly source?: unknown; readonly ref?: unknown };
+
+    if (typeof record.source !== 'string') {
+      return undefined;
+    }
+
+    return { source: record.source, ref: typeof record.ref === 'string' ? record.ref : undefined };
+  } catch {
+    return undefined;
+  }
+};
+
+const readCacheHead = (cachePath: string): string => {
+  const result = runCommand('git', ['rev-parse', 'HEAD'], cachePath);
+  return result.status === 0 ? String(result.stdout).trim() : '';
 };
 
 const parseGitExtensionSource = (source: string): GitExtensionSource | undefined => {
@@ -133,11 +267,16 @@ const cloneGitExtension = (source: GitExtensionSource, cachePath: string): void 
   }
 };
 
-const installGitExtensionDependencies = (cachePath: string): void => {
+const installGitExtensionDependencies = (
+  cachePath: string,
+  source: string,
+  onProgress?: (message: string) => void,
+): void => {
   if (!existsSync(join(cachePath, 'package.json'))) {
     return;
   }
 
+  onProgress?.(`outfitter: installing dependencies for extension ${source}…`);
   const npmArgs = existsSync(join(cachePath, 'package-lock.json')) ? ['ci', '--omit=dev'] : ['install', '--omit=dev'];
   const result = runCommand('npm', npmArgs, cachePath);
 

--- a/code/cli/src/cli/commands/RunCommand.ts
+++ b/code/cli/src/cli/commands/RunCommand.ts
@@ -1,7 +1,5 @@
 // Provides the command object for launching selected profiles.
-import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
 
 import type { ChildProcess } from 'node:child_process';
 import type { Command } from 'commander';
@@ -37,10 +35,14 @@ import {
 import type { AgentProcessLauncher } from '../../agents/AgentLaunch.js';
 import { launchAgentProcess, resolveAgentLaunchExecutable } from '../../agents/AgentLaunch.js';
 import type { CommandObject } from './CommandObject.js';
-import { isNonInteractivePiLaunch, preparePiLoginLaunchPlan } from './PiLoginLaunch.js';
+import { preparePiLoginLaunchPlan } from './PiLoginLaunch.js';
 import type { SetupCommandDependencies } from './SetupCommand.js';
-import { syncProfileSource, type RemoteProfileSource } from './SyncCommand.js';
 import { emitLaunchSummary } from './run/RunLaunchSummary.js';
+import {
+  isInteractiveRunLaunch,
+  prepareFirstRunRuntimeOnboarding,
+  resolveRunProgressWriter,
+} from './run/RunFirstRunOnboarding.js';
 import { createTerminalStateWritePrompt } from './run/RunStateWritePrompt.js';
 import {
   createFirstRunBootstrapProfile,
@@ -132,6 +134,7 @@ export const executeRunCommand = async (
           projectDirectory: input.projectDirectory,
           cacheDirectory: resolvedProfile.cacheDirectory,
           outfitterDocsDirectory: input.outfitterDocsDirectory,
+          onProgress: resolveRunProgressWriter(dependencies),
         },
       ),
       systemPromptExport.outputPath,
@@ -491,68 +494,6 @@ const formatCompositeProfileStateWriteIssue = (adapterId: string, issue: Composi
   }
 
   return `${adapterId} wrote '${issue.relativePath}' with state_persistence '${issue.strategy}' and it was not persisted.`;
-};
-
-interface FirstRunRuntimeOnboarding {
-  readonly defaultProfilesPath: string;
-}
-
-const defaultProfilesSource = {
-  github: 'ai-outfitter/default-profiles',
-  path: 'profiles',
-} as const satisfies RemoteProfileSource;
-
-const prepareFirstRunRuntimeOnboarding = (
-  input: RunCommandInput,
-  dependencies: RunCommandDependencies,
-): FirstRunRuntimeOnboarding | undefined => {
-  if (!shouldUsePiNativeFirstRunOnboarding(input, dependencies)) {
-    return undefined;
-  }
-
-  const syncResult = syncProfileSource(input.homeDirectory, defaultProfilesSource, dependencies.synchronizer);
-
-  /* v8 ignore next -- network/cache failure path is integration-level behavior; setup fallback message is deterministic. */
-  if (syncResult.status === 'failed') {
-    throw new Error(
-      `Cannot start Pi-native onboarding because the default profiles source failed to sync: ${syncResult.message}. ` +
-        'Fix the network/git issue or run `outfitter setup` once the source is reachable.',
-    );
-  }
-
-  return { defaultProfilesPath: join(syncResult.cachePath, defaultProfilesSource.path) };
-};
-
-const shouldUsePiNativeFirstRunOnboarding = (input: RunCommandInput, dependencies: RunCommandDependencies): boolean => {
-  if (input.forceRuntimeOnboarding !== true && existsSync(join(input.homeDirectory, '.outfitter', 'settings.yml'))) {
-    return false;
-  }
-
-  const selectedAgentId = dependencies.adapter?.id ?? selectRunAgentId(input.agentId, undefined);
-
-  /* v8 ignore next -- explicit profile/non-pi paths are covered by normal run command selection tests. */
-  if (input.profileId !== undefined || selectedAgentId !== 'pi') {
-    return false;
-  }
-
-  if (isNonInteractivePiLaunch(input.passThroughArgs ?? [])) {
-    return false;
-  }
-
-  return isInteractiveRunLaunch(dependencies);
-};
-
-const isInteractiveRunLaunch = (dependencies: RunCommandDependencies): boolean => {
-  if (dependencies.interactive !== undefined) {
-    return dependencies.interactive;
-  }
-
-  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
-  const inputIsTty = (dependencies.input ?? process.stdin).isTTY === true;
-  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
-  const outputIsTty = (dependencies.output ?? process.stdout).isTTY === true;
-
-  return inputIsTty && outputIsTty;
 };
 
 const withSystemPromptExportPath = (launchPlan: AgentLaunchPlan, outputPath: string | undefined): AgentLaunchPlan =>

--- a/code/cli/src/cli/commands/SyncCommand.ts
+++ b/code/cli/src/cli/commands/SyncCommand.ts
@@ -1,8 +1,8 @@
 // Provides the command object for synchronizing URI-backed profile and settings sources.
-import { existsSync, mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { homedir } from 'node:os';
-import { dirname } from 'node:path';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import type { Command } from 'commander';
@@ -21,6 +21,7 @@ import {
   type ProfileSourceReference,
   type RemoteSourceReference,
 } from '../../profiles/ProfileSource.js';
+import { refreshPiExtensionCaches } from '../../agents/pi/PiExtensionCache.js';
 import type { RemoteSettingsReference } from '../../settings/Settings.js';
 import {
   discoverSettingsLoadPlan,
@@ -82,7 +83,7 @@ export const executeSyncCommand = (
     throw new Error(`Cannot sync with invalid settings: ${localSettings.issues.map(formatSettingsIssue).join('; ')}`);
   }
 
-  const synchronizer = dependencies.synchronizer ?? createGitSynchronizer();
+  const synchronizer = dependencies.synchronizer ?? createGitSynchronizer(dependencies.writeLine);
   const repositoryVisibilityClassifier =
     dependencies.repositoryVisibilityClassifier ?? createGitHubRepositoryVisibilityClassifier();
   const privateCatalogGate = createPrivateCatalogGate(
@@ -116,17 +117,22 @@ export const executeSyncCommand = (
     ...profileSourceGateResults.skippedResults,
   ];
   const infoMessages = [...remoteSettingsGateResults.messages, ...profileSourceGateResults.messages];
+  const extensionRefreshMessages = refreshPiExtensionCaches(
+    loadedSettings.settings.cacheDirectory ?? join(input.homeDirectory, '.outfitter', 'cache'),
+    { onProgress: dependencies.writeLine },
+  ).map((result) => `${result.status}: pi extension ${result.source} (${result.message})`);
 
   return {
     sources: sourceResults,
     messages:
-      sourceResults.length === 0
+      sourceResults.length === 0 && extensionRefreshMessages.length === 0
         ? ['No URI profile or remote settings sources configured; nothing to sync.']
         : [
             ...infoMessages,
             ...sourceResults.map(
               (result) => `${result.status}: ${result.uri} -> ${result.cachePath} (${result.message})`,
             ),
+            ...extensionRefreshMessages,
           ],
   };
 };
@@ -140,6 +146,8 @@ export const createSyncCommand = (dependencies: SyncCommandDependencies = {}): C
         .command(command.name)
         .description(command.description)
         .action(() => {
+          /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
+          const writeLine = dependencies.writeLine ?? console.log;
           const result = executeSyncCommand(
             {
               /* v8 ignore next -- default process home is exercised by the direct CLI entrypoint, not unit tests. */
@@ -147,12 +155,11 @@ export const createSyncCommand = (dependencies: SyncCommandDependencies = {}): C
               /* v8 ignore next -- default process cwd is exercised by the direct CLI entrypoint, not unit tests. */
               projectDirectory: dependencies.projectDirectory ?? process.cwd(),
             },
-            dependencies,
+            { ...dependencies, writeLine },
           );
 
           for (const message of result.messages) {
-            /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
-            (dependencies.writeLine ?? console.log)(message);
+            writeLine(message);
           }
         });
     },
@@ -226,11 +233,12 @@ const syncUriSource = (
   }
 };
 
-export const createGitSynchronizer = (): UriProfileSourceSynchronizer => ({
+export const createGitSynchronizer = (progress?: (message: string) => void): UriProfileSourceSynchronizer => ({
   sync(source, cachePath) {
     mkdirSync(dirname(cachePath), { recursive: true });
 
     if (existsSync(cachePath)) {
+      progress?.(`outfitter: updating catalog ${formatDisplayUri(source)}…`);
       runGit(['-C', cachePath, 'fetch', '--all', '--tags']);
       if (source.ref === undefined) {
         runGit(['-C', cachePath, 'pull', '--ff-only']);
@@ -240,11 +248,33 @@ export const createGitSynchronizer = (): UriProfileSourceSynchronizer => ({
       return 'updated';
     }
 
-    runGit(['clone', '--', normalizeGitUri(normalizeRemoteSourceUri(source)), cachePath]);
-    checkoutRefIfPresent(cachePath, source.ref);
+    progress?.(`outfitter: cloning catalog ${formatDisplayUri(source)}…`);
+    cloneCatalogSource(source, cachePath);
     return 'updated';
   },
 });
+
+// Catalog caches are shallow single-branch clones to keep first boot fast on large org catalogs.
+// A ref names the branch or tag to shallow-clone directly; refs that are not remote branch/tag
+// names (for example commit SHAs) fall back to a full clone plus checkout.
+const cloneCatalogSource = (source: RemoteSourceReference, cachePath: string): void => {
+  const cloneUri = normalizeGitUri(normalizeRemoteSourceUri(source));
+
+  if (source.ref === undefined) {
+    runGit(['clone', '--depth', '1', '--single-branch', '--', cloneUri, cachePath]);
+    return;
+  }
+
+  assertSafeGitRef(source.ref);
+
+  if (gitSucceeds(['clone', '--depth', '1', '--single-branch', '--branch', source.ref, '--', cloneUri, cachePath])) {
+    return;
+  }
+
+  rmSync(cachePath, { recursive: true, force: true });
+  runGit(['clone', '--', cloneUri, cachePath]);
+  checkoutRefIfPresent(cachePath, source.ref);
+};
 
 const checkoutRefIfPresent = (cachePath: string, ref: string | undefined): void => {
   if (ref === undefined) {

--- a/code/cli/src/cli/commands/run/RunFirstRunOnboarding.ts
+++ b/code/cli/src/cli/commands/run/RunFirstRunOnboarding.ts
@@ -1,0 +1,80 @@
+// Decides whether a run should enter Pi-native first-run onboarding and prepares its inputs.
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { RunCommandDependencies, RunCommandInput } from '../RunCommand.js';
+import { isNonInteractivePiLaunch } from '../PiLoginLaunch.js';
+import { createGitSynchronizer, syncProfileSource, type RemoteProfileSource } from '../SyncCommand.js';
+import { selectRunAgentId } from './RunProfileResolution.js';
+
+export interface FirstRunRuntimeOnboarding {
+  readonly defaultProfilesPath: string;
+}
+
+const defaultProfilesSource = {
+  github: 'ai-outfitter/default-profiles',
+  path: 'profiles',
+} as const satisfies RemoteProfileSource;
+
+export const prepareFirstRunRuntimeOnboarding = (
+  input: RunCommandInput,
+  dependencies: RunCommandDependencies,
+): FirstRunRuntimeOnboarding | undefined => {
+  if (!shouldUsePiNativeFirstRunOnboarding(input, dependencies)) {
+    return undefined;
+  }
+
+  const syncResult = syncProfileSource(
+    input.homeDirectory,
+    defaultProfilesSource,
+    dependencies.synchronizer ?? createGitSynchronizer(resolveRunProgressWriter(dependencies)),
+  );
+
+  /* v8 ignore next -- network/cache failure path is integration-level behavior; setup fallback message is deterministic. */
+  if (syncResult.status === 'failed') {
+    throw new Error(
+      `Cannot start Pi-native onboarding because the default profiles source failed to sync: ${syncResult.message}. ` +
+        'Fix the network/git issue or run `outfitter setup` once the source is reachable.',
+    );
+  }
+
+  return { defaultProfilesPath: join(syncResult.cachePath, defaultProfilesSource.path) };
+};
+
+const shouldUsePiNativeFirstRunOnboarding = (input: RunCommandInput, dependencies: RunCommandDependencies): boolean => {
+  if (input.forceRuntimeOnboarding !== true && existsSync(join(input.homeDirectory, '.outfitter', 'settings.yml'))) {
+    return false;
+  }
+
+  const selectedAgentId = dependencies.adapter?.id ?? selectRunAgentId(input.agentId, undefined);
+
+  /* v8 ignore next -- explicit profile/non-pi paths are covered by normal run command selection tests. */
+  if (input.profileId !== undefined || selectedAgentId !== 'pi') {
+    return false;
+  }
+
+  if (isNonInteractivePiLaunch(input.passThroughArgs ?? [])) {
+    return false;
+  }
+
+  return isInteractiveRunLaunch(dependencies);
+};
+
+// Network/build steps (catalog clones, extension caching) report per-source progress through this
+// writer so first boot never stalls silently before launch.
+export const resolveRunProgressWriter = (dependencies: RunCommandDependencies): ((message: string) => void) =>
+  /* v8 ignore next -- console fallback is direct CLI behavior; tests inject writeLine. */
+  dependencies.writeLine ?? console.log;
+
+export const isInteractiveRunLaunch = (dependencies: RunCommandDependencies): boolean => {
+  if (dependencies.interactive !== undefined) {
+    return dependencies.interactive;
+  }
+
+  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
+  const inputIsTty = (dependencies.input ?? process.stdin).isTTY === true;
+  /* v8 ignore next -- default process streams are direct terminal behavior; tests inject streams. */
+  const outputIsTty = (dependencies.output ?? process.stdout).isTTY === true;
+
+  return inputIsTty && outputIsTty;
+};

--- a/code/cli/tests/unit/pi-extension-cache.test.ts
+++ b/code/cli/tests/unit/pi-extension-cache.test.ts
@@ -1,5 +1,5 @@
 // Tests Pi git extension materialization into the Outfitter cache.
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -7,6 +7,7 @@ import spawn from 'cross-spawn';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { createPiAdapter } from '../../src/agents/pi/PiAdapter.js';
+import { materializePiExtensionSources, refreshPiExtensionCaches } from '../../src/agents/pi/PiExtensionCache.js';
 
 const temporaryPiExtensionCacheTestRoots: string[] = [];
 
@@ -91,6 +92,107 @@ describe('pi extension cache', () => {
 
     expect(() => materializedExtensionPath(`git+file://${remoteRepository}#main`, cacheRoot)).toThrow();
     expect(listCachedExtensions(cacheRoot)).toEqual([]);
+  });
+
+  it('reports per-extension progress while materializing git extensions', () => {
+    const root = createTemporaryRoot();
+    const remoteRepository = createLocalGitExtensionRepository(root, { packageJson: true });
+    const source = `git+file://${remoteRepository}`;
+    const progressLines: string[] = [];
+
+    materializePiExtensionSources([source], {
+      cacheDirectory: join(root, 'cache'),
+      onProgress: (message) => {
+        progressLines.push(message);
+      },
+    });
+
+    expect(progressLines).toEqual([
+      `outfitter: caching extension ${source}…`,
+      `outfitter: installing dependencies for extension ${source}…`,
+    ]);
+  });
+});
+
+describe('pi extension cache refresh', () => {
+  it('refreshes branch-tracking caches and leaves ref-pinned caches immutable', () => {
+    const root = createTemporaryRoot();
+    const remoteRepository = createLocalGitExtensionRepository(root);
+    const cacheDirectory = join(root, 'cache');
+    const branchSource = `git+file://${remoteRepository}`;
+    const pinnedSource = `git+file://${remoteRepository}#main`;
+    const [branchPath] = materializePiExtensionSources([branchSource], { cacheDirectory }) ?? [];
+    const [pinnedPath] = materializePiExtensionSources([pinnedSource], { cacheDirectory }) ?? [];
+
+    const unchangedResults = refreshPiExtensionCaches(cacheDirectory);
+
+    expect(unchangedResults.find((result) => result.cachePath === branchPath)?.status).toBe('unchanged');
+
+    writeFileSync(join(remoteRepository, 'index.ts'), 'export default function updated() {}\n');
+    runGit(['add', 'index.ts'], remoteRepository);
+    runGit(
+      ['-c', 'user.email=test@example.test', '-c', 'user.name=Test User', 'commit', '-m', 'update'],
+      remoteRepository,
+    );
+
+    const progressLines: string[] = [];
+    const refreshedResults = refreshPiExtensionCaches(cacheDirectory, {
+      onProgress: (message) => {
+        progressLines.push(message);
+      },
+    });
+    const branchResult = refreshedResults.find((result) => result.cachePath === branchPath);
+    const pinnedResult = refreshedResults.find((result) => result.cachePath === pinnedPath);
+
+    expect(branchResult?.status).toBe('refreshed');
+    expect(readFileSync(join(branchPath ?? '', 'index.ts'), 'utf8')).toContain('updated');
+    expect(pinnedResult?.status).toBe('pinned');
+    expect(readFileSync(join(pinnedPath ?? '', 'index.ts'), 'utf8')).not.toContain('updated');
+    expect(progressLines.some((line) => line.startsWith('outfitter: refreshing extension '))).toBe(true);
+  });
+
+  it('reports refresh failures without discarding caches and skips unknown entries', () => {
+    const root = createTemporaryRoot();
+    const remoteRepository = createLocalGitExtensionRepository(root);
+    const cacheDirectory = join(root, 'cache');
+    const source = `git+file://${remoteRepository}`;
+    const [cachePath] = materializePiExtensionSources([source], { cacheDirectory }) ?? [];
+    rmSync(remoteRepository, { recursive: true, force: true });
+
+    const gitCacheRoot = join(cacheDirectory, 'extensions', 'git');
+    mkdirSync(join(gitCacheRoot, 'legacy-cache-without-metadata'), { recursive: true });
+    writeFileSync(join(gitCacheRoot, 'broken.source.json'), 'not json\n');
+    writeFileSync(join(gitCacheRoot, 'array.source.json'), '[]\n');
+    writeFileSync(join(gitCacheRoot, 'missing-source-field.source.json'), '{"ref":"main"}\n');
+    writeFileSync(join(gitCacheRoot, 'ghost.source.json'), '{"source":"git+file:///removed"}\n');
+    mkdirSync(join(gitCacheRoot, 'not-a-git-repo'), { recursive: true });
+    writeFileSync(join(gitCacheRoot, 'not-a-git-repo.source.json'), '{"source":"git+file:///not-a-repo"}\n');
+
+    const results = refreshPiExtensionCaches(cacheDirectory);
+
+    expect(results.map((result) => result.status).sort()).toEqual(['failed', 'failed']);
+    expect(results.find((result) => result.cachePath === cachePath)?.status).toBe('failed');
+    expect(existsSync(join(cachePath ?? '', 'index.ts'))).toBe(true);
+    expect(refreshPiExtensionCaches(join(root, 'missing-cache-directory'))).toEqual([]);
+  });
+
+  it('reports dependency install failures after a refreshed cache tip moves', () => {
+    const root = createTemporaryRoot();
+    const remoteRepository = createLocalGitExtensionRepository(root);
+    const cacheDirectory = join(root, 'cache');
+    const source = `git+file://${remoteRepository}`;
+    const [cachePath] = materializePiExtensionSources([source], { cacheDirectory }) ?? [];
+
+    writeFileSync(join(remoteRepository, 'package.json'), '{invalid json}\n');
+    runGit(['add', 'package.json'], remoteRepository);
+    runGit(
+      ['-c', 'user.email=test@example.test', '-c', 'user.name=Test User', 'commit', '-m', 'break package json'],
+      remoteRepository,
+    );
+
+    const results = refreshPiExtensionCaches(cacheDirectory);
+
+    expect(results.find((result) => result.cachePath === cachePath)?.status).toBe('failed');
   });
 });
 

--- a/code/cli/tests/unit/sync-command.test.ts
+++ b/code/cli/tests/unit/sync-command.test.ts
@@ -1,11 +1,12 @@
 // Tests sync command and profile source cache behavior.
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { materializePiExtensionSources } from '../../src/agents/pi/PiExtensionCache.js';
 import { executeSyncCommand } from '../../src/cli/commands/SyncCommand.js';
 import {
   createProfileSourceCachePath,
@@ -389,5 +390,79 @@ describe('sync command', () => {
     expect(executeSyncCommand({ homeDirectory, projectDirectory }).messages).toEqual([
       'No URI profile or remote settings sources configured; nothing to sync.',
     ]);
+  });
+
+  it('creates shallow single-branch catalog caches and reports per-source progress', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const repositoryPath = createGitProfileRepository(root);
+    const uri = `git+file://${repositoryPath}`;
+    writeSettings(homeDirectory, `profile_sources:\n  - uri: ${uri}\n`);
+    const progressLines: string[] = [];
+    const writeLine = (message: string): void => {
+      progressLines.push(message);
+    };
+
+    const firstResult = executeSyncCommand({ homeDirectory, projectDirectory }, { writeLine });
+    const cachePath = createProfileSourceCachePath(homeDirectory, uri);
+
+    expect(firstResult.sources[0]?.status).toBe('updated');
+    expect(existsSync(join(cachePath, '.git', 'shallow'))).toBe(true);
+    expect(progressLines.some((line) => line.startsWith('outfitter: cloning catalog '))).toBe(true);
+
+    progressLines.length = 0;
+    const secondResult = executeSyncCommand({ homeDirectory, projectDirectory }, { writeLine });
+
+    expect(secondResult.sources[0]?.status).toBe('updated');
+    expect(progressLines.some((line) => line.startsWith('outfitter: updating catalog '))).toBe(true);
+
+    execFileSync('git', ['checkout', '-b', 'feature'], { cwd: repositoryPath, stdio: 'pipe' });
+    writeFileSync(join(repositoryPath, 'remote', 'profile.yml'), 'id: remote\nlabel: Feature\ncontrols: {}\n');
+    execFileSync('git', ['add', '.'], { cwd: repositoryPath, stdio: 'pipe' });
+    execFileSync(
+      'git',
+      ['-c', 'user.name=Outfitter Test', '-c', 'user.email=outfitter@example.test', 'commit', '-m', 'feature'],
+      { cwd: repositoryPath, stdio: 'pipe' },
+    );
+    writeSettings(homeDirectory, `profile_sources:\n  - uri: ${uri}\n    ref: feature\n    path: .\n`);
+
+    const branchRefResult = executeSyncCommand({ homeDirectory, projectDirectory }, { writeLine });
+    const branchCachePath = createRemoteRepositoryCachePath(homeDirectory, { uri, ref: 'feature' });
+
+    expect(branchRefResult.sources[0]?.status).toBe('updated');
+    expect(existsSync(join(branchCachePath, '.git', 'shallow'))).toBe(true);
+    expect(readFileSync(join(branchCachePath, 'remote', 'profile.yml'), 'utf8')).toContain('label: Feature');
+  });
+
+  it('refreshes branch-tracking pi extension caches during sync and reports the outcome', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const extensionRepository = createGitProfileRepository(root, 'extension-source');
+    const cacheDirectory = join(homeDirectory, '.outfitter', 'cache');
+    writeSettings(homeDirectory, 'default_profile: default\n');
+    materializePiExtensionSources([`git+file://${extensionRepository}`], { cacheDirectory });
+
+    writeFileSync(join(extensionRepository, 'extension.txt'), 'updated extension\n');
+    execFileSync('git', ['add', '.'], { cwd: extensionRepository, stdio: 'pipe' });
+    execFileSync(
+      'git',
+      ['-c', 'user.name=Outfitter Test', '-c', 'user.email=outfitter@example.test', 'commit', '-m', 'update'],
+      { cwd: extensionRepository, stdio: 'pipe' },
+    );
+
+    const progressLines: string[] = [];
+    const result = executeSyncCommand(
+      { homeDirectory, projectDirectory },
+      {
+        writeLine: (message) => {
+          progressLines.push(message);
+        },
+      },
+    );
+
+    expect(result.messages.some((message) => message.startsWith('refreshed: pi extension '))).toBe(true);
+    expect(progressLines.some((line) => line.startsWith('outfitter: refreshing extension '))).toBe(true);
   });
 });


### PR DESCRIPTION
Cherry-picked from closed #112 (`be9d791`, authored by Tyler Willis) — the last unmerged fix from that PR (the offline starter fallback stays parked per prioritization).

**User-visible symptoms on main today:**
1. Branch-tracking git-extension caches are cloned once and **never refreshed** — `outfitter sync` doesn't update them, so users silently run stale extension code forever.
2. First boot does full-history clones of catalog sources with no progress output — slow and silent.

Changes: shallow catalog clones, `.source.json` metadata so `outfitter sync` can refresh branch-tracking extension caches, and per-source progress output during sync.

Verification: prettier, typecheck, eslint, coverage 99.2% stmts (309 tests) — all green. Rebased onto main after #133–#135 and #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)