### PR TITLE
fix: width-aware header rendering (fixes #162)

### DIFF
--- a/code/cli/tests/unit/pi-login-launch.test.ts
+++ b/code/cli/tests/unit/pi-login-launch.test.ts
@@ -56,6 +56,10 @@ const writeDefaultProfilesCache = (homeDirectory: string): string => {
 const extensionPaths = (plan: AgentLaunchPlan): string[] =>
   plan.args.filter((_arg, index) => plan.args[index - 1] === '--extension');
 
+// Built through the constructor because eslint's no-control-regex rejects a literal escape byte.
+const ansiSequencePattern = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'gu');
+const visibleLineWidth = (line: string): number => line.replace(ansiSequencePattern, '').length;
+
 const readExtension = (plan: AgentLaunchPlan, fileName: string): string => {
   const path = extensionPaths(plan).find((candidate) => candidate.endsWith(fileName));
   if (path === undefined) {
@@ -214,6 +218,7 @@ const createMockContext = (
   const selectCalls: Array<{ readonly title: string; readonly options: readonly string[] }> = [];
   const inputCalls: Array<{ readonly message: string; readonly defaultValue?: string }> = [];
   const headerRenders: string[][] = [];
+  const headerComponents: Array<{ render(width?: number): string[]; invalidate(): void }> = [];
   const customRenders: string[][] = [];
   const submittedInputs: string[] = [];
   const selectedOptions = [...(options.selectedOptions ?? [])];
@@ -233,6 +238,7 @@ const createMockContext = (
     notifications,
     statuses,
     headerRenders,
+    headerComponents,
     customRenders,
     inputCalls,
     selectCalls,
@@ -312,17 +318,17 @@ const createMockContext = (
         factory: (
           _tui: unknown,
           theme: { bold(text: string): string; fg(_color: string, text: string): string },
-        ) => { render(): string[] },
+        ) => { render(width?: number): string[]; invalidate(): void },
       ) => {
-        headerRenders.push(
-          factory(
-            {},
-            {
-              bold: (text: string) => text,
-              fg: (_color: string, text: string) => text,
-            },
-          ).render(),
+        const component = factory(
+          {},
+          {
+            bold: (text: string) => text,
+            fg: (_color: string, text: string) => text,
+          },
         );
+        headerComponents.push(component);
+        headerRenders.push(component.render());
       },
       setStatus: (id: string, text: string) => {
         statuses[id] = text;
@@ -471,6 +477,92 @@ describe('preparePiLoginLaunchPlan', () => {
     expect(header).not.toContain('/outfitter will help you choose a profile catalog and install location.');
     expect(header).not.toContain('____');
     expect(context.notifications.join('\n')).not.toContain('/outfitter');
+  });
+
+  // Regression coverage for https://github.com/ai-outfitter/outfitter/issues/162: pi-tui
+  // throws on render lines wider than the terminal, so the injected header must fit every
+  // width pi passes to render(), including narrow embedder terminals like 80x24 tmux panes.
+  it.each([[80], [40], [20]])('fits every startup header line within a %d-column terminal', async (terminalWidth) => {
+    const agentDir = createAgentDir();
+    const plan = preparePiLoginLaunchPlan({
+      adapterId: 'pi',
+      homeDirectory: agentDir,
+      launchPlan: createLaunchPlan(agentDir),
+      writeLine: () => undefined,
+    });
+    const extension = evaluateOutfitterExtension(readExtension(plan, 'outfitter-extension.js'));
+    const pi = createMockPi();
+    const context = createMockContext();
+
+    extension(pi);
+    await startMockSession(pi, context);
+
+    const lines = context.headerComponents[0]?.render(terminalWidth) ?? [];
+    expect(lines.length).toBeGreaterThan(0);
+    for (const line of lines) {
+      expect(visibleLineWidth(line)).toBeLessThanOrEqual(terminalWidth);
+    }
+    expect(lines.join('\n')).toContain('Outfitter');
+  });
+
+  it.each([[80], [40]])(
+    'fits every first-run startup header line within a %d-column terminal',
+    async (terminalWidth) => {
+      const homeDirectory = createAgentDir();
+      const agentDir = createAgentDir();
+      const plan = preparePiLoginLaunchPlan({
+        adapterId: 'pi',
+        homeDirectory,
+        launchPlan: createLaunchPlan(agentDir),
+        runtimeOnboarding: { autoOpenOutfitter: true },
+        writeLine: () => undefined,
+      });
+      const extension = evaluateOutfitterExtension(readExtension(plan, 'outfitter-extension.js'));
+      const pi = createMockPi();
+      const context = createMockContext();
+
+      extension(pi);
+      await startMockSession(pi, context);
+
+      const lines = context.headerComponents[0]?.render(terminalWidth) ?? [];
+      expect(lines.length).toBeGreaterThan(0);
+      for (const line of lines) {
+        expect(visibleLineWidth(line)).toBeLessThanOrEqual(terminalWidth);
+      }
+      // First-run prose wraps instead of truncating, so no words are lost.
+      expect(lines.join(' ')).toContain('catalogs let teams share setups through GitHub');
+    },
+  );
+
+  it('re-fits the startup header when the terminal width changes and caches per width', async () => {
+    const agentDir = createAgentDir();
+    const plan = preparePiLoginLaunchPlan({
+      adapterId: 'pi',
+      homeDirectory: agentDir,
+      launchPlan: createLaunchPlan(agentDir),
+      writeLine: () => undefined,
+    });
+    const extension = evaluateOutfitterExtension(readExtension(plan, 'outfitter-extension.js'));
+    const pi = createMockPi();
+    const context = createMockContext();
+
+    extension(pi);
+    await startMockSession(pi, context);
+
+    const component = context.headerComponents[0];
+    if (component === undefined) {
+      throw new Error('startup header component was not registered.');
+    }
+    const wideLines = component.render(220);
+    const narrowLines = component.render(80);
+    expect(wideLines.every((line) => visibleLineWidth(line) <= 220)).toBe(true);
+    expect(narrowLines.every((line) => visibleLineWidth(line) <= 80)).toBe(true);
+    expect(narrowLines.length).toBeGreaterThan(wideLines.length);
+    expect(component.render(80)).toBe(narrowLines);
+    component.invalidate();
+    expect(component.render(80)).toEqual(narrowLines);
+    // Renders without a width (e.g. older pi-tui callers) fall back to a sane default.
+    expect(component.render().every((line) => visibleLineWidth(line) <= 120)).toBe(true);
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.7).

--- a/code/pi-extension/src/outfitter-extension.js
+++ b/code/pi-extension/src/outfitter-extension.js
@@ -280,10 +280,24 @@ export default function outfitter(pi) {
     await exportRuntimeSystemPrompt(ctx);
     if (ctx.mode !== "tui") return;
     ctx.ui.setHeader((_tui, theme) => {
-      const lines = createStartupHeaderLines(theme, event.reason === "startup" && OUTFITTER_AUTO_OPEN);
+      const firstRun = event.reason === "startup" && OUTFITTER_AUTO_OPEN;
+      let cachedWidth;
+      let cachedLines;
       return {
-        render: () => lines,
-        invalidate: () => undefined,
+        // Pi-tui rejects render output wider than the terminal, so the header
+        // re-fits its lines to every width pi hands it instead of rendering once.
+        render: (width) => {
+          const maxWidth = typeof width === "number" && width > 0 ? width : 120;
+          if (cachedLines === undefined || cachedWidth !== maxWidth) {
+            cachedLines = createStartupHeaderLines(theme, firstRun, maxWidth);
+            cachedWidth = maxWidth;
+          }
+          return cachedLines;
+        },
+        invalidate: () => {
+          cachedWidth = undefined;
+          cachedLines = undefined;
+        },
       };
     });
     updateModeStatus(ctx);
@@ -334,33 +348,37 @@ export default function outfitter(pi) {
   });
 }
 
-const createStartupHeaderLines = (theme, firstRun) => {
-  const brandLine = theme.bold(theme.fg("accent", "Outfitter")) + theme.fg("dim", " + pi");
-  const commandHelp = theme.fg("muted", "/ commands · ! bash · shift+tab mode · ctrl+shift+t thinking · ctrl+o more");
+// Every emitted line must fit maxWidth: pi-tui throws on over-wide render output,
+// which crashed startup in narrow (e.g. 80x24 tmux) terminals. Prose wraps so no
+// words are lost; ASCII art and the brand line truncate because wrapping them is noise.
+const createStartupHeaderLines = (theme, firstRun, maxWidth) => {
   const lines = [];
+  const addTruncated = (line) => lines.push(visibleWidth(line) > maxWidth ? truncateToWidth(line, maxWidth) : line);
+  const addWrapped = (line) => {
+    for (const wrappedLine of wrapTextWithAnsi(line, Math.max(1, maxWidth))) addTruncated(wrappedLine);
+  };
 
   if (OUTFITTER_STARTUP_ASCII_ART) {
-    lines.push(
-      ...OUTFITTER_ASCII_ART.split("\n").map((line, index) => theme.fg(OUTFITTER_ASCII_GRADIENT[index] ?? "accent", line)),
-      "",
+    OUTFITTER_ASCII_ART.split("\n").forEach((line, index) =>
+      addTruncated(theme.fg(OUTFITTER_ASCII_GRADIENT[index] ?? "accent", line)),
     );
+    lines.push("");
   }
 
-  lines.push(brandLine, commandHelp);
+  addTruncated(theme.bold(theme.fg("accent", "Outfitter")) + theme.fg("dim", " + pi"));
+  addWrapped(theme.fg("muted", "/ commands · ! bash · shift+tab mode · ctrl+shift+t thinking · ctrl+o more"));
 
   if (firstRun) {
-    lines.push(
-      "",
-      theme.fg("dim", "Outfitter turns Pi into a configured working environment:"),
-      theme.fg("dim", "• profiles define model, tools, prompts, skills, and extensions"),
-      theme.fg("dim", "• settings can live in your home folder or this project"),
-      theme.fg("dim", "• catalogs let teams share setups through GitHub"),
-    );
+    lines.push("");
+    addWrapped(theme.fg("dim", "Outfitter turns Pi into a configured working environment:"));
+    addWrapped(theme.fg("dim", "• profiles define model, tools, prompts, skills, and extensions"));
+    addWrapped(theme.fg("dim", "• settings can live in your home folder or this project"));
+    addWrapped(theme.fg("dim", "• catalogs let teams share setups through GitHub"));
     return lines;
   }
 
-  lines.push(
-    "",
+  lines.push("");
+  addWrapped(
     theme.fg(
       "dim",
       "Outfitter + Pi can explain its own features and look up its docs. Ask it how to use or extend Pi or outfitter profiles.",


### PR DESCRIPTION
## What was wrong

The Outfitter runtime extension injected into every interactive `pi` launch (`code/pi-extension/src/outfitter-extension.js`) set a startup header whose component ignored the width pi-tui passes to `render(width)` — it returned pre-rendered lines (`render: () => lines`). The returning-user tagline ("Outfitter + Pi can explain its own features…") is 121 visible columns, and pi-tui deliberately throws on over-wide render output, so pi's TUI crashed at startup in any terminal narrower than the header's widest line. Wide interactive terminals never trip it; embedders launching detached sessions (e.g. 80x24 tmux panes) crash instantly, and no flag disables only the header.

## The fix

The header component now implements `render(width)` per pi-tui's contract (docs/tui.md: "Each line from `render()` must not exceed the `width` parameter"):

- `createStartupHeaderLines` takes the render width and fits every line to it: prose (command hints, first-run bullets, tagline) wraps with `wrapTextWithAnsi`; the ASCII art and brand line truncate with `truncateToWidth`, where wrapping would be noise.
- Every wrapped line is additionally truncated as a backstop, so no emitted line can exceed the width at any width.
- Lines are cached per width and recomputed on resize/invalidate; renders without a width fall back to 120 columns.

This mirrors the width handling the extension's `selectDescribedOption` component already did.

## Empirical repro this resolves

Before (this repo's `main`, built locally, run as `outfitter run --profile smoke --agent pi` in a detached `tmux -x 80 -y 24` pane with an isolated `HOME`):

```
pi exiting due to uncaughtException:
Error: Rendered line 10 exceeds terminal width (119 > 80).
    at TUI.doRender (.../@earendil-works/pi-tui/dist/tui.js:1252:23)
    at Timeout._onTimeout (.../pi-tui/dist/tui.js:540:18)
EXIT_STATUS=1
```

After (same command, same 80x24 pane): the full header renders with the tagline wrapped onto two lines, and pi proceeds past the header to its model-provider/login prompt with no exception. A 40x24 pane also boots cleanly. (The isolated `HOME` has no pi auth, so the session stops at the provider prompt — after the header, which is the proof point.)

## Test coverage added

In `code/cli/tests/unit/pi-login-launch.test.ts` (existing vitest harness that stamps and evaluates the real extension):

- Header render at 80, 40, and 20 columns asserts no emitted line exceeds the width (returning-user header).
- First-run header at 80 and 40 columns asserts the same, plus that first-run prose wraps rather than truncates (no words lost).
- Width-change behavior: per-width caching, invalidate, and the no-width fallback staying within 120 columns.

`npm run lint`, `npm run typecheck`, `prettier --check .`, and `npm run coverage` (56 files, 376 tests) all pass.

Fixes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)

