### PR TITLE
docs(concepts): dotagents core model — concepts, agents, settings, catalogs [stack 01/07]

### DIFF
--- a/docs/documentation/README.md
+++ b/docs/documentation/README.md
@@ -1,24 +1,45 @@
 # Outfitter documentation
 
-User-facing Outfitter documentation.
+User-facing Outfitter documentation. These docs describe the [RFC #165](https://github.com/ai-outfitter/outfitter/issues/165) dotagents end state.
+
+## Getting started
 
 - [Getting started](./getting-started.md)
 - [Concepts](./concepts.md)
 - [CLI reference](./cli.md)
 - [First-time CLI agent users](./first-time-cli-agent-users.md)
-- [Switching to Outfitter](./switching-to-outfitter.md)
-- [Profiles](./profiles.md)
-- [Skills](./skills.md) — Define project and profile-bundled skills, route to specialized resources, and compose external references.
-- [Best practices](./best-practices.md) — Prefer a few stable profiles and many focused, progressively disclosed skills.
-- [Profile repositories](./profile-repository.md) — Publish and consume shareable profiles and standalone skills.
-- [Iterating on local and worktree profiles](./iterating-on-profiles.md)
-- [Running profiles in GitHub Actions](./actions.md)
-- [Adapter support matrix](./support-matrix.md)
+
+## Core concepts
+
+- [Settings](./settings.md) — Scopes, schema, and the flat `settings.local.yml` override file.
+- [Agents](./agents.md) — The `agents/<id>/agent.md` resource and its loadout — what you run.
+- [Agent profiles](./profiles.md) — Why an agent and its loadout _is_ the profile.
+- [Personas](./personas.md) — The base-agent-plus-persona-documents review convention.
+- [Subagents](./subagents.md) — Agents projected as harness delegates; leader-agent delegation.
+- [Skills](./skills.md) — Capability packages with progressive disclosure, references, and routing.
+- [Tasks](./tasks.md) — Placeholder for a separate upcoming RFC.
+
+## Operations
+
+- [Catalogs](./catalogs.md) — Publish and consume shareable `.agents` payloads; standalone and colocated layouts.
+- [Dump](./dump-and-bake.md) — Deterministic, self-contained `.agents/` dumps.
+- [Running an agent in GitHub Actions](./actions.md)
+- [Hooks](./hooks.md) — Harness hook wiring and the protocol gap.
 - [State persistence](./state.md)
+- [Adapter support matrix](./support-matrix.md)
+
+## Adopting Outfitter
+
+- [Switching to Outfitter](./switching-to-outfitter.md)
+- [Porting a Claude Code setup](./porting-claude.md) — Port `~/.claude` into `~/.agents/` with a symlink back.
+- [Local dotagents development](./local-development.md) — A personal standalone `.agents` repo that trickles upstream.
+- [Migration from legacy profiles](./migration.md)
+- [Iterating on an agent](./iterating-on-profiles.md)
+- [Best practices](./best-practices.md)
 - [Philosophy](../philosophy.md)
 
 ## Use cases
 
-- [Organization profile catalog](./usecases/organization-profile-catalog.md) — Publish shared team roles so new users can start with organization-approved defaults.
-- [Engineering profile catalog](./usecases/engineering.md) — Package coding, platform, and review profiles for repeatable engineering workflows.
-- [Persona reviews](./usecases/persona-reviews.md) — Create customer personas to get feedback on ideas, documentation, and designs.
+- [Organization catalog](./usecases/organization-profile-catalog.md) — Publish shared org resources and defaults through an `owner/.outfitter` control repository.
+- [Engineering catalog](./usecases/engineering.md) — Package engineering agents and skills for repeatable workflows.
+- [Persona reviews](./usecases/persona-reviews.md) — A base review agent plus customer-persona documents for feedback on ideas, docs, and designs.

--- a/docs/documentation/agents.md
+++ b/docs/documentation/agents.md
@@ -1,0 +1,84 @@
+# Agents
+
+An agent is the protocol's identity resource — and, in Outfitter, the thing you run. A directory under `agents/<id>/` holds an `agent.md` definition and an optional `config.json`. Together they carry both _who the agent is_ and _what it runs with_: its skills, MCP servers, subagents, extensions, plugins, model, thinking level, and tool policy. That whole bundle — identity plus loadout — is what earlier drafts called a "profile." There is no separate profile resource; **an agent is the profile**. See [Profiles](./profiles.md).
+
+```text
+.agents/
+  agents/
+    engineer/
+      agent.md
+      config.json   # optional
+    code-reviewer/
+      agent.md
+```
+
+## agent.md
+
+`agent.md` describes the identity in markdown — who the agent is, its policy and posture, how it approaches work — and declares its loadout in frontmatter:
+
+```markdown
+---
+name: engineer
+description: Implements features and fixes with a bias toward small, verifiable changes.
+skills: [wiki, research]
+subagents: [code-reviewer]
+extensions: [outfitter-mode]
+plugins: [git-tools]
+mcp: [github]
+model: gpt-5.2
+thinking: high
+tools:
+  allow: [read, edit, bash]
+---
+
+# Engineer
+
+You implement changes directly, keep diffs small, and verify before claiming done...
+```
+
+Keep the prose focused on durable identity and behavior. Per-capability procedures belong in [skills](./skills.md); the frontmatter only _selects_ resources by slug — it never copies their content.
+
+### Loadout fields
+
+| Field        | Selects                                                                      |
+| ------------ | ---------------------------------------------------------------------------- |
+| `skills`     | [Skill](./skills.md) slugs made available to the run.                        |
+| `mcp`        | MCP servers from the tree's `mcp.json` to enable.                            |
+| `subagents`  | Agent slugs projected as harness delegates. See [Subagents](./subagents.md). |
+| `extensions` | Pi extensions to load. First-class, per the adapter.                         |
+| `plugins`    | Pi plugins to load. First-class, per the adapter.                            |
+| `model`      | Provider/model from `models.json`.                                           |
+| `thinking`   | Thinking/effort level.                                                       |
+| `tools`      | Allowed/denied tool policy for the run.                                      |
+
+Every value is a slug resolved across layers, so `skills: [wiki]` uses whichever `skills/wiki/` wins by precedence — nothing is duplicated into the agent.
+
+## config.json
+
+The optional `config.json` carries structured or harness-specific configuration that is awkward in frontmatter, following the protocol's schema for the pinned revision. JSON files merge across layers per the protocol's JSON merge behavior, so a workspace layer can adjust one field of a globally defined agent — swap the model, add an extension — without copying the whole definition.
+
+## Tree-level context
+
+Two files at the tree root complement agent definitions:
+
+- `agents.md` — shared operating context that applies to every run from this tree.
+- `system-prompt.md` — the base system prompt an agent's identity layers on top of.
+
+## Running an agent
+
+Select an agent by slug; choose the harness with `--harness`:
+
+```bash
+outfitter run engineer
+outfitter run engineer --harness claude
+```
+
+`default_agent` in [settings](./settings.md) sets what plain `outfitter` runs.
+
+## Resolution
+
+Agents resolve by slug across layers — workspace, global, then remote sources — with merge-by-ID semantics: a workspace `agents/engineer/` overrides a global or remote one. `outfitter list agents` shows every resolvable agent and its winning source; `outfitter validate` reports broken loadout slugs and shadowed definitions.
+
+## Agents as delegates
+
+The same agent definition can also be selected as a [subagent](./subagents.md) in another agent's `subagents` list — a delegate the run can hand focused work to. A leader agent's loadout is where that delegation is declared.

--- a/docs/documentation/catalogs.md
+++ b/docs/documentation/catalogs.md
@@ -1,0 +1,123 @@
+# Catalogs
+
+A catalog is a git repository that publishes a `.agents` payload — agents, skills, tasks, knowledge, commands — so a person, team, or organization can share it. You can bootstrap a machine or project from one, or add one as an ongoing source that Outfitter keeps synchronized.
+
+```bash
+outfitter setup https://github.com/ncrmro/.agents
+```
+
+The repository names are discovery and distribution conventions; the payload is always the same protocol-shaped tree (pinned protocol revision [`502a9d5`](https://github.com/aj47/dotagentsprotocol-website/blob/502a9d5f886d0aad8d3da83c03354bdfa4b389e7/src/components/Structure.astro)):
+
+| Convention                        | Purpose                                                                          |
+| --------------------------------- | -------------------------------------------------------------------------------- |
+| `owner/.agents` or `owner/.agent` | A shareable personal or team catalog.                                            |
+| `owner/.outfitter`                | An organization/control repository distributing org-wide resources and settings. |
+
+## Standalone `.agents` repositories (preferred)
+
+The primary catalog pattern is a standalone repository whose **root is the payload** — the flat dotagents layout:
+
+```text
+ncrmro/.agents/            # repository root
+  agents.md
+  system-prompt.md
+  agents/
+    engineer/agent.md
+    founder/agent.md
+  skills/
+    wiki/SKILL.md
+    research/SKILL.md
+  tasks/
+    weekly-kpis/task.md
+  knowledge/
+  settings.yml             # Outfitter settings (optional; see settings.md)
+  settings.local.yml       # gitignored machine-local overrides
+```
+
+This is the same layout as `~/.agents/` — a standalone catalog is simply a global layer under version control. That makes it the natural home for personal dotagents development: clone it as `~/.agents` (or point your settings at the checkout), iterate locally, and open pull requests to move improvements upstream into shared catalogs. See [Local development](./local-development.md) for the full workflow.
+
+## Colocated `.agents/` directories (fallback)
+
+When agent configuration should travel with a codebase, colocate the payload as a `.agents/` subdirectory beside the code:
+
+```text
+payments-service/
+  .agents/
+    agents/
+    skills/
+    settings.yml
+  src/
+  docs/
+```
+
+The colocated tree doubles as the protocol's workspace overlay: its resources merge by ID over the global and remote layers for anyone running in that project. Prefer the standalone pattern for anything you intend to share across projects; prefer colocation only for resources that are meaningless outside the one repository.
+
+## Consuming a catalog
+
+Add the repository to `sources` in your [settings](./settings.md):
+
+```yaml
+# ~/.agents/settings.yml
+sources:
+  - github: my-org/.agent # owner/repo shorthand
+    ref: 2f9c1ab0d3e44b6f9d2c8a17e5b40c91d6f3a8e2 # pin a commit, tag, or branch
+  - github: my-org/payments-service
+    ref: v1.2.0
+    path: .agents # colocated payload inside the repo
+  - uri: git+https://git.example.com/team/agents.git # any git URI
+```
+
+Each source entry is one of:
+
+- `path:` — a local directory (no `ref`; read live from disk).
+- `github:` — an `owner/repo` GitHub shorthand.
+- `uri:` — any git-cloneable URI, for non-GitHub hosts.
+
+Remote entries additionally accept:
+
+- `ref:` — a tag, branch, or commit to pin. With a `ref`, `outfitter sync` fetches exactly that ref. Without one, sync fast-forwards the default branch.
+- `path:` — the payload directory inside the repository, for colocated layouts.
+
+Resources from all sources resolve by slug behind local layers, following [layer precedence](./concepts.md#layer-precedence). Outfitter reports shadowed IDs so consumers can see which source supplies a selected resource.
+
+## Organization control repositories
+
+An `owner/.outfitter` repository distributes organization-wide resources plus shared settings that Outfitter layers below each user's local settings:
+
+```yaml
+# ~/.agents/settings.yml
+remote_settings:
+  - github: my-org/.outfitter
+    path: .agents/settings.yml # file path inside the repo
+    ref: 9c47d1e2b8a05f36c4d7e90a12b3f8c5d6e71a04
+```
+
+Remote settings are cached locally and merged at lower precedence than your project and user settings, so anything you set locally wins. This is how an organization distributes shared sources, agents, and defaults without controlling each user's machine. See the [organization catalog use case](./usecases/organization-profile-catalog.md).
+
+## Syncing and updating
+
+`outfitter sync` synchronizes every remote source into the local cache:
+
+1. Remote settings repositories are cloned or updated first, then reloaded.
+2. Remote sources (including any added by remote settings) are cloned or updated.
+3. Each synced source is validated; sync reports `updated`, `unchanged`, `skipped`, or `failed` per source.
+
+Pinned (`ref:`) sources stay on their pinned ref until you change it; unpinned sources fast-forward on every sync.
+
+## Private repositories
+
+Private GitHub catalogs are an enterprise feature. When sync detects a private GitHub repository, it asks for confirmation before use and records the decision in your user settings. Review the Outfitter Enterprise license or your enterprise agreement before enabling private catalogs. Non-GitHub `uri:` sources use whatever git credentials your environment already has; credentials embedded in URIs are redacted from sync output.
+
+## Trust and review
+
+Adding a catalog source means trusting its authors with your agent runtime. A catalog's resources can shape prompts and policy (agents, `agents.md`, `system-prompt.md`), add MCP servers (`mcp.json`), and ship skills whose scripts execute on your machine.
+
+Before adding a source, review it:
+
+1. Read the agent definitions, `agents.md`, and `system-prompt.md` you will compose.
+2. Read every skill you will select, including its scripts and catalog-owned `file` references (see the [trust boundary](./skills.md#trust-boundary)).
+3. Review `mcp.json` — MCP servers are code with whatever access you grant them.
+4. Check `remote_settings` targets: a settings file can add further sources you did not review.
+5. Confirm the repository's ownership and that its maintainers are who you expect.
+
+**Pin a `ref:`** — ideally a full commit SHA — for any catalog you do not maintain yourself, and always for catalogs consumed in CI (see [Running tasks in GitHub Actions](./actions.md)). A pinned ref makes updates an explicit, reviewable action — bump the ref after reviewing the diff — instead of silently pulling whatever the catalog publishes next.

--- a/docs/documentation/cli.md
+++ b/docs/documentation/cli.md
@@ -1,5 +1,7 @@
 # CLI reference
 
+> **Status: RFC [#165](https://github.com/ai-outfitter/outfitter/issues/165) target.** This reference describes the dotagents end-state command surface. The currently released CLI still implements the legacy profile commands; implementation PRs replace them incrementally.
+
 Global options:
 
 | Option          | Description                  |
@@ -7,68 +9,59 @@ Global options:
 | `-V, --version` | Print the Outfitter version. |
 | `-h, --help`    | Show help for a command.     |
 
-## `outfitter run [args...]`
+## `outfitter run [agent] [args...]`
 
-Assemble a composite profile and launch the selected agent CLI. `run` is the default command, so plain `outfitter` and `outfitter run` are equivalent.
+Resolve, compose, and launch an agent. `run` is the default command, so plain `outfitter` and `outfitter run` are equivalent.
 
-| Option                    | Description                                                                |
-| ------------------------- | -------------------------------------------------------------------------- |
-| `-p, --profile <profile>` | Outfitter profile id to run. Defaults to the settings `default_profile`.   |
-| `--agent <agent>`         | Agent adapter to launch: `pi` or `claude`. Defaults to `default_agent`.    |
-| `--strict`                | Fail instead of warning when controls cannot be translated by the adapter. |
+| Argument / Option     | Description                                                                      |
+| --------------------- | -------------------------------------------------------------------------------- |
+| `[agent]`             | Agent slug to run. Defaults to the settings `default_agent`.                     |
+| `--harness <harness>` | Harness to launch in: `pi` or `claude`. Defaults to `default_harness`.           |
+| `--strict`            | Fail instead of warning when the adapter cannot project part of the composition. |
 
-Any other arguments and unrecognized options are passed through to the launched agent CLI:
+Any other arguments and unrecognized options are passed through to the launched harness:
 
 ```bash
-outfitter run --profile engineer --agent claude
-outfitter -p data_analyst -- --print "summarize this repo"
+outfitter run engineer --harness claude
+outfitter run reviewer -- --print "summarize this repo"
 ```
-
-On a first interactive launch with no `~/.outfitter/settings.yml`, `outfitter` starts Pi-native onboarding instead of a normal run.
 
 ## `outfitter setup [source]`
 
-Create initial Outfitter settings and a default profile. Setup launches Pi with the Outfitter onboarding extension and finishes profile selection inside the agent session (see [Getting started](./getting-started.md)).
+Create initial Outfitter settings, or adopt an existing configuration. Setup detects an existing `~/.agents/` tree and uses it as-is; if it finds a `~/.claude` directory instead, it offers to [port and symlink it](./porting-claude.md).
 
-| Argument   | Description                                                                                                    |
-| ---------- | -------------------------------------------------------------------------------------------------------------- |
-| `[source]` | Optional setup source: a local path or a git URL of a [profile repository](./profile-repository.md) to import. |
+| Argument   | Description                                                                       |
+| ---------- | --------------------------------------------------------------------------------- |
+| `[source]` | Optional bootstrap source: a local path or git URL of a [catalog](./catalogs.md). |
 
 ## `outfitter sync`
 
-Synchronize URI-backed profile and remote settings sources into the local cache (`~/.outfitter/cache/`). Takes no options. Reports a per-source status of `updated`, `unchanged`, `skipped`, or `failed`, and validates synced profile sources.
+Synchronize remote sources and remote settings into the local cache. Reports a per-source status of `updated`, `unchanged`, `skipped`, or `failed`, and validates synced sources.
 
-## `outfitter profile`
+## `outfitter list [kind]`
 
-List and manage Outfitter profiles.
+List resolvable resources across all layers, with the winning source for each slug and any shadowed IDs.
 
-### `outfitter profile list`
+| Argument | Description                                                   |
+| -------- | ------------------------------------------------------------- |
+| `[kind]` | Optional filter: `agents`, `skills`, `knowledge`, `commands`. |
 
-List available Outfitter profiles.
+## `outfitter validate`
 
-| Option  | Description                                                       |
-| ------- | ----------------------------------------------------------------- |
-| `--all` | Include template profiles that are intended only for inheritance. |
-
-### `outfitter profile create <name>`
-
-Create a new Outfitter profile skeleton.
-
-| Argument / option | Description                                               |
-| ----------------- | --------------------------------------------------------- |
-| `<name>`          | Filesystem-safe profile name.                             |
-| `--scope <scope>` | Destination scope: `user`, `project`, or `project-local`. |
-| `--path <path>`   | Destination profile source directory.                     |
-
-### `outfitter profile lint`
-
-Validate profiles, inheritance, and typed prompt includes.
+Validate the effective resource set: protocol layout, frontmatter, unresolved slugs in agent loadouts, broken or escaping skill references, and settings schema.
 
 | Option     | Description                              |
 | ---------- | ---------------------------------------- |
 | `--strict` | Exit non-zero when warnings are present. |
 | `--json`   | Print diagnostics as JSON.               |
 
-## `outfitter welcome`
+## `outfitter dump`
 
-Run Outfitter welcome onboarding prompts in the terminal. This is a legacy compatibility command: current onboarding runs natively inside Pi (via `outfitter setup` or the first-run `outfitter` launch), and `welcome` remains for environments that need the older terminal prompt flow. Requires an interactive TTY. Takes no options.
+Write the composed resource tree as a self-contained `.agents/` directory for review, vendoring, or air-gapped use. Identical sources, refs, and selections produce byte-identical output; dumps never contain credentials, sessions, caches, or other mutable runtime state.
+
+| Option         | Description                                          |
+| -------------- | ---------------------------------------------------- |
+| `--agent <id>` | Restrict the dump to one agent's transitive closure. |
+| `--out <dir>`  | Destination directory (default `./.agents`).         |
+
+> **Tasks and `outfitter task bake`** — baking a task and its inputs into an immutable execution artifact — are the subject of a separate upcoming RFC and are not part of this command surface yet. See [Tasks](./tasks.md).

--- a/docs/documentation/concepts.md
+++ b/docs/documentation/concepts.md
@@ -4,51 +4,91 @@ How an `outfitter` launch goes from configuration files to a running agent:
 
 ```mermaid
 flowchart LR
-  A[Settings] --> B[Profile sources]
-  B --> C[Profile stack]
-  C --> D[Composite profile]
-  D --> E[Adapter]
-  E --> F[Agent CLI]
+  A[Settings] --> B[Sources]
+  B --> C[.agents layers]
+  C --> D[Resolver]
+  D --> E[Composed agent]
+  E --> F[Adapter]
+  F --> G[Harness]
 ```
 
-Settings tell Outfitter where profiles come from; profile sources supply profile definitions; the definitions for the selected profile form an ordered stack; the merged stack is written out as a composite profile; an adapter translates that composite profile into agent-specific files, flags, and environment variables; and the agent CLI launches with the result.
+Settings tell Outfitter where `.agents` resources come from; sources supply protocol resource trees; the resolver merges the layered trees into one effective resource set; the selected agent composes its loadout — skills, subagents, model, and so on — from that set by slug; and an adapter projects the composed agent into harness-specific files, flags, and environment variables before launching the harness (pi or Claude Code).
 
-## Profile
+## The `.agents` protocol
 
-A profile is a named, reusable YAML definition of how an agent should be outfitted: model and provider, thinking level, system and append prompts, skills, extensions, subagents, DeepWork jobs, CLI arguments, and environment variables. Profiles can inherit from other profiles and can live as a flat `<id>.yml` file or a directory with a `profile.yml` plus bundled resources. See [Profiles](./profiles.md).
+Outfitter stores and exchanges all agent configuration in the vendor-neutral [Dotagents `.agents` protocol](https://dotagentsprotocol.com/) (pinned at revision [`502a9d5`](https://github.com/aj47/dotagentsprotocol-website/blob/502a9d5f886d0aad8d3da83c03354bdfa4b389e7/src/components/Structure.astro)). Outfitter does not define its own authored configuration format: a `.agents/` tree is useful without Outfitter, and any existing `.agents/` tree is usable by Outfitter without conversion.
 
-## Composite profile
+```text
+.agents/
+  agents.md            # shared operating context
+  system-prompt.md     # base system prompt
+  mcp.json             # MCP server configuration
+  models.json          # model configuration
+  agents/<id>/agent.md # agent definitions (+ optional config.json)
+  skills/<id>/...      # Agent Skills packages
+  tasks/<id>/task.md   # named execution contracts
+  knowledge/...        # reference documents
+  commands/...         # slash commands
+```
 
-A composite profile is the temporary runtime configuration directory Outfitter assembles for one profile and one agent CLI run. It contains the generated files the agent needs, is created under the system temp directory, and is owned by Outfitter for the lifetime of the run — durable state is handled separately (see state persistence below).
+## Resources
 
-## Catalog / profile source
+The protocol resources Outfitter resolves and composes:
 
-A profile source is any place profiles are loaded from: a local directory (`path:`), a GitHub repository (`github: owner/repo`), or a git URI (`uri:`). A shared repository of profiles is called a catalog (or profile repository). Remote sources are cached under `~/.outfitter/cache/` and updated with `outfitter sync`; they support `ref` pinning and `only`/`except` filters. See [Profile repositories](./profile-repository.md).
+- **Agent** — a definition at `agents/<id>/agent.md` (plus optional `config.json`) describing an identity _and_ its loadout: the skills, subagents, MCP servers, extensions, plugins, model, thinking level, and tools it runs with. The agent is what you run. See [Agents](./agents.md).
+- **Skill** — a capability package under `skills/<id>/` with instructions, references, scripts, and assets. See [Skills](./skills.md).
+- **Knowledge** and **commands** — reference documents and slash commands shared across runs.
+
+> Tasks — `tasks/<id>/task.md` execution contracts, structured inputs, and baking — are the subject of a separate upcoming RFC and are not part of this end state. See [Tasks](./tasks.md).
+
+## Profiles, personas, and subagents
+
+Three related terms, none of which is a settings key or a separate file format:
+
+- A **[profile](./profiles.md)** is just an agent and its loadout. "The engineer profile" is the `engineer` agent with everything it composes. There is no `profile.yml` and no `profiles:` map — the loadout lives on the agent.
+- A **[persona](./personas.md)** is a _convention_, not a resource: a base review agent (a base prompt plus how-to-review instructions) that reads an interchangeable persona description document — for example `docs/user-personas/coyote-road-runner-chaser.md` — as input. Swapping the input document swaps the persona.
+- A **[subagent](./subagents.md)** is an agent projected into the harness's native delegation mechanism, selected in another agent's `subagents` loadout. A leader agent delegates to local coding-harness subagents or to issue- and action-backed subagents.
+
+The same agent definition can be run directly or selected as a subagent elsewhere; its loadout decides what it composes.
+
+## Layers
+
+Resources resolve across layers, following the protocol's overlay semantics:
+
+1. `<project>/.agents/` — the workspace layer, committed with a project.
+2. `~/.agents/` — the global layer for one developer.
+3. Remote sources — pinned `.agents` payloads from [catalog repositories](./catalogs.md), in configured order.
+
+Resources merge **by ID**: a workspace `skills/wiki/` overrides a global or remote `skills/wiki/`. JSON files such as `mcp.json` and `models.json` follow the protocol's JSON merge behavior. Standalone `.agents` repositories — where the repository root _is_ the payload — are the primary way to develop and share layers; see [Catalogs](./catalogs.md) and [Local development](./local-development.md).
 
 ## Settings scopes
 
-Outfitter reads `settings.yml` from three local scopes — user (`~/.outfitter/settings.yml`), project (`<project>/.outfitter/settings.yml`), and project-local (`<project>/.outfitter/local/settings.yml`, for personal, uncommitted overrides) — plus cached remote settings supplied by `remote_settings` entries. Settings declare the default profile and agent, profile sources, and other launch behavior.
+Outfitter's own settings live inside the `.agents` tree as `settings.yml`, with a flat, gitignored `settings.local.yml` beside it for personal machine-local overrides:
 
-## Controls
+- `~/.agents/settings.yml` — user defaults, plus optional `~/.agents/settings.local.yml`.
+- `<project>/.agents/settings.yml` — committed project settings.
+- `<project>/.agents/settings.local.yml` — personal, uncommitted overrides for that project. This flat file replaces the old nested project-local directory scope.
 
-Controls are the generic, agent-neutral knobs a profile sets: `model`, `provider`, `thinking`, `system_prompt`, `append_system_prompt`, `skills`, `extensions`, `args`, `environment`, and more. Profiles can also nest adapter-specific overrides under `controls.pi` or `controls.claude` when one agent needs different values.
+Settings declare the default agent and harness, resource sources, and launch behavior — not resource selection, which lives on the agent. Removing the settings files leaves a pure protocol tree. See [Settings](./settings.md).
+
+## One resolver
+
+Listing, validation, running, and dumping all share one resolver. What `outfitter list` shows is what `outfitter run` launches and what `outfitter dump` writes. See [Dump](./dump-and-bake.md).
 
 ## Adapters
 
-An adapter translates generic controls into one agent CLI's native configuration — files, command-line flags, and environment variables. Pi is the primary and most complete adapter; a Claude Code adapter is supported with gaps. When an adapter cannot honor a control it warns to stderr, or fails when `--strict` is set. See the [adapter support matrix](./support-matrix.md) for per-adapter coverage.
+An adapter projects composed resources into one agent CLI's native configuration — files, command-line flags, and environment variables. Pi is the primary and most complete adapter; a Claude Code adapter is supported with gaps. When an adapter cannot honor part of a composition it warns to stderr, or fails when `--strict` is set. See the [adapter support matrix](./support-matrix.md).
 
 ## State persistence
 
-Agents write state during a run — auth, native settings, plugins, sessions. Each adapter declares the state paths it understands and how writes are handled (`symlink`, `discard`, `warn`, `error`, or `prompt`), so useful state survives future runs without Outfitter silently copying unknown files. See [State persistence](./state.md).
+Agents write state during a run — auth, native settings, plugins, sessions. Each adapter declares the state paths it understands and how writes are handled (`symlink`, `discard`, `warn`, `error`, or `prompt`), so useful state survives future runs. See [State persistence](./state.md).
 
 ## Layer precedence
 
-When several layers define the same profile or setting, higher layers win:
+When several layers define the same resource ID or setting, higher layers win:
 
-1. Project-local (`.outfitter/local/`)
-2. Project (`.outfitter/`)
-3. User (`~/.outfitter/`)
+1. Project-local settings (`<project>/.agents/settings.local.yml`)
+2. Project (`<project>/.agents/`)
+3. User (`~/.agents/`, with `settings.local.yml` above `settings.yml`)
 4. Cached remote sources (in configured source order)
 5. Built-in defaults
-
-For profiles, explicitly inherited profiles slot between cached remote sources and built-in defaults, in declared order.

--- a/docs/documentation/getting-started.md
+++ b/docs/documentation/getting-started.md
@@ -9,30 +9,44 @@ outfitter --help
 
 Outfitter launches agent CLIs; install the agents you plan to use separately.
 
+## Already have a `.agents/` directory?
+
+You're most of the way there. Outfitter reads the [Dotagents `.agents` protocol](./concepts.md#the-agents-protocol) directly — your existing agents, skills, knowledge, and commands are usable by slug with no conversion:
+
+```bash
+outfitter list          # see what resolves from ~/.agents and <project>/.agents
+outfitter run           # launch with your defaults
+```
+
+Set `default_agent` in `.agents/settings.yml` to one of your [agent](./agents.md) slugs; that agent's own loadout selects the skills, subagents, model, and so on it runs with. You're done.
+
+If your configuration lives in `~/.claude` instead, `outfitter setup` can port it into `~/.agents/` and symlink it back so Claude Code keeps working natively — see [Porting a Claude Code setup](./porting-claude.md).
+
 ## First-time setup
 
-Set up profiles from the Outfitter [default profiles repo](https://github.com/ai-outfitter/default-profiles), then launch the default profile:
+Bootstrap from the Outfitter [default catalog](https://github.com/ai-outfitter/.agent), then launch the default agent:
 
 ```bash
 outfitter setup
 outfitter
 ```
 
-If you are new to Claude Code, Codex, Pi, and agent CLIs, start with [First-time CLI agent users](./first-time-cli-agent-users.md) for YOLO mode, permissions, context engineering, planning mode, subagents, skills, and extension basics. If you already have an agent workflow, use [Switching to Outfitter](./switching-to-outfitter.md) to migrate the smallest durable set of habits first.
+If you are new to Claude Code, Codex, Pi, and agent CLIs, start with [First-time CLI agent users](./first-time-cli-agent-users.md). If you already have an agent workflow, use [Switching to Outfitter](./switching-to-outfitter.md) to adopt the smallest durable set first.
 
-Learn how shared setup sources work in [Profile repositories](./profile-repository.md), then see [Profiles](./profiles.md) for profile composition, inheritance, and prompt examples.
+Learn how shared sources work in [Catalogs](./catalogs.md), then see [Agents](./agents.md), [Agent profiles](./profiles.md), and [Personas](./personas.md) for composition.
 
 ## Common commands
 
 ```bash
-outfitter run --profile engineering-default
-outfitter run --agent claude --profile support
+outfitter run engineer
+outfitter run reviewer --harness claude
 outfitter sync
-outfitter profile list
-outfitter profile create regulated --scope user
+outfitter list agents
+outfitter validate
+outfitter dump --out ./review
 ```
 
-See the [CLI reference](./cli.md) for every command and flag, and [Concepts](./concepts.md) for how settings, profiles, and adapters fit together. (`outfitter welcome` also exists as a legacy compatibility command for the older terminal onboarding prompts; current onboarding runs inside Pi via `outfitter setup`.)
+See the [CLI reference](./cli.md) for every command and flag, and [Concepts](./concepts.md) for how settings, resources, and adapters fit together.
 
 ## Other install options
 

--- a/docs/documentation/profiles.md
+++ b/docs/documentation/profiles.md
@@ -1,183 +1,30 @@
-# Profiles
+# Agent profiles
 
-Profiles define the accoutrements that shape an Outfitter-managed agent launch.
+"Profile" is a description, not a resource or a settings key. There is no `profile.yml`, no `profiles:` map, and no profile file format. What earlier drafts modeled as a standalone profile — a named selection of skills, subagents, model, and so on — is now just an [agent](./agents.md) and its loadout.
 
-A profile can compose:
+## Profiles are agents
 
-- context and prompts
-- model and provider settings
-- Pi extensions
-- skills
-- subagents
-- DeepWork workflows
-- agent-specific CLI flags and environment variables
+An **agent profile** is the whole bundle an agent carries: its identity (`agent.md`) plus the loadout declared in that agent's frontmatter or `config.json` — skills, MCP servers, subagents, extensions, plugins, model, thinking level, and tool policy. When someone says "the engineer profile," they mean the `engineer` agent with everything it composes.
 
-Profiles can be local to a user or project, inherited from other profiles, or loaded from a shared profile repository. See [Profile repositories](./profile-repository.md) for shared setup sources.
+Folding profiles into agents removes a layer of indirection. Instead of a settings map that points at resources that point at an identity, one agent directory holds identity and loadout together, resolves by slug like any other resource, and is what you run:
 
-## Profile layouts
-
-Outfitter supports two profile layouts inside any configured `profile_sources` directory.
-
-### Flat profile layout
-
-Use the flat layout for small profile catalogs where each profile is mostly YAML and does not need its own resource folder. Each `*.yml` or `*.yaml` file directly under the profile source is a profile. If the file omits `id`, Outfitter uses the filename stem as the profile id.
-
-```text
-~/.outfitter/profiles/
-  founder.yml
-  engineer.yml
-  data-analyst.yaml
+```bash
+outfitter run engineer
+outfitter run engineer --harness claude
 ```
 
-```yaml
-# ~/.outfitter/profiles/founder.yml
-label: Founder
-description: Founder-operator defaults for product, engineering, research, and prose.
-controls:
-  append_system_prompt: |
-    Think like a founder-operator: connect product judgment, implementation, and evidence.
-```
+`outfitter list agents` shows every resolvable agent and where each resolves from, including shadowed IDs. Set `default_agent` in [settings](./settings.md) to choose what plain `outfitter` runs.
 
-Flat profiles are easy to scan, diff, and copy between setup repositories. Generated Pi prompt exports for flat profiles are written beside the flat file as `<profile-id>.generated-system-prompt.md` when `profile_export` is enabled.
+## Where the loadout lives
 
-### Directory profile layout
+The loadout lives on the agent, not in settings. Add or change what an agent composes by editing that agent's `agents/<id>/agent.md` frontmatter or `config.json` — see [Agents](./agents.md#loadout-fields) for the field list. To override just one field from a higher layer (swap the model, add an extension) without redefining the agent, put it in the agent's `config.json`: JSON files shallow-merge by key across layers. An `agent.md` resolves whole-resource by ID — the winning layer's `agent.md` replaces lower ones rather than field-merging — so a partial `agent.md` would discard the base identity.
 
-The original layout is one folder per profile with a required `profile.yml`. Use it when a profile owns prompts, skills, extensions, DeepWork jobs, or CLI-specific files that should travel with that profile.
+Settings ([settings.md](./settings.md)) is left with just resolution and launch concerns — `default_agent`, `default_harness`, `sources`, and state policy — not resource selection.
 
-```text
-~/.outfitter/profiles/
-  home-default/
-    profile.yml
-    prompts/
-      system.md
-    skills/
-    extensions/
-    deepwork/
-      jobs/
-    cli_specific/
-      pi/
-```
+## Composing from a base
 
-```yaml
-# ~/.outfitter/profiles/home-default/profile.yml
-id: home-default
-label: Home Default
-controls:
-  system_prompt: ./prompts/system.md
-  skills:
-    - ./skills/review
-```
+To share behavior across several agents, keep shared operating context in the tree's `system-prompt.md` and `agents.md` — every agent in the tree inherits those — and put shared procedures in [skills](./skills.md) each agent selects. Selecting an agent as a subagent does _not_ share its policy; it only makes that agent available as a delegation target. The [persona](./personas.md) convention builds on the shared-context idea: one base review agent, many interchangeable persona description documents fed as input.
 
-Directory profiles keep bundled resources close to the profile that references them. Generated Pi prompt exports for directory profiles are written as `generated-system-prompt.md` inside the profile directory when `profile_export` is enabled.
+## Migrating from authored profiles
 
-## Home and project example
-
-A home profile SHOULD hold reusable defaults for one developer.
-A project profile SHOULD live with the repository and add only the behavior that project needs.
-The comments below name the files; each `---` starts a separate YAML document in the same example block.
-
-```yaml
-# ~/.outfitter/settings.yml
-default_profile: home-default
-default_agent: pi
-profile_sources:
-  - path: ./profiles
-
----
-# ~/.outfitter/profiles/home-default.yml
-id: home-default
-label: Home Default
-description: Reusable personal defaults for Outfitter-managed Pi runs.
-controls:
-  provider: openai-codex
-  model: gpt-5.5
-  thinking: high
-  append_system_prompt:
-    - |
-      Use concise, evidence-backed engineering prose.
-      Prefer small, reviewable changes.
-      Keep durable decisions in repo files.
-    - file: prompts/personal-policy.md
-    - repo_file: docs/mission.md
-
----
-# ~/repos/acme/example/.outfitter/settings.yml
-default_profile: acme-example
-profile_export: true
-profile_sources:
-  # Relative to this settings.yml; exposes ~/.outfitter/profiles to the project.
-  - path: ../../../../.outfitter/profiles
-    only:
-      - home-default
-  - path: ./profiles
-
----
-# ~/repos/acme/example/.outfitter/profiles/acme-example/profile.yml
-id: acme-example
-label: Acme Example
-description: Checked-in project profile for ~/repos/acme/example.
-inherits:
-  - home-default
-controls:
-  thinking: xhigh
-  append_system_prompt:
-    - |
-      You are working in ~/repos/acme/example.
-      Honor the project test contract before calling work complete.
-      Prefer repository-local conventions over personal defaults.
-    - file: .outfitter/prompts/review-policy.md
-  environment:
-    ACME_PROJECT: example
-```
-
-`home-default` is the home-folder profile: it supplies personal defaults that can work across repositories.
-`acme-example` is the project profile: it inherits those defaults, then overrides the thinking level and adds project-specific prompt and environment settings.
-When a project `settings.yml` declares `profile_sources`, it SHOULD include any home profile source that project profiles inherit from.
-Because `append_system_prompt` composes instead of replacing, the higher-precedence project prompt is passed first and the inherited home prompt follows.
-Typed prompt includes read `{ file: string }` entries before launch and pass the file contents as repeated append-prompt text. Raw strings remain literal prompt text; if a raw string looks like a whole file path, Outfitter warns so the profile can be migrated to `{ file: ... }`.
-
-### Append prompt file includes
-
-`append_system_prompt` accepts a literal string, a multiline string, `{ file: string }`, `{ repo_file: string }`, or an ordered list mixing those entry types. Outfitter does not support `{ text: ... }`; use raw YAML strings for inline prompt text, `{ file: ... }` for maintained profile/catalog files, and `{ repo_file: ... }` for files that should come from the active project.
-
-Profile-owned file includes resolve from the source root of the profile layer that declares the entry, including inherited layers:
-
-| Declaring profile location                                                         | Include root               |
-| ---------------------------------------------------------------------------------- | -------------------------- |
-| `~/.outfitter/profiles/<id>/profile.yml` or `~/.outfitter/profiles/<id>.yml`       | `~/.outfitter`             |
-| `<project>/.outfitter/profiles/<id>/profile.yml`                                   | `<project>`                |
-| Catalog repo `outfitter/profiles/<id>/profile.yml`                                 | Catalog repository root    |
-| Explicit `profile_sources[].path` without `.outfitter/` or `outfitter/` convention | The configured source path |
-
-`repo_file:` resolves from the active project directory where Outfitter launches the agent. This lets a reusable catalog or home profile request project-local governance context such as `docs/mission.md` without copying those docs into the catalog.
-
-Run `outfitter profile lint` to report schema and inheritance errors, missing typed include files, and raw string append-prompt entries that look like file paths. Add `--strict` to exit non-zero for warnings, and `--json` for machine-readable diagnostics.
-
-With `profile_export: true`, the selected project directory profile can write `generated-system-prompt.md` beside `profile.yml`.
-For this example, the generated prompt fallback would show the composed prompt inputs like this:
-
-```text
-<!-- Generated by Outfitter from Pi runtime ctx.getSystemPrompt(). Safe to review or git-ignore. Do not edit by hand. -->
-# Generated Pi runtime system prompt
-
-You are an expert coding assistant operating inside pi, a coding agent harness. You help users by reading files, executing commands, editing code, and writing new files.
-
-Available tools:
-- read: Read file contents
-- bash: Execute bash commands (ls, grep, find, etc.)
-- edit: Make precise file edits with exact text replacement, including multiple disjoint edits in one call
-
-....
-
-## append_system_prompt[0]
-
-You are working in ~/repos/acme/example.
-Honor the project test contract before calling work complete.
-Prefer repository-local conventions over personal defaults.
-
-## append_system_prompt[1]
-
-Use concise, evidence-backed engineering prose.
-Prefer small, reviewable changes.
-Keep durable decisions in repo files.
-```
+Earlier Outfitter versions defined profiles as authored YAML files (`.outfitter/profiles/`, `profile.yml`, inheritance, `controls`). That system is removed with no compatibility mode. See the [migration reference](./migration.md) for the manual mapping from the legacy format to agents and their loadouts.

--- a/docs/documentation/settings.md
+++ b/docs/documentation/settings.md
@@ -1,0 +1,61 @@
+# Settings
+
+Outfitter settings configure how resources are resolved and launched. They live inside the `.agents` tree so a tree carries everything it needs, and they are the only Outfitter-specific files in it — deleting them leaves a pure protocol payload.
+
+Settings do not carry resource selections. An agent's loadout — its skills, subagents, model, and so on — lives on the [agent](./agents.md), not here. Settings is only about where resources come from and how a run launches.
+
+## Scopes
+
+| Scope         | File                                                       | Purpose                                                        |
+| ------------- | ---------------------------------------------------------- | -------------------------------------------------------------- |
+| Project-local | `<project>/.agents/settings.local.yml`                     | Personal, uncommitted overrides for one machine. Gitignore it. |
+| Project       | `<project>/.agents/settings.yml`                           | Committed settings shared by everyone on the project.          |
+| User          | `~/.agents/settings.yml` (+ optional `settings.local.yml`) | Personal defaults across projects.                             |
+| Remote        | Cached files from `remote_settings`                        | Organization-distributed defaults.                             |
+
+`settings.local.yml` is a flat file beside `settings.yml` — there is no nested local directory. It overlays its sibling with the same schema and higher precedence, and is the natural home for machine-specific values such as absolute paths to local checkouts (see [Local development](./local-development.md)).
+
+In a standalone `.agents` repository the repository root is the tree, so the files are simply `settings.yml` and `settings.local.yml` at the root.
+
+## Schema
+
+```yaml
+# .agents/settings.yml
+default_agent: engineer # which agent runs by default
+default_harness: pi # which harness to launch: pi or claude
+
+# Where protocol resources come from, beyond this tree and ~/.agents.
+sources:
+  - github: ai-outfitter/.agent # owner/repo shorthand
+    ref: 2f9c1ab0d3e44b6f9d2c8a17e5b40c91d6f3a8e2 # pin a commit, tag, or branch
+    # path: optional subdirectory containing the payload
+  - uri: git+https://git.example.com/team/agents.git
+    ref: v1.2.0
+  - path: ../shared-agents # local directory, read live from disk
+
+# Organization-distributed settings, layered below local settings.
+remote_settings:
+  - github: my-org/.outfitter
+    path: .agents/settings.yml
+    ref: 9c47d1e2b8a05f36c4d7e90a12b3f8c5d6e71a04
+
+cache_directory: ~/.agents/cache
+```
+
+- `default_agent` / `default_harness` — which agent plain `outfitter` runs, and the harness it launches in.
+- `sources` — ordered list of remote or local `.agents` payloads. Remote entries (`github:` / `uri:`) accept `ref:` pinning and an optional `path:` to the payload inside the repository; see [Catalogs](./catalogs.md) for conventions and trust guidance.
+- `remote_settings` — shared settings a repository distributes; cached locally and merged below your project and user settings, so anything you set locally wins.
+- `cache_directory` — where remote sources are cached (`outfitter sync` updates them).
+
+## Precedence
+
+Higher wins:
+
+1. `<project>/.agents/settings.local.yml`
+2. `<project>/.agents/settings.yml`
+3. `~/.agents/settings.local.yml`
+4. `~/.agents/settings.yml`
+5. Cached remote settings (in configured order)
+6. Built-in defaults
+
+Scalar settings override; list-valued settings such as `sources` follow last-wins ordering per scope so a local file can reorder or replace where resources come from.


### PR DESCRIPTION
**Stack 01/07** of the RFC #165 dotagents docs end state, topic-sliced from #169 so each PR is self-consistent and Copilot-reviewable. Squash-merged onto `main` in order; final human review before release.

## This slice — core concepts & resource model
- `concepts.md` — `.agents` protocol pipeline and resource model
- `agents.md` — agent = identity (`agent.md`) + loadout (`config.json`); the anchor doc
- `profiles.md` — profiles fold into agents ("an agent is the profile")
- `settings.md` — schema: `default_agent`/`default_harness`/`sources` (no `profiles:` map)
- `catalogs.md` — shared sources & trust
- `cli.md` — `outfitter run <agent-id>`, `--harness pi|claude`, `list agents`
- `README.md` (docs index), `getting-started.md`

Docs-only. Internal links to docs that land in later slices are temporarily dangling on `main` and converge by slice 07.

🤖 Generated with [Claude Code](https://claude.com/claude-code)