### PR TITLE
feat(extension): show current profile in TUI

### DIFF
--- a/code/cli/src/cli/commands/PiLoginLaunch.ts
+++ b/code/cli/src/cli/commands/PiLoginLaunch.ts
@@ -14,10 +14,16 @@ export interface PiRuntimeOnboardingLaunchInput {
   readonly setupSourceUri?: string;
 }
 
+export interface PiLaunchProfileIdentity {
+  readonly id: string;
+  readonly label?: string;
+}
+
 export interface PiLoginLaunchPlanInput {
   readonly adapterId: string;
   readonly homeDirectory: string;
   readonly launchPlan: AgentLaunchPlan;
+  readonly profile?: PiLaunchProfileIdentity;
   readonly runtimeOnboarding?: PiRuntimeOnboardingLaunchInput;
   readonly startupAsciiArt?: boolean;
   readonly writeLine?: (message: string) => void;
@@ -63,6 +69,7 @@ export const preparePiLoginLaunchPlan = (input: PiLoginLaunchPlanInput): AgentLa
       autoOpenOutfitter: input.runtimeOnboarding?.autoOpenOutfitter === true,
       defaultProfilesPath: input.runtimeOnboarding?.defaultProfilesPath,
       homeDirectory: input.homeDirectory,
+      profile: input.profile,
       projectDirectory: resolve(input.runtimeOnboarding?.projectDirectory ?? process.cwd()),
       setupSourceUri: input.runtimeOnboarding?.setupSourceUri,
       startupAsciiArt: input.startupAsciiArt ?? true,
@@ -158,6 +165,7 @@ const createPiOutfitterExtensionContent = (input: {
   readonly autoOpenOutfitter: boolean;
   readonly defaultProfilesPath?: string;
   readonly homeDirectory: string;
+  readonly profile?: PiLaunchProfileIdentity;
   readonly projectDirectory: string;
   readonly setupSourceUri?: string;
   readonly startupAsciiArt: boolean;
@@ -168,6 +176,7 @@ const createPiOutfitterExtensionContent = (input: {
     OUTFITTER_DEFAULT_PROFILES_PATH: input.defaultProfilesPath,
     OUTFITTER_SETUP_SOURCE_URI: input.setupSourceUri,
     OUTFITTER_AUTO_OPEN: input.autoOpenOutfitter,
+    OUTFITTER_ACTIVE_PROFILE: input.profile,
     OUTFITTER_DEFAULT_SETTINGS_TEMPLATE: createSetupDefaultSettingsContent('__OUTFITTER_PROFILE_ID__'),
     OUTFITTER_STARTUP_ASCII_ART: input.startupAsciiArt,
     OUTFITTER_ASCII_ART: readFileSync(new URL('./assets/outfitter-ascii.txt', import.meta.url), 'utf8').trimEnd(),

--- a/code/cli/src/cli/commands/RunCommand.ts
+++ b/code/cli/src/cli/commands/RunCommand.ts
@@ -123,6 +123,7 @@ export const executeRunCommand = async (
   const launchPlan = preparePiLoginLaunchPlan({
     adapterId: adapter.id,
     homeDirectory: input.homeDirectory,
+    profile: { id: resolvedProfile.profile.id, label: resolvedProfile.profile.label },
     launchPlan: withSystemPromptExportPath(
       adapter.createLaunchPlan(
         compositeProfilePlan.compositeProfile,

--- a/code/cli/tests/unit/pi-login-launch.test.ts
+++ b/code/cli/tests/unit/pi-login-launch.test.ts
@@ -210,6 +210,7 @@ const createMockContext = (
   let editorText = '';
   let terminalInputHandler: ((data: string) => { readonly consume?: boolean } | undefined) | undefined;
   const notifications: string[] = [];
+  const statuses: Record<string, string> = {};
   const selectCalls: Array<{ readonly title: string; readonly options: readonly string[] }> = [];
   const inputCalls: Array<{ readonly message: string; readonly defaultValue?: string }> = [];
   const headerRenders: string[][] = [];
@@ -230,6 +231,7 @@ const createMockContext = (
       return editorText;
     },
     notifications,
+    statuses,
     headerRenders,
     customRenders,
     inputCalls,
@@ -322,7 +324,9 @@ const createMockContext = (
           ).render(),
         );
       },
-      setStatus: () => undefined,
+      setStatus: (id: string, text: string) => {
+        statuses[id] = text;
+      },
       theme: {
         bold: (text: string) => text,
         fg: (_color: string, text: string) => text,
@@ -529,6 +533,66 @@ describe('preparePiLoginLaunchPlan', () => {
     await expect(
       runMockContextFilter(pi, context, [{ customType: 'outfitter-mode-context' }, { role: 'user' }]),
     ).resolves.toEqual({ messages: [{ role: 'user' }] });
+  });
+
+  it('shows the active profile in the status line, preferring the label over the id', async () => {
+    const agentDir = createAgentDir();
+    const plan = preparePiLoginLaunchPlan({
+      adapterId: 'pi',
+      homeDirectory: agentDir,
+      launchPlan: createLaunchPlan(agentDir),
+      profile: { id: 'engineer', label: 'Engineer' },
+      writeLine: () => undefined,
+    });
+    const stamped = readExtension(plan, 'outfitter-extension.js');
+    expect(stamped).toContain('const OUTFITTER_ACTIVE_PROFILE = {"id":"engineer","label":"Engineer"}');
+
+    const extension = evaluateOutfitterExtension(stamped);
+    const pi = createMockPi();
+    const context = createMockContext();
+
+    extension(pi);
+    await startMockSession(pi, context);
+
+    expect(context.statuses['outfitter-profile']).toBe('profile: Engineer');
+  });
+
+  it('falls back to the profile id in the status line when the profile has no label', async () => {
+    const agentDir = createAgentDir();
+    const plan = preparePiLoginLaunchPlan({
+      adapterId: 'pi',
+      homeDirectory: agentDir,
+      launchPlan: createLaunchPlan(agentDir),
+      profile: { id: 'engineer' },
+      writeLine: () => undefined,
+    });
+    const extension = evaluateOutfitterExtension(readExtension(plan, 'outfitter-extension.js'));
+    const pi = createMockPi();
+    const context = createMockContext();
+
+    extension(pi);
+    await startMockSession(pi, context);
+
+    expect(context.statuses['outfitter-profile']).toBe('profile: engineer');
+  });
+
+  it('shows no profile status when the launch has no resolved profile', async () => {
+    const agentDir = createAgentDir();
+    const plan = preparePiLoginLaunchPlan({
+      adapterId: 'pi',
+      homeDirectory: agentDir,
+      launchPlan: createLaunchPlan(agentDir),
+      writeLine: () => undefined,
+    });
+    const extension = evaluateOutfitterExtension(readExtension(plan, 'outfitter-extension.js'));
+    const pi = createMockPi();
+    const context = createMockContext();
+
+    extension(pi);
+    await startMockSession(pi, context);
+
+    expect(context.statuses['outfitter-profile']).toBeUndefined();
+    expect(context.statuses['outfitter-mode']).toBe('mode: build');
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.7).

--- a/code/cli/tests/unit/run-command.test.ts
+++ b/code/cli/tests/unit/run-command.test.ts
@@ -235,6 +235,38 @@ describe('run command', () => {
     expect(existsSync(join(homeDirectory, '.outfitter', 'settings.yml'))).toBe(false);
   });
 
+  it('stamps the resolved profile identity into the Outfitter pi extension', async () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    writeSettings(homeDirectory, 'default_profile: engineer\nprofile_sources:\n  - path: ./profiles\n');
+    writeProfile(
+      join(homeDirectory, '.outfitter', 'profiles'),
+      'engineer',
+      'id: engineer\nlabel: Engineer\ncontrols: {}\n',
+    );
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory },
+      {
+        writeLine: () => undefined,
+        launcher: {
+          launch() {
+            return Promise.resolve(0);
+          },
+        },
+      },
+    );
+
+    const extensionPath = result.launchPlan.args[result.launchPlan.args.indexOf('--extension') + 1];
+    if (extensionPath === undefined) {
+      throw new Error('Outfitter extension path was not injected.');
+    }
+    expect(readFileSync(extensionPath, 'utf8')).toContain(
+      'const OUTFITTER_ACTIVE_PROFILE = {"id":"engineer","label":"Engineer"}',
+    );
+  });
+
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.4).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('emits runtime login kickoff guidance when no native login state is configured', async () => {

--- a/code/pi-extension/src/outfitter-extension.js
+++ b/code/pi-extension/src/outfitter-extension.js
@@ -11,6 +11,7 @@ const OUTFITTER_PROJECT = "__OUTFITTER_PROJECT__";
 const OUTFITTER_DEFAULT_PROFILES_PATH = "__OUTFITTER_DEFAULT_PROFILES_PATH__";
 const OUTFITTER_SETUP_SOURCE_URI = "__OUTFITTER_SETUP_SOURCE_URI__";
 const OUTFITTER_AUTO_OPEN = "__OUTFITTER_AUTO_OPEN__";
+const OUTFITTER_ACTIVE_PROFILE = "__OUTFITTER_ACTIVE_PROFILE__";
 const OUTFITTER_DEFAULT_SETTINGS_TEMPLATE = "__OUTFITTER_DEFAULT_SETTINGS_TEMPLATE__";
 const OUTFITTER_STARTUP_ASCII_ART = "__OUTFITTER_STARTUP_ASCII_ART__";
 const OUTFITTER_ASCII_ART = "__OUTFITTER_ASCII_ART__";
@@ -26,6 +27,15 @@ export default function outfitter(pi) {
   const updateModeStatus = (ctx) => {
     const color = mode === "plan" ? "warning" : "muted";
     ctx.ui.setStatus("outfitter-mode", ctx.ui.theme.fg(color, "mode: " + mode));
+  };
+
+  const updateProfileStatus = (ctx) => {
+    // Stays a string when the placeholder is unstamped (file loaded outside an
+    // Outfitter launch) and `undefined` when the launch had no resolved profile.
+    if (typeof OUTFITTER_ACTIVE_PROFILE !== "object" || OUTFITTER_ACTIVE_PROFILE === null) return;
+    const name = OUTFITTER_ACTIVE_PROFILE.label ?? OUTFITTER_ACTIVE_PROFILE.id;
+    if (!name) return;
+    ctx.ui.setStatus("outfitter-profile", ctx.ui.theme.fg("muted", "profile: " + name));
   };
 
   const enterPlanMode = (ctx) => {
@@ -277,6 +287,7 @@ export default function outfitter(pi) {
       };
     });
     updateModeStatus(ctx);
+    updateProfileStatus(ctx);
     ctx.ui.onTerminalInput((data) => {
       if (!matchesKey(data, "shift+tab")) return undefined;
       cycleOutfitterMode(ctx);


### PR DESCRIPTION
## Summary

The Outfitter pi extension now shows which profile the session was launched with, as a persistent status-line entry (`profile: Engineer`, muted) next to the existing `mode: build|plan` indicator.

## How profile identity flows

The launch-plan env is locked by the hard-requirement pi adapter test (OFTR-006), so the profile travels through the extension's existing placeholder-stamping mechanism instead:

- `executeRunCommand` passes the resolved profile's `id`/`label` to `preparePiLoginLaunchPlan`.
- `PiLoginLaunch` stamps them as a new `__OUTFITTER_ACTIVE_PROFILE__` runtime value (JSON `{id, label}`) when it writes `outfitter-extension.js` into the pi agent directory.
- On `session_start` in the TUI, the extension renders `ctx.ui.setStatus("outfitter-profile", …)` preferring the label, falling back to the id.

If the placeholder is unstamped (extension file loaded outside an Outfitter launch) or the launch had no resolved profile, no status entry is shown.

## Verification

- `prettier --check .`, `npm run typecheck`, `npm run lint`: clean
- `npm run coverage`: 317/317 tests pass, thresholds met (99.2% statements)
- New tests: status shows label, falls back to id, absent when unstamped (`pi-login-launch.test.ts`); run command stamps the resolved profile identity end to end (`run-command.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)