### PR TITLE
fix(run): let launches proceed when a remote profile source has never synced

### DIFF
--- a/code/cli/src/cli/commands/run/RunProfileResolution.ts
+++ b/code/cli/src/cli/commands/run/RunProfileResolution.ts
@@ -1,5 +1,5 @@
 // Resolves the effective profile, layers, and profile sources for a run command launch.
-import { mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 import { createEmptyProfile, type Profile } from '../../../profiles/Profile.js';
@@ -166,6 +166,14 @@ export const loadProfileSources = (
 
   for (const source of sources) {
     const materializedSource = materializeSource(homeDirectory, source);
+
+    // A remote source whose cache has never synced (degraded-offline onboarding, blocked
+    // network) contributes no profiles instead of failing the launch; a later successful
+    // `outfitter sync` upgrades it to the full catalog.
+    if (isUnsyncedRemoteProfileSource(source, materializedSource.path)) {
+      continue;
+    }
+
     const result = loadLocalProfileSource(materializedSource);
     profiles.push(...result.profiles.map((profile) => ({ ...profile, source })));
     issues.push(...result.issues);
@@ -173,6 +181,11 @@ export const loadProfileSources = (
 
   return { profiles, issues };
 };
+
+const isUnsyncedRemoteProfileSource = (source: ProfileSourceReference, materializedPath: string | undefined): boolean =>
+  (source.uri !== undefined || source.github !== undefined) &&
+  materializedPath !== undefined &&
+  !existsSync(materializedPath);
 
 const materializeSource = (homeDirectory: string, source: ProfileSourceReference): ProfileSourceReference => {
   if (source.uri === undefined && source.github === undefined) {

--- a/code/cli/tests/unit/run-command.test.ts
+++ b/code/cli/tests/unit/run-command.test.ts
@@ -569,6 +569,43 @@ describe('run command', () => {
     expect(spawnedResult.exitCode).toBe(0);
   });
 
+  it('launches with local profiles when a remote source cache has never synced', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'unsynced-remote-home');
+    const projectDirectory = join(root, 'project');
+    writeSettings(
+      homeDirectory,
+      [
+        'default_profile: local',
+        'profile_sources:',
+        '  - github: ai-outfitter/default-profiles',
+        '    path: profiles',
+        '  - path: ./profiles',
+        '',
+      ].join('\n'),
+    );
+    writeProfile(join(homeDirectory, '.outfitter', 'profiles'), 'local', 'id: local\ncontrols: {}\n');
+    allowTestConsoleOutput(
+      ({ method, text }) =>
+        method === 'log' &&
+        (isRunCommandSummaryMessage(text) || text.startsWith('Outfitter will ask Pi to open `/login` automatically')),
+    );
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory, profileId: 'local' },
+      {
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    expect(result.profileId).toBe('local');
+    expect(result.exitCode).toBe(0);
+  });
+
   it('maps child process exits and signals to command exit codes', () => {
     expect(resolveChildExitCode(7, null)).toBe(7);
     expect(resolveChildExitCode(null, 'SIGINT')).toBe(130);


### PR DESCRIPTION
**User-visible symptom on main today** (reproduced in the included test, red without the fix): any settings file listing a remote profile source whose cache has never synced — degraded-offline onboarding, blocked network, cleaned cache — fails *every* launch with `Cannot run with invalid profiles: … Profile source must be an existing directory.`, even when the selected profile comes from a perfectly good local source.

Unsynced remote sources now contribute zero profiles instead of failing the launch; a later successful `outfitter sync` upgrades them to the full catalog.

Extracted from #118's `2bbc3ae` (authored by Tyler Willis), where this guard was bundled into the much larger claude first-run onboarding feature. #118 remains open for the feature itself.

Verification: new regression test fails without the fix and passes with it; typecheck, eslint, prettier, coverage 99.2% (310 tests) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)