### PR TITLE
chore(cli): amend OFTR-001.5 and remove dead dependencies

### DIFF
--- a/code/cli/package.json
+++ b/code/cli/package.json
@@ -44,11 +44,7 @@
     "chalk": "^5.6.2",
     "commander": "^14.0.3",
     "cross-spawn": "^7.0.6",
-    "defu": "^6.1.7",
-    "glob": "^13.0.6",
-    "hosted-git-info": "^9.0.3",
     "liquidjs": "^10.27.0",
-    "typebox": "^1.1.38",
     "yaml": "^2.9.0"
   },
   "devDependencies": {

--- a/code/cli/tests/cli.test.ts
+++ b/code/cli/tests/cli.test.ts
@@ -85,25 +85,20 @@ describe('project foundation', () => {
     expect(eslintConfigSource).toContain("complexity: ['error', 10]");
   });
 
-  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-001.5).
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-001.5, as amended 2026-07-01).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('declares the initial dependency set and Commander-based CLI shell', () => {
-    const requiredDependencies = [
-      'ajv',
-      'chalk',
-      'commander',
-      'cross-spawn',
-      'defu',
-      'glob',
-      'hosted-git-info',
-      'yaml',
-    ];
+  it('declares the amended dependency set and Commander-based CLI shell', () => {
+    const requiredDependencies = ['ajv', 'chalk', 'commander', 'cross-spawn', 'yaml'];
 
     for (const dependency of requiredDependencies) {
       expect(packageJson.dependencies).toHaveProperty(dependency);
     }
 
-    expect(packageJson.dependencies).toHaveProperty('typebox');
+    // The 2026-07-01 amendment to OFTR-001.5 removed the never-imported packages
+    // and requires that no unused production dependencies are declared.
+    for (const removedDependency of ['defu', 'glob', 'hosted-git-info', 'typebox']) {
+      expect(packageJson.dependencies).not.toHaveProperty(removedDependency);
+    }
 
     const program = createProgram();
 

--- a/docs/requirements/OFTR-001-project-foundation.md
+++ b/docs/requirements/OFTR-001-project-foundation.md
@@ -42,12 +42,15 @@ This document specifies the baseline runtime, language, test, lint, and document
 
 ### OFTR-001.5: Initial Dependency Set
 
+Amendment (2026-07-01): statements 4, 5, 7, and 8 were removed and statement 10 was added, following the amendment process in `docs/requirements/README.md`. Rationale: `typebox`, `defu`, `glob`, and `hosted-git-info` were declared but never imported by any shipped source. Settings and profile merging is implemented by purpose-built merge code with policy-specific semantics (`code/cli/src/settings/SettingsMerger.ts`), profile discovery walks directories directly, and git URI handling is implemented in `code/cli/src/profiles/ProfileCache.ts`. Keeping the unused packages pinned only shipped supply-chain surface to every install.
+
 1. The project MUST use Commander as the CLI framework.
 2. The project MUST use `yaml` for YAML parsing and serialization.
 3. The project MUST use AJV for runtime JSON Schema validation.
-4. The project SHOULD use TypeBox when TypeScript-friendly schema authoring is useful.
-5. The project MUST use `defu` for controlled settings and profile deep merging unless a documented merge-specific reason requires custom code.
+4. REQUIREMENT REMOVED (2026-07-01): TypeBox was never adopted; JSON Schemas are authored as JSON files under `code/cli/src/schemas/`.
+5. REQUIREMENT REMOVED (2026-07-01): `defu` was never adopted; controlled settings and profile deep merging use documented merge-specific custom code.
 6. The project MUST use `cross-spawn` for launching inner agent CLI processes.
-7. The project SHOULD use `glob` for profile and resource discovery.
-8. The project SHOULD use `hosted-git-info` for hosted git URI parsing when the URI format is supported by that library.
+7. REQUIREMENT REMOVED (2026-07-01): `glob` was never adopted; profile and resource discovery reads directories directly.
+8. REQUIREMENT REMOVED (2026-07-01): `hosted-git-info` was never adopted; hosted git URI parsing is implemented in `ProfileCache`.
 9. The project MAY use `chalk` for terminal diagnostics.
+10. The CLI package MUST NOT declare production dependencies that are not imported by shipped source code.

--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -1,0 +1,31 @@
+# Outfitter requirements
+
+Formal, numbered project obligations live here as `OFTR-NNN-<topic>.md` files.
+Their format and governance are themselves specified by
+[OFTR-008: Requirements Governance](./OFTR-008-requirements-governance.md);
+machine-verifiable requirements are pinned by tests carrying a
+`THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-NNN.M)` traceability comment.
+
+## Amending requirements
+
+Pinned tests say "YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT
+CHANGES" — so when reality and a requirement disagree, change the requirement
+first, with a trace, then the test. The process:
+
+1. **Amend the requirement file first.** Edit the relevant `OFTR-NNN.M`
+   section in this directory. Never renumber or reassign existing statement or
+   section IDs: replace a withdrawn statement in place with
+   `REQUIREMENT REMOVED (YYYY-MM-DD): <rationale>` and append new statements
+   at the end of the list. Add a short `Amendment (YYYY-MM-DD): ...` note
+   under the section heading recording what changed and why.
+2. **Then update the pinned tests.** Adjust every test whose traceability
+   comment references the amended requirement so it validates the new text.
+   The amendment note in step 1 is the trace that authorizes touching a
+   "must not modify" test.
+3. **Then change the implementation** (dependencies, behavior, config) to
+   match, in the same change set, and run the full suite.
+
+Amendments are reviewed like any other change: the requirement edit, test
+edit, and implementation edit should land together so the diff shows the
+whole trace. Example: the 2026-07-01 amendment to OFTR-001.5 removed the
+never-adopted `typebox`, `defu`, `glob`, and `hosted-git-info` dependencies.

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,11 +25,7 @@
         "chalk": "^5.6.2",
         "commander": "^14.0.3",
         "cross-spawn": "^7.0.6",
-        "defu": "^6.1.7",
-        "glob": "^13.0.6",
-        "hosted-git-info": "^9.0.3",
         "liquidjs": "^10.27.0",
-        "typebox": "^1.1.38",
         "yaml": "^2.9.0"
       },
       "bin": {
@@ -626,7 +622,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -3077,6 +3073,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -3086,6 +3083,7 @@
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
       "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -3182,12 +3180,6 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/defu": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
-      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
     },
     "node_modules/detect-libc": {
@@ -3709,23 +3701,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3760,18 +3735,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/hosted-git-info": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
-      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^11.1.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/html-escaper": {
@@ -4284,15 +4247,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lru-cache": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4359,6 +4313,7 @@
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
@@ -4378,15 +4333,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -4561,22 +4507,6 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -5079,12 +5009,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/typebox": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.2.tgz",
-      "integrity": "sha512-/JwVcKLrZkcmqtiX7hhvhxyJxEOSs22bzuTBMdzcdEfl9qNbQ0ZL7sg/z3QLEf7vLxo0TTLyH49Ca7TjagmRvw==",
-      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "6.0.3",


### PR DESCRIPTION
The last unmerged piece of #117 (`9259ca9`, authored by Tyler Willis) — the extraction (#120) and command decomposition (#127) already landed.

Removes four dependencies nothing imports anymore: `defu`, `glob`, `hosted-git-info`, `@sinclair/typebox`. Follows the documented amendment process: OFTR-001.5 amended first, then the pinned dependency test, then the deps; adds the "Amending requirements" process note to `docs/requirements/README.md`. ⚠️ Pinned-test amendment — worth a maintainer look.

Lockfile regenerated against current main (remaining `hosted-git-info` entries are transitive deps of the bundled pi package, not ours).

Verification: prettier, typecheck, eslint, build, 313 tests, coverage 99.2% — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)