### PR TITLE
feat(skills): file, directory, and glob targets for references, scripts, and assets

### DIFF
--- a/code/cli/src/skills/SkillResolution.ts
+++ b/code/cli/src/skills/SkillResolution.ts
@@ -341,7 +341,6 @@ const resolveReferenceMaterialization = (input: {
 
   const stats = statSync(sourcePath);
 
-  /* v8 ignore next 3 -- only reachable with special files such as FIFOs or sockets. */
   if (!stats.isFile() && !stats.isDirectory()) {
     return error(`Reference ${kind} '${declaredPath}' must be a regular file or directory.`);
   }
@@ -364,7 +363,7 @@ const resolveReferenceMaterialization = (input: {
   };
 };
 
-/** Describes the first escaping or cyclic path inside a directory target, if any. */
+/** Describes the first escaping, cyclic, or special path inside a directory target, if any. */
 const describeDirectoryTargetIssue = (
   stats: Stats,
   sourcePath: string,
@@ -386,24 +385,30 @@ const describeDirectoryTargetIssue = (
   }
 
   const containedPath = relative(sourcePath, issue.path);
+  const problemDescriptions: Record<ContainedPathIssue['problem'], string> = {
+    escaping: `which resolves outside its ${context.rootLabel} root '${context.root}'`,
+    cyclic: 'which creates a symlink cycle',
+    special: 'which is not a regular file or directory',
+  };
 
-  return issue.problem === 'escaping'
-    ? `Reference ${context.kind} '${context.declaredPath}' contains '${containedPath}', ` +
-        `which resolves outside its ${context.rootLabel} root '${context.root}'.`
-    : `Reference ${context.kind} '${context.declaredPath}' contains '${containedPath}', which creates a symlink cycle.`;
+  return (
+    `Reference ${context.kind} '${context.declaredPath}' contains ` +
+    `'${containedPath}', ${problemDescriptions[issue.problem]}.`
+  );
 };
 
 interface ContainedPathIssue {
   readonly path: string;
-  readonly problem: 'escaping' | 'cyclic';
+  readonly problem: 'escaping' | 'cyclic' | 'special';
 }
 
 /**
  * Finds the first path inside a directory target whose realpath escapes the
- * reference root, or a symlink that cycles back into an ancestor directory.
- * Directory materialization dereferences symlinks recursively, so an escaping
- * link would smuggle outside content into the generated skill and a cyclic
- * link would never finish copying.
+ * reference root, a symlink that cycles back into an ancestor directory, or an
+ * entry that is neither a regular file nor a directory. Directory
+ * materialization dereferences symlinks recursively, so an escaping link would
+ * smuggle outside content into the generated skill, a cyclic link would never
+ * finish copying, and a special file such as a FIFO could block the copy.
  */
 const scanDirectoryTarget = (
   directory: string,
@@ -420,8 +425,15 @@ const scanDirectoryTarget = (
       return { path: entryPath, problem: 'escaping' };
     }
 
-    // statSync follows symlinks, so in-root symlinked subdirectories are scanned too.
-    if (!statSync(entryPath).isDirectory()) {
+    // statSync follows symlinks, so in-root symlinked subdirectories are
+    // scanned too and a link to a special file is rejected like the file itself.
+    const entryStats = statSync(entryPath);
+
+    if (!entryStats.isFile() && !entryStats.isDirectory()) {
+      return { path: entryPath, problem: 'special' };
+    }
+
+    if (!entryStats.isDirectory()) {
       continue;
     }
 

--- a/code/cli/src/skills/SkillResolution.ts
+++ b/code/cli/src/skills/SkillResolution.ts
@@ -1,5 +1,15 @@
 // Resolves selected skill IDs, validates references, and materializes generated skills.
-import { copyFileSync, cpSync, existsSync, mkdirSync, readdirSync, realpathSync, statSync, type Stats } from 'node:fs';
+import {
+  copyFileSync,
+  cpSync,
+  existsSync,
+  globSync,
+  mkdirSync,
+  readdirSync,
+  realpathSync,
+  statSync,
+  type Stats,
+} from 'node:fs';
 import { basename, isAbsolute, join, relative, sep } from 'node:path';
 
 import type { SkillControlEntry, SkillReference, SkillSelection } from '../profiles/Profile.js';
@@ -245,10 +255,10 @@ const planSectionMaterializations = (
   diagnostics: SkillResolutionDiagnostic[],
 ): readonly SkillMaterialization[] => {
   const materializations: SkillMaterialization[] = [];
-  const destinationNames = new Set<string>();
+  const destinationSources = new Map<string, string>();
 
   for (const { reference, fileRoot } of entries) {
-    const resolved = resolveReferenceMaterialization({
+    const outcomes = resolveReferenceMaterializations({
       reference,
       section,
       fileRoot,
@@ -256,42 +266,53 @@ const planSectionMaterializations = (
       skillPath: input.catalogEntry.skillPath,
     });
 
-    if (resolved === undefined) {
-      continue;
-    }
+    for (const resolved of outcomes) {
+      if ('message' in resolved) {
+        diagnostics.push(resolved);
+        continue;
+      }
 
-    if ('message' in resolved) {
-      diagnostics.push(resolved);
-      continue;
-    }
+      const collision = describeDestinationCollision(input, section, resolved, destinationSources);
 
-    if (destinationNames.has(resolved.destinationName)) {
-      diagnostics.push({
-        severity: 'error',
-        path: input.catalogEntry.skillPath,
-        message: `Destination '${section}/${resolved.destinationName}' is declared more than once.`,
-      });
-      continue;
-    }
+      if (collision !== undefined) {
+        diagnostics.push({ severity: 'error', path: input.catalogEntry.skillPath, message: collision });
+        continue;
+      }
 
-    // Checked against the source skill directory during planning so lint reports
-    // shipped-file collisions without materializing anything.
-    if (existsSync(join(input.catalogEntry.directory, section, resolved.destinationName))) {
-      diagnostics.push({
-        severity: 'error',
-        path: input.catalogEntry.skillPath,
-        message:
-          `Destination '${section}/${resolved.destinationName}' collides with a file ` +
-          `already shipped by skill '${input.catalogEntry.id}'.`,
-      });
-      continue;
+      destinationSources.set(resolved.destinationName, resolved.sourcePath);
+      materializations.push(resolved);
     }
-
-    destinationNames.add(resolved.destinationName);
-    materializations.push(resolved);
   }
 
   return materializations;
+};
+
+/** Reports a destination claimed twice or already shipped inside the skill directory. */
+const describeDestinationCollision = (
+  input: CatalogSkillResolutionInput,
+  section: SkillMaterializationSection,
+  resolved: SkillMaterialization,
+  destinationSources: ReadonlyMap<string, string>,
+): string | undefined => {
+  const previousSource = destinationSources.get(resolved.destinationName);
+
+  if (previousSource !== undefined) {
+    return (
+      `Destination '${section}/${resolved.destinationName}' is declared more than once ` +
+      `(by '${previousSource}' and '${resolved.sourcePath}').`
+    );
+  }
+
+  // Checked against the source skill directory during planning so lint reports
+  // shipped-file collisions without materializing anything.
+  if (existsSync(join(input.catalogEntry.directory, section, resolved.destinationName))) {
+    return (
+      `Destination '${section}/${resolved.destinationName}' collides with a file ` +
+      `already shipped by skill '${input.catalogEntry.id}'.`
+    );
+  }
+
+  return undefined;
 };
 
 interface DescribedReference {
@@ -310,55 +331,125 @@ const describeReference = (
     ? { declaredPath: reference.repo_file, root: projectDirectory, kind: 'repo_file', rootLabel: 'project' }
     : { declaredPath: reference.file, root: fileRoot, kind: 'file', rootLabel: 'catalog' };
 
-const resolveReferenceMaterialization = (input: {
+/** One reference's resolved root and labels, shared by every target it names. */
+interface ReferenceTargetContext {
+  readonly root: string;
+  readonly kind: 'file' | 'repo_file';
+  readonly rootLabel: 'catalog' | 'project';
+  readonly section: SkillMaterializationSection;
+  readonly skillPath: string;
+}
+
+const targetError = (skillPath: string, message: string): SkillResolutionDiagnostic => ({
+  severity: 'error',
+  path: skillPath,
+  message,
+});
+
+/**
+ * Resolves one reference entry to its materializations: one for a literal
+ * target, one per match for a glob target, and none for an omitted missing
+ * `repo_file` target.
+ */
+const resolveReferenceMaterializations = (input: {
   readonly reference: SkillReference;
   readonly section: SkillMaterializationSection;
   readonly fileRoot: string;
   readonly projectDirectory?: string;
   readonly skillPath: string;
-}): SkillMaterialization | SkillResolutionDiagnostic | undefined => {
+}): readonly (SkillMaterialization | SkillResolutionDiagnostic)[] => {
   const { declaredPath, root, kind, rootLabel } = describeReference(
     input.reference,
     input.fileRoot,
     input.projectDirectory,
   );
-  const error = (message: string): SkillResolutionDiagnostic => ({
-    severity: 'error',
-    path: input.skillPath,
-    message,
-  });
 
   if (root === undefined) {
-    return error(`Reference ${kind} '${declaredPath}' has no ${rootLabel} root to resolve from.`);
+    return [
+      targetError(input.skillPath, `Reference ${kind} '${declaredPath}' has no ${rootLabel} root to resolve from.`),
+    ];
   }
 
-  const sourcePath = isAbsolute(declaredPath) ? declaredPath : join(root, declaredPath);
+  const context: ReferenceTargetContext = { root, kind, rootLabel, section: input.section, skillPath: input.skillPath };
+
+  if (isGlobPattern(declaredPath)) {
+    return expandGlobMaterializations(declaredPath, context);
+  }
+
+  const resolved = resolveTargetMaterialization(declaredPath, context);
+
+  return resolved === undefined ? [] : [resolved];
+};
+
+/** Matches when a target uses glob syntax instead of naming one literal path. */
+const isGlobPattern = (declaredPath: string): boolean => /[*?[{]/u.test(declaredPath);
+
+/**
+ * Expands a glob target against its root. Each match then follows the same
+ * rules as a literal target, so a matched directory materializes recursively
+ * while an escaping or special match fails validation individually.
+ */
+const expandGlobMaterializations = (
+  pattern: string,
+  context: ReferenceTargetContext,
+): readonly (SkillMaterialization | SkillResolutionDiagnostic)[] => {
+  // Sorted so diagnostics and collisions are deterministic across platforms.
+  const matches = globSync(pattern, { cwd: context.root }).sort();
+
+  if (matches.length === 0) {
+    // A consuming project may not contain repo_file matches; the reference is omitted.
+    return context.kind === 'repo_file'
+      ? []
+      : [targetError(context.skillPath, `Reference file glob '${pattern}' matched no files under '${context.root}'.`)];
+  }
+
+  const resolved: (SkillMaterialization | SkillResolutionDiagnostic)[] = [];
+
+  for (const match of matches) {
+    const outcome = resolveTargetMaterialization(match, context);
+
+    if (outcome !== undefined) {
+      resolved.push(outcome);
+    }
+  }
+
+  return resolved;
+};
+
+/** Validates one concrete target path — a literal target or a single glob match. */
+const resolveTargetMaterialization = (
+  targetPath: string,
+  context: ReferenceTargetContext,
+): SkillMaterialization | SkillResolutionDiagnostic | undefined => {
+  const { root, kind, rootLabel, skillPath } = context;
+  const error = (message: string): SkillResolutionDiagnostic => targetError(skillPath, message);
+  const sourcePath = isAbsolute(targetPath) ? targetPath : join(root, targetPath);
 
   if (!existsSync(sourcePath)) {
     // A consuming project may not contain a repo_file target; the reference is omitted.
-    return kind === 'repo_file' ? undefined : error(`Reference file '${declaredPath}' was not found under '${root}'.`);
+    return kind === 'repo_file' ? undefined : error(`Reference file '${targetPath}' was not found under '${root}'.`);
   }
 
   const stats = statSync(sourcePath);
 
   if (!stats.isFile() && !stats.isDirectory()) {
-    return error(`Reference ${kind} '${declaredPath}' must be a regular file or directory.`);
+    return error(`Reference ${kind} '${targetPath}' must be a regular file or directory.`);
   }
 
   if (escapesRoot(sourcePath, root)) {
-    return error(`Reference ${kind} '${declaredPath}' resolves outside its ${rootLabel} root '${root}'.`);
+    return error(`Reference ${kind} '${targetPath}' resolves outside its ${rootLabel} root '${root}'.`);
   }
 
-  const directoryIssue = describeDirectoryTargetIssue(stats, sourcePath, { root, declaredPath, kind, rootLabel });
+  const directoryIssue = describeDirectoryTargetIssue(stats, sourcePath, targetPath, context);
 
   if (directoryIssue !== undefined) {
     return error(directoryIssue);
   }
 
   return {
-    section: input.section,
+    section: context.section,
     sourcePath,
-    destinationName: basename(declaredPath),
+    destinationName: basename(targetPath),
     kind: stats.isDirectory() ? 'directory' : 'file',
   };
 };
@@ -367,12 +458,8 @@ const resolveReferenceMaterialization = (input: {
 const describeDirectoryTargetIssue = (
   stats: Stats,
   sourcePath: string,
-  context: {
-    readonly root: string;
-    readonly declaredPath: string;
-    readonly kind: 'file' | 'repo_file';
-    readonly rootLabel: 'catalog' | 'project';
-  },
+  targetPath: string,
+  context: ReferenceTargetContext,
 ): string | undefined => {
   if (!stats.isDirectory()) {
     return undefined;
@@ -392,8 +479,7 @@ const describeDirectoryTargetIssue = (
   };
 
   return (
-    `Reference ${context.kind} '${context.declaredPath}' contains ` +
-    `'${containedPath}', ${problemDescriptions[issue.problem]}.`
+    `Reference ${context.kind} '${targetPath}' contains ` + `'${containedPath}', ${problemDescriptions[issue.problem]}.`
   );
 };
 

--- a/code/cli/src/skills/SkillResolution.ts
+++ b/code/cli/src/skills/SkillResolution.ts
@@ -381,8 +381,12 @@ const resolveReferenceMaterializations = (input: {
   return resolved === undefined ? [] : [resolved];
 };
 
-/** Matches when a target uses glob syntax instead of naming one literal path. */
-const isGlobPattern = (declaredPath: string): boolean => /[*?[{]/u.test(declaredPath);
+/**
+ * Matches when a target uses glob syntax instead of naming one literal path.
+ * Only the gitignore-style metacharacters count; braces are literal path
+ * characters, so a braced filename resolves as a literal target.
+ */
+const isGlobPattern = (declaredPath: string): boolean => /[*?[]/u.test(declaredPath);
 
 /**
  * Expands a glob target against its root. Each match then follows the same
@@ -393,6 +397,19 @@ const expandGlobMaterializations = (
   pattern: string,
   context: ReferenceTargetContext,
 ): readonly (SkillMaterialization | SkillResolutionDiagnostic)[] => {
+  // Braces are literal path characters in this contract, but globSync
+  // brace-expands them textually and offers no escape, so mixing them with
+  // glob syntax fails validation rather than silently matching other paths.
+  if (/[{}]/u.test(pattern)) {
+    return [
+      targetError(
+        context.skillPath,
+        `Reference ${context.kind} glob '${pattern}' must not contain braces; ` +
+          `braces are literal path characters, not glob syntax.`,
+      ),
+    ];
+  }
+
   // Sorted so diagnostics and collisions are deterministic across platforms.
   const matches = globSync(pattern, { cwd: context.root }).sort();
 

--- a/code/cli/src/skills/SkillResolution.ts
+++ b/code/cli/src/skills/SkillResolution.ts
@@ -1,5 +1,5 @@
 // Resolves selected skill IDs, validates references, and materializes generated skills.
-import { copyFileSync, cpSync, existsSync, mkdirSync, realpathSync, statSync } from 'node:fs';
+import { copyFileSync, cpSync, existsSync, mkdirSync, readdirSync, realpathSync, statSync, type Stats } from 'node:fs';
 import { basename, isAbsolute, join, relative, sep } from 'node:path';
 
 import type { SkillControlEntry, SkillReference, SkillSelection } from '../profiles/Profile.js';
@@ -192,8 +192,16 @@ const resolveCatalogSkill = (
   for (const materialization of materializations) {
     const sectionDirectory = join(generatedDirectory, materialization.section);
     mkdirSync(sectionDirectory, { recursive: true });
-    // copyFileSync preserves the source mode, so materialized scripts stay executable.
-    copyFileSync(materialization.sourcePath, join(sectionDirectory, materialization.destinationName));
+    const destinationPath = join(sectionDirectory, materialization.destinationName);
+
+    // Both copies preserve the source mode, so materialized scripts stay
+    // executable. Directory targets dereference symlinks that the contained
+    // scan already validated, so the generated skill is self-contained.
+    if (materialization.kind === 'directory') {
+      copyDirectoryDereferenced(materialization.sourcePath, destinationPath);
+    } else {
+      copyFileSync(materialization.sourcePath, destinationPath);
+    }
   }
 
   return { generatedDirectory, diagnostics };
@@ -203,6 +211,7 @@ interface SkillMaterialization {
   readonly section: SkillMaterializationSection;
   readonly sourcePath: string;
   readonly destinationName: string;
+  readonly kind: 'file' | 'directory';
 }
 
 const planSkillMaterializations = (
@@ -330,15 +339,131 @@ const resolveReferenceMaterialization = (input: {
     return kind === 'repo_file' ? undefined : error(`Reference file '${declaredPath}' was not found under '${root}'.`);
   }
 
-  if (!statSync(sourcePath).isFile()) {
-    return error(`Reference ${kind} '${declaredPath}' must be a regular file.`);
+  const stats = statSync(sourcePath);
+
+  /* v8 ignore next 3 -- only reachable with special files such as FIFOs or sockets. */
+  if (!stats.isFile() && !stats.isDirectory()) {
+    return error(`Reference ${kind} '${declaredPath}' must be a regular file or directory.`);
   }
 
   if (escapesRoot(sourcePath, root)) {
     return error(`Reference ${kind} '${declaredPath}' resolves outside its ${rootLabel} root '${root}'.`);
   }
 
-  return { section: input.section, sourcePath, destinationName: basename(declaredPath) };
+  const directoryIssue = describeDirectoryTargetIssue(stats, sourcePath, { root, declaredPath, kind, rootLabel });
+
+  if (directoryIssue !== undefined) {
+    return error(directoryIssue);
+  }
+
+  return {
+    section: input.section,
+    sourcePath,
+    destinationName: basename(declaredPath),
+    kind: stats.isDirectory() ? 'directory' : 'file',
+  };
+};
+
+/** Describes the first escaping or cyclic path inside a directory target, if any. */
+const describeDirectoryTargetIssue = (
+  stats: Stats,
+  sourcePath: string,
+  context: {
+    readonly root: string;
+    readonly declaredPath: string;
+    readonly kind: 'file' | 'repo_file';
+    readonly rootLabel: 'catalog' | 'project';
+  },
+): string | undefined => {
+  if (!stats.isDirectory()) {
+    return undefined;
+  }
+
+  const issue = scanDirectoryTarget(sourcePath, context.root, [realpathSync(sourcePath)], new Set());
+
+  if (issue === undefined) {
+    return undefined;
+  }
+
+  const containedPath = relative(sourcePath, issue.path);
+
+  return issue.problem === 'escaping'
+    ? `Reference ${context.kind} '${context.declaredPath}' contains '${containedPath}', ` +
+        `which resolves outside its ${context.rootLabel} root '${context.root}'.`
+    : `Reference ${context.kind} '${context.declaredPath}' contains '${containedPath}', which creates a symlink cycle.`;
+};
+
+interface ContainedPathIssue {
+  readonly path: string;
+  readonly problem: 'escaping' | 'cyclic';
+}
+
+/**
+ * Finds the first path inside a directory target whose realpath escapes the
+ * reference root, or a symlink that cycles back into an ancestor directory.
+ * Directory materialization dereferences symlinks recursively, so an escaping
+ * link would smuggle outside content into the generated skill and a cyclic
+ * link would never finish copying.
+ */
+const scanDirectoryTarget = (
+  directory: string,
+  root: string,
+  /** Realpaths of the directories on the current descent, for cycle detection. */
+  ancestry: readonly string[],
+  /** Realpaths of fully scanned directories, so shared subtrees scan once. */
+  scanned: Set<string>,
+): ContainedPathIssue | undefined => {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = join(directory, entry.name);
+
+    if (escapesRoot(entryPath, root)) {
+      return { path: entryPath, problem: 'escaping' };
+    }
+
+    // statSync follows symlinks, so in-root symlinked subdirectories are scanned too.
+    if (!statSync(entryPath).isDirectory()) {
+      continue;
+    }
+
+    const resolvedEntryPath = realpathSync(entryPath);
+
+    if (ancestry.includes(resolvedEntryPath)) {
+      return { path: entryPath, problem: 'cyclic' };
+    }
+
+    if (!scanned.has(resolvedEntryPath)) {
+      scanned.add(resolvedEntryPath);
+      const issue = scanDirectoryTarget(entryPath, root, [...ancestry, resolvedEntryPath], scanned);
+
+      if (issue !== undefined) {
+        return issue;
+      }
+    }
+  }
+
+  return undefined;
+};
+
+/**
+ * Copies a directory target while dereferencing symlinks, so the generated
+ * skill has no links back into catalog or project checkouts. cpSync's
+ * dereference option only follows the top-level source path, so nested entries
+ * are walked explicitly; copyFileSync preserves each file's mode.
+ */
+const copyDirectoryDereferenced = (source: string, destination: string): void => {
+  mkdirSync(destination, { recursive: true });
+
+  for (const entry of readdirSync(source, { withFileTypes: true })) {
+    const sourcePath = join(source, entry.name);
+    const destinationPath = join(destination, entry.name);
+
+    // statSync follows symlinks; scanDirectoryTarget already rejected cycles.
+    if (statSync(sourcePath).isDirectory()) {
+      copyDirectoryDereferenced(sourcePath, destinationPath);
+    } else {
+      copyFileSync(sourcePath, destinationPath);
+    }
+  }
 };
 
 /** Targets must remain within their root after following symlinks. */

--- a/code/cli/tests/unit/skill-directory-targets.test.ts
+++ b/code/cli/tests/unit/skill-directory-targets.test.ts
@@ -1,4 +1,5 @@
 // Tests directory targets in skill reference, script, and asset materialization.
+import { execFileSync } from 'node:child_process';
 import {
   existsSync,
   lstatSync,
@@ -163,6 +164,28 @@ describe('directory targets in reference materialization', () => {
     expect(resolve('escaping-linked-dir')[0]?.message).toContain(
       `contains '${join('shared-link', 'escape.md')}', which resolves outside`,
     );
+  });
+
+  // Windows has no mkfifo; the FIFO branches are guarded by the same statSync
+  // checks that the covered file and directory cases exercise.
+  it.skipIf(process.platform === 'win32')('fails FIFO targets declared directly and inside a directory target', () => {
+    const project = createRoot();
+    mkdirSync(join(project, 'pipes'), { recursive: true });
+    execFileSync('mkfifo', [join(project, 'pipes', 'stream.fifo')]);
+    writeSkill(join(project, '.outfitter', 'skills'), 'piped-dir', 'name: piped-dir\nassets:\n  - file: pipes');
+    writeSkill(
+      join(project, '.outfitter', 'skills'),
+      'piped-file',
+      'name: piped-file\nassets:\n  - file: pipes/stream.fifo',
+    );
+    const catalog = discoverSkillCatalog({ projectDirectory: project });
+    const resolve = (id: string) =>
+      resolveSkillEntries({ entries: [{ entry: id }], catalog, projectDirectory: project }).diagnostics;
+
+    expect(resolve('piped-dir')[0]?.message).toContain(
+      "contains 'stream.fifo', which is not a regular file or directory",
+    );
+    expect(resolve('piped-file')[0]?.message).toContain('must be a regular file or directory');
   });
 
   it('fails a directory target containing a symlink cycle', () => {

--- a/code/cli/tests/unit/skill-directory-targets.test.ts
+++ b/code/cli/tests/unit/skill-directory-targets.test.ts
@@ -1,0 +1,183 @@
+// Tests directory targets in skill reference, script, and asset materialization.
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { discoverSkillCatalog } from '../../src/skills/SkillCatalog.js';
+import { resolveSkillEntries } from '../../src/skills/SkillResolution.js';
+
+const temporaryRoots: string[] = [];
+
+const createRoot = (prefix = 'outfitter-skill-dirs-'): string => {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  temporaryRoots.push(root);
+  return root;
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+const writeSkill = (skillsDirectory: string, id: string, frontmatter: string, body = '# Skill\n'): string => {
+  const directory = join(skillsDirectory, id);
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(join(directory, 'SKILL.md'), `---\n${frontmatter}\n---\n${body}`);
+  return directory;
+};
+
+describe('directory targets in reference materialization', () => {
+  it('materializes a directory target recursively with dereferenced symlinks and preserved modes', () => {
+    const project = createRoot();
+    const output = createRoot();
+    writeSkill(
+      join(project, '.outfitter', 'skills'),
+      'template-shipper',
+      'name: template-shipper\nassets:\n  - file: code/project-repo-template',
+    );
+    const template = join(project, 'code', 'project-repo-template');
+    mkdirSync(join(template, 'scripts'), { recursive: true });
+    writeFileSync(join(template, 'README.md'), 'template readme\n');
+    writeFileSync(join(template, 'scripts', 'setup.sh'), '#!/bin/sh\n', { mode: 0o755 });
+    writeFileSync(join(project, 'code', 'shared.md'), 'shared\n');
+    // In-root symlinks are dereferenced so the generated skill is self-contained;
+    // the duplicate directory link also exercises the scan's shared-subtree memo.
+    symlinkSync(join(project, 'code', 'shared.md'), join(template, 'shared-link.md'));
+    symlinkSync(join(template, 'scripts'), join(template, 'scripts-link'));
+
+    const catalog = discoverSkillCatalog({ projectDirectory: project });
+    const resolution = resolveSkillEntries({
+      entries: [{ entry: 'template-shipper' }],
+      catalog,
+      projectDirectory: project,
+      outputDirectory: output,
+    });
+
+    expect(resolution.diagnostics).toEqual([]);
+    const materialized = join(output, 'template-shipper', 'assets', 'project-repo-template');
+    expect(readFileSync(join(materialized, 'README.md'), 'utf8')).toBe('template readme\n');
+    expect(readFileSync(join(materialized, 'scripts', 'setup.sh'), 'utf8')).toBe('#!/bin/sh\n');
+    expect(statSync(join(materialized, 'scripts', 'setup.sh')).mode & 0o100).toBe(0o100);
+    expect(readFileSync(join(materialized, 'shared-link.md'), 'utf8')).toBe('shared\n');
+    expect(lstatSync(join(materialized, 'shared-link.md')).isSymbolicLink()).toBe(false);
+    expect(readFileSync(join(materialized, 'scripts-link', 'setup.sh'), 'utf8')).toBe('#!/bin/sh\n');
+  });
+
+  it('omits a missing directory repo_file target and materializes a present one', () => {
+    const catalogRepo = createRoot();
+    mkdirSync(join(catalogRepo, 'profiles'), { recursive: true });
+    writeSkill(
+      join(catalogRepo, 'skills'),
+      'template-shipper',
+      'name: template-shipper\nassets:\n  - repo_file: code/project-repo-template',
+    );
+    const bareProject = createRoot();
+    const templateProject = createRoot();
+    mkdirSync(join(templateProject, 'code', 'project-repo-template'), { recursive: true });
+    writeFileSync(join(templateProject, 'code', 'project-repo-template', 'config.yml'), 'kind: template\n');
+    const resolve = (projectDirectory: string, outputDirectory: string) =>
+      resolveSkillEntries({
+        entries: [{ entry: 'template-shipper' }],
+        catalog: discoverSkillCatalog({ projectDirectory, sourcePaths: [join(catalogRepo, 'profiles')] }),
+        projectDirectory,
+        outputDirectory,
+      });
+
+    const bareOutput = createRoot();
+    const templateOutput = createRoot();
+    const omitted = resolve(bareProject, bareOutput);
+    const present = resolve(templateProject, templateOutput);
+
+    expect(omitted.diagnostics).toEqual([]);
+    expect(existsSync(join(bareOutput, 'template-shipper', 'assets'))).toBe(false);
+    expect(present.diagnostics).toEqual([]);
+    expect(
+      readFileSync(join(templateOutput, 'template-shipper', 'assets', 'project-repo-template', 'config.yml'), 'utf8'),
+    ).toBe('kind: template\n');
+  });
+
+  it('fails a basename collision between a directory target and a file target', () => {
+    const project = createRoot();
+    mkdirSync(join(project, 'docs'), { recursive: true });
+    mkdirSync(join(project, 'other'), { recursive: true });
+    writeFileSync(join(project, 'docs', 'design.md'), 'design\n');
+    writeFileSync(join(project, 'other', 'docs'), 'a file named docs\n');
+    writeSkill(
+      join(project, '.outfitter', 'skills'),
+      'colliding-kinds',
+      'name: colliding-kinds\nreferences:\n  - file: docs\n  - repo_file: other/docs',
+    );
+    const catalog = discoverSkillCatalog({ projectDirectory: project });
+
+    const resolution = resolveSkillEntries({
+      entries: [{ entry: 'colliding-kinds' }],
+      catalog,
+      projectDirectory: project,
+    });
+
+    expect(resolution.diagnostics[0]?.message).toContain("Destination 'references/docs' is declared more than once");
+  });
+
+  it('fails a directory target containing a symlink that escapes the reference root', () => {
+    const project = createRoot();
+    const outside = createRoot();
+    writeFileSync(join(outside, 'secret.md'), 'secret\n');
+    mkdirSync(join(project, 'docs', 'nested'), { recursive: true });
+    writeFileSync(join(project, 'docs', 'design.md'), 'design\n');
+    symlinkSync(join(outside, 'secret.md'), join(project, 'docs', 'nested', 'escape.md'));
+    mkdirSync(join(project, 'shared'), { recursive: true });
+    symlinkSync(join(outside, 'secret.md'), join(project, 'shared', 'escape.md'));
+    mkdirSync(join(project, 'linking'), { recursive: true });
+    // The in-root directory link is followed, so its escaping content still fails.
+    symlinkSync(join(project, 'shared'), join(project, 'linking', 'shared-link'));
+    writeSkill(
+      join(project, '.outfitter', 'skills'),
+      'escaping-dir',
+      'name: escaping-dir\nreferences:\n  - file: docs',
+    );
+    writeSkill(
+      join(project, '.outfitter', 'skills'),
+      'escaping-linked-dir',
+      'name: escaping-linked-dir\nreferences:\n  - file: linking',
+    );
+    const catalog = discoverSkillCatalog({ projectDirectory: project });
+    const resolve = (id: string) =>
+      resolveSkillEntries({ entries: [{ entry: id }], catalog, projectDirectory: project }).diagnostics;
+
+    expect(resolve('escaping-dir')[0]?.message).toContain(
+      `contains '${join('nested', 'escape.md')}', which resolves outside`,
+    );
+    expect(resolve('escaping-linked-dir')[0]?.message).toContain(
+      `contains '${join('shared-link', 'escape.md')}', which resolves outside`,
+    );
+  });
+
+  it('fails a directory target containing a symlink cycle', () => {
+    const project = createRoot();
+    mkdirSync(join(project, 'looping'), { recursive: true });
+    symlinkSync(join(project, 'looping'), join(project, 'looping', 'loop'));
+    writeSkill(join(project, '.outfitter', 'skills'), 'cyclic-dir', 'name: cyclic-dir\nassets:\n  - file: looping');
+    const catalog = discoverSkillCatalog({ projectDirectory: project });
+
+    const resolution = resolveSkillEntries({
+      entries: [{ entry: 'cyclic-dir' }],
+      catalog,
+      projectDirectory: project,
+    });
+
+    expect(resolution.diagnostics[0]?.message).toContain("contains 'loop', which creates a symlink cycle");
+  });
+});

--- a/code/cli/tests/unit/skill-glob-targets.test.ts
+++ b/code/cli/tests/unit/skill-glob-targets.test.ts
@@ -1,0 +1,191 @@
+// Tests glob targets in skill reference, script, and asset materialization.
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { discoverSkillCatalog } from '../../src/skills/SkillCatalog.js';
+import { resolveSkillEntries } from '../../src/skills/SkillResolution.js';
+
+const temporaryRoots: string[] = [];
+
+const createRoot = (prefix = 'outfitter-skill-globs-'): string => {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  temporaryRoots.push(root);
+  return root;
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+const writeSkill = (skillsDirectory: string, id: string, frontmatter: string, body = '# Skill\n'): string => {
+  const directory = join(skillsDirectory, id);
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(join(directory, 'SKILL.md'), `---\n${frontmatter}\n---\n${body}`);
+  return directory;
+};
+
+describe('glob targets in reference materialization', () => {
+  it('expands file and repo_file globs so each match materializes by basename', () => {
+    const project = createRoot();
+    const output = createRoot();
+    writeSkill(
+      join(project, '.outfitter', 'skills'),
+      'globbed',
+      'name: globbed\nreferences:\n  - file: docs/*.md\nassets:\n  - repo_file: templates/*.json',
+    );
+    mkdirSync(join(project, 'docs'), { recursive: true });
+    mkdirSync(join(project, 'templates'), { recursive: true });
+    writeFileSync(join(project, 'docs', 'alpha.md'), 'alpha\n');
+    writeFileSync(join(project, 'docs', 'beta.md'), 'beta\n');
+    writeFileSync(join(project, 'docs', 'notes.txt'), 'not matched\n');
+    writeFileSync(join(project, 'templates', 'report.json'), '{}\n');
+    // A matched broken symlink resolves to a missing repo_file target and is omitted.
+    symlinkSync(join(project, 'templates', 'nonexistent.json'), join(project, 'templates', 'broken.json'));
+
+    const catalog = discoverSkillCatalog({ projectDirectory: project });
+    const resolution = resolveSkillEntries({
+      entries: [{ entry: 'globbed' }],
+      catalog,
+      projectDirectory: project,
+      outputDirectory: output,
+    });
+
+    expect(resolution.diagnostics).toEqual([]);
+    expect(readFileSync(join(output, 'globbed', 'references', 'alpha.md'), 'utf8')).toBe('alpha\n');
+    expect(readFileSync(join(output, 'globbed', 'references', 'beta.md'), 'utf8')).toBe('beta\n');
+    expect(existsSync(join(output, 'globbed', 'references', 'notes.txt'))).toBe(false);
+    expect(readFileSync(join(output, 'globbed', 'assets', 'report.json'), 'utf8')).toBe('{}\n');
+    expect(existsSync(join(output, 'globbed', 'assets', 'broken.json'))).toBe(false);
+  });
+
+  it('recurses ** globs and materializes matched directories recursively', () => {
+    const project = createRoot();
+    const output = createRoot();
+    writeSkill(
+      join(project, '.outfitter', 'skills'),
+      'deep-glob',
+      'name: deep-glob\nreferences:\n  - file: docs/**/*.md\nassets:\n  - file: code/*',
+    );
+    mkdirSync(join(project, 'docs', 'guides'), { recursive: true });
+    writeFileSync(join(project, 'docs', 'top.md'), 'top\n');
+    writeFileSync(join(project, 'docs', 'guides', 'deep.md'), 'deep\n');
+    const template = join(project, 'code', 'project-repo-template');
+    mkdirSync(join(template, 'scripts'), { recursive: true });
+    writeFileSync(join(template, 'scripts', 'setup.sh'), '#!/bin/sh\n', { mode: 0o755 });
+    writeFileSync(join(project, 'code', 'notes.md'), 'notes\n');
+
+    const catalog = discoverSkillCatalog({ projectDirectory: project });
+    const resolution = resolveSkillEntries({
+      entries: [{ entry: 'deep-glob' }],
+      catalog,
+      projectDirectory: project,
+      outputDirectory: output,
+    });
+
+    expect(resolution.diagnostics).toEqual([]);
+    expect(readFileSync(join(output, 'deep-glob', 'references', 'top.md'), 'utf8')).toBe('top\n');
+    expect(readFileSync(join(output, 'deep-glob', 'references', 'deep.md'), 'utf8')).toBe('deep\n');
+    const materializedTemplate = join(output, 'deep-glob', 'assets', 'project-repo-template');
+    expect(readFileSync(join(materializedTemplate, 'scripts', 'setup.sh'), 'utf8')).toBe('#!/bin/sh\n');
+    expect(statSync(join(materializedTemplate, 'scripts', 'setup.sh')).mode & 0o100).toBe(0o100);
+    expect(readFileSync(join(output, 'deep-glob', 'assets', 'notes.md'), 'utf8')).toBe('notes\n');
+  });
+
+  it('fails a zero-match file glob and omits a zero-match repo_file glob', () => {
+    const project = createRoot();
+    const output = createRoot();
+    writeSkill(
+      join(project, '.outfitter', 'skills'),
+      'empty-file-glob',
+      'name: empty-file-glob\nreferences:\n  - file: docs/*.md',
+    );
+    writeSkill(
+      join(project, '.outfitter', 'skills'),
+      'empty-repo-glob',
+      'name: empty-repo-glob\nreferences:\n  - repo_file: docs/*.md',
+    );
+    const catalog = discoverSkillCatalog({ projectDirectory: project });
+
+    const failing = resolveSkillEntries({
+      entries: [{ entry: 'empty-file-glob' }],
+      catalog,
+      projectDirectory: project,
+    });
+    const omitted = resolveSkillEntries({
+      entries: [{ entry: 'empty-repo-glob' }],
+      catalog,
+      projectDirectory: project,
+      outputDirectory: output,
+    });
+
+    expect(failing.diagnostics[0]?.message).toContain("Reference file glob 'docs/*.md' matched no files under");
+    expect(omitted.diagnostics).toEqual([]);
+    expect(omitted.sources).toEqual([join(output, 'empty-repo-glob')]);
+    expect(existsSync(join(output, 'empty-repo-glob', 'references'))).toBe(false);
+  });
+
+  it('fails glob-induced basename collisions naming both sources', () => {
+    const project = createRoot();
+    mkdirSync(join(project, 'docs', 'alpha'), { recursive: true });
+    mkdirSync(join(project, 'docs', 'beta'), { recursive: true });
+    writeFileSync(join(project, 'docs', 'alpha', 'readme.md'), 'alpha\n');
+    writeFileSync(join(project, 'docs', 'beta', 'readme.md'), 'beta\n');
+    writeSkill(
+      join(project, '.outfitter', 'skills'),
+      'colliding-glob',
+      'name: colliding-glob\nreferences:\n  - file: docs/**/readme.md',
+    );
+    const catalog = discoverSkillCatalog({ projectDirectory: project });
+
+    const resolution = resolveSkillEntries({
+      entries: [{ entry: 'colliding-glob' }],
+      catalog,
+      projectDirectory: project,
+    });
+
+    const message = resolution.diagnostics[0]?.message;
+    expect(message).toContain("Destination 'references/readme.md' is declared more than once");
+    expect(message).toContain(join(project, 'docs', 'alpha', 'readme.md'));
+    expect(message).toContain(join(project, 'docs', 'beta', 'readme.md'));
+  });
+
+  it('fails a glob match that escapes the reference root through a symlink', () => {
+    const project = createRoot();
+    const outside = createRoot();
+    writeFileSync(join(outside, 'secret.md'), 'secret\n');
+    mkdirSync(join(project, 'docs'), { recursive: true });
+    writeFileSync(join(project, 'docs', 'design.md'), 'design\n');
+    symlinkSync(join(outside, 'secret.md'), join(project, 'docs', 'escape.md'));
+    writeSkill(
+      join(project, '.outfitter', 'skills'),
+      'escaping-glob',
+      'name: escaping-glob\nreferences:\n  - file: docs/*.md',
+    );
+    const catalog = discoverSkillCatalog({ projectDirectory: project });
+
+    const resolution = resolveSkillEntries({
+      entries: [{ entry: 'escaping-glob' }],
+      catalog,
+      projectDirectory: project,
+    });
+
+    expect(resolution.diagnostics[0]?.message).toContain(
+      "Reference file 'docs/escape.md' resolves outside its catalog root",
+    );
+    expect(resolution.sources).toEqual([]);
+  });
+});

--- a/code/cli/tests/unit/skill-glob-targets.test.ts
+++ b/code/cli/tests/unit/skill-glob-targets.test.ts
@@ -163,6 +163,42 @@ describe('glob targets in reference materialization', () => {
     expect(message).toContain(join(project, 'docs', 'beta', 'readme.md'));
   });
 
+  it('treats braced paths as literal targets and rejects braces inside glob patterns', () => {
+    const project = createRoot();
+    const output = createRoot();
+    mkdirSync(join(project, 'docs'), { recursive: true });
+    writeFileSync(join(project, 'docs', 'notes{1}.md'), 'braced\n');
+    writeFileSync(join(project, 'docs', 'a-notes.md'), 'a\n');
+    writeSkill(
+      join(project, '.outfitter', 'skills'),
+      'braced-literal',
+      'name: braced-literal\nreferences:\n  - file: docs/notes{1}.md',
+    );
+    writeSkill(
+      join(project, '.outfitter', 'skills'),
+      'braced-glob',
+      'name: braced-glob\nreferences:\n  - file: docs/{a,b}*.md',
+    );
+    const catalog = discoverSkillCatalog({ projectDirectory: project });
+
+    const literal = resolveSkillEntries({
+      entries: [{ entry: 'braced-literal' }],
+      catalog,
+      projectDirectory: project,
+      outputDirectory: output,
+    });
+    const braced = resolveSkillEntries({
+      entries: [{ entry: 'braced-glob' }],
+      catalog,
+      projectDirectory: project,
+    });
+
+    expect(literal.diagnostics).toEqual([]);
+    expect(readFileSync(join(output, 'braced-literal', 'references', 'notes{1}.md'), 'utf8')).toBe('braced\n');
+    expect(braced.diagnostics[0]?.message).toContain("Reference file glob 'docs/{a,b}*.md' must not contain braces");
+    expect(braced.sources).toEqual([]);
+  });
+
   it('fails a glob match that escapes the reference root through a symlink', () => {
     const project = createRoot();
     const outside = createRoot();

--- a/code/cli/tests/unit/skill-resolution.test.ts
+++ b/code/cli/tests/unit/skill-resolution.test.ts
@@ -234,7 +234,7 @@ describe('skill resolution and reference materialization', () => {
     expect(broken.diagnostics[0]?.message).toContain("Reference file 'docs/absent.md' was not found");
   });
 
-  it('fails duplicate reference destinations, directory targets, and root-escaping symlinks', () => {
+  it('fails duplicate reference destinations and root-escaping symlinks', () => {
     const project = createRoot();
     const outside = createRoot();
     writeFileSync(join(outside, 'secret.md'), 'secret\n');
@@ -248,11 +248,6 @@ describe('skill resolution and reference materialization', () => {
     );
     writeSkill(
       join(project, '.outfitter', 'skills'),
-      'directory-ref',
-      'name: directory-ref\nreferences:\n  - file: docs',
-    );
-    writeSkill(
-      join(project, '.outfitter', 'skills'),
       'escaping',
       'name: escaping\nreferences:\n  - file: docs/escape.md',
     );
@@ -261,7 +256,6 @@ describe('skill resolution and reference materialization', () => {
       resolveSkillEntries({ entries: [{ entry: id }], catalog, projectDirectory: project }).diagnostics;
 
     expect(resolve('colliding')[0]?.message).toContain('declared more than once');
-    expect(resolve('directory-ref')[0]?.message).toContain('must be a regular file');
     expect(resolve('escaping')[0]?.message).toContain('resolves outside');
   });
 

--- a/docs/documentation/skills.md
+++ b/docs/documentation/skills.md
@@ -329,9 +329,13 @@ it available to the skill but does not load its contents into model context.
   `<section>/<source basename>/`, preserving the nested layout and file modes.
   Symlinks inside the directory are dereferenced so the generated skill is
   self-contained.
-- **Glob.** A target containing `*`, `?`, `[`, or `{` is a glob, expanded at
-  resolution time against its root — the profile-repository checkout for
-  `file`, the active project root for `repo_file`:
+- **Glob.** A target containing `*`, `?`, or `[` is a glob in the familiar
+  gitignore and GitHub Actions path-filter style: `*` matches within a path
+  segment, `**` matches across segments, `?` matches one character, and
+  `[...]` matches a character range — nothing more. Braces are literal path
+  characters, not glob syntax, so a glob pattern must not contain them. Globs
+  expand at resolution time against their root — the profile-repository
+  checkout for `file`, the active project root for `repo_file`:
 
   ```yaml
   references:
@@ -343,8 +347,7 @@ it available to the skill but does not load its contents into model context.
   A `file` glob matching zero files fails validation, like a broken `file`
   target; a `repo_file` glob matching zero files is omitted, like a missing
   `repo_file` target. Matches MUST remain within their root after symlink
-  normalization, per [Trust boundary](#trust-boundary); `**` is allowed under
-  the same constraint.
+  normalization, per [Trust boundary](#trust-boundary).
 
 Every materialized target lands at `<section>/<source basename>`. Two targets
 or glob matches whose sources share a basename fail validation; rename one of

--- a/docs/documentation/skills.md
+++ b/docs/documentation/skills.md
@@ -404,11 +404,13 @@ boundaries, or the user's request.
 
 Outfitter resolves and normalizes reference targets before launch. Targets MUST
 remain within their Outfitter, profile-repository, or project root after
-following symlinks. A directory target is additionally scanned recursively, and
-any contained symlink that resolves outside that root fails validation, so a
-directory cannot smuggle outside content into the generated skill. Escaping,
-colliding, and broken `file` references fail validation; a missing `repo_file`
-target is omitted rather than failing, as described above.
+following symlinks. A directory target is additionally scanned recursively: a
+contained symlink that resolves outside that root fails validation, so a
+directory cannot smuggle outside content into the generated skill, and a
+contained entry that is not a regular file or directory (such as a FIFO or
+socket) also fails validation. Escaping, colliding, and broken `file`
+references fail validation; a missing `repo_file` target is omitted rather
+than failing, as described above.
 
 ## Resolution and launch
 

--- a/docs/documentation/skills.md
+++ b/docs/documentation/skills.md
@@ -317,16 +317,38 @@ the skill is later published: `file` follows the skill into its profile
 repository, while `repo_file` continues to target whichever project consumes
 the skill.
 
-References are regular files or directories. They are not interpolated or
-added to the system prompt. Materializing a reference makes it available to
-the skill but does not load its contents into model context.
+### Target kinds
 
-A file target materializes as `references/<source basename>`. A directory
-target materializes recursively as `references/<source basename>/`, preserving
-the nested layout and file modes; symlinks inside the directory are
-dereferenced so the generated skill is self-contained. Two references whose
-sources share a basename fail validation; rename one of the source targets to
-resolve the collision.
+A `file` or `repo_file` target names a regular file, a directory, or a glob;
+`references`, `scripts`, and `assets` entries share this contract. Targets are
+not interpolated or added to the system prompt. Materializing a target makes
+it available to the skill but does not load its contents into model context.
+
+- **File.** A regular file materializes as `<section>/<source basename>`.
+- **Directory.** A directory materializes recursively as
+  `<section>/<source basename>/`, preserving the nested layout and file modes.
+  Symlinks inside the directory are dereferenced so the generated skill is
+  self-contained.
+- **Glob.** A target containing `*`, `?`, `[`, or `{` is a glob, expanded at
+  resolution time against its root — the profile-repository checkout for
+  `file`, the active project root for `repo_file`:
+
+  ```yaml
+  references:
+    - file: docs/*.md
+  ```
+
+  Each match materializes by basename exactly as if listed individually, and a
+  matched directory materializes recursively like a declared directory target.
+  A `file` glob matching zero files fails validation, like a broken `file`
+  target; a `repo_file` glob matching zero files is omitted, like a missing
+  `repo_file` target. Matches MUST remain within their root after symlink
+  normalization, per [Trust boundary](#trust-boundary); `**` is allowed under
+  the same constraint.
+
+Every materialized target lands at `<section>/<source basename>`. Two targets
+or glob matches whose sources share a basename fail validation; rename one of
+the sources to resolve the collision.
 
 ### Scripts and assets
 
@@ -404,7 +426,8 @@ boundaries, or the user's request.
 
 Outfitter resolves and normalizes reference targets before launch. Targets MUST
 remain within their Outfitter, profile-repository, or project root after
-following symlinks. A directory target is additionally scanned recursively: a
+following symlinks, and every glob match is validated individually under the
+same rules. A directory target is additionally scanned recursively: a
 contained symlink that resolves outside that root fails validation, so a
 directory cannot smuggle outside content into the generated skill, and a
 contained entry that is not a regular file or directory (such as a FIFO or
@@ -420,15 +443,15 @@ For each selected skill, Outfitter:
    directories, contributing directory profiles, and catalog `skills/`
    directories — following [layer precedence](./concepts.md#layer-precedence).
 2. Validates `SKILL.md` and confirms `name` matches the directory name.
-3. Resolves `file` and `repo_file` reference entries.
+3. Resolves `file` and `repo_file` reference entries, expanding glob targets.
 4. Creates a generated skill directory for the run.
 5. Materializes references under that directory's `references/` folder.
 6. Passes the generated skill to the selected agent adapter.
 7. Removes the generated skill with the temporary composite profile.
 
 Run `outfitter profile lint` to diagnose unresolved skill IDs, invalid
-frontmatter, missing `file` references, escaping paths, and destination
-collisions before launch.
+frontmatter, missing or zero-match `file` references, escaping paths, and
+destination collisions before launch.
 
 ## Progressive disclosure
 

--- a/docs/documentation/skills.md
+++ b/docs/documentation/skills.md
@@ -317,13 +317,16 @@ the skill is later published: `file` follows the skill into its profile
 repository, while `repo_file` continues to target whichever project consumes
 the skill.
 
-References are regular files. They are not interpolated or added to the system
-prompt. Materializing a reference makes it available to the skill but does not
-load its contents into model context.
+References are regular files or directories. They are not interpolated or
+added to the system prompt. Materializing a reference makes it available to
+the skill but does not load its contents into model context.
 
-Each reference materializes as `references/<source basename>`. Two references
-whose sources share a basename fail validation; rename one of the source
-documents to resolve the collision.
+A file target materializes as `references/<source basename>`. A directory
+target materializes recursively as `references/<source basename>/`, preserving
+the nested layout and file modes; symlinks inside the directory are
+dereferenced so the generated skill is self-contained. Two references whose
+sources share a basename fail validation; rename one of the source targets to
+resolve the collision.
 
 ### Scripts and assets
 
@@ -344,6 +347,22 @@ assets:
   - repo_file: templates/report.json # assets/report.json
 ---
 ```
+
+A directory target ships an entire tree with the skill. For example, a profile
+repository can publish a scaffolding skill beside the project template it
+instantiates:
+
+```yaml
+---
+name: project-scaffolding
+assets:
+  - file: code/project-repo-template # assets/project-repo-template/
+---
+```
+
+The generated skill contains `assets/project-repo-template/` with the
+template's full contents — nested scripts keep their executable mode — so the
+skill body can copy the template into the consuming project.
 
 Files already inside the skill directory (`scripts/`, `references/`, `assets/`)
 ship with the skill as before; frontmatter entries add external files beside
@@ -385,9 +404,11 @@ boundaries, or the user's request.
 
 Outfitter resolves and normalizes reference targets before launch. Targets MUST
 remain within their Outfitter, profile-repository, or project root after
-following symlinks. Escaping, non-file, colliding, and broken `file` references
-fail validation; a missing `repo_file` target is omitted rather than failing,
-as described above.
+following symlinks. A directory target is additionally scanned recursively, and
+any contained symlink that resolves outside that root fails validation, so a
+directory cannot smuggle outside content into the generated skill. Escaping,
+colliding, and broken `file` references fail validation; a missing `repo_file`
+target is omitted rather than failing, as described above.
 
 ## Resolution and launch
 


### PR DESCRIPTION
## Motivation

Two downstream consumers need richer reference targets than single literal files:

- [ai-outfitter/link](https://github.com/ai-outfitter/link) wants to ship a whole template directory with a skill — `assets: [{file: code/project-repo-template}]` — so downstream consumers receive `assets/project-repo-template/` with the template's full contents.
- [ai-outfitter/actions](https://github.com/ai-outfitter/actions) needs glob targets for the outfitter-actions skill (ai-outfitter/actions#13), e.g. `references: [{file: docs/*.md}]`, instead of enumerating every file by hand.

This PR implements one unified target contract: a `file` or `repo_file` target names a regular file, a directory, or a glob, with identical semantics across `references`, `scripts`, and `assets`. It implements and supersedes #157 (the docs-only glob spec) and unifies its wording into the docs.

## Semantics

| Target resolves to | `file:` | `repo_file:` |
| --- | --- | --- |
| Regular file | Materializes as `<section>/<basename>` (unchanged) | Materializes as `<section>/<basename>` (unchanged) |
| Directory | Materializes recursively as `<section>/<basename>/` | Materializes recursively as `<section>/<basename>/` |
| Glob (gitignore-style: `*`, `**`, `?`, `[...]`) | Expanded against the catalog root; each match follows the file/directory rules above; zero matches fail validation | Expanded against the project root; each match follows the file/directory rules above; zero matches are omitted |
| Missing | Hard validation error (unchanged) | Silently omitted (unchanged) |

- Glob syntax is the simple gitignore / GitHub Actions path-filter style: `*` within a segment, `**` across segments, `?` for one character, `[...]` character ranges — nothing more. Braces are literal path characters: a braced filename resolves as a literal target, and a glob pattern containing braces fails validation (Node's `globSync` brace-expands patterns textually and ignores backslash and character-class escapes — verified on Node 22 and 24 — so failing fast beats silently matching brace-expanded alternatives; braced filenames stay reachable literally or via brace-free globs like `docs/*`).
- Glob expansion uses Node's `fs.globSync` (no new dependency; the `>=22.19.0` engines baseline includes it) with matches sorted for deterministic diagnostics.
- A glob match that is a directory materializes recursively, exactly like a declared directory target — the two features share one code path (`resolveTargetMaterialization`) rather than being bolted together.
- Directory copies preserve file modes (nested scripts stay executable) and dereference symlinks so the generated skill is self-contained.
- Basename collisions — including glob-induced ones — fail validation with a diagnostic naming both colliding sources; shipped-file destination collisions apply unchanged.

## Security

- The existing realpath escape check runs on every literal target and on every individual glob match, so a glob cannot smuggle content via `..` patterns, absolute patterns, or symlinked matches.
- Directory targets (declared or glob-matched) are additionally scanned recursively before copying, following in-root symlinked subdirectories, rejecting: contained symlinks whose realpath escapes the reference root (a catalog directory containing a link to `/etc/passwd` fails validation), symlink cycles (which would never finish copying), and entries that are neither regular files nor directories (a FIFO would block `copyFileSync` indefinitely).
- Note: the copy is an explicit dereferencing walk rather than `cpSync {dereference: true}`, because Node's `cpSync` only dereferences the top-level source path — nested symlinks are copied verbatim (verified empirically on Node 22/24).

## Test coverage

New `code/cli/tests/unit/skill-directory-targets.test.ts`:

- directory `file:` target materializes recursively (nested layout, dereferenced in-root file and directory symlinks, preserved executable mode);
- missing directory `repo_file:` target omitted while a present one materializes;
- basename collision between a directory target and a file target;
- contained escaping symlink (directly nested and reached through an in-root symlinked subdirectory);
- contained symlink cycle;
- FIFO targets rejected both as the declared target and nested inside a directory (skipped on Windows).

New `code/cli/tests/unit/skill-glob-targets.test.ts`:

- `file:` and `repo_file:` glob expansion by basename, non-matches excluded, matched broken symlink omitted for `repo_file`;
- `**` recursion and a glob match that is a directory materializing recursively with preserved modes;
- zero-match `file:` glob fails while zero-match `repo_file:` glob is omitted;
- glob-induced basename collision fails naming both sources;
- glob match escaping the reference root through a symlink fails;
- braced paths resolve as literal targets while braces inside glob patterns fail validation.

Full gate locally: `prettier --check .`, `npm run lint`, `npm run typecheck`, `npm run coverage` (56 files, 370 tests, coverage above thresholds), and `npm run docs:ci` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
