### PR TITLE
refactor(settings): .agents settings + agent/harness model [rfc-165 impl 1/4]

### DIFF
--- a/code/cli/src/schemas/settings.schema.json
+++ b/code/cli/src/schemas/settings.schema.json
@@ -4,10 +4,14 @@
   "title": "Outfitter settings",
   "type": "object",
   "properties": {
-    "default_profile": { "type": "string", "minLength": 1 },
-    "default_agent": { "enum": ["pi", "claude"] },
+    "default_agent": { "type": "string", "minLength": 1 },
+    "default_harness": { "enum": ["pi", "claude"] },
     "cache_directory": { "type": "string", "minLength": 1 },
-    "profile_export": { "type": "boolean" },
+    "state_persistence": {
+      "type": "object",
+      "description": "Maps adapter-declared state paths to a persistence strategy.",
+      "additionalProperties": { "enum": ["symlink", "discard", "warn", "error", "prompt"] }
+    },
     "startup": {
       "type": "object",
       "description": "Controls Outfitter startup presentation inside launched agents.",
@@ -21,18 +25,32 @@
     },
     "enterprise": {
       "type": "object",
-      "description": "Enterprise governance settings. User-home ~/.outfitter/settings.yml is the source of truth for these controls.",
+      "description": "Enterprise governance settings. User-home ~/.agents/settings.yml is the source of truth for these controls.",
       "properties": {
-        "private_profile_catalogs": {
+        "private_catalogs": {
           "type": "boolean",
-          "description": "Enable confirmed-private GitHub profile catalogs after reviewing the Outfitter Enterprise license or enterprise agreement."
+          "description": "Enable confirmed-private GitHub catalogs after reviewing the Outfitter Enterprise license or enterprise agreement."
         }
       },
       "additionalProperties": false
     },
-    "profile_sources": {
+    "sources": {
       "type": "array",
-      "items": { "$ref": "profile-source.schema.json" }
+      "items": {
+        "type": "object",
+        "oneOf": [
+          { "required": ["path"], "not": { "anyOf": [{ "required": ["uri"] }, { "required": ["github"] }] } },
+          { "required": ["uri"], "not": { "required": ["github"] } },
+          { "required": ["github"], "not": { "required": ["uri"] } }
+        ],
+        "properties": {
+          "path": { "type": "string", "minLength": 1 },
+          "uri": { "type": "string", "minLength": 1 },
+          "github": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$" },
+          "ref": { "type": "string", "minLength": 1 }
+        },
+        "additionalProperties": false
+      }
     },
     "remote_settings": {
       "type": "array",
@@ -53,7 +71,7 @@
     },
     "custom_settings": {
       "type": "object",
-      "description": "Arbitrary YAML-compatible values exposed to Outfitter compositeProfile templates as outfitter.custom_settings."
+      "description": "Arbitrary YAML-compatible values exposed to Outfitter composition templates as outfitter.custom_settings."
     }
   },
   "additionalProperties": true

--- a/code/cli/src/schemas/settings.schema.json
+++ b/code/cli/src/schemas/settings.schema.json
@@ -39,7 +39,12 @@
       "items": {
         "type": "object",
         "oneOf": [
-          { "required": ["path"], "not": { "anyOf": [{ "required": ["uri"] }, { "required": ["github"] }] } },
+          {
+            "required": ["path"],
+            "not": {
+              "anyOf": [{ "required": ["uri"] }, { "required": ["github"] }, { "required": ["ref"] }]
+            }
+          },
           { "required": ["uri"], "not": { "required": ["github"] } },
           { "required": ["github"], "not": { "required": ["uri"] } }
         ],

--- a/code/cli/src/settings/Settings.ts
+++ b/code/cli/src/settings/Settings.ts
@@ -18,13 +18,15 @@ export type Harness = 'pi' | 'claude';
 export type StatePersistenceStrategy = 'symlink' | 'discard' | 'warn' | 'error' | 'prompt';
 export type StatePersistence = Readonly<Record<string, StatePersistenceStrategy>>;
 
-/** An ordered `.agents` payload source: a local path, a remote URI, or a `github` shorthand. */
-export interface SourceReference {
-  readonly path?: string;
-  readonly uri?: string;
-  readonly github?: string;
-  readonly ref?: string;
-}
+/**
+ * An ordered `.agents` payload source: a local path, a remote URI, or a `github` shorthand.
+ * Modeled as a discriminated union so exactly one of `path`/`uri`/`github` is present and `ref`
+ * is available only for remote sources.
+ */
+export type SourceReference =
+  | { readonly path: string; readonly uri?: never; readonly github?: never; readonly ref?: never }
+  | { readonly uri: string; readonly github?: never; readonly ref?: string; readonly path?: string }
+  | { readonly github: string; readonly uri?: never; readonly ref?: string; readonly path?: string };
 
 export interface StartupSettings {
   readonly asciiArt?: boolean;

--- a/code/cli/src/settings/Settings.ts
+++ b/code/cli/src/settings/Settings.ts
@@ -1,32 +1,54 @@
 // Defines the internal Settings shape produced from Outfitter settings files.
-import type { ProfileSourceReference, RemoteSourceReference } from '../profiles/ProfileSource.js';
+import type { RemoteSourceReference } from '../profiles/ProfileSource.js';
 
 export type RemoteSettingsReference = RemoteSourceReference & { readonly path: string };
 export type SettingsValue =
-  string | number | boolean | null | readonly SettingsValue[] | { readonly [key: string]: SettingsValue };
+  | string
+  | number
+  | boolean
+  | null
+  | readonly SettingsValue[]
+  | { readonly [key: string]: SettingsValue };
 export type CustomSettings = Readonly<Record<string, SettingsValue>>;
+
+/** Harnesses Outfitter can launch a composed agent in. */
+export type Harness = 'pi' | 'claude';
+
+/** Functional persistence strategies for adapter-declared state paths. */
+export type StatePersistenceStrategy = 'symlink' | 'discard' | 'warn' | 'error' | 'prompt';
+export type StatePersistence = Readonly<Record<string, StatePersistenceStrategy>>;
+
+/** An ordered `.agents` payload source: a local path, a remote URI, or a `github` shorthand. */
+export interface SourceReference {
+  readonly path?: string;
+  readonly uri?: string;
+  readonly github?: string;
+  readonly ref?: string;
+}
 
 export interface StartupSettings {
   readonly asciiArt?: boolean;
 }
 
 export interface EnterpriseSettings {
-  readonly privateProfileCatalogs?: boolean;
+  readonly privateCatalogs?: boolean;
 }
 
 export interface Settings {
-  readonly defaultProfile?: string;
+  /** Agent slug that plain `outfitter` runs when no agent is selected. */
   readonly defaultAgent?: string;
-  readonly profileSources?: readonly ProfileSourceReference[];
+  /** Harness that plain `outfitter` launches when `--harness` is omitted. */
+  readonly defaultHarness?: Harness;
+  readonly sources?: readonly SourceReference[];
   readonly remoteSettings?: readonly RemoteSettingsReference[];
   readonly cacheDirectory?: string;
+  readonly statePersistence?: StatePersistence;
   readonly customSettings?: CustomSettings;
-  readonly profileExport?: boolean;
   readonly startup?: StartupSettings;
   readonly enterprise?: EnterpriseSettings;
 }
 
 export const emptySettings = (): Settings => ({
-  profileSources: [],
+  sources: [],
   remoteSettings: [],
 });

--- a/code/cli/src/settings/SettingsLoader.ts
+++ b/code/cli/src/settings/SettingsLoader.ts
@@ -3,15 +3,20 @@ import { existsSync, readFileSync } from 'node:fs';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 
 import { createRemoteRepositoryCachePath, resolveRemoteRepositorySubpath } from '../profiles/ProfileCache.js';
-import type { ProfileSourceReference } from '../profiles/ProfileSource.js';
 import type { ValidationIssue } from '../validation/SchemaValidator.js';
 import { validateSchema } from '../validation/SchemaValidator.js';
 import { parseYamlDocument } from '../validation/YamlDocument.js';
-import type { CustomSettings, RemoteSettingsReference, Settings } from './Settings.js';
+import type {
+  CustomSettings,
+  RemoteSettingsReference,
+  Settings,
+  SourceReference,
+  StatePersistence,
+} from './Settings.js';
 import { mergeSettingsStack } from './SettingsMerger.js';
 
 export interface SettingsLocation {
-  readonly scope: 'user' | 'project' | 'project-local' | 'remote';
+  readonly scope: 'user' | 'user-local' | 'project' | 'project-local' | 'remote';
   readonly path: string;
 }
 
@@ -38,32 +43,30 @@ export interface SettingsLoadIssue extends ValidationIssue {
 }
 
 interface SettingsDocument {
-  readonly default_profile?: string;
   readonly default_agent?: string;
-  readonly profile_sources?: readonly ProfileSourceDocument[];
+  readonly default_harness?: 'pi' | 'claude';
+  readonly sources?: readonly SourceDocument[];
   readonly remote_settings?: readonly RemoteSettingsDocument[];
   readonly cache_directory?: string;
+  readonly state_persistence?: StatePersistence;
   readonly custom_settings?: CustomSettings;
-  readonly profile_export?: boolean;
   readonly startup?: StartupSettingsDocument;
   readonly enterprise?: EnterpriseSettingsDocument;
 }
 
 interface EnterpriseSettingsDocument {
-  readonly private_profile_catalogs?: boolean;
+  readonly private_catalogs?: boolean;
 }
 
 interface StartupSettingsDocument {
   readonly ascii_art?: boolean;
 }
 
-interface ProfileSourceDocument {
+interface SourceDocument {
   readonly path?: string;
   readonly uri?: string;
   readonly github?: string;
   readonly ref?: string;
-  readonly only?: readonly string[];
-  readonly except?: readonly string[];
 }
 
 interface RemoteSettingsDocument {
@@ -82,11 +85,15 @@ export const createSettingsLoadPlan = (locations: readonly SettingsLocation[]): 
   locations,
 });
 
+const agentsSettings = (directory: string, ...rest: string[]): string => join(directory, '.agents', ...rest);
+
+// Ordered lowest-to-highest precedence so later files fold over earlier ones during merge.
 export const discoverSettingsLoadPlan = (input: SettingsDiscoveryInput): SettingsLoadPlan =>
   createSettingsLoadPlan([
-    { scope: 'user', path: join(input.homeDirectory, '.outfitter', 'settings.yml') },
-    { scope: 'project', path: join(input.projectDirectory, '.outfitter', 'settings.yml') },
-    { scope: 'project-local', path: join(input.projectDirectory, '.outfitter', 'local', 'settings.yml') },
+    { scope: 'user', path: agentsSettings(input.homeDirectory, 'settings.yml') },
+    { scope: 'user-local', path: agentsSettings(input.homeDirectory, 'settings.local.yml') },
+    { scope: 'project', path: agentsSettings(input.projectDirectory, 'settings.yml') },
+    { scope: 'project-local', path: agentsSettings(input.projectDirectory, 'settings.local.yml') },
   ]);
 
 export const discoverRemoteSettingsLoadPlan = (
@@ -102,8 +109,8 @@ export const resolveCachedRemoteSettingsPath = (homeDirectory: string, source: R
     return configuredPath;
   }
 
-  const nestedOutfitterSettingsPath = resolveRemoteRepositorySubpath(repositoryPath, '.outfitter/settings.yml');
-  return existsSync(nestedOutfitterSettingsPath) ? nestedOutfitterSettingsPath : configuredPath;
+  const nestedAgentsSettingsPath = resolveRemoteRepositorySubpath(repositoryPath, '.agents/settings.yml');
+  return existsSync(nestedAgentsSettingsPath) ? nestedAgentsSettingsPath : configuredPath;
 };
 
 export const loadSettingsFiles = (plan: SettingsLoadPlan): SettingsLoadResult => {
@@ -217,16 +224,16 @@ const addSettingsFile = (
 };
 
 const convertSettingsDocument = (document: SettingsDocument, settingsDirectory: string): Settings => ({
-  defaultProfile: document.default_profile,
   defaultAgent: document.default_agent,
-  profileSources: document.profile_sources?.map((source) => convertProfileSource(source, settingsDirectory)),
+  defaultHarness: document.default_harness,
+  sources: document.sources?.map((source) => convertSource(source, settingsDirectory)),
   remoteSettings: document.remote_settings?.map(convertRemoteSettingsSource),
   cacheDirectory:
     document.cache_directory === undefined
       ? undefined
       : resolveConfigDirectory(document.cache_directory, settingsDirectory),
+  statePersistence: document.state_persistence,
   customSettings: document.custom_settings,
-  profileExport: document.profile_export,
   startup: convertStartupSettings(document.startup),
   enterprise: convertEnterpriseSettings(document.enterprise),
 });
@@ -235,7 +242,7 @@ const convertStartupSettings = (startup: StartupSettingsDocument | undefined): S
   startup === undefined ? undefined : { asciiArt: startup.ascii_art };
 
 const convertEnterpriseSettings = (enterprise: EnterpriseSettingsDocument | undefined): Settings['enterprise'] =>
-  enterprise === undefined ? undefined : { privateProfileCatalogs: enterprise.private_profile_catalogs };
+  enterprise === undefined ? undefined : { privateCatalogs: enterprise.private_catalogs };
 
 const convertRemoteSettingsSource = (source: RemoteSettingsDocument): RemoteSettingsReference => {
   if (source.uri !== undefined) {
@@ -245,25 +252,17 @@ const convertRemoteSettingsSource = (source: RemoteSettingsDocument): RemoteSett
   return { github: source.github!, ref: source.ref, path: source.path };
 };
 
-const convertProfileSource = (source: ProfileSourceDocument, settingsDirectory: string): ProfileSourceReference => {
-  const filters = {
-    only: source.only,
-    except: source.except,
-  };
-
+const convertSource = (source: SourceDocument, settingsDirectory: string): SourceReference => {
   if (source.uri !== undefined) {
-    return { ...filters, uri: source.uri, ref: source.ref, path: source.path };
+    return { uri: source.uri, ref: source.ref, path: source.path };
   }
 
   if (source.github !== undefined) {
-    return { ...filters, github: source.github, ref: source.ref, path: source.path };
+    return { github: source.github, ref: source.ref, path: source.path };
   }
 
-  return { ...filters, path: resolveProfileSourcePath(source.path!, settingsDirectory) };
+  return { path: resolveConfigDirectory(source.path!, settingsDirectory) };
 };
-
-const resolveProfileSourcePath = (sourcePath: string, settingsDirectory: string): string =>
-  resolveConfigDirectory(sourcePath, settingsDirectory);
 
 const resolveConfigDirectory = (configuredPath: string, settingsDirectory: string): string => {
   if (isAbsolute(configuredPath)) {

--- a/code/cli/src/settings/SettingsLoader.ts
+++ b/code/cli/src/settings/SettingsLoader.ts
@@ -219,11 +219,19 @@ const addSettingsFile = (
 
   files.push({
     location,
-    settings: convertSettingsDocument(parsed.document as SettingsDocument, dirname(location.path)),
+    settings: convertSettingsDocument(parsed.document as SettingsDocument, dirname(location.path), location.scope),
   });
 };
 
-const convertSettingsDocument = (document: SettingsDocument, settingsDirectory: string): Settings => ({
+// Enterprise governance controls are honored only from the user's own ~/.agents settings so a
+// checked-in project or remote catalog cannot enable private catalogs on the user's behalf.
+const isHomeScope = (scope: SettingsLocation['scope']): boolean => scope === 'user' || scope === 'user-local';
+
+const convertSettingsDocument = (
+  document: SettingsDocument,
+  settingsDirectory: string,
+  scope: SettingsLocation['scope'],
+): Settings => ({
   defaultAgent: document.default_agent,
   defaultHarness: document.default_harness,
   sources: document.sources?.map((source) => convertSource(source, settingsDirectory)),
@@ -235,7 +243,7 @@ const convertSettingsDocument = (document: SettingsDocument, settingsDirectory: 
   statePersistence: document.state_persistence,
   customSettings: document.custom_settings,
   startup: convertStartupSettings(document.startup),
-  enterprise: convertEnterpriseSettings(document.enterprise),
+  enterprise: isHomeScope(scope) ? convertEnterpriseSettings(document.enterprise) : undefined,
 });
 
 const convertStartupSettings = (startup: StartupSettingsDocument | undefined): Settings['startup'] =>

--- a/code/cli/src/settings/SettingsMerger.ts
+++ b/code/cli/src/settings/SettingsMerger.ts
@@ -1,51 +1,49 @@
 /* eslint-disable complexity */
 // Provides deterministic Settings merge scaffolding.
 import { mergeObjectsWithPolicy } from '../merge/SettingsValueMerger.js';
-import type { CustomSettings, Settings } from './Settings.js';
+import type { CustomSettings, Settings, StatePersistence } from './Settings.js';
 import { emptySettings } from './Settings.js';
 
 export const mergeSettingsStack = (settingsStack: readonly Settings[]): Settings => {
-  let defaultProfile: string | undefined;
   let defaultAgent: string | undefined;
-  let profileSources: Settings['profileSources'];
+  let defaultHarness: Settings['defaultHarness'];
+  let sources: Settings['sources'];
   let remoteSettings: Settings['remoteSettings'];
   let cacheDirectory: string | undefined;
+  let statePersistence: StatePersistence | undefined;
   let customSettings: CustomSettings | undefined;
-  let profileExport: boolean | undefined;
   let startup: Settings['startup'];
   let enterprise: Settings['enterprise'];
 
   for (const settings of settingsStack) {
-    defaultProfile = settings.defaultProfile ?? defaultProfile;
     defaultAgent = settings.defaultAgent ?? defaultAgent;
+    defaultHarness = settings.defaultHarness ?? defaultHarness;
 
-    profileSources = settings.profileSources ?? profileSources;
+    sources = settings.sources ?? sources;
     remoteSettings = settings.remoteSettings ?? remoteSettings;
     cacheDirectory = settings.cacheDirectory ?? cacheDirectory;
+    statePersistence =
+      settings.statePersistence === undefined
+        ? statePersistence
+        : { ...statePersistence, ...settings.statePersistence };
     customSettings = mergeOptionalCustomSettings(customSettings, settings.customSettings);
-    profileExport = mergeOptionalBoolean(profileExport, settings.profileExport);
     startup = settings.startup === undefined ? startup : { ...startup, ...settings.startup };
     enterprise = settings.enterprise === undefined ? enterprise : { ...enterprise, ...settings.enterprise };
   }
 
   return {
     ...emptySettings(),
-    defaultProfile,
     defaultAgent,
-    profileSources: profileSources ?? [],
+    defaultHarness,
+    sources: sources ?? [],
     remoteSettings: remoteSettings ?? [],
     cacheDirectory,
+    statePersistence: statePersistence ?? {},
     customSettings: customSettings ?? {},
-    profileExport,
     startup: startup ?? {},
     enterprise: enterprise ?? {},
   };
 };
-
-const mergeOptionalBoolean = (
-  lowerPrecedence: boolean | undefined,
-  higherPrecedence: boolean | undefined,
-): boolean | undefined => higherPrecedence ?? lowerPrecedence;
 
 const mergeOptionalCustomSettings = (
   lowerPrecedence: CustomSettings | undefined,

--- a/code/cli/tests/unit/settings-loader.test.ts
+++ b/code/cli/tests/unit/settings-loader.test.ts
@@ -98,17 +98,18 @@ describe('settings loading', () => {
     expect(loaded.settings.defaultHarness).toBe('pi');
   });
 
-  it('loads and merges startup display and enterprise settings', () => {
+  it('merges startup display across scopes but honors enterprise controls only from home', () => {
     const root = createTemporaryRoot();
     const homeDirectory = join(root, 'home');
     const projectDirectory = join(root, 'project');
+    // Home enables private catalogs; a checked-in project MUST NOT be able to flip it.
     writeSettings(
       join(homeDirectory, '.agents', 'settings.yml'),
-      'startup:\n  ascii_art: true\nenterprise:\n  private_catalogs: false\n',
+      'startup:\n  ascii_art: true\nenterprise:\n  private_catalogs: true\n',
     );
     writeSettings(
       join(projectDirectory, '.agents', 'settings.yml'),
-      'startup:\n  ascii_art: false\nenterprise:\n  private_catalogs: true\n',
+      'startup:\n  ascii_art: false\nenterprise:\n  private_catalogs: false\n',
     );
 
     const loaded = loadSettings(discoverSettingsLoadPlan({ homeDirectory, projectDirectory }));
@@ -116,6 +117,18 @@ describe('settings loading', () => {
     expect(loaded.issues).toEqual([]);
     expect(loaded.settings.startup).toEqual({ asciiArt: false });
     expect(loaded.settings.enterprise).toEqual({ privateCatalogs: true });
+  });
+
+  it('ignores enterprise controls set outside home settings', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    writeSettings(join(projectDirectory, '.agents', 'settings.yml'), 'enterprise:\n  private_catalogs: true\n');
+
+    const loaded = loadSettings(discoverSettingsLoadPlan({ homeDirectory, projectDirectory }));
+
+    expect(loaded.issues).toEqual([]);
+    expect(loaded.settings.enterprise).toEqual({});
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.8).
@@ -184,6 +197,20 @@ describe('settings loading', () => {
     expect(result.files[0]?.settings.remoteSettings).toEqual([
       { github: 'example/outfitter-config', ref: 'main', path: 'settings.yml' },
     ]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('rejects a local source that specifies ref, which is only valid for remote sources', () => {
+    const root = createTemporaryRoot();
+    const settingsPath = join(root, '.agents', 'settings.yml');
+    writeSettings(settingsPath, 'sources:\n  - path: ./agents\n    ref: main\n');
+
+    const result = loadSettingsFiles(createSettingsLoadPlan([{ scope: 'user', path: settingsPath }]));
+
+    expect(result.files).toEqual([]);
+    expect(result.issues[0]?.filePath).toBe(settingsPath);
+    expect(result.issues[0]?.path).toBe('/sources/0');
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.7).

--- a/code/cli/tests/unit/settings-loader.test.ts
+++ b/code/cli/tests/unit/settings-loader.test.ts
@@ -39,16 +39,17 @@ afterEach(() => {
 describe('settings loading', () => {
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.1).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('discovers user, project, and project-local settings.yml locations', () => {
+  it('discovers user, user-local, project, and project-local .agents settings locations', () => {
     const homeDirectory = '/home/example';
     const projectDirectory = '/work/project';
 
     const plan = discoverSettingsLoadPlan({ homeDirectory, projectDirectory });
 
     expect(plan.locations).toEqual([
-      { scope: 'user', path: '/home/example/.outfitter/settings.yml' },
-      { scope: 'project', path: '/work/project/.outfitter/settings.yml' },
-      { scope: 'project-local', path: '/work/project/.outfitter/local/settings.yml' },
+      { scope: 'user', path: '/home/example/.agents/settings.yml' },
+      { scope: 'user-local', path: '/home/example/.agents/settings.local.yml' },
+      { scope: 'project', path: '/work/project/.agents/settings.yml' },
+      { scope: 'project-local', path: '/work/project/.agents/settings.local.yml' },
     ]);
   });
 
@@ -59,28 +60,42 @@ describe('settings loading', () => {
     const homeDirectory = join(root, 'home');
     const projectDirectory = join(root, 'project');
     writeSettings(
-      join(homeDirectory, '.outfitter', 'settings.yml'),
-      'default_profile: user-default\ndefault_agent: pi\ncache_directory: ./user-cache\nprofile_export: false\nprofile_sources:\n  - path: ./profiles\n',
+      join(homeDirectory, '.agents', 'settings.yml'),
+      'default_agent: user-default\ndefault_harness: pi\ncache_directory: ./user-cache\nsources:\n  - path: ./agents\n',
     );
     writeSettings(
-      join(projectDirectory, '.outfitter', 'settings.yml'),
-      'default_profile: project-default\ndefault_agent: claude\ncache_directory: ./project-cache\n',
+      join(projectDirectory, '.agents', 'settings.yml'),
+      'default_agent: project-default\ndefault_harness: claude\ncache_directory: ./project-cache\n',
     );
     writeSettings(
-      join(projectDirectory, '.outfitter', 'local', 'settings.yml'),
-      'default_profile: local-default\ncache_directory: ./local-cache\nprofile_export: true\n',
+      join(projectDirectory, '.agents', 'settings.local.yml'),
+      'default_agent: local-default\ncache_directory: ./local-cache\n',
     );
 
     const loaded = loadSettings(discoverSettingsLoadPlan({ homeDirectory, projectDirectory }));
 
     expect(loaded.issues).toEqual([]);
     expect(loaded.files.map((file) => file.location.scope)).toEqual(['user', 'project', 'project-local']);
-    expect(loaded.settings.defaultProfile).toBe('local-default');
-    expect(loaded.settings.defaultAgent).toBe('claude');
-    expect(loaded.settings.profileSources).toEqual([{ path: join(homeDirectory, '.outfitter', 'profiles') }]);
+    expect(loaded.settings.defaultAgent).toBe('local-default');
+    expect(loaded.settings.defaultHarness).toBe('claude');
+    expect(loaded.settings.sources).toEqual([{ path: join(homeDirectory, '.agents', 'agents') }]);
     expect(loaded.settings.remoteSettings).toEqual([]);
-    expect(loaded.settings.cacheDirectory).toBe(join(projectDirectory, '.outfitter', 'local', 'local-cache'));
-    expect(loaded.settings.profileExport).toBe(true);
+    expect(loaded.settings.cacheDirectory).toBe(join(projectDirectory, '.agents', 'local-cache'));
+  });
+
+  it('applies user-local settings above user settings', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    writeSettings(join(homeDirectory, '.agents', 'settings.yml'), 'default_agent: user\ndefault_harness: pi\n');
+    writeSettings(join(homeDirectory, '.agents', 'settings.local.yml'), 'default_agent: user-local\n');
+
+    const loaded = loadSettings(discoverSettingsLoadPlan({ homeDirectory, projectDirectory }));
+
+    expect(loaded.issues).toEqual([]);
+    expect(loaded.files.map((file) => file.location.scope)).toEqual(['user', 'user-local']);
+    expect(loaded.settings.defaultAgent).toBe('user-local');
+    expect(loaded.settings.defaultHarness).toBe('pi');
   });
 
   it('loads and merges startup display and enterprise settings', () => {
@@ -88,32 +103,37 @@ describe('settings loading', () => {
     const homeDirectory = join(root, 'home');
     const projectDirectory = join(root, 'project');
     writeSettings(
-      join(homeDirectory, '.outfitter', 'settings.yml'),
-      'startup:\n  ascii_art: true\nenterprise:\n  private_profile_catalogs: false\n',
+      join(homeDirectory, '.agents', 'settings.yml'),
+      'startup:\n  ascii_art: true\nenterprise:\n  private_catalogs: false\n',
     );
     writeSettings(
-      join(projectDirectory, '.outfitter', 'settings.yml'),
-      'startup:\n  ascii_art: false\nenterprise:\n  private_profile_catalogs: true\n',
+      join(projectDirectory, '.agents', 'settings.yml'),
+      'startup:\n  ascii_art: false\nenterprise:\n  private_catalogs: true\n',
     );
 
     const loaded = loadSettings(discoverSettingsLoadPlan({ homeDirectory, projectDirectory }));
 
     expect(loaded.issues).toEqual([]);
     expect(loaded.settings.startup).toEqual({ asciiArt: false });
-    expect(loaded.settings.enterprise).toEqual({ privateProfileCatalogs: true });
+    expect(loaded.settings.enterprise).toEqual({ privateCatalogs: true });
   });
 
-  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.8, OFTR-005.7).
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.8).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('loads profile_export as the default generated prompt export setting', () => {
+  it('loads and merges state_persistence maps with higher-precedence overrides', () => {
     const root = createTemporaryRoot();
-    const settingsPath = join(root, '.outfitter', 'settings.yml');
-    writeSettings(settingsPath, 'profile_export: true\n');
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    writeSettings(
+      join(homeDirectory, '.agents', 'settings.yml'),
+      'state_persistence:\n  "settings.json": discard\n  "auth.json": symlink\n',
+    );
+    writeSettings(join(projectDirectory, '.agents', 'settings.yml'), 'state_persistence:\n  "settings.json": warn\n');
 
-    const result = loadSettingsFiles(createSettingsLoadPlan([{ scope: 'user', path: settingsPath }]));
+    const loaded = loadSettings(discoverSettingsLoadPlan({ homeDirectory, projectDirectory }));
 
-    expect(result.issues).toEqual([]);
-    expect(result.files[0]?.settings.profileExport).toBe(true);
+    expect(loaded.issues).toEqual([]);
+    expect(loaded.settings.statePersistence).toEqual({ 'settings.json': 'warn', 'auth.json': 'symlink' });
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.3).
@@ -123,7 +143,7 @@ describe('settings loading', () => {
     const malformedPath = join(root, 'malformed.yml');
     const invalidPath = join(root, 'invalid.yml');
     writeSettings(malformedPath, ': invalid: yaml:');
-    writeSettings(invalidPath, 'profile_sources:\n  - only:\n      - engineering\n');
+    writeSettings(invalidPath, 'default_harness: bun\n');
 
     const result = loadSettingsFiles(
       createSettingsLoadPlan([
@@ -137,8 +157,8 @@ describe('settings loading', () => {
     expect(result.issues[0]?.path).toBe(malformedPath);
     expect(result.issues).toContainEqual({
       filePath: invalidPath,
-      path: '/profile_sources/0',
-      message: "must have required property 'path'",
+      path: '/default_harness',
+      message: 'must be equal to one of the allowed values',
     });
   });
 
@@ -146,20 +166,20 @@ describe('settings loading', () => {
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('validates local, URI, GitHub, and remote settings entries from settings files', () => {
     const root = createTemporaryRoot();
-    const settingsPath = join(root, '.outfitter', 'settings.yml');
+    const settingsPath = join(root, '.agents', 'settings.yml');
     writeSettings(
       settingsPath,
-      `profile_sources:\n  - path: ./profiles\n    only: [engineering]\n  - path: ${join(root, 'absolute-profiles')}\n  - uri: git+https://example.test/profiles.git\n    path: team/profiles\n    ref: main\n    except: [sandbox]\n  - github: example/outfitter-config\n    path: profiles\nremote_settings:\n  - github: example/outfitter-config\n    ref: main\n    path: settings.yml\n`,
+      `sources:\n  - path: ./agents\n  - path: ${join(root, 'absolute-agents')}\n  - uri: git+https://example.test/agents.git\n    path: team/agents\n    ref: main\n  - github: example/.agent\n    path: agents\nremote_settings:\n  - github: example/outfitter-config\n    ref: main\n    path: settings.yml\n`,
     );
 
     const result = loadSettingsFiles(createSettingsLoadPlan([{ scope: 'user', path: settingsPath }]));
 
     expect(result.issues).toEqual([]);
-    expect(result.files[0]?.settings.profileSources).toEqual([
-      { path: join(root, '.outfitter', 'profiles'), only: ['engineering'] },
-      { path: join(root, 'absolute-profiles') },
-      { uri: 'git+https://example.test/profiles.git', path: 'team/profiles', ref: 'main', except: ['sandbox'] },
-      { github: 'example/outfitter-config', path: 'profiles' },
+    expect(result.files[0]?.settings.sources).toEqual([
+      { path: join(root, '.agents', 'agents') },
+      { path: join(root, 'absolute-agents') },
+      { uri: 'git+https://example.test/agents.git', path: 'team/agents', ref: 'main' },
+      { github: 'example/.agent', path: 'agents' },
     ]);
     expect(result.files[0]?.settings.remoteSettings).toEqual([
       { github: 'example/outfitter-config', ref: 'main', path: 'settings.yml' },
@@ -173,7 +193,7 @@ describe('settings loading', () => {
     const homeDirectory = join(root, 'home');
     const projectDirectory = join(root, 'project');
     writeSettings(
-      join(homeDirectory, '.outfitter', 'settings.yml'),
+      join(homeDirectory, '.agents', 'settings.yml'),
       [
         'custom_settings:',
         '  build_commands:',
@@ -185,7 +205,7 @@ describe('settings loading', () => {
       ].join('\n'),
     );
     writeSettings(
-      join(projectDirectory, '.outfitter', 'settings.yml'),
+      join(projectDirectory, '.agents', 'settings.yml'),
       ['custom_settings:', '  build_commands:', '    lint: npm run lint:ci', '  tools:', '    - prettier', ''].join(
         '\n',
       ),
@@ -205,13 +225,13 @@ describe('settings loading', () => {
 
   it('resolves configured cache directories relative to the containing settings file', () => {
     const root = createTemporaryRoot();
-    const settingsPath = join(root, '.outfitter', 'settings.yml');
+    const settingsPath = join(root, '.agents', 'settings.yml');
     writeSettings(settingsPath, 'cache_directory: ./cache\n');
 
     const result = loadSettingsFiles(createSettingsLoadPlan([{ scope: 'user', path: settingsPath }]));
 
     expect(result.issues).toEqual([]);
-    expect(result.files[0]?.settings.cacheDirectory).toBe(join(root, '.outfitter', 'cache'));
+    expect(result.files[0]?.settings.cacheDirectory).toBe(join(root, '.agents', 'cache'));
   });
 
   it('skips missing settings files and exposes generic YAML and schema helpers', () => {
@@ -223,7 +243,7 @@ describe('settings loading', () => {
       issues: [],
     });
     expect(parseYamlDocument('answer: 42\n', '/inline')).toEqual({ ok: true, document: { answer: 42 } });
-    expect(validateSchema('profile-source', { path: './profiles' })).toEqual({ valid: true, issues: [] });
+    expect(validateSchema('settings', { default_agent: 'engineer' })).toEqual({ valid: true, issues: [] });
     expect(validateSchema('settings', null).issues[0]?.path).toBe('/');
   });
 
@@ -234,8 +254,8 @@ describe('settings loading', () => {
     const homeDirectory = join(root, 'home');
     const projectDirectory = join(root, 'project');
     writeSettings(
-      join(homeDirectory, '.outfitter', 'settings.yml'),
-      'default_profile: local\nremote_settings:\n  - uri: git+https://github.com/example/outfitter-config.git\n    ref: main\n    path: settings.yml\n',
+      join(homeDirectory, '.agents', 'settings.yml'),
+      'default_agent: local\nremote_settings:\n  - uri: git+https://github.com/example/outfitter-config.git\n    ref: main\n    path: settings.yml\n',
     );
     const remoteSettingsPath = join(
       createRemoteRepositoryCachePath(homeDirectory, {
@@ -246,23 +266,21 @@ describe('settings loading', () => {
     );
     writeSettings(
       remoteSettingsPath,
-      'default_profile: remote\nprofile_sources:\n  - github: example/outfitter-config\n    path: remote-profiles\n',
+      'default_agent: remote\nsources:\n  - github: example/.agent\n    path: remote-agents\n',
     );
 
     const loaded = loadSettingsWithCachedRemoteSettings({ homeDirectory, projectDirectory });
 
     expect(loaded.issues).toEqual([]);
-    expect(loaded.settings.defaultProfile).toBe('local');
-    expect(loaded.settings.profileSources).toEqual([{ github: 'example/outfitter-config', path: 'remote-profiles' }]);
+    expect(loaded.settings.defaultAgent).toBe('local');
+    expect(loaded.settings.sources).toEqual([{ github: 'example/.agent', path: 'remote-agents' }]);
 
     writeSettings(
-      join(homeDirectory, '.outfitter', 'settings.yml'),
-      'default_profile: local\nprofile_sources:\n  - path: ./local-profiles\nremote_settings:\n  - uri: git+https://github.com/example/outfitter-config.git\n    ref: main\n    path: settings.yml\n',
+      join(homeDirectory, '.agents', 'settings.yml'),
+      'default_agent: local\nsources:\n  - path: ./local-agents\nremote_settings:\n  - uri: git+https://github.com/example/outfitter-config.git\n    ref: main\n    path: settings.yml\n',
     );
     const localOverrideLoaded = loadSettingsWithCachedRemoteSettings({ homeDirectory, projectDirectory });
-    expect(localOverrideLoaded.settings.profileSources).toEqual([
-      { path: join(homeDirectory, '.outfitter', 'local-profiles') },
-    ]);
+    expect(localOverrideLoaded.settings.sources).toEqual([{ path: join(homeDirectory, '.agents', 'local-agents') }]);
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.6).
@@ -272,7 +290,7 @@ describe('settings loading', () => {
     const homeDirectory = join(root, 'home');
     const projectDirectory = join(root, 'project');
     writeSettings(
-      join(homeDirectory, '.outfitter', 'settings.yml'),
+      join(homeDirectory, '.agents', 'settings.yml'),
       'remote_settings:\n  - github: example/absolute\n    path: /tmp/settings.yml\n  - github: example/escape\n    path: ../settings.yml\n',
     );
 

--- a/docs/requirements/OFTR-002-settings.md
+++ b/docs/requirements/OFTR-002-settings.md
@@ -1,28 +1,39 @@
 # OFTR-002: Settings Discovery and Validation
 
-> **Transition (RFC [#165](https://github.com/ai-outfitter/outfitter/issues/165)):** this requirement describes pre-dotagents behavior and will be amended or superseded by the RFC #165 implementation PRs together with its pinned tests. The target design lives in [docs/documentation](../documentation/README.md) and [docs/architecture](../architecture/README.md).
+> **Amendment (2026-07-17, RFC [#165](https://github.com/ai-outfitter/outfitter/issues/165)):**
+> settings moved from `.outfitter/` to the `.agents` tree and dropped resource-selection keys.
+> `default_profile` → `default_agent` (an agent slug); the former `default_agent` (harness) →
+> `default_harness`; `profile_sources` → `sources`; `state_persistence` moved into settings; the
+> nested `local/` directory became a flat `settings.local.yml`; the `profile_export` key and the
+> `profiles:` map were removed. Section IDs are preserved so pinned-test traceability holds. The
+> target design lives in [docs/documentation/settings.md](../documentation/settings.md).
 
 ## Overview
 
-Outfitter settings are the merged result of user, project, and project-local `.outfitter/settings.yml` files.
-The internal Settings object is the single source of resolved configuration for commands.
+Outfitter settings are the merged result of user, user-local, project, and project-local
+`.agents/settings.yml` (and sibling `.agents/settings.local.yml`) files.
+The internal Settings object is the single source of resolved configuration for commands. Settings
+carry no resource selections — an agent's loadout lives on the agent, not in settings.
 
 ## Requirements
 
 ### OFTR-002.1: Settings Locations
 
-1. Outfitter MUST support a user settings file at `~/.outfitter/settings.yml`.
-2. Outfitter MUST support a project settings file at `<project>/.outfitter/settings.yml`.
-3. Outfitter MUST support a project-local settings file at `<project>/.outfitter/local/settings.yml`.
-4. Outfitter MUST collectively refer to discovered settings files as `settings.yml` in user-facing documentation when discussing the merged settings concept.
+1. Outfitter MUST support a user settings file at `~/.agents/settings.yml`.
+2. Outfitter MUST support a user-local settings file at `~/.agents/settings.local.yml`.
+3. Outfitter MUST support a project settings file at `<project>/.agents/settings.yml`.
+4. Outfitter MUST support a project-local settings file at `<project>/.agents/settings.local.yml`.
+5. `settings.local.yml` MUST be a flat file beside `settings.yml`; there is no nested local directory.
+6. Outfitter MUST collectively refer to discovered settings files as `settings.yml` in user-facing documentation when discussing the merged settings concept.
 
 ### OFTR-002.2: Settings Precedence
 
 1. Project-local settings MUST take precedence over project settings.
-2. Project settings MUST take precedence over user settings.
-3. User settings MUST take precedence over built-in defaults.
-4. Outfitter MUST expose the merged result as a conceptual internal `Settings` object.
-5. The Settings loader SHOULD be designed so future settings sources can be added without changing command implementations.
+2. Project settings MUST take precedence over user-local settings.
+3. User-local settings MUST take precedence over user settings.
+4. User settings MUST take precedence over cached remote settings, which take precedence over built-in defaults.
+5. Outfitter MUST expose the merged result as a conceptual internal `Settings` object.
+6. The Settings loader SHOULD be designed so future settings sources can be added without changing command implementations.
 
 ### OFTR-002.3: Settings Schema
 
@@ -31,24 +42,22 @@ The internal Settings object is the single source of resolved configuration for 
 3. Validation diagnostics MUST identify the file that failed validation.
 4. Validation diagnostics SHOULD identify the failing setting path when the validator provides that information.
 
-### OFTR-002.4: Default Profile
+### OFTR-002.4: Default Agent and Harness
 
-1. The user settings file `~/.outfitter/settings.yml` MUST declare a default profile after the Pi-native setup flow writes home settings.
-2. `outfitter run` MUST use the resolved default profile when no profile is selected with `-p` or `--profile`.
-3. Outfitter MUST report an actionable error when no selected profile and no default profile are available.
+1. `settings.yml` MAY declare a `default_agent` naming the agent slug that plain `outfitter` runs when no agent is selected.
+2. `settings.yml` MAY declare a `default_harness` of `pi` or `claude` selecting the harness launched when `--harness` is omitted.
+3. `outfitter run` MUST use the resolved `default_agent` when no agent is selected on the command line.
+4. Outfitter MUST report an actionable error when no selected agent and no `default_agent` are available.
 
-### OFTR-002.5: Profile Sources in Settings
+### OFTR-002.5: Sources in Settings
 
-1. `settings.yml` MAY contain a `profile_sources` array.
-2. Each `profile_sources` entry MUST specify either a local `path`, a remote `uri`, or a `github` shorthand.
-3. A local-only `path` profile source MUST resolve relative to the settings file containing it when the path is relative.
-4. A local-only `path` profile source MUST point to a folder containing profile folders rather than to one specific profile folder.
-5. A `uri` or `github` profile source MUST be syncable by `outfitter sync`.
-6. A `uri` or `github` profile source MAY specify `ref` to select a branch, tag, or commit.
-7. A `uri` or `github` profile source MAY specify `path` to load profiles from a repository subdirectory.
-8. A profile source MAY specify `only` to allow only named profiles from that source.
-9. A profile source MAY specify `except` to exclude named profiles from that source.
-10. If neither `only` nor `except` is specified, Outfitter MUST load all profiles from the source.
+1. `settings.yml` MAY contain a `sources` array of `.agents` payload sources.
+2. Each `sources` entry MUST specify either a local `path`, a remote `uri`, or a `github` shorthand.
+3. A local-only `path` source MUST resolve relative to the settings file containing it when the path is relative.
+4. A local-only `path` source MUST point to a directory containing a `.agents` payload.
+5. A `uri` or `github` source MUST be syncable by `outfitter sync`.
+6. A `uri` or `github` source MAY specify `ref` to select a branch, tag, or commit.
+7. A `uri` or `github` source MAY specify `path` to load the payload from a repository subdirectory.
 
 ### OFTR-002.6: Remote Settings Sources
 
@@ -63,12 +72,12 @@ The internal Settings object is the single source of resolved configuration for 
 
 1. `settings.yml` MAY contain a `cache_directory` path.
 2. Relative `cache_directory` values MUST resolve relative to the settings file containing them.
-3. When `cache_directory` is not configured, Outfitter MUST use `~/.outfitter/cache` as the default cache directory.
-4. Agent adapters MUST receive the resolved cache directory when assembling a composite profile so persistent composite profile links use the configured cache location.
+3. When `cache_directory` is not configured, Outfitter MUST use `~/.agents/cache` as the default cache directory.
+4. Agent adapters MUST receive the resolved cache directory when composing a run so persistent projection links use the configured cache location.
 
-### OFTR-002.8: Profile Export Setting
+### OFTR-002.8: State Persistence in Settings
 
-1. `settings.yml` MAY contain top-level `profile_export`.
-2. Outfitter MUST validate `profile_export` as a boolean when present.
-3. When `profile_export` is omitted from all settings scopes, generated prompt export MUST remain disabled by default.
-4. Higher-precedence settings files MUST override lower-precedence `profile_export` values.
+1. `settings.yml` MAY contain a `state_persistence` object mapping adapter-declared state paths to a persistence strategy.
+2. Outfitter MUST validate `state_persistence` strategy values as one of `symlink`, `discard`, `warn`, `error`, or `prompt`.
+3. When `state_persistence` is omitted from all settings scopes, Outfitter MUST fall back to adapter default strategies.
+4. Higher-precedence settings files MUST override lower-precedence `state_persistence` entries per state path.


### PR DESCRIPTION
**Stack 1/4** of the RFC #165 *implementation* refactor (docs landed in #169). Each PR is cut from `main` head, Copilot-reviewed, and squash-merged.

## This PR — settings layer
Amends **OFTR-002** and refactors the settings layer to the dotagents `.agents` model:
- discovery `.outfitter/` → `~/.agents` + `<project>/.agents`; flat `settings.local.yml` (user, user-local, project, project-local scopes)
- `default_profile` → `default_agent` (agent slug); old `default_agent` (harness) → `default_harness`
- `profile_sources` → `sources`; `state_persistence` moves into settings; `profile_export` + inline `profiles:` map removed
- `enterprise.private_profile_catalogs` → `enterprise.private_catalogs`

Schema + `Settings`/`SettingsLoader`/`SettingsMerger` + OFTR-002 pinned tests updated together (OFTR-008). Settings suite green (15 tests).

## Intentionally out of scope / known-red
Per the agreed strategy (**clean commits, `main` partial between refactor PRs, final release review is the green gate**), the 19 downstream files that read the old settings fields (run/setup/sync/profile commands) are **not** updated here — they're retargeted in stack PRs 2–4. So the full suite is red until the stack completes; the settings layer itself is coherent and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)