### PR TITLE
fix(sync): resolve nested remote settings files

### DIFF
--- a/code/cli/src/cli/commands/SyncCommand.ts
+++ b/code/cli/src/cli/commands/SyncCommand.ts
@@ -27,6 +27,7 @@ import {
   discoverSettingsLoadPlan,
   loadSettings,
   loadSettingsWithCachedRemoteSettings,
+  resolveCachedRemoteSettingsPath,
 } from '../../settings/SettingsLoader.js';
 import type { CommandObject } from './CommandObject.js';
 
@@ -177,8 +178,11 @@ const syncRemoteSettingsSource = (
   const displayUri = formatDisplayUri(source);
 
   try {
-    const settingsPath = resolveRemoteRepositorySubpath(cachePath, source.path);
+    // Resolving the configured subpath before syncing rejects unsafe (absolute or
+    // cache-escaping) paths without invoking the synchronizer.
+    resolveRemoteRepositorySubpath(cachePath, source.path);
     const status = synchronizer.sync(source, cachePath);
+    const settingsPath = resolveCachedRemoteSettingsPath(homeDirectory, source);
 
     if (!existsSync(settingsPath)) {
       return {

--- a/code/cli/src/settings/SettingsLoader.ts
+++ b/code/cli/src/settings/SettingsLoader.ts
@@ -94,6 +94,18 @@ export const discoverRemoteSettingsLoadPlan = (
   remoteSettings: readonly RemoteSettingsReference[],
 ): SettingsLoadPlan => discoverRemoteSettingsLocations(homeDirectory, remoteSettings).plan;
 
+export const resolveCachedRemoteSettingsPath = (homeDirectory: string, source: RemoteSettingsReference): string => {
+  const repositoryPath = createRemoteRepositoryCachePath(homeDirectory, source);
+  const configuredPath = resolveRemoteRepositorySubpath(repositoryPath, source.path);
+
+  if (existsSync(configuredPath) || source.path !== 'settings.yml') {
+    return configuredPath;
+  }
+
+  const nestedOutfitterSettingsPath = resolveRemoteRepositorySubpath(repositoryPath, '.outfitter/settings.yml');
+  return existsSync(nestedOutfitterSettingsPath) ? nestedOutfitterSettingsPath : configuredPath;
+};
+
 export const loadSettingsFiles = (plan: SettingsLoadPlan): SettingsLoadResult => {
   const files: LoadedSettingsFile[] = [];
   const issues: SettingsLoadIssue[] = [];
@@ -151,7 +163,7 @@ const discoverRemoteSettingsLocations = (
     try {
       locations.push({
         scope: 'remote',
-        path: resolveRemoteRepositorySubpath(createRemoteRepositoryCachePath(homeDirectory, source), source.path),
+        path: resolveCachedRemoteSettingsPath(homeDirectory, source),
       });
     } catch (error) {
       issues.push({

--- a/code/cli/tests/unit/profile-command.test.ts
+++ b/code/cli/tests/unit/profile-command.test.ts
@@ -13,7 +13,7 @@ import {
   executeProfileLintCommand,
 } from '../../src/cli/commands/profile/Command.js';
 import { createSetupCommand } from '../../src/cli/commands/SetupCommand.js';
-import { createSyncCommand } from '../../src/cli/commands/SyncCommand.js';
+import { createSyncCommand, executeSyncCommand } from '../../src/cli/commands/SyncCommand.js';
 import { createProfileSourceCachePath, createRemoteRepositoryCachePath } from '../../src/profiles/ProfileCache.js';
 
 const temporaryRoots: string[] = [];
@@ -184,6 +184,39 @@ describe('profile command', () => {
         setupSourceUri: 'https://example.test/catalog.git',
       },
     ]);
+  });
+
+  it('resolves remote settings from nested .outfitter/settings.yml when root settings.yml is absent', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const setupSourceUri = join(root, 'link');
+    writeSettings(
+      homeDirectory,
+      ['remote_settings:', `  - uri: ${JSON.stringify(setupSourceUri)}`, '    path: settings.yml', ''].join('\n'),
+    );
+
+    const result = executeSyncCommand(
+      { homeDirectory, projectDirectory },
+      {
+        repositoryVisibilityClassifier: { classify: () => 'unknown' },
+        synchronizer: {
+          sync(_source, cachePath) {
+            mkdirSync(join(cachePath, '.outfitter'), { recursive: true });
+            writeFileSync(
+              join(cachePath, '.outfitter', 'settings.yml'),
+              'profile_sources:\n  - github: ai-outfitter/default-profiles\n    path: profiles\n',
+            );
+            mkdirSync(join(cachePath, 'profiles'), { recursive: true });
+            return 'updated';
+          },
+        },
+      },
+    );
+
+    expect(result.messages.join('\n')).toContain('.outfitter/settings.yml');
+    expect(result.sources[0]?.status).toBe('updated');
+    expect(result.sources[0]?.message).toContain('Remote settings file available');
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.7, OFTR-004.5).


### PR DESCRIPTION
First commit of #119 (`00ccc22`, authored by @ncrmro), split out so it can land independently — the rest of #119 needs a port onto the extracted pi-extension workspace (see comment there).

**Symptom:** setup-style remote settings sources that store their file at `.outfitter/settings.yml` while configured as `path: settings.yml` fail to resolve after sync.

**One adjustment during the split:** the original commit moved subpath resolution to after `synchronizer.sync()`, which bypassed the safety gate that rejects absolute/cache-escaping subpaths before any network access — caught by `remote-sources.test.ts` (added to main after #119 was written). This PR validates the configured subpath *before* syncing, then applies the nested-settings fallback after, so both behaviors hold. All 312 tests green, coverage 99.2%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)