### PR TITLE
feat(skills): implement catalog skill selection and reference materialization

### DIFF
--- a/code/cli/src/agents/AdapterProfileControls.ts
+++ b/code/cli/src/agents/AdapterProfileControls.ts
@@ -1,6 +1,6 @@
 // Shared helpers for adapter profile controls and argv construction.
 import type { AppendSystemPromptControl, ProfileControls } from '../profiles/Profile.js';
-import { mergeLaunchResourceSources } from './LaunchResources.js';
+import { mergeLaunchResourceSources, mergeSkillControlSources } from './LaunchResources.js';
 
 export const genericControlNames = new Set([
   'model',
@@ -45,7 +45,7 @@ export const mergeAgentSpecificControls = <T extends ProfileControls>(
     environment: { ...controls.environment, ...agentControls?.environment },
     args: agentControls?.args ?? controls.args,
     extensions: mergeLaunchResourceSources('extension', controls.extensions, agentControls?.extensions),
-    skills: mergeLaunchResourceSources('skill', controls.skills, agentControls?.skills),
+    skills: mergeSkillControlSources(controls.skills, agentControls?.skills),
   } as T;
 };
 

--- a/code/cli/src/agents/LaunchResources.ts
+++ b/code/cli/src/agents/LaunchResources.ts
@@ -1,4 +1,6 @@
 // Models launch inputs as precedence-bearing resources that can be merged and deduplicated.
+import type { SkillControlEntry } from '../profiles/Profile.js';
+import { isValidSkillId } from '../skills/SkillDocument.js';
 import { normalizeExtensionResourceIdentity, normalizeLaunchResourceIdentity } from './ResourceIdentity.js';
 
 export type LaunchResourceKind = 'extension' | 'skill';
@@ -62,4 +64,41 @@ const createLaunchResourceIdentity = (kind: LaunchResourceKind, source: string):
   }
 
   return normalizeLaunchResourceIdentity(source);
+};
+
+/** Identity for `controls.skills` entries: bare IDs and `{ id }` objects dedupe together. */
+export const skillControlEntryIdentity = (entry: unknown): string => {
+  if (typeof entry === 'string') {
+    const trimmed = entry.trim();
+    return isValidSkillId(trimmed) ? `id:${trimmed}` : normalizeLaunchResourceIdentity(trimmed);
+  }
+
+  if (entry !== null && typeof entry === 'object' && typeof (entry as { readonly id?: unknown }).id === 'string') {
+    return `id:${(entry as { readonly id: string }).id}`;
+  }
+
+  /* v8 ignore next -- schema validation rejects other entry shapes before merging. */
+  return normalizeLaunchResourceIdentity(String(entry));
+};
+
+export const mergeSkillControlSources = (
+  lowerPrecedence: readonly SkillControlEntry[] | undefined,
+  higherPrecedence: readonly SkillControlEntry[] | undefined,
+): readonly SkillControlEntry[] | undefined => {
+  if (lowerPrecedence === undefined && higherPrecedence === undefined) {
+    return undefined;
+  }
+
+  const merged = [...(higherPrecedence ?? []), ...(lowerPrecedence ?? [])];
+  const winners = new Map<string, SkillControlEntry>();
+
+  for (const entry of merged) {
+    const identity = skillControlEntryIdentity(entry);
+
+    if (!winners.has(identity)) {
+      winners.set(identity, entry);
+    }
+  }
+
+  return merged.filter((entry) => winners.get(skillControlEntryIdentity(entry)) === entry);
 };

--- a/code/cli/src/agents/pi/PiArgs.ts
+++ b/code/cli/src/agents/pi/PiArgs.ts
@@ -11,6 +11,9 @@ export const createPiArgs = (controls: PiProfileControls): readonly string[] => 
   ...flagValue('--system-prompt', controls.systemPrompt),
   ...repeatFlagValue('--append-system-prompt', controls.appendSystemPrompt),
   ...repeatFlag('--extension', controls.extensions),
-  ...repeatFlag('--skill', controls.skills),
+  ...repeatFlag(
+    '--skill',
+    (controls.skills ?? []).filter((source): source is string => typeof source === 'string'),
+  ),
   ...(controls.args ?? []),
 ];

--- a/code/cli/src/agents/pi/PiSkillSources.ts
+++ b/code/cli/src/agents/pi/PiSkillSources.ts
@@ -13,7 +13,11 @@ export const createPiSkillSources = (input: {
 }): readonly string[] => [
   ...new Set([
     input.builtInOutfitterSkill,
-    ...(input.controls.skills ?? []).map((source) => resolveProfileSkillSource(source, input.profileLayers)),
+    // Catalog-ID entries are resolved to generated skill paths before the adapter runs;
+    // any remaining object entries carry no path source and are skipped here.
+    ...(input.controls.skills ?? [])
+      .filter((source): source is string => typeof source === 'string')
+      .map((source) => resolveProfileSkillSource(source, input.profileLayers)),
     ...input.profileFolders.flatMap(skillSourcesForProfile),
   ]),
 ];

--- a/code/cli/src/cli/commands/RunCommand.ts
+++ b/code/cli/src/cli/commands/RunCommand.ts
@@ -43,11 +43,13 @@ import {
   resolveRunProgressWriter,
 } from './run/RunFirstRunOnboarding.js';
 import { createTerminalStateWritePrompt } from './run/RunStateWritePrompt.js';
+import { resolveProfileSkillControls } from '../../skills/ProfileSkillResolution.js';
 import {
   createFirstRunBootstrapProfile,
   createLaunchProfileLayers,
   loadProfileSources,
   loadResolvedProfile,
+  materializeProfileSourcePaths,
   selectRunAgentId,
   type ResolvedRunProfile,
 } from './run/RunProfileResolution.js';
@@ -90,18 +92,19 @@ export const executeRunCommand = async (
 ): Promise<RunCommandResult> => {
   sweepStaleCompositeProfileDirectories();
   const runtimeOnboarding = prepareFirstRunRuntimeOnboarding(input, dependencies);
-  const resolvedProfile =
+  const loadedProfile =
     runtimeOnboarding === undefined ? loadResolvedProfile(input) : createFirstRunBootstrapProfile(input);
   const adapter =
-    dependencies.adapter ?? createAgentAdapter(selectRunAgentId(input.agentId, resolvedProfile.settings.defaultAgent));
-  const compositeProfileRootDirectory = createCompositeProfileRootDirectory(resolvedProfile.profile.id, adapter.id);
+    dependencies.adapter ?? createAgentAdapter(selectRunAgentId(input.agentId, loadedProfile.settings.defaultAgent));
+  const compositeProfileRootDirectory = createCompositeProfileRootDirectory(loadedProfile.profile.id, adapter.id);
   prepareCompositeProfileTeardown(input, compositeProfileRootDirectory, dependencies);
+  const resolvedProfile = resolveRunProfileSkills(loadedProfile, compositeProfileRootDirectory);
   const compositeProfilePlan = createAdapterCompositeProfilePlan(
     adapter,
     resolvedProfile,
     compositeProfileRootDirectory,
   );
-  const warnings = compositeProfilePlan.warnings;
+  const warnings = [...resolvedProfile.skillWarnings, ...compositeProfilePlan.warnings];
 
   failStrictOnWarnings(adapter.id, warnings, input.strict);
   emitWarnings(warnings, dependencies.writeError);
@@ -264,6 +267,40 @@ const configureRunCommander = (
 };
 
 /* v8 ignore stop */
+
+type SkillResolvedRunProfile = ResolvedRunProfile & { readonly skillWarnings: readonly string[] };
+
+// Catalog skill IDs are resolved to generated skill directories under the composite
+// profile root before adapters run, so adapters keep receiving plain path sources and
+// the generated skills are removed with the composite profile at exit.
+const resolveRunProfileSkills = (
+  resolvedProfile: ResolvedRunProfile,
+  compositeProfileRootDirectory: string,
+): SkillResolvedRunProfile => {
+  const resolution = resolveProfileSkillControls({
+    profile: resolvedProfile.profile,
+    profileLayers: resolvedProfile.profileLayers,
+    sourcePaths: materializeProfileSourcePaths(
+      resolvedProfile.homeDirectory,
+      resolvedProfile.settings.profileSources ?? [],
+    ),
+    projectDirectory: resolvedProfile.projectDirectory,
+    outputDirectory: compositeProfileRootDirectory,
+  });
+  const errors = resolution.diagnostics.filter((diagnostic) => diagnostic.severity === 'error');
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Cannot resolve profile skills: ${errors.map((issue) => `${issue.path} ${issue.message}`).join('; ')}`,
+    );
+  }
+
+  return {
+    ...resolvedProfile,
+    profile: resolution.profile,
+    skillWarnings: resolution.diagnostics.map((diagnostic) => diagnostic.message),
+  };
+};
 
 const failStrictOnWarnings = (adapterId: string, warnings: readonly string[], strict: boolean | undefined): void => {
   if (strict === true && warnings.length > 0) {

--- a/code/cli/src/cli/commands/profile/LintCommand.ts
+++ b/code/cli/src/cli/commands/profile/LintCommand.ts
@@ -8,6 +8,8 @@ import { createCompositeProfileRootDirectory } from '../../../compositeProfile/C
 import { createPromptIncludeDiagnostics } from '../../../profiles/PromptIncludes.js';
 import { resolveProfile } from '../../../profiles/ProfileMerger.js';
 import { loadSettingsWithCachedRemoteSettings } from '../../../settings/SettingsLoader.js';
+import { resolveProfileSkillControls } from '../../../skills/ProfileSkillResolution.js';
+import { materializeProfileSourcePaths } from '../run/RunProfileResolution.js';
 import { createLaunchProfileLayers, loadProfileSources } from '../RunCommand.js';
 import type { AgentLaunchProfileLayer } from '../../../agents/AgentAdapter.js';
 import type { Profile, ProfileControls } from '../../../profiles/Profile.js';
@@ -100,8 +102,48 @@ const collectProfileLintDiagnostics = (input: ProfileLintCommandInput): readonly
     }),
   );
   const adapterDiagnostics = lintAdapterWarnings(loadedProfiles.profiles, input.projectDirectory);
+  const skillDiagnostics = lintProfileSkills(loadedProfiles.profiles, input);
 
-  return [...loadDiagnostics, ...inheritanceDiagnostics, ...promptDiagnostics, ...adapterDiagnostics];
+  return [
+    ...loadDiagnostics,
+    ...inheritanceDiagnostics,
+    ...promptDiagnostics,
+    ...adapterDiagnostics,
+    ...skillDiagnostics,
+  ];
+};
+
+// Diagnoses unresolved skill IDs, invalid SKILL.md frontmatter, missing `file`
+// references, escaping paths, and destination collisions without materializing.
+const lintProfileSkills = (
+  profiles: Parameters<typeof createPromptIncludeDiagnostics>[0],
+  input: ProfileLintCommandInput,
+): readonly ProfileLintDiagnostic[] => {
+  const settings = loadSettingsWithCachedRemoteSettings(input);
+  const sourcePaths = materializeProfileSourcePaths(input.homeDirectory, settings.settings.profileSources ?? []);
+
+  return [...new Set(profiles.map((profile) => profile.profile.id))].flatMap((profileId) => {
+    const resolution = resolveProfile({ profiles, profileId });
+
+    if (resolution.profile === undefined || resolution.issues.length > 0) {
+      return [];
+    }
+
+    const stackProfiles = profiles.filter((profile) =>
+      resolution.profileStack.some((stackProfile) => stackProfile.id === profile.profile.id),
+    );
+
+    return resolveProfileSkillControls({
+      profile: resolution.profile,
+      profileLayers: stackProfiles,
+      sourcePaths,
+      projectDirectory: input.projectDirectory,
+    }).diagnostics.map((diagnostic) => ({
+      severity: diagnostic.severity,
+      path: `/profiles/${profileId}: ${diagnostic.path}`,
+      message: diagnostic.message,
+    }));
+  });
 };
 
 const lintProfileInheritance = (

--- a/code/cli/src/cli/commands/run/RunProfileResolution.ts
+++ b/code/cli/src/cli/commands/run/RunProfileResolution.ts
@@ -182,6 +182,15 @@ export const loadProfileSources = (
   return { profiles, issues };
 };
 
+/** Materialized on-disk paths for configured sources, in configured (precedence) order. */
+export const materializeProfileSourcePaths = (
+  homeDirectory: string,
+  sources: readonly ProfileSourceReference[],
+): readonly string[] =>
+  sources
+    .map((source) => materializeSource(homeDirectory, source).path)
+    .filter((path): path is string => path !== undefined && existsSync(path));
+
 const isUnsyncedRemoteProfileSource = (source: ProfileSourceReference, materializedPath: string | undefined): boolean =>
   (source.uri !== undefined || source.github !== undefined) &&
   materializedPath !== undefined &&

--- a/code/cli/src/profiles/Profile.ts
+++ b/code/cli/src/profiles/Profile.ts
@@ -11,6 +11,21 @@ export interface PromptRepoFileInclude {
 export type AppendSystemPromptEntry = string | PromptFileInclude | PromptRepoFileInclude;
 export type AppendSystemPromptControl = AppendSystemPromptEntry | readonly AppendSystemPromptEntry[];
 
+export interface SkillFileReference {
+  readonly file: string;
+}
+export interface SkillRepoFileReference {
+  readonly repo_file: string;
+}
+export type SkillReference = SkillFileReference | SkillRepoFileReference;
+
+/** Expanded `controls.skills` entry appending profile-owned references to a selected skill. */
+export interface SkillSelection {
+  readonly id: string;
+  readonly references?: readonly SkillReference[];
+}
+export type SkillControlEntry = string | SkillSelection;
+
 export interface DeepWorkProfileControls {
   readonly jobs?: readonly string[];
 }
@@ -24,7 +39,7 @@ interface BaseProfileControls {
   readonly args?: readonly string[];
   readonly sessionDirectory?: string;
   readonly extensions?: readonly string[];
-  readonly skills?: readonly string[];
+  readonly skills?: readonly SkillControlEntry[];
   readonly promptTemplate?: string;
   readonly systemPrompt?: string;
   readonly appendSystemPrompt?: AppendSystemPromptControl;

--- a/code/cli/src/profiles/ProfileLoader.ts
+++ b/code/cli/src/profiles/ProfileLoader.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import type { ValidationIssue } from '../validation/SchemaValidator.js';
 import { validateSchema } from '../validation/SchemaValidator.js';
 import { parseYamlDocument } from '../validation/YamlDocument.js';
+import { isSkillReference } from '../skills/SkillDocument.js';
 import { isPromptFileInclude, isPromptRepoFileInclude } from './PromptIncludes.js';
 import type {
   AgentSpecificProfileControls,
@@ -13,6 +14,7 @@ import type {
   DeepWorkProfileControls,
   Profile,
   ProfileControls,
+  SkillControlEntry,
   StatePersistenceOverrides,
 } from './Profile.js';
 import type { ProfileSourceReference } from './ProfileSource.js';
@@ -296,6 +298,28 @@ const readOptionalStringArray = (value: unknown): readonly string[] | undefined 
   return undefined;
 };
 
+const isSkillSelection = (value: unknown): value is Exclude<SkillControlEntry, string> => {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const record = value as { readonly id?: unknown; readonly references?: unknown };
+
+  return (
+    typeof record.id === 'string' &&
+    Object.keys(record).every((key) => key === 'id' || key === 'references') &&
+    (record.references === undefined || (Array.isArray(record.references) && record.references.every(isSkillReference)))
+  );
+};
+
+const readOptionalSkillControlEntries = (value: unknown): readonly SkillControlEntry[] | undefined => {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value.filter((item): item is SkillControlEntry => typeof item === 'string' || isSkillSelection(item));
+};
+
 const readOptionalAppendSystemPrompt = (value: unknown): AppendSystemPromptControl | undefined => {
   if (typeof value === 'string' || isPromptFileInclude(value) || isPromptRepoFileInclude(value)) {
     return value;
@@ -327,7 +351,7 @@ const readControls = (value: unknown): ProfileControls => {
     args: readOptionalStringArray(controls.args),
     sessionDirectory: readOptionalString(controls.session_directory),
     extensions: readOptionalStringArray(controls.extensions),
-    skills: readOptionalStringArray(controls.skills),
+    skills: readOptionalSkillControlEntries(controls.skills),
     promptTemplate: readOptionalString(controls.prompt_template),
     systemPrompt: readOptionalString(controls.system_prompt),
     appendSystemPrompt: readOptionalAppendSystemPrompt(controls.append_system_prompt),
@@ -366,7 +390,7 @@ const readAgentSpecificControls = (value: unknown): AgentSpecificProfileControls
     args: readOptionalStringArray(controls.args),
     sessionDirectory: readOptionalString(controls.session_directory),
     extensions: readOptionalStringArray(controls.extensions),
-    skills: readOptionalStringArray(controls.skills),
+    skills: readOptionalSkillControlEntries(controls.skills),
     promptTemplate: readOptionalString(controls.prompt_template),
     systemPrompt: readOptionalString(controls.system_prompt),
     appendSystemPrompt: readOptionalAppendSystemPrompt(controls.append_system_prompt),

--- a/code/cli/src/profiles/ProfileMerger.ts
+++ b/code/cli/src/profiles/ProfileMerger.ts
@@ -2,7 +2,8 @@
 import type { ArrayMergePolicy } from '../merge/ArrayMergePolicy.js';
 import type { MergePath } from '../merge/SettingsValueMerger.js';
 import { mergeObjectsWithPolicy } from '../merge/SettingsValueMerger.js';
-import { normalizeExtensionResourceIdentity, normalizeLaunchResourceIdentity } from '../agents/ResourceIdentity.js';
+import { normalizeExtensionResourceIdentity } from '../agents/ResourceIdentity.js';
+import { skillControlEntryIdentity } from '../agents/LaunchResources.js';
 import type { Profile } from './Profile.js';
 import type { LoadedProfile } from './ProfileLoader.js';
 
@@ -77,7 +78,7 @@ const profileArrayPolicy = (path: MergePath): ArrayMergePolicy | undefined => {
       mode: 'uniqueBy',
       order: 'prepend',
       winner: 'first',
-      key: (source: unknown) => normalizeLaunchResourceIdentity(String(source)),
+      key: (source: unknown) => skillControlEntryIdentity(source),
     };
   }
 

--- a/code/cli/src/schemas/profile.schema.json
+++ b/code/cli/src/schemas/profile.schema.json
@@ -42,7 +42,7 @@
         },
         "skills": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": { "$ref": "#/$defs/skillEntry" }
         },
         "prompt_template": { "type": "string" },
         "system_prompt": { "type": "string" },
@@ -81,7 +81,7 @@
             },
             "skills": {
               "type": "array",
-              "items": { "type": "string" }
+              "items": { "$ref": "#/$defs/skillEntry" }
             },
             "prompt_template": { "type": "string" },
             "system_prompt": { "type": "string" },
@@ -111,7 +111,7 @@
             },
             "skills": {
               "type": "array",
-              "items": { "type": "string" }
+              "items": { "$ref": "#/$defs/skillEntry" }
             },
             "prompt_template": { "type": "string" },
             "system_prompt": { "type": "string" },
@@ -129,6 +129,43 @@
   },
   "additionalProperties": true,
   "$defs": {
+    "skillReference": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["file"],
+          "properties": {
+            "file": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": ["repo_file"],
+          "properties": {
+            "repo_file": { "type": "string" }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "skillEntry": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": { "type": "string" },
+            "references": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/skillReference" }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
     "appendSystemPromptEntry": {
       "oneOf": [
         { "type": "string" },

--- a/code/cli/src/skills/ProfileSkillResolution.ts
+++ b/code/cli/src/skills/ProfileSkillResolution.ts
@@ -1,0 +1,147 @@
+// Resolves a profile's selected skill IDs into generated skill sources before adapter launch.
+import { join } from 'node:path';
+
+import type { LoadedProfile } from '../profiles/ProfileLoader.js';
+import type { Profile, ProfileControls, SkillControlEntry } from '../profiles/Profile.js';
+import { inferProfileIncludeSourceRoot } from '../profiles/PromptIncludes.js';
+import { skillControlEntryIdentity } from '../agents/LaunchResources.js';
+import { discoverSkillCatalog, type SkillCatalog } from './SkillCatalog.js';
+import {
+  resolveSkillEntries,
+  type SkillEntryInput,
+  type SkillMaterializationCache,
+  type SkillResolutionDiagnostic,
+} from './SkillResolution.js';
+
+type SkillControlScope = 'skills' | 'pi' | 'claude';
+
+export interface ProfileSkillResolutionInput {
+  readonly profile: Profile;
+  readonly profileLayers: readonly LoadedProfile[];
+  /** Materialized configured profile-source paths, in configured order. */
+  readonly sourcePaths: readonly string[];
+  readonly projectDirectory: string;
+  /** Composite profile root; generated skills are written beneath `outfitter/skills/`. */
+  readonly outputDirectory?: string;
+}
+
+export interface ProfileSkillResolutionResult {
+  readonly profile: Profile;
+  readonly diagnostics: readonly SkillResolutionDiagnostic[];
+}
+
+/**
+ * Resolves catalog skill IDs in `controls.skills` (generic and adapter-scoped) to
+ * generated skill directories, so adapters keep receiving plain path sources.
+ */
+export const resolveProfileSkillControls = (input: ProfileSkillResolutionInput): ProfileSkillResolutionResult => {
+  const catalog = discoverSkillCatalog({
+    projectDirectory: input.projectDirectory,
+    profileLayers: input.profileLayers,
+    sourcePaths: input.sourcePaths,
+  });
+  const diagnostics: SkillResolutionDiagnostic[] = [];
+  const outputDirectory =
+    input.outputDirectory === undefined ? undefined : join(input.outputDirectory, 'outfitter', 'skills');
+  // One skill ID materializes once; selecting it from several control scopes reuses
+  // the same generated directory, and conflicting reference sets are an error.
+  const materializationCache: SkillMaterializationCache = new Map();
+  const resolveEntries = (
+    entries: readonly SkillControlEntry[],
+    scope: SkillControlScope,
+  ): readonly SkillControlEntry[] => {
+    const resolution = resolveSkillEntries({
+      entries: entries.map((entry) => toSkillEntryInput(entry, scope, input.profileLayers)),
+      catalog,
+      projectDirectory: input.projectDirectory,
+      outputDirectory,
+      materializationCache,
+    });
+    diagnostics.push(...resolution.diagnostics);
+
+    return resolution.sources;
+  };
+
+  const controls = resolveSkillControls(input.profile.controls, resolveEntries);
+  diagnostics.push(...createShadowedSkillDiagnostics(catalog, input.profile.controls));
+
+  return { profile: { ...input.profile, controls }, diagnostics };
+};
+
+const resolveSkillControls = (
+  controls: ProfileControls,
+  resolveEntries: (entries: readonly SkillControlEntry[], scope: SkillControlScope) => readonly SkillControlEntry[],
+): ProfileControls => ({
+  ...controls,
+  ...(controls.skills === undefined ? {} : { skills: resolveEntries(controls.skills, 'skills') }),
+  ...(controls.pi?.skills === undefined
+    ? {}
+    : { pi: { ...controls.pi, skills: resolveEntries(controls.pi.skills, 'pi') } }),
+  ...(controls.claude?.skills === undefined
+    ? {}
+    : { claude: { ...controls.claude, skills: resolveEntries(controls.claude.skills, 'claude') } }),
+});
+
+/**
+ * Profile-added `file` references resolve from the repository containing the
+ * declaring profile. The lookup stays within the entry's own control scope so an
+ * object selection in another scope cannot supply the wrong repository root.
+ */
+const toSkillEntryInput = (
+  entry: SkillControlEntry,
+  scope: SkillControlScope,
+  profileLayers: readonly LoadedProfile[],
+): SkillEntryInput => {
+  if (typeof entry === 'string') {
+    return { entry };
+  }
+
+  const identity = skillControlEntryIdentity(entry);
+  const declaringLayer = [...profileLayers]
+    .reverse()
+    .find((layer) =>
+      readScopedSkillEntries(layer.profile.controls, scope).some(
+        (layerEntry) => typeof layerEntry !== 'string' && skillControlEntryIdentity(layerEntry) === identity,
+      ),
+    );
+
+  return {
+    entry,
+    profileReferenceRoot:
+      declaringLayer === undefined
+        ? undefined
+        : inferProfileIncludeSourceRoot({
+            sourceRootPath: declaringLayer.sourceRootPath,
+            profilePath: declaringLayer.profilePath,
+          }),
+  };
+};
+
+const readScopedSkillEntries = (controls: ProfileControls, scope: SkillControlScope): readonly SkillControlEntry[] =>
+  (scope === 'skills' ? controls.skills : controls[scope]?.skills) ?? [];
+
+const readLayerSkillEntries = (controls: ProfileControls): readonly SkillControlEntry[] => [
+  ...(controls.skills ?? []),
+  ...(controls.pi?.skills ?? []),
+  ...(controls.claude?.skills ?? []),
+];
+
+/** Reports shadowing only for IDs the profile actually selects. */
+const createShadowedSkillDiagnostics = (
+  catalog: SkillCatalog,
+  controls: ProfileControls,
+): readonly SkillResolutionDiagnostic[] => {
+  const selectedIds = new Set(
+    readLayerSkillEntries(controls).map((entry) => (typeof entry === 'string' ? entry : entry.id)),
+  );
+
+  return catalog.shadowed
+    .filter((shadow) => selectedIds.has(shadow.selected.id))
+    .map((shadow) => ({
+      severity: 'warning',
+      path: shadow.shadowedDirectory,
+      message:
+        `Skill ID '${shadow.selected.id}' is supplied by ${shadow.selected.origin} ('${shadow.selected.directory}') ` +
+        `and shadows '${shadow.shadowedDirectory}'.`,
+    }));
+};

--- a/code/cli/src/skills/SkillCatalog.ts
+++ b/code/cli/src/skills/SkillCatalog.ts
@@ -1,0 +1,175 @@
+// Discovers catalog skills across project, directory-profile, and configured-source roots.
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+
+import { inferProfileIncludeSourceRoot } from '../profiles/PromptIncludes.js';
+import { isValidSkillId } from './SkillDocument.js';
+
+export interface SkillCatalogRoot {
+  /** Directory scanned for `<skill-id>/SKILL.md` entries. */
+  readonly skillsDirectory: string;
+  /** Root that skill `file` references resolve from (the repository containing the skill). */
+  readonly referenceRoot: string;
+  /** Human-readable origin for shadowing diagnostics. */
+  readonly origin: string;
+}
+
+export interface SkillCatalogEntry {
+  readonly id: string;
+  readonly directory: string;
+  readonly skillPath: string;
+  readonly referenceRoot: string;
+  readonly origin: string;
+}
+
+export interface SkillCatalog {
+  readonly entries: ReadonlyMap<string, SkillCatalogEntry>;
+  readonly shadowed: readonly { readonly selected: SkillCatalogEntry; readonly shadowedDirectory: string }[];
+}
+
+export interface SkillCatalogInput {
+  readonly projectDirectory?: string;
+  /** Directory-profile resource roots contributing bundled `skills/` folders. */
+  readonly profileLayers?: readonly { readonly sourceRootPath?: string; readonly resourceRootPath?: string }[];
+  /** Materialized configured profile-source paths, in configured (precedence) order. */
+  readonly sourcePaths?: readonly string[];
+}
+
+/**
+ * Builds the skill ID catalog following layer precedence: project-local, project,
+ * bundled directory-profile skills (highest-precedence layer first), then
+ * configured sources (later entries outrank earlier ones, matching profile
+ * precedence). The first root supplying an ID wins; later roots are reported as
+ * shadowed.
+ */
+export const discoverSkillCatalog = (input: SkillCatalogInput): SkillCatalog => {
+  const entries = new Map<string, SkillCatalogEntry>();
+  const shadowed: { readonly selected: SkillCatalogEntry; readonly shadowedDirectory: string }[] = [];
+
+  for (const root of createSkillCatalogRoots(input)) {
+    for (const entry of readSkillCatalogRootEntries(root)) {
+      const selected = entries.get(entry.id);
+
+      if (selected === undefined) {
+        entries.set(entry.id, entry);
+      } else if (selected.directory !== entry.directory) {
+        shadowed.push({ selected, shadowedDirectory: entry.directory });
+      }
+    }
+  }
+
+  return { entries, shadowed };
+};
+
+export const createSkillCatalogRoots = (input: SkillCatalogInput): readonly SkillCatalogRoot[] => {
+  const roots: SkillCatalogRoot[] = [];
+
+  if (input.projectDirectory !== undefined) {
+    roots.push(
+      {
+        skillsDirectory: join(input.projectDirectory, '.outfitter', 'local', 'skills'),
+        referenceRoot: input.projectDirectory,
+        origin: 'project-local skills',
+      },
+      {
+        skillsDirectory: join(input.projectDirectory, '.outfitter', 'skills'),
+        referenceRoot: input.projectDirectory,
+        origin: 'project skills',
+      },
+    );
+  }
+
+  // Profile layers arrive lowest-precedence first (see ProfileMerger); reverse so
+  // the selected profile's bundled skill outranks an inherited base profile's.
+  for (const layer of [...(input.profileLayers ?? [])].reverse()) {
+    if (layer.resourceRootPath === undefined) {
+      continue;
+    }
+
+    roots.push({
+      skillsDirectory: join(layer.resourceRootPath, 'skills'),
+      referenceRoot:
+        inferProfileIncludeSourceRoot({
+          sourceRootPath: layer.sourceRootPath,
+          profilePath: join(layer.resourceRootPath, 'profile.yml'),
+          /* v8 ignore next -- directory profiles always sit under a source root. */
+        }) ?? layer.resourceRootPath,
+      origin: `profile '${basename(layer.resourceRootPath)}' skills`,
+    });
+  }
+
+  // Later configured sources outrank earlier ones for profiles; mirror that here.
+  for (const sourcePath of [...(input.sourcePaths ?? [])].reverse()) {
+    const catalogRoot = resolveCatalogRoot(sourcePath);
+    roots.push({
+      skillsDirectory: join(catalogRoot, 'skills'),
+      referenceRoot: basename(catalogRoot) === '.outfitter' ? dirname(catalogRoot) : catalogRoot,
+      origin: `source '${sourcePath}'`,
+    });
+  }
+
+  return dedupeSkillCatalogRoots(roots);
+};
+
+/**
+ * The catalog root is the directory containing `profiles/`. A source path that
+ * points directly at the profiles directory resolves to its parent.
+ */
+const resolveCatalogRoot = (sourcePath: string): string =>
+  basename(sourcePath) === 'profiles' ? dirname(sourcePath) : sourcePath;
+
+const dedupeSkillCatalogRoots = (roots: readonly SkillCatalogRoot[]): readonly SkillCatalogRoot[] => {
+  const seen = new Set<string>();
+
+  return roots.filter((root) => {
+    if (seen.has(root.skillsDirectory)) {
+      return false;
+    }
+
+    seen.add(root.skillsDirectory);
+    return true;
+  });
+};
+
+const readSkillCatalogRootEntries = (root: SkillCatalogRoot): readonly SkillCatalogEntry[] =>
+  readOptionalDirectoryNames(root.skillsDirectory)
+    .filter((name) => isValidSkillId(name) && existsSync(join(root.skillsDirectory, name, 'SKILL.md')))
+    .sort()
+    .map((name) => ({
+      id: name,
+      directory: join(root.skillsDirectory, name),
+      skillPath: join(root.skillsDirectory, name, 'SKILL.md'),
+      referenceRoot: root.referenceRoot,
+      origin: root.origin,
+    }));
+
+const readOptionalDirectoryNames = (directory: string): readonly string[] => {
+  try {
+    return readdirSync(directory, { withFileTypes: true })
+      .filter(
+        (entry) => entry.isDirectory() || isSymlinkedDirectory(join(directory, entry.name), entry.isSymbolicLink()),
+      )
+      .map((entry) => entry.name);
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return [];
+    }
+
+    throw new Error(`Could not read skills directory '${directory}': ${String(error)}`, { cause: error });
+  }
+};
+
+const isSymlinkedDirectory = (path: string, isSymbolicLink: boolean): boolean => {
+  if (!isSymbolicLink) {
+    return false;
+  }
+
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+};
+
+const isMissingPathError = (error: unknown): boolean =>
+  error !== null && typeof error === 'object' && 'code' in error && error.code === 'ENOENT';

--- a/code/cli/src/skills/SkillDocument.ts
+++ b/code/cli/src/skills/SkillDocument.ts
@@ -1,0 +1,138 @@
+// Parses and validates SKILL.md frontmatter for catalog skill resolution.
+import { readFileSync } from 'node:fs';
+
+import { parseYamlDocument } from '../validation/YamlDocument.js';
+import type { SkillReference } from '../profiles/Profile.js';
+
+export const isSkillReference = (value: unknown): value is SkillReference =>
+  value !== null &&
+  typeof value === 'object' &&
+  !Array.isArray(value) &&
+  Object.keys(value).length === 1 &&
+  (typeof (value as { readonly file?: unknown }).file === 'string' ||
+    typeof (value as { readonly repo_file?: unknown }).repo_file === 'string');
+
+const skillNamePattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
+const skillNameMaxLength = 64;
+
+/** Frontmatter keys that materialize external files into a generated skill directory. */
+export const skillMaterializationSections = ['references', 'scripts', 'assets'] as const;
+export type SkillMaterializationSection = (typeof skillMaterializationSections)[number];
+
+export interface SkillDocument {
+  readonly name: string;
+  readonly description?: string;
+  readonly references: readonly SkillReference[];
+  readonly scripts: readonly SkillReference[];
+  readonly assets: readonly SkillReference[];
+}
+
+export interface SkillDocumentIssue {
+  readonly path: string;
+  readonly message: string;
+}
+
+/** Skill IDs and directory names: lowercase alphanumerics and single hyphens, at most 64 characters. */
+export const isValidSkillId = (value: string): boolean =>
+  value.length <= skillNameMaxLength && skillNamePattern.test(value);
+
+export const parseSkillDocument = (content: string, skillPath: string): SkillDocument | SkillDocumentIssue => {
+  const frontmatter = parseSkillFrontmatter(content, skillPath);
+
+  if ('message' in frontmatter) {
+    return frontmatter;
+  }
+
+  const { name, description } = frontmatter.record as {
+    readonly name?: unknown;
+    readonly description?: unknown;
+  };
+
+  if (typeof name !== 'string' || !isValidSkillId(name)) {
+    return {
+      path: skillPath,
+      message:
+        `SKILL.md 'name' must use lowercase letters, numbers, and single hyphens ` +
+        `(max ${skillNameMaxLength} characters).`,
+    };
+  }
+
+  const sections: Partial<Record<SkillMaterializationSection, readonly SkillReference[]>> = {};
+
+  for (const section of skillMaterializationSections) {
+    const entries = frontmatter.record[section];
+
+    if (entries !== undefined && (!Array.isArray(entries) || !entries.every(isSkillReference))) {
+      return {
+        path: skillPath,
+        message: `SKILL.md '${section}' entries must each contain exactly one 'file' or 'repo_file' source.`,
+      };
+    }
+
+    sections[section] = entries ?? [];
+  }
+
+  return {
+    name,
+    description: typeof description === 'string' ? description : undefined,
+    references: sections.references!,
+    scripts: sections.scripts!,
+    assets: sections.assets!,
+  };
+};
+
+const parseSkillFrontmatter = (
+  content: string,
+  skillPath: string,
+): { readonly record: Readonly<Record<string, unknown>> } | SkillDocumentIssue => {
+  const frontmatter = extractFrontmatter(content);
+
+  if (frontmatter === undefined) {
+    return { path: skillPath, message: 'SKILL.md must start with a `---` YAML frontmatter block.' };
+  }
+
+  const parsed = parseYamlDocument(frontmatter, skillPath);
+
+  if (!parsed.ok) {
+    return { path: skillPath, message: `SKILL.md frontmatter is not valid YAML: ${parsed.issue.message}` };
+  }
+
+  const record = parsed.document;
+
+  if (record === null || typeof record !== 'object' || Array.isArray(record)) {
+    return { path: skillPath, message: 'SKILL.md frontmatter must be a YAML mapping.' };
+  }
+
+  return { record: record as Readonly<Record<string, unknown>> };
+};
+
+export const readSkillDocument = (skillPath: string): SkillDocument | SkillDocumentIssue => {
+  let content: string;
+
+  try {
+    content = readFileSync(skillPath, 'utf8');
+  } catch (error) {
+    return { path: skillPath, message: `Could not read SKILL.md: ${String(error)}` };
+  }
+
+  return parseSkillDocument(content, skillPath);
+};
+
+export const isSkillDocumentIssue = (value: SkillDocument | SkillDocumentIssue): value is SkillDocumentIssue =>
+  'message' in value;
+
+const extractFrontmatter = (content: string): string | undefined => {
+  const lines = content.split('\n');
+
+  if (lines[0]?.trimEnd() !== '---') {
+    return undefined;
+  }
+
+  const closingIndex = lines.findIndex((line, index) => index > 0 && line.trimEnd() === '---');
+
+  if (closingIndex === -1) {
+    return undefined;
+  }
+
+  return lines.slice(1, closingIndex).join('\n');
+};

--- a/code/cli/src/skills/SkillResolution.ts
+++ b/code/cli/src/skills/SkillResolution.ts
@@ -1,0 +1,361 @@
+// Resolves selected skill IDs, validates references, and materializes generated skills.
+import { copyFileSync, cpSync, existsSync, mkdirSync, realpathSync, statSync } from 'node:fs';
+import { basename, isAbsolute, join, relative, sep } from 'node:path';
+
+import type { SkillControlEntry, SkillReference, SkillSelection } from '../profiles/Profile.js';
+import type { SkillCatalog, SkillCatalogEntry } from './SkillCatalog.js';
+import {
+  isSkillDocumentIssue,
+  isValidSkillId,
+  readSkillDocument,
+  skillMaterializationSections,
+  type SkillDocument,
+  type SkillMaterializationSection,
+} from './SkillDocument.js';
+
+export interface SkillResolutionDiagnostic {
+  readonly severity: 'error' | 'warning';
+  readonly path: string;
+  readonly message: string;
+}
+
+export interface SkillEntryInput {
+  readonly entry: SkillControlEntry;
+  /** Root for `file` references appended by the declaring profile. */
+  readonly profileReferenceRoot?: string;
+}
+
+/**
+ * Shared across control scopes so one skill ID materializes once; a second
+ * selection reuses the generated directory, and differing reference sets error.
+ */
+export type SkillMaterializationCache = Map<
+  string,
+  { readonly referencesKey: string; readonly generatedDirectory?: string }
+>;
+
+export interface SkillResolutionInput {
+  readonly entries: readonly SkillEntryInput[];
+  readonly catalog: SkillCatalog;
+  readonly projectDirectory?: string;
+  /** When set, resolved skills are copied here as `<id>/` with materialized references. */
+  readonly outputDirectory?: string;
+  readonly materializationCache?: SkillMaterializationCache;
+}
+
+export interface SkillResolutionResult {
+  /** Skill sources in entry order: generated directories for resolved IDs, original strings otherwise. */
+  readonly sources: readonly string[];
+  readonly diagnostics: readonly SkillResolutionDiagnostic[];
+}
+
+export const resolveSkillEntries = (input: SkillResolutionInput): SkillResolutionResult => {
+  const sources: string[] = [];
+  const diagnostics: SkillResolutionDiagnostic[] = [];
+
+  for (const entryInput of input.entries) {
+    const outcome = resolveSkillEntry(input, entryInput);
+    sources.push(...outcome.sources);
+    diagnostics.push(...outcome.diagnostics);
+  }
+
+  return { sources, diagnostics };
+};
+
+const resolveSkillEntry = (input: SkillResolutionInput, entryInput: SkillEntryInput): SkillResolutionResult => {
+  const { entry, profileReferenceRoot } = entryInput;
+  const selection: SkillSelection = typeof entry === 'string' ? { id: entry } : entry;
+  const catalogEntry = input.catalog.entries.get(selection.id);
+
+  if (catalogEntry === undefined) {
+    return resolveUncataloguedEntry(entry, selection.id);
+  }
+
+  const references = selection.references ?? [];
+  const referencesKey = JSON.stringify(references);
+  const cached = input.materializationCache?.get(selection.id);
+
+  if (cached !== undefined) {
+    return resolveCachedEntry(cached, referencesKey, selection.id);
+  }
+
+  const resolved = resolveCatalogSkill({
+    catalogEntry,
+    references,
+    profileReferenceRoot,
+    projectDirectory: input.projectDirectory,
+    outputDirectory: input.outputDirectory,
+  });
+  input.materializationCache?.set(selection.id, {
+    referencesKey,
+    generatedDirectory: resolved.generatedDirectory,
+  });
+
+  return { sources: toEntrySources(resolved.generatedDirectory), diagnostics: resolved.diagnostics };
+};
+
+const resolveCachedEntry = (
+  cached: { readonly referencesKey: string; readonly generatedDirectory?: string },
+  referencesKey: string,
+  id: string,
+): SkillResolutionResult => {
+  if (cached.referencesKey !== referencesKey) {
+    return {
+      sources: [],
+      diagnostics: [
+        {
+          severity: 'error',
+          path: `controls.skills/${id}`,
+          message: `Skill '${id}' is selected with conflicting reference sets across control scopes.`,
+        },
+      ],
+    };
+  }
+
+  return { sources: toEntrySources(cached.generatedDirectory), diagnostics: [] };
+};
+
+const toEntrySources = (generatedDirectory: string | undefined): readonly string[] =>
+  generatedDirectory === undefined ? [] : [generatedDirectory];
+
+const resolveUncataloguedEntry = (entry: SkillControlEntry, id: string): SkillResolutionResult => {
+  if (typeof entry !== 'string') {
+    return {
+      sources: [],
+      diagnostics: [
+        {
+          severity: 'error',
+          path: `controls.skills/${id}`,
+          message: `Skill ID '${id}' does not resolve in any skills directory.`,
+        },
+      ],
+    };
+  }
+
+  if (isValidSkillId(entry)) {
+    return {
+      sources: [entry],
+      diagnostics: [
+        {
+          severity: 'warning',
+          path: `controls.skills/${entry}`,
+          message: `Skill '${entry}' does not resolve in any skills directory; passing it through as a path source.`,
+        },
+      ],
+    };
+  }
+
+  return { sources: [entry], diagnostics: [] };
+};
+
+interface CatalogSkillResolutionInput {
+  readonly catalogEntry: SkillCatalogEntry;
+  /** Profile-added references appended to the skill's own declared references. */
+  readonly references: readonly SkillReference[];
+  readonly profileReferenceRoot?: string;
+  readonly projectDirectory?: string;
+  readonly outputDirectory?: string;
+}
+
+const resolveCatalogSkill = (
+  input: CatalogSkillResolutionInput,
+): { readonly generatedDirectory?: string; readonly diagnostics: readonly SkillResolutionDiagnostic[] } => {
+  const { catalogEntry } = input;
+  const diagnostics: SkillResolutionDiagnostic[] = [];
+  const document = readSkillDocument(catalogEntry.skillPath);
+
+  if (isSkillDocumentIssue(document)) {
+    return { diagnostics: [{ severity: 'error', path: document.path, message: document.message }] };
+  }
+
+  if (document.name !== catalogEntry.id) {
+    return {
+      diagnostics: [
+        {
+          severity: 'error',
+          path: catalogEntry.skillPath,
+          message: `SKILL.md 'name' ('${document.name}') must match its directory name ('${catalogEntry.id}').`,
+        },
+      ],
+    };
+  }
+
+  const materializations = planSkillMaterializations(input, document, diagnostics);
+
+  if (diagnostics.some((diagnostic) => diagnostic.severity === 'error') || input.outputDirectory === undefined) {
+    return { diagnostics };
+  }
+
+  const generatedDirectory = join(input.outputDirectory, catalogEntry.id);
+  cpSync(catalogEntry.directory, generatedDirectory, { recursive: true });
+
+  for (const materialization of materializations) {
+    const sectionDirectory = join(generatedDirectory, materialization.section);
+    mkdirSync(sectionDirectory, { recursive: true });
+    // copyFileSync preserves the source mode, so materialized scripts stay executable.
+    copyFileSync(materialization.sourcePath, join(sectionDirectory, materialization.destinationName));
+  }
+
+  return { generatedDirectory, diagnostics };
+};
+
+interface SkillMaterialization {
+  readonly section: SkillMaterializationSection;
+  readonly sourcePath: string;
+  readonly destinationName: string;
+}
+
+const planSkillMaterializations = (
+  input: CatalogSkillResolutionInput,
+  document: SkillDocument,
+  diagnostics: SkillResolutionDiagnostic[],
+): readonly SkillMaterialization[] => {
+  const materializations: SkillMaterialization[] = [];
+
+  for (const section of skillMaterializationSections) {
+    const entries = [
+      ...document[section].map((reference) => ({ reference, fileRoot: input.catalogEntry.referenceRoot })),
+      // Profile-added references resolve `file` from the declaring profile's repository.
+      ...(section === 'references'
+        ? input.references.map((reference) => ({
+            reference,
+            fileRoot: input.profileReferenceRoot ?? input.projectDirectory ?? input.catalogEntry.referenceRoot,
+          }))
+        : []),
+    ];
+    materializations.push(...planSectionMaterializations(input, section, entries, diagnostics));
+  }
+
+  return materializations;
+};
+
+const planSectionMaterializations = (
+  input: CatalogSkillResolutionInput,
+  section: SkillMaterializationSection,
+  entries: readonly { readonly reference: SkillReference; readonly fileRoot: string }[],
+  diagnostics: SkillResolutionDiagnostic[],
+): readonly SkillMaterialization[] => {
+  const materializations: SkillMaterialization[] = [];
+  const destinationNames = new Set<string>();
+
+  for (const { reference, fileRoot } of entries) {
+    const resolved = resolveReferenceMaterialization({
+      reference,
+      section,
+      fileRoot,
+      projectDirectory: input.projectDirectory,
+      skillPath: input.catalogEntry.skillPath,
+    });
+
+    if (resolved === undefined) {
+      continue;
+    }
+
+    if ('message' in resolved) {
+      diagnostics.push(resolved);
+      continue;
+    }
+
+    if (destinationNames.has(resolved.destinationName)) {
+      diagnostics.push({
+        severity: 'error',
+        path: input.catalogEntry.skillPath,
+        message: `Destination '${section}/${resolved.destinationName}' is declared more than once.`,
+      });
+      continue;
+    }
+
+    // Checked against the source skill directory during planning so lint reports
+    // shipped-file collisions without materializing anything.
+    if (existsSync(join(input.catalogEntry.directory, section, resolved.destinationName))) {
+      diagnostics.push({
+        severity: 'error',
+        path: input.catalogEntry.skillPath,
+        message:
+          `Destination '${section}/${resolved.destinationName}' collides with a file ` +
+          `already shipped by skill '${input.catalogEntry.id}'.`,
+      });
+      continue;
+    }
+
+    destinationNames.add(resolved.destinationName);
+    materializations.push(resolved);
+  }
+
+  return materializations;
+};
+
+interface DescribedReference {
+  readonly declaredPath: string;
+  readonly root: string | undefined;
+  readonly kind: 'file' | 'repo_file';
+  readonly rootLabel: 'catalog' | 'project';
+}
+
+const describeReference = (
+  reference: SkillReference,
+  fileRoot: string,
+  projectDirectory: string | undefined,
+): DescribedReference =>
+  'repo_file' in reference
+    ? { declaredPath: reference.repo_file, root: projectDirectory, kind: 'repo_file', rootLabel: 'project' }
+    : { declaredPath: reference.file, root: fileRoot, kind: 'file', rootLabel: 'catalog' };
+
+const resolveReferenceMaterialization = (input: {
+  readonly reference: SkillReference;
+  readonly section: SkillMaterializationSection;
+  readonly fileRoot: string;
+  readonly projectDirectory?: string;
+  readonly skillPath: string;
+}): SkillMaterialization | SkillResolutionDiagnostic | undefined => {
+  const { declaredPath, root, kind, rootLabel } = describeReference(
+    input.reference,
+    input.fileRoot,
+    input.projectDirectory,
+  );
+  const error = (message: string): SkillResolutionDiagnostic => ({
+    severity: 'error',
+    path: input.skillPath,
+    message,
+  });
+
+  if (root === undefined) {
+    return error(`Reference ${kind} '${declaredPath}' has no ${rootLabel} root to resolve from.`);
+  }
+
+  const sourcePath = isAbsolute(declaredPath) ? declaredPath : join(root, declaredPath);
+
+  if (!existsSync(sourcePath)) {
+    // A consuming project may not contain a repo_file target; the reference is omitted.
+    return kind === 'repo_file' ? undefined : error(`Reference file '${declaredPath}' was not found under '${root}'.`);
+  }
+
+  if (!statSync(sourcePath).isFile()) {
+    return error(`Reference ${kind} '${declaredPath}' must be a regular file.`);
+  }
+
+  if (escapesRoot(sourcePath, root)) {
+    return error(`Reference ${kind} '${declaredPath}' resolves outside its ${rootLabel} root '${root}'.`);
+  }
+
+  return { section: input.section, sourcePath, destinationName: basename(declaredPath) };
+};
+
+/** Targets must remain within their root after following symlinks. */
+const escapesRoot = (sourcePath: string, root: string): boolean => {
+  let resolvedSource: string;
+  let resolvedRoot: string;
+
+  try {
+    resolvedSource = realpathSync(sourcePath);
+    resolvedRoot = realpathSync(root);
+  } catch {
+    /* v8 ignore next 2 -- existsSync guards the source; a vanished root is a race we treat as escaping. */
+    return true;
+  }
+
+  const relativePath = relative(resolvedRoot, resolvedSource);
+
+  // A bare '..' or a '../' prefix escapes; a sibling name like '..config' does not.
+  return relativePath === '..' || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath);
+};

--- a/code/cli/tests/fixtures/integration/adapter_specific_overrides/expected/claude/warnings.json
+++ b/code/cli/tests/fixtures/integration/adapter_specific_overrides/expected/claude/warnings.json
@@ -1,1 +1,4 @@
-["claude wrote undeclared composite profile state 'unexpected-claude.txt' and it was not persisted."]
+[
+  "Skill 'repo-review' does not resolve in any skills directory; passing it through as a path source.",
+  "claude wrote undeclared composite profile state 'unexpected-claude.txt' and it was not persisted."
+]

--- a/code/cli/tests/fixtures/integration/adapter_specific_overrides/expected/pi/warnings.json
+++ b/code/cli/tests/fixtures/integration/adapter_specific_overrides/expected/pi/warnings.json
@@ -1,1 +1,4 @@
-["pi wrote undeclared composite profile state 'unexpected-pi.txt' and it was not persisted."]
+[
+  "Skill 'repo-review' does not resolve in any skills directory; passing it through as a path source.",
+  "pi wrote undeclared composite profile state 'unexpected-pi.txt' and it was not persisted."
+]

--- a/code/cli/tests/fixtures/integration/heavily_overridden_engineering/expected/pi/warnings.json
+++ b/code/cli/tests/fixtures/integration/heavily_overridden_engineering/expected/pi/warnings.json
@@ -1,1 +1,4 @@
-["pi wrote undeclared composite profile state 'unexpected-local.txt' and it was not persisted."]
+[
+  "Skill 'code-review' does not resolve in any skills directory; passing it through as a path source.",
+  "pi wrote undeclared composite profile state 'unexpected-local.txt' and it was not persisted."
+]

--- a/code/cli/tests/fixtures/integration/language_stack_with_personal_default/expected/pi/warnings.json
+++ b/code/cli/tests/fixtures/integration/language_stack_with_personal_default/expected/pi/warnings.json
@@ -1,1 +1,4 @@
-["pi wrote undeclared composite profile state 'scratch.log' and it was not persisted."]
+[
+  "Skill 'strict-typescript' does not resolve in any skills directory; passing it through as a path source.",
+  "pi wrote undeclared composite profile state 'scratch.log' and it was not persisted."
+]

--- a/code/cli/tests/fixtures/integration/profile_owned_cli_state/expected/claude/warnings.json
+++ b/code/cli/tests/fixtures/integration/profile_owned_cli_state/expected/claude/warnings.json
@@ -1,4 +1,5 @@
 [
+  "Skill 'repo-audit' does not resolve in any skills directory; passing it through as a path source.",
   "claude adapter cannot translate requested control 'provider'.",
   "claude adapter cannot translate requested control 'skills'."
 ]

--- a/code/cli/tests/fixtures/integration/profile_owned_cli_state/expected/pi/warnings.json
+++ b/code/cli/tests/fixtures/integration/profile_owned_cli_state/expected/pi/warnings.json
@@ -1,1 +1,1 @@
-[]
+["Skill 'repo-audit' does not resolve in any skills directory; passing it through as a path source."]

--- a/code/cli/tests/unit/run-command-catalog-skills.test.ts
+++ b/code/cli/tests/unit/run-command-catalog-skills.test.ts
@@ -1,0 +1,138 @@
+// Tests catalog skill ID resolution and reference materialization during run launches.
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { executeRunCommand } from '../../src/cli/commands/RunCommand.js';
+import { executeProfileLintCommand } from '../../src/cli/commands/profile/LintCommand.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-run-catalog-skills-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+const noopDependencies = {
+  launcher: {
+    launch() {
+      return Promise.resolve(0);
+    },
+  },
+  writeLine: () => undefined,
+  writeError: () => undefined,
+} as const;
+
+const writeProjectFixture = (root: string, skillFrontmatter: string, profileSkillsYaml: string) => {
+  const homeDirectory = join(root, 'home');
+  const projectDirectory = join(root, 'project');
+  mkdirSync(join(homeDirectory, '.outfitter'), { recursive: true });
+  writeFileSync(
+    join(homeDirectory, '.outfitter', 'settings.yml'),
+    'default_profile: platform\nprofile_sources:\n  - path: ./profiles\n',
+  );
+  mkdirSync(join(homeDirectory, '.outfitter', 'profiles', 'platform'), { recursive: true });
+  writeFileSync(
+    join(homeDirectory, '.outfitter', 'profiles', 'platform', 'profile.yml'),
+    `id: platform\ncontrols:\n  skills:\n${profileSkillsYaml}`,
+  );
+  const skillDirectory = join(projectDirectory, '.outfitter', 'skills', 'deploy-review');
+  mkdirSync(skillDirectory, { recursive: true });
+  writeFileSync(join(skillDirectory, 'SKILL.md'), `---\n${skillFrontmatter}\n---\n# Deploy Review\n`);
+  mkdirSync(join(projectDirectory, 'docs'), { recursive: true });
+  writeFileSync(join(projectDirectory, 'docs', 'runbook.md'), 'runbook\n');
+
+  return { homeDirectory, projectDirectory };
+};
+
+describe('run command catalog skill selection', () => {
+  it('resolves a bare skill ID to a generated skill with materialized references', async () => {
+    const root = createTemporaryRoot();
+    const { homeDirectory, projectDirectory } = writeProjectFixture(
+      root,
+      'name: deploy-review\nreferences:\n  - repo_file: docs/runbook.md',
+      '    - deploy-review\n',
+    );
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory, passThroughArgs: ['--debug'] },
+      noopDependencies,
+    );
+
+    const generatedDirectory = join(result.compositeProfileDirectory, 'outfitter', 'skills', 'deploy-review');
+    expect(result.warnings).toEqual([]);
+    expect(result.launchPlan.args).toContain('--skill');
+    expect(result.launchPlan.args).toContain(generatedDirectory);
+    expect(readFileSync(join(generatedDirectory, 'references', 'runbook.md'), 'utf8')).toBe('runbook\n');
+  });
+
+  it('materializes profile-added references from an { id, references } selection', async () => {
+    const root = createTemporaryRoot();
+    const { homeDirectory, projectDirectory } = writeProjectFixture(
+      root,
+      'name: deploy-review',
+      '    - id: deploy-review\n      references:\n        - repo_file: docs/runbook.md\n',
+    );
+
+    const result = await executeRunCommand(
+      { homeDirectory, projectDirectory, passThroughArgs: ['--debug'] },
+      noopDependencies,
+    );
+
+    const generatedDirectory = join(result.compositeProfileDirectory, 'outfitter', 'skills', 'deploy-review');
+    expect(readFileSync(join(generatedDirectory, 'references', 'runbook.md'), 'utf8')).toBe('runbook\n');
+  });
+
+  it('fails the launch when a selected skill has a broken catalog file reference', async () => {
+    const root = createTemporaryRoot();
+    const { homeDirectory, projectDirectory } = writeProjectFixture(
+      root,
+      'name: deploy-review\nreferences:\n  - file: docs/absent.md',
+      '    - deploy-review\n',
+    );
+
+    await expect(executeRunCommand({ homeDirectory, projectDirectory }, noopDependencies)).rejects.toThrow(
+      /Cannot resolve profile skills.*absent\.md/u,
+    );
+  });
+});
+
+describe('profile lint catalog skill diagnostics', () => {
+  it('reports unresolved object selections and broken references without materializing', () => {
+    const root = createTemporaryRoot();
+    const { homeDirectory, projectDirectory } = writeProjectFixture(
+      root,
+      'name: deploy-review\nreferences:\n  - file: docs/absent.md',
+      '    - deploy-review\n    - id: missing-skill\n',
+    );
+
+    const result = executeProfileLintCommand({ homeDirectory, projectDirectory });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.diagnostics.some((diagnostic) => diagnostic.message.includes("'missing-skill'"))).toBe(true);
+    expect(result.diagnostics.some((diagnostic) => diagnostic.message.includes('absent.md'))).toBe(true);
+  });
+
+  it('passes a valid catalog skill selection', () => {
+    const root = createTemporaryRoot();
+    const { homeDirectory, projectDirectory } = writeProjectFixture(
+      root,
+      'name: deploy-review\nreferences:\n  - repo_file: docs/runbook.md',
+      '    - deploy-review\n',
+    );
+
+    const result = executeProfileLintCommand({ homeDirectory, projectDirectory });
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/code/cli/tests/unit/skill-controls.test.ts
+++ b/code/cli/tests/unit/skill-controls.test.ts
@@ -1,0 +1,226 @@
+// Tests skill control entry merging, pi argv filtering, and bundled Outfitter skill files.
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  mergeLaunchResourceSources,
+  mergeSkillControlSources,
+  skillControlEntryIdentity,
+} from '../../src/agents/LaunchResources.js';
+import { repeatFlagValue } from '../../src/agents/AdapterProfileControls.js';
+import { createPiArgs } from '../../src/agents/pi/PiArgs.js';
+import { createOutfitterPluginCompositeFiles } from '../../src/agents/OutfitterSkill.js';
+import { discoverSkillCatalog } from '../../src/skills/SkillCatalog.js';
+import { resolveSkillEntries } from '../../src/skills/SkillResolution.js';
+import { resolveProfileSkillControls } from '../../src/skills/ProfileSkillResolution.js';
+import { parseProfileYaml } from '../../src/profiles/ProfileLoader.js';
+
+const temporaryRoots: string[] = [];
+
+const createRoot = (prefix = 'outfitter-skill-controls-'): string => {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  temporaryRoots.push(root);
+  return root;
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+const writeSkill = (skillsDirectory: string, id: string, frontmatter: string, body = '# Skill\n'): string => {
+  const directory = join(skillsDirectory, id);
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(join(directory, 'SKILL.md'), `---\n${frontmatter}\n---\n${body}`);
+  return directory;
+};
+
+describe('skill control entry merging', () => {
+  it('dedupes bare IDs against { id } selections and keeps path identities separate', () => {
+    expect(skillControlEntryIdentity('deploy-review')).toBe(skillControlEntryIdentity({ id: 'deploy-review' }));
+    expect(skillControlEntryIdentity('./skills/review')).not.toBe(skillControlEntryIdentity('deploy-review'));
+
+    const merged = mergeSkillControlSources(
+      ['deploy-review', './skills/review'],
+      [{ id: 'deploy-review', references: [{ repo_file: 'docs/a.md' }] }],
+    );
+
+    expect(merged).toEqual([{ id: 'deploy-review', references: [{ repo_file: 'docs/a.md' }] }, './skills/review']);
+    expect(mergeSkillControlSources(undefined, undefined)).toBeUndefined();
+    expect(mergeSkillControlSources(['deploy-review'], undefined)).toEqual(['deploy-review']);
+  });
+
+  it('filters non-string entries from pi --skill args', () => {
+    expect(createPiArgs({ skills: ['./skills/review', { id: 'deploy-review' }] })).toEqual([
+      '--skill',
+      './skills/review',
+    ]);
+    expect(createPiArgs({})).toEqual([]);
+    expect(typeof skillControlEntryIdentity(42)).toBe('string');
+    expect(mergeLaunchResourceSources('skill', ['./skills/review'], ['./skills/review'])).toEqual(['./skills/review']);
+    expect(repeatFlagValue('--append-system-prompt', { file: 'prompts/team.md' })).toEqual([]);
+  });
+
+  it('reports a repo_file reference without a project root as an error', () => {
+    const project = createRoot();
+    writeSkill(
+      join(project, '.outfitter', 'skills'),
+      'rootless',
+      'name: rootless\nreferences:\n  - repo_file: docs/runbook.md',
+    );
+    const catalog = discoverSkillCatalog({ projectDirectory: project });
+
+    const resolution = resolveSkillEntries({ entries: [{ entry: 'rootless' }], catalog });
+
+    expect(resolution.diagnostics[0]?.message).toContain('has no project root');
+  });
+});
+
+describe('bundled Outfitter skill materialization', () => {
+  it('materializes the skill without references and rejects malformed reference entries', () => {
+    const root = createRoot();
+    const plainSkill = join(root, 'plain');
+    mkdirSync(plainSkill, { recursive: true });
+    writeFileSync(join(plainSkill, 'SKILL.md'), '---\nname: outfitter\n---\n# Outfitter\n');
+    const badSkill = join(root, 'bad');
+    mkdirSync(badSkill, { recursive: true });
+    writeFileSync(join(badSkill, 'SKILL.md'), '---\nname: outfitter\nreferences:\n  - docs/plain-string.md\n---\n');
+    const listlessSkill = join(root, 'listless');
+    mkdirSync(listlessSkill, { recursive: true });
+    writeFileSync(join(listlessSkill, 'SKILL.md'), '---\nname: outfitter\nreferences: not-a-list\n---\n');
+
+    const files = createOutfitterPluginCompositeFiles(root, {
+      skillDirectory: plainSkill,
+      referenceRootDirectory: root,
+    });
+
+    expect(files.map((file) => file.relativePath)).toEqual([
+      'outfitter/plugin/.claude-plugin/plugin.json',
+      'outfitter/plugin/skills/outfitter/SKILL.md',
+    ]);
+    expect(() =>
+      createOutfitterPluginCompositeFiles(root, {
+        skillDirectory: badSkill,
+        referenceRootDirectory: root,
+      }),
+    ).toThrow(/must be \{ file: <path> \} entries/u);
+    expect(() =>
+      createOutfitterPluginCompositeFiles(root, {
+        skillDirectory: listlessSkill,
+        referenceRootDirectory: root,
+      }),
+    ).toThrow(/must be a list/u);
+  });
+});
+
+describe('skill precedence and cross-scope selection', () => {
+  it('lets later configured sources and higher profile layers win, matching profile precedence', () => {
+    const earlySource = createRoot();
+    const lateSource = createRoot();
+    const project = createRoot();
+    for (const catalog of [earlySource, lateSource]) {
+      mkdirSync(join(catalog, 'profiles'), { recursive: true });
+      writeSkill(join(catalog, 'skills'), 'deploy-review', 'name: deploy-review');
+    }
+    const baseProfile = join(project, '.outfitter', 'profiles', 'base');
+    const selectedProfile = join(project, '.outfitter', 'profiles', 'selected');
+    writeSkill(join(baseProfile, 'skills'), 'issue-planning', 'name: issue-planning');
+    writeSkill(join(selectedProfile, 'skills'), 'issue-planning', 'name: issue-planning');
+
+    const sourceCatalog = discoverSkillCatalog({ sourcePaths: [earlySource, lateSource] });
+    const layerCatalog = discoverSkillCatalog({
+      profileLayers: [
+        { sourceRootPath: join(project, '.outfitter', 'profiles'), resourceRootPath: baseProfile },
+        { sourceRootPath: join(project, '.outfitter', 'profiles'), resourceRootPath: selectedProfile },
+      ],
+    });
+
+    expect(sourceCatalog.entries.get('deploy-review')?.directory).toBe(join(lateSource, 'skills', 'deploy-review'));
+    expect(layerCatalog.entries.get('issue-planning')?.directory).toBe(
+      join(selectedProfile, 'skills', 'issue-planning'),
+    );
+  });
+
+  it('materializes an ID selected by several control scopes once and rejects conflicting references', () => {
+    const project = createRoot();
+    const output = createRoot();
+    writeSkill(join(project, '.outfitter', 'skills'), 'deploy-review', 'name: deploy-review');
+    mkdirSync(join(project, 'docs'), { recursive: true });
+    writeFileSync(join(project, 'docs', 'runbook.md'), 'runbook\n');
+    const sharedProfile = parseProfileYaml(
+      'id: platform\ncontrols:\n  skills:\n    - deploy-review\n  pi:\n    skills:\n      - deploy-review\n',
+      'platform',
+    );
+    const conflictingProfile = parseProfileYaml(
+      [
+        'id: platform',
+        'controls:',
+        '  skills:',
+        '    - deploy-review',
+        '  pi:',
+        '    skills:',
+        '      - id: deploy-review',
+        '        references:',
+        '          - repo_file: docs/runbook.md',
+      ].join('\n'),
+      'platform',
+    );
+
+    if ('message' in sharedProfile || 'message' in conflictingProfile) {
+      throw new Error('fixture profiles must parse');
+    }
+
+    const shared = resolveProfileSkillControls({
+      profile: sharedProfile,
+      profileLayers: [],
+      sourcePaths: [],
+      projectDirectory: project,
+      outputDirectory: output,
+    });
+    const conflicting = resolveProfileSkillControls({
+      profile: conflictingProfile,
+      profileLayers: [],
+      sourcePaths: [],
+      projectDirectory: project,
+    });
+
+    const generated = join(output, 'outfitter', 'skills', 'deploy-review');
+    expect(shared.diagnostics).toEqual([]);
+    expect(shared.profile.controls.skills).toEqual([generated]);
+    expect(shared.profile.controls.pi?.skills).toEqual([generated]);
+    expect(
+      conflicting.diagnostics.some((diagnostic) => diagnostic.message.includes('conflicting reference sets')),
+    ).toBe(true);
+  });
+
+  it('reports shipped-file collisions without materializing and allows dot-prefixed sibling names', () => {
+    const project = createRoot();
+    const shippedSkill = writeSkill(
+      join(project, '.outfitter', 'skills'),
+      'shipped',
+      'name: shipped\nscripts:\n  - repo_file: tools/collect.sh',
+    );
+    mkdirSync(join(shippedSkill, 'scripts'), { recursive: true });
+    writeFileSync(join(shippedSkill, 'scripts', 'collect.sh'), 'shipped\n');
+    mkdirSync(join(project, 'tools'), { recursive: true });
+    writeFileSync(join(project, 'tools', 'collect.sh'), 'external\n');
+    writeSkill(
+      join(project, '.outfitter', 'skills'),
+      'dotted',
+      'name: dotted\nreferences:\n  - repo_file: ..config/guide.md',
+    );
+    mkdirSync(join(project, '..config'), { recursive: true });
+    writeFileSync(join(project, '..config', 'guide.md'), 'guide\n');
+    const catalog = discoverSkillCatalog({ projectDirectory: project });
+
+    const shipped = resolveSkillEntries({ entries: [{ entry: 'shipped' }], catalog, projectDirectory: project });
+    const dotted = resolveSkillEntries({ entries: [{ entry: 'dotted' }], catalog, projectDirectory: project });
+
+    expect(shipped.diagnostics[0]?.message).toContain('collides with a file already shipped');
+    expect(dotted.diagnostics).toEqual([]);
+  });
+});

--- a/code/cli/tests/unit/skill-resolution.test.ts
+++ b/code/cli/tests/unit/skill-resolution.test.ts
@@ -1,0 +1,505 @@
+// Tests catalog skill discovery, reference materialization, and profile skill resolution.
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { parseProfileYaml } from '../../src/profiles/ProfileLoader.js';
+import { discoverSkillCatalog } from '../../src/skills/SkillCatalog.js';
+import { isValidSkillId, parseSkillDocument, readSkillDocument } from '../../src/skills/SkillDocument.js';
+import { resolveSkillEntries } from '../../src/skills/SkillResolution.js';
+import { resolveProfileSkillControls } from '../../src/skills/ProfileSkillResolution.js';
+
+const temporaryRoots: string[] = [];
+
+const createRoot = (prefix = 'outfitter-skills-'): string => {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  temporaryRoots.push(root);
+  return root;
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+const writeSkill = (skillsDirectory: string, id: string, frontmatter: string, body = '# Skill\n'): string => {
+  const directory = join(skillsDirectory, id);
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(join(directory, 'SKILL.md'), `---\n${frontmatter}\n---\n${body}`);
+  return directory;
+};
+
+describe('skill IDs and SKILL.md documents', () => {
+  it('accepts lowercase hyphenated ids up to 64 characters and rejects other names', () => {
+    expect(isValidSkillId('outfitter-actions')).toBe(true);
+    expect(isValidSkillId('a')).toBe(true);
+    expect(isValidSkillId('a'.repeat(64))).toBe(true);
+    expect(isValidSkillId('a'.repeat(65))).toBe(false);
+    expect(isValidSkillId('-leading')).toBe(false);
+    expect(isValidSkillId('trailing-')).toBe(false);
+    expect(isValidSkillId('double--hyphen')).toBe(false);
+    expect(isValidSkillId('Upper')).toBe(false);
+    expect(isValidSkillId('dots.name')).toBe(false);
+  });
+
+  it('parses frontmatter name, description, and references', () => {
+    const document = parseSkillDocument(
+      '---\nname: deploy-review\ndescription: Review deployments.\nreferences:\n  - file: docs/design.md\n  - repo_file: docs/runbook.md\n---\n# Deploy\n',
+      'SKILL.md',
+    );
+
+    expect(document).toEqual({
+      name: 'deploy-review',
+      description: 'Review deployments.',
+      references: [{ file: 'docs/design.md' }, { repo_file: 'docs/runbook.md' }],
+      scripts: [],
+      assets: [],
+    });
+  });
+
+  it('parses scripts and assets sections with the same reference union', () => {
+    const document = parseSkillDocument(
+      '---\nname: deploy-review\nscripts:\n  - file: tools/process.sh\nassets:\n  - repo_file: templates/report.json\n---\n',
+      'SKILL.md',
+    );
+
+    expect(document).toEqual({
+      name: 'deploy-review',
+      description: undefined,
+      references: [],
+      scripts: [{ file: 'tools/process.sh' }],
+      assets: [{ repo_file: 'templates/report.json' }],
+    });
+    expect(parseSkillDocument('---\nname: ok\nscripts:\n  - tools/process.sh\n---\n', 'SKILL.md')).toHaveProperty(
+      'message',
+    );
+  });
+
+  it('rejects missing frontmatter, invalid names, and malformed reference entries', () => {
+    expect(parseSkillDocument('# No frontmatter\n', 'SKILL.md')).toHaveProperty('message');
+    expect(parseSkillDocument('---\nname: Bad Name\n---\n', 'SKILL.md')).toHaveProperty('message');
+    expect(
+      parseSkillDocument('---\nname: ok\nreferences:\n  - file: a.md\n    repo_file: b.md\n---\n', 'SKILL.md'),
+    ).toHaveProperty('message');
+    expect(parseSkillDocument('---\nname: ok\nreferences:\n  - name: a.md\n---\n', 'SKILL.md')).toHaveProperty(
+      'message',
+    );
+  });
+});
+
+describe('skill catalog discovery', () => {
+  it('prefers project skills over configured sources and reports shadowing', () => {
+    const project = createRoot();
+    const catalog = createRoot();
+    writeSkill(join(project, '.outfitter', 'skills'), 'deploy-review', 'name: deploy-review');
+    writeSkill(join(catalog, 'skills'), 'deploy-review', 'name: deploy-review');
+    mkdirSync(join(catalog, 'profiles'), { recursive: true });
+
+    const discovered = discoverSkillCatalog({
+      projectDirectory: project,
+      sourcePaths: [join(catalog, 'profiles')],
+    });
+
+    expect(discovered.entries.get('deploy-review')?.directory).toBe(
+      join(project, '.outfitter', 'skills', 'deploy-review'),
+    );
+    expect(discovered.shadowed).toHaveLength(1);
+    expect(discovered.shadowed[0].shadowedDirectory).toBe(join(catalog, 'skills', 'deploy-review'));
+  });
+
+  it('resolves the catalog root from a source path pointing directly at the profiles directory', () => {
+    const catalog = createRoot();
+    mkdirSync(join(catalog, 'profiles'), { recursive: true });
+    writeSkill(join(catalog, 'skills'), 'kpi-reporting', 'name: kpi-reporting');
+
+    const discovered = discoverSkillCatalog({ sourcePaths: [join(catalog, 'profiles')] });
+
+    expect(discovered.entries.has('kpi-reporting')).toBe(true);
+  });
+
+  it('exposes bundled directory-profile skills and ignores invalid directory names', () => {
+    const project = createRoot();
+    const profileRoot = join(project, '.outfitter', 'profiles', 'platform');
+    writeSkill(join(profileRoot, 'skills'), 'issue-planning', 'name: issue-planning');
+    writeSkill(join(project, '.outfitter', 'skills'), 'Invalid.Name', 'name: whatever');
+
+    const discovered = discoverSkillCatalog({
+      projectDirectory: project,
+      profileLayers: [{ sourceRootPath: join(project, '.outfitter', 'profiles'), resourceRootPath: profileRoot }],
+    });
+
+    expect(discovered.entries.has('issue-planning')).toBe(true);
+    expect(discovered.entries.has('Invalid.Name')).toBe(false);
+  });
+});
+
+describe('skill resolution and reference materialization', () => {
+  it('materializes catalog file and project repo_file references beneath references/', () => {
+    const project = createRoot();
+    const output = createRoot();
+    const skillsDirectory = join(project, '.outfitter', 'skills');
+    writeSkill(
+      skillsDirectory,
+      'deploy-review',
+      'name: deploy-review\nreferences:\n  - file: docs/design.md\n  - repo_file: docs/runbooks/deploy.md',
+    );
+    mkdirSync(join(project, 'docs', 'runbooks'), { recursive: true });
+    writeFileSync(join(project, 'docs', 'design.md'), 'design\n');
+    writeFileSync(join(project, 'docs', 'runbooks', 'deploy.md'), 'runbook\n');
+
+    const catalog = discoverSkillCatalog({ projectDirectory: project });
+    const resolution = resolveSkillEntries({
+      entries: [{ entry: 'deploy-review' }],
+      catalog,
+      projectDirectory: project,
+      outputDirectory: output,
+    });
+
+    expect(resolution.diagnostics).toEqual([]);
+    expect(resolution.sources).toEqual([join(output, 'deploy-review')]);
+    expect(readFileSync(join(output, 'deploy-review', 'references', 'design.md'), 'utf8')).toBe('design\n');
+    expect(readFileSync(join(output, 'deploy-review', 'references', 'deploy.md'), 'utf8')).toBe('runbook\n');
+    expect(existsSync(join(output, 'deploy-review', 'SKILL.md'))).toBe(true);
+  });
+
+  it('materializes scripts and assets beneath their own generated directories', () => {
+    const project = createRoot();
+    const output = createRoot();
+    writeSkill(
+      join(project, '.outfitter', 'skills'),
+      'deploy-review',
+      'name: deploy-review\nscripts:\n  - file: tools/process.sh\nassets:\n  - repo_file: templates/report.json',
+    );
+    mkdirSync(join(project, 'tools'), { recursive: true });
+    mkdirSync(join(project, 'templates'), { recursive: true });
+    writeFileSync(join(project, 'tools', 'process.sh'), '#!/bin/sh\n', { mode: 0o755 });
+    writeFileSync(join(project, 'templates', 'report.json'), '{}\n');
+
+    const catalog = discoverSkillCatalog({ projectDirectory: project });
+    const resolution = resolveSkillEntries({
+      entries: [{ entry: 'deploy-review' }],
+      catalog,
+      projectDirectory: project,
+      outputDirectory: output,
+    });
+
+    expect(resolution.diagnostics).toEqual([]);
+    expect(readFileSync(join(output, 'deploy-review', 'scripts', 'process.sh'), 'utf8')).toBe('#!/bin/sh\n');
+    expect(statSync(join(output, 'deploy-review', 'scripts', 'process.sh')).mode & 0o100).toBe(0o100);
+    expect(readFileSync(join(output, 'deploy-review', 'assets', 'report.json'), 'utf8')).toBe('{}\n');
+  });
+
+  it('omits a missing repo_file reference and fails a missing file reference', () => {
+    const project = createRoot();
+    const output = createRoot();
+    writeSkill(
+      join(project, '.outfitter', 'skills'),
+      'optional-ref',
+      'name: optional-ref\nreferences:\n  - repo_file: docs/absent.md',
+    );
+    writeSkill(
+      join(project, '.outfitter', 'skills'),
+      'broken-ref',
+      'name: broken-ref\nreferences:\n  - file: docs/absent.md',
+    );
+    const catalog = discoverSkillCatalog({ projectDirectory: project });
+
+    const optional = resolveSkillEntries({
+      entries: [{ entry: 'optional-ref' }],
+      catalog,
+      projectDirectory: project,
+      outputDirectory: output,
+    });
+    const broken = resolveSkillEntries({
+      entries: [{ entry: 'broken-ref' }],
+      catalog,
+      projectDirectory: project,
+    });
+
+    expect(optional.diagnostics).toEqual([]);
+    expect(existsSync(join(output, 'optional-ref', 'references'))).toBe(false);
+    expect(broken.diagnostics[0]?.severity).toBe('error');
+    expect(broken.diagnostics[0]?.message).toContain("Reference file 'docs/absent.md' was not found");
+  });
+
+  it('fails duplicate reference destinations, directory targets, and root-escaping symlinks', () => {
+    const project = createRoot();
+    const outside = createRoot();
+    writeFileSync(join(outside, 'secret.md'), 'secret\n');
+    mkdirSync(join(project, 'docs'), { recursive: true });
+    writeFileSync(join(project, 'docs', 'design.md'), 'design\n');
+    symlinkSync(join(outside, 'secret.md'), join(project, 'docs', 'escape.md'));
+    writeSkill(
+      join(project, '.outfitter', 'skills'),
+      'colliding',
+      'name: colliding\nreferences:\n  - file: docs/design.md\n  - repo_file: docs/design.md',
+    );
+    writeSkill(
+      join(project, '.outfitter', 'skills'),
+      'directory-ref',
+      'name: directory-ref\nreferences:\n  - file: docs',
+    );
+    writeSkill(
+      join(project, '.outfitter', 'skills'),
+      'escaping',
+      'name: escaping\nreferences:\n  - file: docs/escape.md',
+    );
+    const catalog = discoverSkillCatalog({ projectDirectory: project });
+    const resolve = (id: string) =>
+      resolveSkillEntries({ entries: [{ entry: id }], catalog, projectDirectory: project }).diagnostics;
+
+    expect(resolve('colliding')[0]?.message).toContain('declared more than once');
+    expect(resolve('directory-ref')[0]?.message).toContain('must be a regular file');
+    expect(resolve('escaping')[0]?.message).toContain('resolves outside');
+  });
+
+  it('fails when the SKILL.md name does not match the directory name', () => {
+    const project = createRoot();
+    writeSkill(join(project, '.outfitter', 'skills'), 'misnamed', 'name: other-name');
+    const catalog = discoverSkillCatalog({ projectDirectory: project });
+
+    const resolution = resolveSkillEntries({ entries: [{ entry: 'misnamed' }], catalog, projectDirectory: project });
+
+    expect(resolution.diagnostics[0]?.message).toContain('must match its directory name');
+  });
+
+  it('errors on unresolved object selections and passes through unresolved path-like strings', () => {
+    const project = createRoot();
+    const catalog = discoverSkillCatalog({ projectDirectory: project });
+
+    const resolution = resolveSkillEntries({
+      entries: [{ entry: { id: 'missing-skill' } }, { entry: './skills/review' }, { entry: 'bare-name' }],
+      catalog,
+      projectDirectory: project,
+    });
+
+    expect(resolution.diagnostics.map((diagnostic) => diagnostic.severity)).toEqual(['error', 'warning']);
+    expect(resolution.sources).toEqual(['./skills/review', 'bare-name']);
+  });
+});
+
+describe('profile skill resolution', () => {
+  it('parses bare IDs and { id, references } selections from profile YAML', () => {
+    const profile = parseProfileYaml(
+      [
+        'id: platform',
+        'controls:',
+        '  skills:',
+        '    - outfitter-actions',
+        '    - id: deploy-review',
+        '      references:',
+        '        - repo_file: docs/runbooks/deploy.md',
+      ].join('\n'),
+      'platform',
+    );
+
+    expect('message' in profile).toBe(false);
+    expect('controls' in profile ? profile.controls.skills : undefined).toEqual([
+      'outfitter-actions',
+      { id: 'deploy-review', references: [{ repo_file: 'docs/runbooks/deploy.md' }] },
+    ]);
+  });
+
+  it('materializes profile-added references beside skill-declared references without forking the skill', () => {
+    const project = createRoot();
+    const output = createRoot();
+    writeSkill(
+      join(project, '.outfitter', 'skills'),
+      'deploy-review',
+      'name: deploy-review\nreferences:\n  - file: docs/design.md',
+    );
+    mkdirSync(join(project, 'docs', 'runbooks'), { recursive: true });
+    writeFileSync(join(project, 'docs', 'design.md'), 'design\n');
+    writeFileSync(join(project, 'docs', 'runbooks', 'deploy.md'), 'runbook\n');
+    const profilePath = join(project, '.outfitter', 'profiles', 'platform', 'profile.yml');
+    mkdirSync(join(project, '.outfitter', 'profiles', 'platform'), { recursive: true });
+    writeFileSync(profilePath, 'id: platform\n');
+    const profile = parseProfileYaml(
+      [
+        'id: platform',
+        'controls:',
+        '  skills:',
+        '    - id: deploy-review',
+        '      references:',
+        '        - repo_file: docs/runbooks/deploy.md',
+      ].join('\n'),
+      'platform',
+    );
+
+    expect('message' in profile).toBe(false);
+    if ('message' in profile) {
+      return;
+    }
+
+    const resolution = resolveProfileSkillControls({
+      profile,
+      profileLayers: [
+        {
+          source: { path: join(project, '.outfitter', 'profiles') },
+          folderPath: join(project, '.outfitter', 'profiles', 'platform'),
+          profilePath,
+          profile,
+          sourceRootPath: join(project, '.outfitter', 'profiles'),
+          resourceRootPath: join(project, '.outfitter', 'profiles', 'platform'),
+          layout: 'directory',
+        },
+      ],
+      sourcePaths: [],
+      projectDirectory: project,
+      outputDirectory: output,
+    });
+
+    expect(resolution.diagnostics).toEqual([]);
+    const generated = join(output, 'outfitter', 'skills', 'deploy-review');
+    expect(resolution.profile.controls.skills).toEqual([generated]);
+    expect(readFileSync(join(generated, 'references', 'design.md'), 'utf8')).toBe('design\n');
+    expect(readFileSync(join(generated, 'references', 'deploy.md'), 'utf8')).toBe('runbook\n');
+  });
+
+  it('warns when a selected skill ID shadows the same ID from a lower-precedence source', () => {
+    const project = createRoot();
+    const catalogRepo = createRoot();
+    writeSkill(join(project, '.outfitter', 'skills'), 'deploy-review', 'name: deploy-review');
+    writeSkill(join(catalogRepo, 'skills'), 'deploy-review', 'name: deploy-review');
+    mkdirSync(join(catalogRepo, 'profiles'), { recursive: true });
+    const profile = parseProfileYaml('id: platform\ncontrols:\n  skills:\n    - deploy-review\n', 'platform');
+
+    expect('message' in profile).toBe(false);
+    if ('message' in profile) {
+      return;
+    }
+
+    const resolution = resolveProfileSkillControls({
+      profile,
+      profileLayers: [],
+      sourcePaths: [catalogRepo],
+      projectDirectory: project,
+    });
+
+    expect(resolution.diagnostics.some((diagnostic) => diagnostic.message.includes('shadows'))).toBe(true);
+  });
+});
+
+describe('skill document and catalog edge cases', () => {
+  it('reports unreadable, unterminated, and non-mapping SKILL.md frontmatter', () => {
+    const project = createRoot();
+    expect(parseSkillDocument('---\nname: [unclosed\n---\n', 'SKILL.md')).toHaveProperty('message');
+    expect(parseSkillDocument('---\nname: never-closed\n', 'SKILL.md')).toHaveProperty('message');
+    expect(parseSkillDocument('---\n- a\n- b\n---\n', 'SKILL.md')).toHaveProperty('message');
+    expect(readSkillDocument(join(project, 'missing', 'SKILL.md'))).toHaveProperty('message');
+  });
+
+  it('discovers symlinked skill directories and ignores plain files and broken symlinks', () => {
+    const project = createRoot();
+    const shared = createRoot();
+    const skillsDirectory = join(project, '.outfitter', 'skills');
+    const sharedSkill = writeSkill(shared, 'linked-skill', 'name: linked-skill');
+    mkdirSync(skillsDirectory, { recursive: true });
+    symlinkSync(sharedSkill, join(skillsDirectory, 'linked-skill'));
+    symlinkSync(join(shared, 'absent'), join(skillsDirectory, 'broken-link'));
+    writeFileSync(join(skillsDirectory, 'stray-file'), 'not a skill\n');
+
+    const discovered = discoverSkillCatalog({ projectDirectory: project });
+
+    expect(discovered.entries.has('linked-skill')).toBe(true);
+    expect(discovered.entries.has('broken-link')).toBe(false);
+    expect(discovered.entries.has('stray-file')).toBe(false);
+  });
+
+  it('throws when a skills directory cannot be read', () => {
+    const project = createRoot();
+    mkdirSync(join(project, '.outfitter'), { recursive: true });
+    writeFileSync(join(project, '.outfitter', 'skills'), 'a file where a directory belongs\n');
+
+    expect(() => discoverSkillCatalog({ projectDirectory: project })).toThrow(/Could not read skills directory/u);
+  });
+
+  it('surfaces invalid frontmatter and shipped-file collisions through resolution', () => {
+    const project = createRoot();
+    const output = createRoot();
+    const skillsDirectory = join(project, '.outfitter', 'skills');
+    writeSkill(skillsDirectory, 'invalid-frontmatter', 'name: [unclosed');
+    const shippedSkill = writeSkill(
+      skillsDirectory,
+      'shipped-collision',
+      'name: shipped-collision\nreferences:\n  - repo_file: docs/design.md',
+    );
+    mkdirSync(join(shippedSkill, 'references'), { recursive: true });
+    writeFileSync(join(shippedSkill, 'references', 'design.md'), 'shipped\n');
+    mkdirSync(join(project, 'docs'), { recursive: true });
+    writeFileSync(join(project, 'docs', 'design.md'), 'external\n');
+    const catalog = discoverSkillCatalog({ projectDirectory: project });
+
+    const invalid = resolveSkillEntries({
+      entries: [{ entry: 'invalid-frontmatter' }],
+      catalog,
+      projectDirectory: project,
+    });
+    const collision = resolveSkillEntries({
+      entries: [{ entry: 'shipped-collision' }],
+      catalog,
+      projectDirectory: project,
+      outputDirectory: output,
+    });
+
+    expect(invalid.diagnostics[0]?.message).toContain('frontmatter');
+    expect(collision.diagnostics[0]?.message).toContain('collides with a file already shipped');
+    expect(collision.sources).toEqual([]);
+  });
+
+  it('resolves adapter-scoped skill IDs and falls back to the project root for unmatched selections', () => {
+    const project = createRoot();
+    const output = createRoot();
+    writeSkill(join(project, '.outfitter', 'skills'), 'pi-only', 'name: pi-only');
+    writeSkill(join(project, '.outfitter', 'skills'), 'claude-only', 'name: claude-only');
+    mkdirSync(join(project, 'docs'), { recursive: true });
+    writeFileSync(join(project, 'docs', 'extra.md'), 'extra\n');
+    const profile = parseProfileYaml(
+      [
+        'id: platform',
+        'controls:',
+        '  pi:',
+        '    skills:',
+        '      - id: pi-only',
+        '        references:',
+        '          - file: docs/extra.md',
+        '  claude:',
+        '    skills:',
+        '      - claude-only',
+      ].join('\n'),
+      'platform',
+    );
+
+    expect('message' in profile).toBe(false);
+    if ('message' in profile) {
+      return;
+    }
+
+    const resolution = resolveProfileSkillControls({
+      profile,
+      profileLayers: [],
+      sourcePaths: [],
+      projectDirectory: project,
+      outputDirectory: output,
+    });
+
+    expect(resolution.diagnostics).toEqual([]);
+    expect(resolution.profile.controls.pi?.skills).toEqual([join(output, 'outfitter', 'skills', 'pi-only')]);
+    expect(resolution.profile.controls.claude?.skills).toEqual([join(output, 'outfitter', 'skills', 'claude-only')]);
+    expect(readFileSync(join(output, 'outfitter', 'skills', 'pi-only', 'references', 'extra.md'), 'utf8')).toBe(
+      'extra\n',
+    );
+  });
+});

--- a/docs/documentation/skills.md
+++ b/docs/documentation/skills.md
@@ -1,10 +1,10 @@
 # Skills
 
-> **Status:** this page is the docs-first contract for skills, tracked in
-> [#149](https://github.com/ai-outfitter/outfitter/issues/149). Bare-ID
-> selection, reference materialization, and the lint checks described here
-> land with that implementation; the
-> [adapter support matrix](./support-matrix.md) reflects what works today.
+> **Status:** implemented for the Pi adapter
+> ([#149](https://github.com/ai-outfitter/outfitter/issues/149)): bare-ID
+> selection, materialized references, and the lint checks described here. The
+> [adapter support matrix](./support-matrix.md) reflects per-adapter behavior,
+> including the current Claude Code gap for generic `controls.skills`.
 
 Skills are focused capability packages that an agent loads progressively. A
 profile selects the skills available to a run, while each skill owns the
@@ -324,6 +324,30 @@ load its contents into model context.
 Each reference materializes as `references/<source basename>`. Two references
 whose sources share a basename fail validation; rename one of the source
 documents to resolve the collision.
+
+### Scripts and assets
+
+The `scripts` and `assets` frontmatter keys use the same entry union and
+validation rules as `references`, materializing under the generated skill's
+`scripts/` and `assets/` directories. Use them to reuse human-maintained helper
+scripts and templates without copying them into the skill folder; materialized
+scripts keep their executable mode.
+
+```yaml
+---
+name: deploy-review
+references:
+  - repo_file: docs/runbooks/deploy.md
+scripts:
+  - file: tools/smoke-test.sh # scripts/smoke-test.sh
+assets:
+  - repo_file: templates/report.json # assets/report.json
+---
+```
+
+Files already inside the skill directory (`scripts/`, `references/`, `assets/`)
+ship with the skill as before; frontmatter entries add external files beside
+them, and a destination that collides with a shipped file fails validation.
 
 ### Profile-added references
 

--- a/docs/documentation/support-matrix.md
+++ b/docs/documentation/support-matrix.md
@@ -32,7 +32,7 @@ When a profile requests a control an adapter cannot translate, Outfitter warns t
 ## Claude Code notes
 
 - **Config and session state** — Outfitter points `CLAUDE_CONFIG_DIR` at the composite profile, declares Claude state paths (`settings.json`, `agents/`, `skills/`, `commands/`, `plugins/`, `projects/`) for persistence, and lets `session_directory` choose where `projects/` session state is symlinked from. There is no standalone session-dir flag.
-- **Skills (Partial)** — native Claude skills work when a profile ships them as `cli_specific/claude/skills/` directories, which Outfitter places in the profiled config directory. The generic `controls.skills` selector is not translated for Claude and warns if requested.
+- **Skills (Partial)** — native Claude skills work when a profile ships them as `cli_specific/claude/skills/` directories, which Outfitter places in the profiled config directory. The generic `controls.skills` selector (including catalog skill IDs) is not translated for Claude yet and warns if requested; the bundled Outfitter skill ships through the plugin channel instead.
 - **Prompt templates (Partial)** — same shape: native `cli_specific/claude/commands/` directories work, but the generic `controls.prompt_template` selector is not translated and warns.
 - **Model selection (Partial)** — `model` maps to `--model` and `thinking` maps to `--effort`, but `provider` is not translated for Claude and warns if requested.
 - **Extensions** — `controls.extensions` entries are passed as repeated `--plugin-dir` flags.
@@ -42,6 +42,7 @@ When a profile requests a control an adapter cannot translate, Outfitter warns t
 ## Pi notes
 
 - Pi translates the full generic control set: `provider`, `model`, `thinking`, `system_prompt`, `append_system_prompt`, `extensions` (`--extension`), `skills` (`--skill`), `prompt_template` (`--prompt-template`), `environment`, `args`, `session_directory`, and DeepWork job selection.
+- **Catalog skills** — `controls.skills` entries may be catalog skill IDs (bare strings or `{ id, references }` objects). Outfitter resolves IDs across project, directory-profile, and configured-source `skills/` directories following layer precedence, materializes `references`, `scripts`, and `assets` frontmatter into a generated skill beneath the composite profile, and passes the generated directory via `--skill`. `outfitter profile lint` validates selections and references before launch.
 - Bootstrap behavior (for example the onboarding flow) uses an explicit Pi bootstrap extension via `--extension`.
 - Every launch also passes Outfitter's own self-documentation skill — materialized with its documentation references into the composite profile — through `--skill`.
 


### PR DESCRIPTION
Implements the docs-first skills contract from #150 (tracked in #149). Supersedes #153 — that PR carried both this work and the bundled self-docs skill (now merged separately as #154) in one commit. This PR is one squashed commit containing the catalog implementation **with the Copilot review fixes from #153 already folded in**: its tree is byte-identical to the final reviewed state of #153.

- `controls.skills` accepts bare catalog IDs and `{ id, references }` objects (schema, parser, types); adapter-scoped skills accept the same forms
- skill discovery across project-local, project, directory-profile, and configured-source `skills/` directories following layer precedence, with shadowed-ID warnings
- `SKILL.md` validation: frontmatter `name` must match the directory; skill names are lowercase alphanumerics with single hyphens, max 64 chars
- `references`, `scripts`, and `assets` frontmatter keys share one `file` / `repo_file` union and materialize beneath the generated skill; missing `file` targets, escaping paths, non-files, and destination collisions fail validation while missing `repo_file` targets are omitted
- profile-added references resolve `file` entries from the declaring profile's repository
- generated skills are written under the composite profile root and removed with it; pi receives them via `--skill`, Claude keeps warning for generic `controls.skills` (support matrix updated)
- `outfitter profile lint` diagnoses unresolved skill IDs, invalid frontmatter, broken references, escaping paths, and collisions
- per Copilot review on #153: catalog precedence fixed to match the layer contract, scope-preserving reference roots, lint collision coverage without materialization, and `..`-prefix root-escape checks no longer false-positive on names like `..config`

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)