### PR TITLE
refactor(resolver): .agents resolver + list/validate [rfc-165 impl 2/4]

### DIFF
--- a/code/cli/src/cli/OutfitterCli.ts
+++ b/code/cli/src/cli/OutfitterCli.ts
@@ -4,10 +4,11 @@ import { readFileSync } from 'node:fs';
 import { Command } from 'commander';
 
 import type { CommandObject } from './commands/CommandObject.js';
-import { createProfileCommands } from './commands/profile/Command.js';
+import { createListCommand } from './commands/ListCommand.js';
 import { createRunCommand, executeRunCommand } from './commands/RunCommand.js';
 import { createSetupCommand } from './commands/SetupCommand.js';
 import { createSyncCommand } from './commands/SyncCommand.js';
+import { createValidateCommand } from './commands/ValidateCommand.js';
 import { createWelcomeCommand } from './commands/WelcomeCommand.js';
 
 export const createDefaultCommands = (): CommandObject[] => [
@@ -23,7 +24,8 @@ export const createDefaultCommands = (): CommandObject[] => [
   }),
   createSyncCommand(),
   createWelcomeCommand(),
-  ...createProfileCommands(),
+  createListCommand(),
+  createValidateCommand(),
 ];
 
 export const createOutfitterProgram = (commands: readonly CommandObject[] = createDefaultCommands()): Command => {

--- a/code/cli/src/cli/commands/ListCommand.ts
+++ b/code/cli/src/cli/commands/ListCommand.ts
@@ -1,0 +1,98 @@
+// Provides `outfitter list [kind]` over the effective resource set.
+import { homedir } from 'node:os';
+
+import { Command } from 'commander';
+
+import type { ResourceKind } from '../../resolver/Resource.js';
+import { listResources, resourceKinds } from '../../resolver/Resource.js';
+import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
+import type { CommandObject } from './CommandObject.js';
+
+export interface ListInput {
+  readonly homeDirectory: string;
+  readonly projectDirectory: string;
+  readonly kind?: string;
+}
+
+export interface ListResult {
+  readonly messages: readonly string[];
+}
+
+export interface ListCommandDependencies {
+  readonly homeDirectory?: string;
+  readonly projectDirectory?: string;
+  readonly writeLine?: (message: string) => void;
+}
+
+const kindByPlural: ReadonlyMap<string, ResourceKind> = new Map([
+  ['agents', 'agent'],
+  ['skills', 'skill'],
+  ['knowledge', 'knowledge'],
+  ['commands', 'command'],
+]);
+
+const pluralByKind: ReadonlyMap<ResourceKind, string> = new Map([
+  ['agent', 'agents'],
+  ['skill', 'skills'],
+  ['knowledge', 'knowledge'],
+  ['command', 'commands'],
+]);
+
+const resolveKindFilter = (kind: string | undefined): readonly ResourceKind[] => {
+  if (kind === undefined) {
+    return resourceKinds;
+  }
+
+  const resolved = kindByPlural.get(kind);
+
+  if (resolved === undefined) {
+    throw new Error(`Unknown resource kind '${kind}'. Expected one of: ${[...kindByPlural.keys()].join(', ')}.`);
+  }
+
+  return [resolved];
+};
+
+export const executeListCommand = (input: ListInput): ListResult => {
+  const { set, settingsIssues } = resolveEffectiveSet(input);
+
+  if (settingsIssues.length > 0) {
+    throw new Error(`Cannot list resources with invalid settings: ${settingsIssues.map((i) => i.message).join('; ')}`);
+  }
+
+  const messages: string[] = [];
+
+  for (const kind of resolveKindFilter(input.kind)) {
+    const resources = listResources(set, kind);
+    messages.push(`${pluralByKind.get(kind)!}:`);
+    messages.push(
+      ...(resources.length === 0 ? ['  (none)'] : resources.map((r) => `  ${r.slug}  [${r.winner.layer.label}]`)),
+    );
+  }
+
+  return { messages };
+};
+
+export const createListCommand = (dependencies: ListCommandDependencies = {}): CommandObject => ({
+  name: 'list',
+  description: 'List resolvable resources (agents, skills, knowledge, commands).',
+  register(program: Command): void {
+    program.addCommand(
+      new Command('list')
+        .description('List resolvable resources (agents, skills, knowledge, commands).')
+        .argument('[kind]', 'Restrict to one kind: agents, skills, knowledge, or commands.')
+        .action((kind: string | undefined) => {
+          const result = executeListCommand({
+            /* v8 ignore next 2 -- process defaults are exercised by the CLI entrypoint, not unit tests. */
+            homeDirectory: dependencies.homeDirectory ?? homedir(),
+            projectDirectory: dependencies.projectDirectory ?? process.cwd(),
+            kind,
+          });
+
+          for (const message of result.messages) {
+            /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
+            (dependencies.writeLine ?? console.log)(message);
+          }
+        }),
+    );
+  },
+});

--- a/code/cli/src/cli/commands/ListCommand.ts
+++ b/code/cli/src/cli/commands/ListCommand.ts
@@ -56,7 +56,8 @@ export const executeListCommand = (input: ListInput): ListResult => {
   const { set, settingsIssues } = resolveEffectiveSet(input);
 
   if (settingsIssues.length > 0) {
-    throw new Error(`Cannot list resources with invalid settings: ${settingsIssues.map((i) => i.message).join('; ')}`);
+    const detail = settingsIssues.map((issue) => `${issue.filePath}#${issue.path} ${issue.message}`).join('; ');
+    throw new Error(`Cannot list resources with invalid settings: ${detail}`);
   }
 
   const messages: string[] = [];

--- a/code/cli/src/cli/commands/ValidateCommand.ts
+++ b/code/cli/src/cli/commands/ValidateCommand.ts
@@ -1,0 +1,90 @@
+// Provides `outfitter validate [--strict] [--json]` over the effective resource set.
+import { homedir } from 'node:os';
+
+import { Command } from 'commander';
+
+import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
+import type { ValidationFinding } from '../../resolver/ResolverValidation.js';
+import { validateEffectiveSet } from '../../resolver/ResolverValidation.js';
+import type { CommandObject } from './CommandObject.js';
+
+export interface ValidateInput {
+  readonly homeDirectory: string;
+  readonly projectDirectory: string;
+  readonly strict?: boolean;
+  readonly json?: boolean;
+}
+
+export interface ValidateResult {
+  readonly findings: readonly ValidationFinding[];
+  readonly ok: boolean;
+  readonly messages: readonly string[];
+}
+
+export interface ValidateCommandDependencies {
+  readonly homeDirectory?: string;
+  readonly projectDirectory?: string;
+  readonly writeLine?: (message: string) => void;
+}
+
+const settingsFindings = (messages: readonly string[]): readonly ValidationFinding[] =>
+  messages.map((message) => ({ severity: 'error' as const, resource: 'settings', message }));
+
+export const executeValidateCommand = (input: ValidateInput): ValidateResult => {
+  const { set, settingsIssues } = resolveEffectiveSet(input);
+  const findings = [
+    ...settingsFindings(settingsIssues.map((issue) => `${issue.filePath}#${issue.path} ${issue.message}`)),
+    ...validateEffectiveSet(set),
+  ];
+
+  const hasErrors = findings.some((finding) => finding.severity === 'error');
+  const hasWarnings = findings.some((finding) => finding.severity === 'warning');
+  const ok = !hasErrors && !(input.strict === true && hasWarnings);
+
+  const messages = input.json === true ? [JSON.stringify({ ok, findings }, null, 2)] : formatFindings(findings, ok);
+
+  return { findings, ok, messages };
+};
+
+const formatFindings = (findings: readonly ValidationFinding[], ok: boolean): readonly string[] => {
+  if (findings.length === 0) {
+    return ['✓ No issues found.'];
+  }
+
+  const lines = findings.map(
+    (finding) => `${finding.severity === 'error' ? '✗' : '⚠'} ${finding.resource}: ${finding.message}`,
+  );
+
+  return [...lines, ok ? '✓ Passed (warnings only).' : '✗ Validation failed.'];
+};
+
+export const createValidateCommand = (dependencies: ValidateCommandDependencies = {}): CommandObject => ({
+  name: 'validate',
+  description: 'Validate the resolved .agents tree: schemas, loadout slugs, and shadowing.',
+  register(program: Command): void {
+    program.addCommand(
+      new Command('validate')
+        .description('Validate the resolved .agents tree: schemas, loadout slugs, and shadowing.')
+        .option('--strict', 'Treat warnings (such as shadowed definitions) as failures.')
+        .option('--json', 'Emit findings as JSON.')
+        .action((options: { strict?: boolean; json?: boolean }) => {
+          const result = executeValidateCommand({
+            /* v8 ignore next 2 -- process defaults are exercised by the CLI entrypoint, not unit tests. */
+            homeDirectory: dependencies.homeDirectory ?? homedir(),
+            projectDirectory: dependencies.projectDirectory ?? process.cwd(),
+            strict: options.strict,
+            json: options.json,
+          });
+
+          for (const message of result.messages) {
+            /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
+            (dependencies.writeLine ?? console.log)(message);
+          }
+
+          if (!result.ok) {
+            process.exitCode = 1;
+          }
+        }),
+    );
+  },
+});

--- a/code/cli/src/resolver/AgentDefinition.ts
+++ b/code/cli/src/resolver/AgentDefinition.ts
@@ -1,0 +1,139 @@
+// Parses `agents/<id>/agent.md` frontmatter (plus optional config.json) into an agent identity + loadout.
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { validateSchema } from '../validation/SchemaValidator.js';
+import { parseYamlDocument } from '../validation/YamlDocument.js';
+import type { Loadout } from './Resource.js';
+import { emptyLoadout } from './Resource.js';
+
+export interface AgentDefinition {
+  readonly name: string;
+  readonly description?: string;
+  /** Markdown body after the frontmatter — the agent's identity prose. */
+  readonly body: string;
+  readonly loadout: Loadout;
+}
+
+export interface AgentDefinitionIssue {
+  readonly path: string;
+  readonly message: string;
+}
+
+export const isAgentDefinitionIssue = (value: AgentDefinition | AgentDefinitionIssue): value is AgentDefinitionIssue =>
+  'message' in value;
+
+interface FrontmatterSplit {
+  readonly frontmatter: string;
+  readonly body: string;
+}
+
+/** Splits leading `---` YAML frontmatter from the markdown body. */
+export const splitFrontmatter = (content: string): FrontmatterSplit | undefined => {
+  const lines = content.split('\n');
+
+  if (lines[0]?.trimEnd() !== '---') {
+    return undefined;
+  }
+
+  const closingIndex = lines.findIndex((line, index) => index > 0 && line.trimEnd() === '---');
+
+  if (closingIndex === -1) {
+    return undefined;
+  }
+
+  return {
+    frontmatter: lines.slice(1, closingIndex).join('\n'),
+    body: lines
+      .slice(closingIndex + 1)
+      .join('\n')
+      .replace(/^\n/, ''),
+  };
+};
+
+const asStringArray = (value: unknown): readonly string[] =>
+  Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : [];
+
+const asString = (value: unknown): string | undefined => (typeof value === 'string' ? value : undefined);
+
+const loadoutFromRecord = (record: Readonly<Record<string, unknown>>): Loadout => {
+  const tools = record.tools as { readonly allow?: unknown; readonly deny?: unknown } | undefined;
+
+  return {
+    ...emptyLoadout(),
+    skills: asStringArray(record.skills),
+    subagents: asStringArray(record.subagents),
+    mcp: asStringArray(record.mcp),
+    extensions: asStringArray(record.extensions),
+    plugins: asStringArray(record.plugins),
+    model: asString(record.model),
+    thinking: asString(record.thinking),
+    tools: tools === undefined ? undefined : { allow: asStringArray(tools.allow), deny: asStringArray(tools.deny) },
+  };
+};
+
+/** Reads the optional per-agent `config.json` loadout overrides beside `agent.md`. */
+const readConfigOverrides = (agentDirectory: string): Readonly<Record<string, unknown>> => {
+  const configPath = join(agentDirectory, 'config.json');
+
+  if (!existsSync(configPath)) {
+    return {};
+  }
+
+  const parsed = JSON.parse(readFileSync(configPath, 'utf8')) as unknown;
+  return parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+    ? (parsed as Readonly<Record<string, unknown>>)
+    : {};
+};
+
+export const parseAgentDefinition = (
+  content: string,
+  agentDirectory: string,
+  agentPath: string,
+): AgentDefinition | AgentDefinitionIssue => {
+  const split = splitFrontmatter(content);
+
+  if (split === undefined) {
+    return { path: agentPath, message: 'agent.md must start with a `---` YAML frontmatter block.' };
+  }
+
+  const parsed = parseYamlDocument(split.frontmatter, agentPath);
+
+  if (!parsed.ok) {
+    return { path: agentPath, message: `agent.md frontmatter is not valid YAML: ${parsed.issue.message}` };
+  }
+
+  if (parsed.document === null || typeof parsed.document !== 'object' || Array.isArray(parsed.document)) {
+    return { path: agentPath, message: 'agent.md frontmatter must be a YAML mapping.' };
+  }
+
+  // config.json shallow-merges by key over the frontmatter loadout.
+  const record = { ...(parsed.document as Record<string, unknown>), ...readConfigOverrides(agentDirectory) };
+  const validation = validateSchema('agent', record);
+
+  if (!validation.valid) {
+    return { path: agentPath, message: `agent.md is invalid: ${validation.issues[0]?.message ?? 'schema error'}` };
+  }
+
+  return {
+    name: record.name as string,
+    description: asString(record.description),
+    body: split.body,
+    loadout: loadoutFromRecord(record),
+  };
+};
+
+export const readAgentDefinition = (
+  agentDirectory: string,
+  agentPath: string,
+): AgentDefinition | AgentDefinitionIssue => {
+  let content: string;
+
+  try {
+    content = readFileSync(agentPath, 'utf8');
+  } catch (error) {
+    return { path: agentPath, message: `Could not read agent.md: ${String(error)}` };
+  }
+
+  return parseAgentDefinition(content, agentDirectory, agentPath);
+};

--- a/code/cli/src/resolver/AgentDefinition.ts
+++ b/code/cli/src/resolver/AgentDefinition.ts
@@ -1,6 +1,5 @@
-// Parses `agents/<id>/agent.md` frontmatter (plus optional config.json) into an agent identity + loadout.
-import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+// Parses `agents/<id>/agent.md` frontmatter and merges per-layer config.json loadout overrides.
+import { readFileSync } from 'node:fs';
 
 import { validateSchema } from '../validation/SchemaValidator.js';
 import { parseYamlDocument } from '../validation/YamlDocument.js';
@@ -22,6 +21,9 @@ export interface AgentDefinitionIssue {
 
 export const isAgentDefinitionIssue = (value: AgentDefinition | AgentDefinitionIssue): value is AgentDefinitionIssue =>
   'message' in value;
+
+/** Loadout fields a per-agent config.json may override; identity fields (`name`) are frontmatter-only. */
+const loadoutKeys = ['skills', 'subagents', 'mcp', 'extensions', 'plugins', 'model', 'thinking', 'tools'] as const;
 
 interface FrontmatterSplit {
   readonly frontmatter: string;
@@ -72,25 +74,28 @@ const loadoutFromRecord = (record: Readonly<Record<string, unknown>>): Loadout =
   };
 };
 
-/** Reads the optional per-agent `config.json` loadout overrides beside `agent.md`. */
-const readConfigOverrides = (agentDirectory: string): Readonly<Record<string, unknown>> => {
-  const configPath = join(agentDirectory, 'config.json');
+/** Reads one config.json, restricting it to loadout keys; parse/read/non-object failures are issues. */
+const readConfigLoadout = (configPath: string): Readonly<Record<string, unknown>> | AgentDefinitionIssue => {
+  let parsed: unknown;
 
-  if (!existsSync(configPath)) {
-    return {};
+  try {
+    parsed = JSON.parse(readFileSync(configPath, 'utf8'));
+  } catch (error) {
+    return { path: configPath, message: `config.json is not readable JSON: ${String(error)}` };
   }
 
-  const parsed = JSON.parse(readFileSync(configPath, 'utf8')) as unknown;
-  return parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
-    ? (parsed as Readonly<Record<string, unknown>>)
-    : {};
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { path: configPath, message: 'config.json must be a JSON object of loadout overrides.' };
+  }
+
+  const record = parsed as Record<string, unknown>;
+  return Object.fromEntries(loadoutKeys.filter((key) => key in record).map((key) => [key, record[key]]));
 };
 
-export const parseAgentDefinition = (
+const parseFrontmatterRecord = (
   content: string,
-  agentDirectory: string,
   agentPath: string,
-): AgentDefinition | AgentDefinitionIssue => {
+): { readonly record: Record<string, unknown>; readonly body: string } | AgentDefinitionIssue => {
   const split = splitFrontmatter(content);
 
   if (split === undefined) {
@@ -107,25 +112,55 @@ export const parseAgentDefinition = (
     return { path: agentPath, message: 'agent.md frontmatter must be a YAML mapping.' };
   }
 
-  // config.json shallow-merges by key over the frontmatter loadout.
-  const record = { ...(parsed.document as Record<string, unknown>), ...readConfigOverrides(agentDirectory) };
-  const validation = validateSchema('agent', record);
+  // Validate the frontmatter on its own so config.json cannot supply required identity fields.
+  const validation = validateSchema('agent', parsed.document);
 
   if (!validation.valid) {
     return { path: agentPath, message: `agent.md is invalid: ${validation.issues[0]?.message ?? 'schema error'}` };
   }
 
+  return { record: parsed.document as Record<string, unknown>, body: split.body };
+};
+
+/**
+ * Parses an agent definition. `configPaths` are highest-precedence first; each is a loadout-only
+ * override that JSON-merges by key across layers over the frontmatter loadout.
+ */
+export const parseAgentDefinition = (
+  content: string,
+  configPaths: readonly string[],
+  agentPath: string,
+): AgentDefinition | AgentDefinitionIssue => {
+  const frontmatter = parseFrontmatterRecord(content, agentPath);
+
+  if (isAgentDefinitionIssue(frontmatter)) {
+    return frontmatter;
+  }
+
+  let merged: Record<string, unknown> = { ...frontmatter.record };
+
+  // Apply lowest precedence first so higher layers win per key.
+  for (const configPath of [...configPaths].reverse()) {
+    const config = readConfigLoadout(configPath);
+
+    if (isAgentDefinitionIssue(config)) {
+      return config;
+    }
+
+    merged = { ...merged, ...config };
+  }
+
   return {
-    name: record.name as string,
-    description: asString(record.description),
-    body: split.body,
-    loadout: loadoutFromRecord(record),
+    name: frontmatter.record.name as string,
+    description: asString(frontmatter.record.description),
+    body: frontmatter.body,
+    loadout: loadoutFromRecord(merged),
   };
 };
 
 export const readAgentDefinition = (
-  agentDirectory: string,
   agentPath: string,
+  configPaths: readonly string[] = [],
 ): AgentDefinition | AgentDefinitionIssue => {
   let content: string;
 
@@ -135,5 +170,5 @@ export const readAgentDefinition = (
     return { path: agentPath, message: `Could not read agent.md: ${String(error)}` };
   }
 
-  return parseAgentDefinition(content, agentDirectory, agentPath);
+  return parseAgentDefinition(content, configPaths, agentPath);
 };

--- a/code/cli/src/resolver/Layer.ts
+++ b/code/cli/src/resolver/Layer.ts
@@ -1,0 +1,42 @@
+// Builds the ordered `.agents` layer stack (workspace over global over remote sources) from settings.
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { createRemoteRepositoryCachePath, resolveRemoteRepositorySubpath } from '../profiles/ProfileCache.js';
+import type { Settings, SourceReference } from '../settings/Settings.js';
+import type { Layer } from './Resource.js';
+
+export interface LayerDiscoveryInput {
+  readonly homeDirectory: string;
+  readonly projectDirectory: string;
+  readonly settings: Settings;
+}
+
+const agentsRoot = (directory: string): string => join(directory, '.agents');
+
+const sourceLayer = (homeDirectory: string, source: SourceReference): Layer => {
+  if (source.path !== undefined && source.uri === undefined && source.github === undefined) {
+    return { root: source.path, origin: 'source', label: source.path };
+  }
+
+  const remote = source as { readonly uri?: string; readonly github?: string; readonly ref?: string };
+  const repositoryPath = createRemoteRepositoryCachePath(homeDirectory, remote as never);
+  const root = source.path === undefined ? repositoryPath : resolveRemoteRepositorySubpath(repositoryPath, source.path);
+  const label = remote.uri ?? `github:${remote.github}`;
+
+  return { root, origin: 'source', label };
+};
+
+/**
+ * Orders layers highest precedence first: workspace `.agents`, then global `~/.agents`,
+ * then configured sources in order. Only layers whose root exists on disk are included.
+ */
+export const discoverLayers = (input: LayerDiscoveryInput): readonly Layer[] => {
+  const candidates: Layer[] = [
+    { root: agentsRoot(input.projectDirectory), origin: 'workspace', label: 'workspace' },
+    { root: agentsRoot(input.homeDirectory), origin: 'global', label: 'global' },
+    ...(input.settings.sources ?? []).map((source) => sourceLayer(input.homeDirectory, source)),
+  ];
+
+  return candidates.filter((layer) => existsSync(layer.root));
+};

--- a/code/cli/src/resolver/Layer.ts
+++ b/code/cli/src/resolver/Layer.ts
@@ -2,7 +2,7 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { createRemoteRepositoryCachePath, resolveRemoteRepositorySubpath } from '../profiles/ProfileCache.js';
+import { encodeRemoteSource, resolveRemoteRepositorySubpath } from '../profiles/ProfileCache.js';
 import type { Settings, SourceReference } from '../settings/Settings.js';
 import type { Layer } from './Resource.js';
 
@@ -14,13 +14,17 @@ export interface LayerDiscoveryInput {
 
 const agentsRoot = (directory: string): string => join(directory, '.agents');
 
-const sourceLayer = (homeDirectory: string, source: SourceReference): Layer => {
+// Remote sources cache under the configured cache_directory, defaulting to ~/.agents/cache.
+const cacheRoot = (input: LayerDiscoveryInput): string =>
+  input.settings.cacheDirectory ?? join(input.homeDirectory, '.agents', 'cache');
+
+const sourceLayer = (input: LayerDiscoveryInput, source: SourceReference): Layer => {
   if (source.path !== undefined && source.uri === undefined && source.github === undefined) {
     return { root: source.path, origin: 'source', label: source.path };
   }
 
   const remote = source as { readonly uri?: string; readonly github?: string; readonly ref?: string };
-  const repositoryPath = createRemoteRepositoryCachePath(homeDirectory, remote as never);
+  const repositoryPath = join(cacheRoot(input), 'repos', encodeRemoteSource(remote as never));
   const root = source.path === undefined ? repositoryPath : resolveRemoteRepositorySubpath(repositoryPath, source.path);
   const label = remote.uri ?? `github:${remote.github}`;
 
@@ -35,7 +39,7 @@ export const discoverLayers = (input: LayerDiscoveryInput): readonly Layer[] => 
   const candidates: Layer[] = [
     { root: agentsRoot(input.projectDirectory), origin: 'workspace', label: 'workspace' },
     { root: agentsRoot(input.homeDirectory), origin: 'global', label: 'global' },
-    ...(input.settings.sources ?? []).map((source) => sourceLayer(input.homeDirectory, source)),
+    ...(input.settings.sources ?? []).map((source) => sourceLayer(input, source)),
   ];
 
   return candidates.filter((layer) => existsSync(layer.root));

--- a/code/cli/src/resolver/Resolver.ts
+++ b/code/cli/src/resolver/Resolver.ts
@@ -1,9 +1,27 @@
 // Resolves protocol resources from layered `.agents` trees into one immutable effective resource set.
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync, readdirSync, statSync } from 'node:fs';
 import { join, posix, relative, sep } from 'node:path';
 
 import type { EffectiveResourceSet, Layer, ResourceDefinition, ResourceKind, ResolvedResource } from './Resource.js';
 import { resourceKinds } from './Resource.js';
+
+/** True when the path resolves (following symlinks) to a directory; false for broken links. */
+const resolvesToDirectory = (path: string): boolean => {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+};
+
+/** True when the path resolves (following symlinks) to a file; false for broken links. */
+const resolvesToFile = (path: string): boolean => {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+};
 
 const directoryResourceKinds: ReadonlyMap<ResourceKind, string> = new Map([
   ['agent', 'agents'],
@@ -20,13 +38,14 @@ const fileTreeResourceKinds: ReadonlyMap<ResourceKind, string> = new Map([
   ['command', 'commands'],
 ]);
 
+// Symlinked directories are followed (matching the skill catalog), so a resource can be a link.
 const listSubdirectories = (directory: string): readonly string[] => {
   if (!existsSync(directory)) {
     return [];
   }
 
   return readdirSync(directory, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
+    .filter((entry) => resolvesToDirectory(join(directory, entry.name)))
     .map((entry) => entry.name);
 };
 
@@ -40,9 +59,9 @@ const listFilesRecursively = (root: string): readonly string[] => {
   for (const entry of readdirSync(root, { withFileTypes: true })) {
     const entryPath = join(root, entry.name);
 
-    if (entry.isDirectory()) {
+    if (resolvesToDirectory(entryPath)) {
       files.push(...listFilesRecursively(entryPath));
-    } else if (entry.isFile()) {
+    } else if (resolvesToFile(entryPath)) {
       files.push(entryPath);
     }
   }
@@ -57,9 +76,26 @@ const discoverDirectoryResources = (layer: Layer, kind: ResourceKind): readonly 
   const entryFile = entryFileByKind.get(kind)!;
 
   return listSubdirectories(container)
-    .filter((slug) => existsSync(join(container, slug, entryFile)))
+    .filter((slug) => resolvesToFile(join(container, slug, entryFile)))
     .map((slug) => ({ kind, slug, layer, path: join(container, slug, entryFile) }));
 };
+
+// Per-agent config.json paths across every layer that defines the agent, highest precedence first.
+const collectAgentConfigPaths = (layers: readonly Layer[], slug: string): readonly string[] =>
+  layers
+    .map((layer) => join(layer.root, 'agents', slug, 'config.json'))
+    .filter((configPath) => resolvesToFile(configPath));
+
+const withAgentConfigPaths = (
+  layers: readonly Layer[],
+  agents: ReadonlyMap<string, ResolvedResource>,
+): ReadonlyMap<string, ResolvedResource> =>
+  new Map(
+    [...agents.entries()].map(([slug, resource]) => [
+      slug,
+      { ...resource, configPaths: collectAgentConfigPaths(layers, slug) },
+    ]),
+  );
 
 const discoverFileResources = (layer: Layer, kind: ResourceKind): readonly ResourceDefinition[] => {
   const container = join(layer.root, fileTreeResourceKinds.get(kind)!);
@@ -99,7 +135,8 @@ export const resolveResources = (layers: readonly Layer[]): EffectiveResourceSet
   const resources = new Map<ResourceKind, ReadonlyMap<string, ResolvedResource>>();
 
   for (const kind of resourceKinds) {
-    resources.set(kind, resolveKind(layers, kind));
+    const resolved = resolveKind(layers, kind);
+    resources.set(kind, kind === 'agent' ? withAgentConfigPaths(layers, resolved) : resolved);
   }
 
   return { layers, resources };

--- a/code/cli/src/resolver/Resolver.ts
+++ b/code/cli/src/resolver/Resolver.ts
@@ -1,0 +1,106 @@
+// Resolves protocol resources from layered `.agents` trees into one immutable effective resource set.
+import { existsSync, readdirSync } from 'node:fs';
+import { join, posix, relative, sep } from 'node:path';
+
+import type { EffectiveResourceSet, Layer, ResourceDefinition, ResourceKind, ResolvedResource } from './Resource.js';
+import { resourceKinds } from './Resource.js';
+
+const directoryResourceKinds: ReadonlyMap<ResourceKind, string> = new Map([
+  ['agent', 'agents'],
+  ['skill', 'skills'],
+]);
+
+const entryFileByKind: ReadonlyMap<ResourceKind, string> = new Map([
+  ['agent', 'agent.md'],
+  ['skill', 'SKILL.md'],
+]);
+
+const fileTreeResourceKinds: ReadonlyMap<ResourceKind, string> = new Map([
+  ['knowledge', 'knowledge'],
+  ['command', 'commands'],
+]);
+
+const listSubdirectories = (directory: string): readonly string[] => {
+  if (!existsSync(directory)) {
+    return [];
+  }
+
+  return readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+};
+
+const listFilesRecursively = (root: string): readonly string[] => {
+  if (!existsSync(root)) {
+    return [];
+  }
+
+  const files: string[] = [];
+
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const entryPath = join(root, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...listFilesRecursively(entryPath));
+    } else if (entry.isFile()) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+};
+
+const toSlug = (root: string, entryPath: string): string => relative(root, entryPath).split(sep).join(posix.sep);
+
+const discoverDirectoryResources = (layer: Layer, kind: ResourceKind): readonly ResourceDefinition[] => {
+  const container = join(layer.root, directoryResourceKinds.get(kind)!);
+  const entryFile = entryFileByKind.get(kind)!;
+
+  return listSubdirectories(container)
+    .filter((slug) => existsSync(join(container, slug, entryFile)))
+    .map((slug) => ({ kind, slug, layer, path: join(container, slug, entryFile) }));
+};
+
+const discoverFileResources = (layer: Layer, kind: ResourceKind): readonly ResourceDefinition[] => {
+  const container = join(layer.root, fileTreeResourceKinds.get(kind)!);
+
+  return listFilesRecursively(container).map((path) => ({ kind, slug: toSlug(container, path), layer, path }));
+};
+
+const discoverLayerResources = (layer: Layer, kind: ResourceKind): readonly ResourceDefinition[] =>
+  directoryResourceKinds.has(kind) ? discoverDirectoryResources(layer, kind) : discoverFileResources(layer, kind);
+
+const resolveKind = (layers: readonly Layer[], kind: ResourceKind): ReadonlyMap<string, ResolvedResource> => {
+  const bySlug = new Map<string, { winner: ResourceDefinition; shadowed: ResourceDefinition[] }>();
+
+  // Layers are ordered highest precedence first, so the first definition of a slug wins.
+  for (const layer of layers) {
+    for (const definition of discoverLayerResources(layer, kind)) {
+      const existing = bySlug.get(definition.slug);
+
+      if (existing === undefined) {
+        bySlug.set(definition.slug, { winner: definition, shadowed: [] });
+      } else {
+        existing.shadowed.push(definition);
+      }
+    }
+  }
+
+  return new Map(
+    [...bySlug.entries()].map(([slug, entry]) => [
+      slug,
+      { kind, slug, winner: entry.winner, shadowed: entry.shadowed },
+    ]),
+  );
+};
+
+/** Produces the single effective resource set consumed by list, validate, run, and dump. */
+export const resolveResources = (layers: readonly Layer[]): EffectiveResourceSet => {
+  const resources = new Map<ResourceKind, ReadonlyMap<string, ResolvedResource>>();
+
+  for (const kind of resourceKinds) {
+    resources.set(kind, resolveKind(layers, kind));
+  }
+
+  return { layers, resources };
+};

--- a/code/cli/src/resolver/ResolverContext.ts
+++ b/code/cli/src/resolver/ResolverContext.ts
@@ -1,0 +1,24 @@
+// Shared entry point that turns a home/project location into one effective resource set.
+import { loadSettingsWithCachedRemoteSettings } from '../settings/SettingsLoader.js';
+import type { SettingsLoadIssue } from '../settings/SettingsLoader.js';
+import { discoverLayers } from './Layer.js';
+import type { EffectiveResourceSet } from './Resource.js';
+import { resolveResources } from './Resolver.js';
+
+export interface ResolveInput {
+  readonly homeDirectory: string;
+  readonly projectDirectory: string;
+}
+
+export interface ResolveResult {
+  readonly set: EffectiveResourceSet;
+  readonly settingsIssues: readonly SettingsLoadIssue[];
+}
+
+/** The single shared resolution path used by list, validate, run, and dump. */
+export const resolveEffectiveSet = (input: ResolveInput): ResolveResult => {
+  const loadedSettings = loadSettingsWithCachedRemoteSettings(input);
+  const layers = discoverLayers({ ...input, settings: loadedSettings.settings });
+
+  return { set: resolveResources(layers), settingsIssues: loadedSettings.issues };
+};

--- a/code/cli/src/resolver/ResolverValidation.ts
+++ b/code/cli/src/resolver/ResolverValidation.ts
@@ -1,6 +1,5 @@
-// Validates an effective resource set: agent frontmatter, unresolved loadout slugs, and shadowing.
-import { dirname } from 'node:path';
-
+// Validates an effective resource set: agent + skill definitions, unresolved loadout slugs, shadowing.
+import { isSkillDocumentIssue, readSkillDocument } from '../skills/SkillDocument.js';
 import { isAgentDefinitionIssue, readAgentDefinition } from './AgentDefinition.js';
 import type { EffectiveResourceSet, ResolvedResource } from './Resource.js';
 import { listResources } from './Resource.js';
@@ -27,7 +26,7 @@ const loadoutSlugReference = (
     }));
 
 const validateAgent = (set: EffectiveResourceSet, agent: ResolvedResource): readonly ValidationFinding[] => {
-  const definition = readAgentDefinition(dirname(agent.winner.path), agent.winner.path);
+  const definition = readAgentDefinition(agent.winner.path, agent.configPaths ?? []);
 
   if (isAgentDefinitionIssue(definition)) {
     return [{ severity: 'error', resource: `agent:${agent.slug}`, message: definition.message }];
@@ -49,6 +48,26 @@ const validateAgent = (set: EffectiveResourceSet, agent: ResolvedResource): read
   ];
 };
 
+const validateSkill = (skill: ResolvedResource): readonly ValidationFinding[] => {
+  const document = readSkillDocument(skill.winner.path);
+
+  if (isSkillDocumentIssue(document)) {
+    return [{ severity: 'error', resource: `skill:${skill.slug}`, message: document.message }];
+  }
+
+  if (document.name !== skill.slug) {
+    return [
+      {
+        severity: 'error',
+        resource: `skill:${skill.slug}`,
+        message: `SKILL.md name '${document.name}' must match its directory '${skill.slug}'.`,
+      },
+    ];
+  }
+
+  return [];
+};
+
 const shadowFindings = (resource: ResolvedResource): readonly ValidationFinding[] =>
   resource.shadowed.map((definition) => ({
     severity: 'warning' as const,
@@ -56,12 +75,19 @@ const shadowFindings = (resource: ResolvedResource): readonly ValidationFinding[
     message: `shadowed definition in ${definition.layer.label} is overridden by ${resource.winner.layer.label}.`,
   }));
 
-/** Collects validation findings across the effective set. Errors fail `--strict`; warnings are advisory. */
+/**
+ * Collects validation findings across the effective set. `error` findings always fail validation;
+ * `warning` findings (such as shadowed definitions) fail only under `--strict`.
+ */
 export const validateEffectiveSet = (set: EffectiveResourceSet): readonly ValidationFinding[] => {
   const findings: ValidationFinding[] = [];
 
   for (const agent of listResources(set, 'agent')) {
     findings.push(...validateAgent(set, agent));
+  }
+
+  for (const skill of listResources(set, 'skill')) {
+    findings.push(...validateSkill(skill));
   }
 
   for (const kind of ['agent', 'skill', 'knowledge', 'command'] as const) {

--- a/code/cli/src/resolver/ResolverValidation.ts
+++ b/code/cli/src/resolver/ResolverValidation.ts
@@ -1,0 +1,74 @@
+// Validates an effective resource set: agent frontmatter, unresolved loadout slugs, and shadowing.
+import { dirname } from 'node:path';
+
+import { isAgentDefinitionIssue, readAgentDefinition } from './AgentDefinition.js';
+import type { EffectiveResourceSet, ResolvedResource } from './Resource.js';
+import { listResources } from './Resource.js';
+
+export interface ValidationFinding {
+  readonly severity: 'error' | 'warning';
+  readonly resource: string;
+  readonly message: string;
+}
+
+const loadoutSlugReference = (
+  set: EffectiveResourceSet,
+  agentSlug: string,
+  kind: 'agent' | 'skill',
+  field: string,
+  slugs: readonly string[],
+): readonly ValidationFinding[] =>
+  slugs
+    .filter((slug) => set.resources.get(kind)?.get(slug) === undefined)
+    .map((slug) => ({
+      severity: 'error' as const,
+      resource: `agent:${agentSlug}`,
+      message: `loadout ${field} references unknown ${kind} '${slug}'.`,
+    }));
+
+const validateAgent = (set: EffectiveResourceSet, agent: ResolvedResource): readonly ValidationFinding[] => {
+  const definition = readAgentDefinition(dirname(agent.winner.path), agent.winner.path);
+
+  if (isAgentDefinitionIssue(definition)) {
+    return [{ severity: 'error', resource: `agent:${agent.slug}`, message: definition.message }];
+  }
+
+  if (definition.name !== agent.slug) {
+    return [
+      {
+        severity: 'error',
+        resource: `agent:${agent.slug}`,
+        message: `agent.md name '${definition.name}' must match its directory '${agent.slug}'.`,
+      },
+    ];
+  }
+
+  return [
+    ...loadoutSlugReference(set, agent.slug, 'skill', 'skills', definition.loadout.skills),
+    ...loadoutSlugReference(set, agent.slug, 'agent', 'subagents', definition.loadout.subagents),
+  ];
+};
+
+const shadowFindings = (resource: ResolvedResource): readonly ValidationFinding[] =>
+  resource.shadowed.map((definition) => ({
+    severity: 'warning' as const,
+    resource: `${resource.kind}:${resource.slug}`,
+    message: `shadowed definition in ${definition.layer.label} is overridden by ${resource.winner.layer.label}.`,
+  }));
+
+/** Collects validation findings across the effective set. Errors fail `--strict`; warnings are advisory. */
+export const validateEffectiveSet = (set: EffectiveResourceSet): readonly ValidationFinding[] => {
+  const findings: ValidationFinding[] = [];
+
+  for (const agent of listResources(set, 'agent')) {
+    findings.push(...validateAgent(set, agent));
+  }
+
+  for (const kind of ['agent', 'skill', 'knowledge', 'command'] as const) {
+    for (const resource of listResources(set, kind)) {
+      findings.push(...shadowFindings(resource));
+    }
+  }
+
+  return findings;
+};

--- a/code/cli/src/resolver/Resource.ts
+++ b/code/cli/src/resolver/Resource.ts
@@ -51,7 +51,16 @@ export interface ResolvedResource {
   readonly slug: string;
   readonly winner: ResourceDefinition;
   readonly shadowed: readonly ResourceDefinition[];
+  /**
+   * For agents: existing `config.json` paths across all layers, highest precedence first. Per-agent
+   * JSON merges across layers independently of the markdown merge-by-ID, so a workspace config can
+   * override one loadout field of a globally defined agent.
+   */
+  readonly configPaths?: readonly string[];
 }
+
+/** Locale-independent, deterministic slug ordering (code-unit comparison). */
+export const compareSlugs = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0);
 
 /** One immutable effective resource set per invocation, keyed by kind then slug. */
 export interface EffectiveResourceSet {
@@ -66,7 +75,7 @@ export const listResources = (set: EffectiveResourceSet, kind: ResourceKind): re
     return [];
   }
 
-  return [...bySlug.values()].sort((left, right) => left.slug.localeCompare(right.slug));
+  return [...bySlug.values()].sort((left, right) => compareSlugs(left.slug, right.slug));
 };
 
 export const findResource = (

--- a/code/cli/src/resolver/Resource.ts
+++ b/code/cli/src/resolver/Resource.ts
@@ -1,0 +1,76 @@
+// Core resource-model types shared across the resolver, list, validate, run, and dump paths.
+
+/** Kinds of protocol resources Outfitter resolves by slug across `.agents` layers. */
+export type ResourceKind = 'agent' | 'skill' | 'knowledge' | 'command';
+
+export const resourceKinds: readonly ResourceKind[] = ['agent', 'skill', 'knowledge', 'command'];
+
+/** Where a layer originates, highest precedence first. */
+export type LayerOrigin = 'workspace' | 'global' | 'source';
+
+export interface Layer {
+  /** Absolute path to the `.agents` payload root for this layer. */
+  readonly root: string;
+  readonly origin: LayerOrigin;
+  /** Human-readable label for diagnostics, e.g. `workspace`, `global`, or a source URI. */
+  readonly label: string;
+}
+
+/** An agent's loadout — the resources and runtime options it composes with. */
+export interface Loadout {
+  readonly skills: readonly string[];
+  readonly subagents: readonly string[];
+  readonly mcp: readonly string[];
+  readonly extensions: readonly string[];
+  readonly plugins: readonly string[];
+  readonly model?: string;
+  readonly thinking?: string;
+  readonly tools?: { readonly allow?: readonly string[]; readonly deny?: readonly string[] };
+}
+
+export const emptyLoadout = (): Loadout => ({
+  skills: [],
+  subagents: [],
+  mcp: [],
+  extensions: [],
+  plugins: [],
+});
+
+/** A single resource definition discovered in one layer. */
+export interface ResourceDefinition {
+  readonly kind: ResourceKind;
+  readonly slug: string;
+  readonly layer: Layer;
+  /** Absolute path to the resource's defining file or directory. */
+  readonly path: string;
+}
+
+/** The winning definition for a slug plus any lower-precedence definitions it shadows. */
+export interface ResolvedResource {
+  readonly kind: ResourceKind;
+  readonly slug: string;
+  readonly winner: ResourceDefinition;
+  readonly shadowed: readonly ResourceDefinition[];
+}
+
+/** One immutable effective resource set per invocation, keyed by kind then slug. */
+export interface EffectiveResourceSet {
+  readonly layers: readonly Layer[];
+  readonly resources: ReadonlyMap<ResourceKind, ReadonlyMap<string, ResolvedResource>>;
+}
+
+export const listResources = (set: EffectiveResourceSet, kind: ResourceKind): readonly ResolvedResource[] => {
+  const bySlug = set.resources.get(kind);
+
+  if (bySlug === undefined) {
+    return [];
+  }
+
+  return [...bySlug.values()].sort((left, right) => left.slug.localeCompare(right.slug));
+};
+
+export const findResource = (
+  set: EffectiveResourceSet,
+  kind: ResourceKind,
+  slug: string,
+): ResolvedResource | undefined => set.resources.get(kind)?.get(slug);

--- a/code/cli/src/schemas/agent.schema.json
+++ b/code/cli/src/schemas/agent.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://outfitter.dev/schemas/agent.schema.json",
+  "title": "Outfitter agent definition frontmatter",
+  "type": "object",
+  "required": ["name"],
+  "properties": {
+    "name": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$", "maxLength": 64 },
+    "description": { "type": "string" },
+    "skills": { "$ref": "#/$defs/slugList" },
+    "subagents": { "$ref": "#/$defs/slugList" },
+    "mcp": { "$ref": "#/$defs/slugList" },
+    "extensions": { "$ref": "#/$defs/slugList" },
+    "plugins": { "$ref": "#/$defs/slugList" },
+    "model": { "type": "string", "minLength": 1 },
+    "thinking": { "type": "string", "minLength": 1 },
+    "tools": {
+      "type": "object",
+      "properties": {
+        "allow": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+        "deny": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "slugList": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    }
+  }
+}

--- a/code/cli/src/validation/SchemaValidator.ts
+++ b/code/cli/src/validation/SchemaValidator.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs';
 import type { AnySchema, ErrorObject, ValidateFunction } from 'ajv';
 import { Ajv2020 } from 'ajv/dist/2020.js';
 
-export type SchemaName = 'settings' | 'profile' | 'profile-source';
+export type SchemaName = 'settings' | 'profile' | 'profile-source' | 'agent';
 
 export interface ValidationIssue {
   readonly path: string;
@@ -22,12 +22,14 @@ const readSchema = (schemaFileName: string): unknown =>
 const settingsSchema = readSchema('settings.schema.json');
 const profileSchema = readSchema('profile.schema.json');
 const profileSourceSchema = readSchema('profile-source.schema.json');
+const agentSchema = readSchema('agent.schema.json');
 
 const createAjv = (): Ajv2020 => {
   const ajv = new Ajv2020({ allErrors: true });
   ajv.addSchema(profileSourceSchema as AnySchema, 'profile-source.schema.json');
   ajv.addSchema(profileSchema as AnySchema, 'profile.schema.json');
   ajv.addSchema(settingsSchema as AnySchema, 'settings.schema.json');
+  ajv.addSchema(agentSchema as AnySchema, 'agent.schema.json');
   return ajv;
 };
 
@@ -37,6 +39,7 @@ const validators: Record<SchemaName, ValidateFunction> = {
   settings: ajv.compile(settingsSchema as AnySchema),
   profile: ajv.compile(profileSchema as AnySchema),
   'profile-source': ajv.compile(profileSourceSchema as AnySchema),
+  agent: ajv.compile(agentSchema as AnySchema),
 };
 
 export const createValidationResult = (issues: readonly ValidationIssue[]): ValidationResult => ({

--- a/code/cli/tests/unit/resolver-cli.test.ts
+++ b/code/cli/tests/unit/resolver-cli.test.ts
@@ -1,0 +1,101 @@
+// Exercises the list/validate command objects through Commander parseAsync (the user-facing path).
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { Command } from 'commander';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createListCommand } from '../../src/cli/commands/ListCommand.js';
+import { createValidateCommand, executeValidateCommand } from '../../src/cli/commands/ValidateCommand.js';
+
+const temporaryRoots: string[] = [];
+let previousExitCode: typeof process.exitCode;
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-cli-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const write = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+
+beforeEach(() => {
+  previousExitCode = process.exitCode;
+});
+
+afterEach(() => {
+  process.exitCode = previousExitCode;
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+const project = (): string => {
+  const root = createTemporaryRoot();
+  write(
+    join(root, 'project', '.agents', 'agents', 'engineer', 'agent.md'),
+    '---\nname: engineer\nskills: [ghost]\n---\n\nBody.\n',
+  );
+  return root;
+};
+
+const buildProgram = (root: string, lines: string[]): Command => {
+  const program = new Command();
+  const deps = {
+    homeDirectory: join(root, 'home'),
+    projectDirectory: join(root, 'project'),
+    writeLine: (message: string) => lines.push(message),
+  };
+  createListCommand(deps).register(program);
+  createValidateCommand(deps).register(program);
+  return program;
+};
+
+describe('resolver command objects', () => {
+  it('list forwards the positional kind and writes through the injected writer', async () => {
+    const lines: string[] = [];
+    await buildProgram(project(), lines).parseAsync(['node', 'outfitter', 'list', 'agents']);
+    expect(lines.join('\n')).toContain('engineer  [workspace]');
+  });
+
+  it('validate forwards --strict/--json and sets a nonzero exit code on failure', async () => {
+    const lines: string[] = [];
+    await buildProgram(project(), lines).parseAsync(['node', 'outfitter', 'validate', '--json']);
+    // The engineer agent references an unknown skill, so validation fails.
+    expect(process.exitCode).toBe(1);
+    expect(lines[0]).toContain('"ok": false');
+    expect(lines[0]).toContain('ghost');
+  });
+
+  it('surfaces invalid settings: list throws, validate reports a finding', async () => {
+    const root = createTemporaryRoot();
+    write(join(root, 'project', '.agents', 'settings.yml'), 'default_harness: bun\n');
+    const lines: string[] = [];
+
+    await expect(buildProgram(root, lines).parseAsync(['node', 'outfitter', 'list'])).rejects.toThrow(
+      /invalid settings/,
+    );
+
+    const validation = executeValidateCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: join(root, 'project'),
+    });
+    expect(validation.ok).toBe(false);
+    expect(validation.findings.some((f) => f.resource === 'settings')).toBe(true);
+  });
+
+  it('reports a clean validation when nothing is wrong', () => {
+    const root = createTemporaryRoot();
+    write(join(root, 'project', '.agents', 'agents', 'ok', 'agent.md'), '---\nname: ok\n---\n\nBody.\n');
+    const result = executeValidateCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: join(root, 'project'),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.messages).toContain('✓ No issues found.');
+  });
+});

--- a/code/cli/tests/unit/resolver.test.ts
+++ b/code/cli/tests/unit/resolver.test.ts
@@ -1,0 +1,207 @@
+// Tests the .agents resolver: layer ordering, merge-by-ID shadowing, agent parsing, and validation.
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  parseAgentDefinition,
+  readAgentDefinition,
+  isAgentDefinitionIssue,
+} from '../../src/resolver/AgentDefinition.js';
+import { discoverLayers } from '../../src/resolver/Layer.js';
+import { findResource, listResources } from '../../src/resolver/Resource.js';
+import { resolveResources } from '../../src/resolver/Resolver.js';
+import { validateEffectiveSet } from '../../src/resolver/ResolverValidation.js';
+import { executeListCommand } from '../../src/cli/commands/ListCommand.js';
+import { executeValidateCommand } from '../../src/cli/commands/ValidateCommand.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-resolver-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const write = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+
+const agentMd = (name: string, extra = ''): string =>
+  `---\nname: ${name}\ndescription: The ${name} agent.\n${extra}---\n\n# ${name}\n\nBody for ${name}.\n`;
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('agent definition parsing', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.1, OFTR-003.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('parses frontmatter loadout and markdown body', () => {
+    const parsed = parseAgentDefinition(
+      agentMd(
+        'engineer',
+        'skills: [wiki, research]\nsubagents: [code-reviewer]\nmodel: gpt-5.2\nthinking: high\ntools:\n  allow: [read, edit]\n',
+      ),
+      '/nowhere',
+      '/nowhere/agent.md',
+    );
+
+    expect(isAgentDefinitionIssue(parsed)).toBe(false);
+    if (isAgentDefinitionIssue(parsed)) return;
+    expect(parsed.name).toBe('engineer');
+    expect(parsed.loadout.skills).toEqual(['wiki', 'research']);
+    expect(parsed.loadout.subagents).toEqual(['code-reviewer']);
+    expect(parsed.loadout.model).toBe('gpt-5.2');
+    expect(parsed.loadout.tools).toEqual({ allow: ['read', 'edit'], deny: [] });
+    expect(parsed.body).toContain('# engineer');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.4).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('merges config.json loadout over frontmatter by key', () => {
+    const root = createTemporaryRoot();
+    const agentDir = join(root, 'agents', 'engineer');
+    write(join(agentDir, 'agent.md'), agentMd('engineer', 'skills: [wiki]\nmodel: gpt-5.2\n'));
+    write(join(agentDir, 'config.json'), JSON.stringify({ model: 'gpt-5.3-mini' }));
+
+    const parsed = readAgentDefinition(agentDir, join(agentDir, 'agent.md'));
+
+    expect(isAgentDefinitionIssue(parsed)).toBe(false);
+    if (isAgentDefinitionIssue(parsed)) return;
+    expect(parsed.loadout.skills).toEqual(['wiki']);
+    expect(parsed.loadout.model).toBe('gpt-5.3-mini');
+  });
+
+  it('reports missing frontmatter, invalid YAML, non-mapping, schema, and read errors', () => {
+    expect(parseAgentDefinition('no frontmatter', '/x', '/x/agent.md')).toMatchObject({
+      message: expect.stringContaining('frontmatter block'),
+    });
+    expect(parseAgentDefinition('---\n: bad: yaml:\n---\n', '/x', '/x/agent.md')).toMatchObject({
+      message: expect.stringContaining('not valid YAML'),
+    });
+    expect(parseAgentDefinition('---\n- 1\n- 2\n---\n', '/x', '/x/agent.md')).toMatchObject({
+      message: expect.stringContaining('YAML mapping'),
+    });
+    expect(parseAgentDefinition('---\ndescription: no name\n---\n', '/x', '/x/agent.md')).toMatchObject({
+      message: expect.stringContaining('invalid'),
+    });
+    expect(readAgentDefinition('/missing', '/missing/agent.md')).toMatchObject({
+      message: expect.stringContaining('Could not read'),
+    });
+  });
+});
+
+describe('layer discovery', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('orders workspace over global over sources and drops missing roots', () => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    const shared = join(root, 'shared');
+    write(join(home, '.agents', 'agents', 'a', 'agent.md'), agentMd('a'));
+    write(join(project, '.agents', 'agents', 'b', 'agent.md'), agentMd('b'));
+    write(join(shared, 'agents', 'c', 'agent.md'), agentMd('c'));
+
+    const layers = discoverLayers({
+      homeDirectory: home,
+      projectDirectory: project,
+      settings: { sources: [{ path: shared }, { path: join(root, 'absent') }] },
+    });
+
+    expect(layers.map((layer) => layer.origin)).toEqual(['workspace', 'global', 'source']);
+  });
+});
+
+describe('resource resolution', () => {
+  const buildTree = (): { home: string; project: string } => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    // global defines engineer + a skill; workspace shadows engineer and adds knowledge/commands.
+    write(join(home, '.agents', 'agents', 'engineer', 'agent.md'), agentMd('engineer', 'skills: [wiki]\n'));
+    write(join(home, '.agents', 'skills', 'wiki', 'SKILL.md'), '---\nname: wiki\n---\n');
+    write(join(project, '.agents', 'agents', 'engineer', 'agent.md'), agentMd('engineer', 'skills: [wiki]\n'));
+    write(join(project, '.agents', 'knowledge', 'arch', 'overview.md'), '# overview\n');
+    write(join(project, '.agents', 'commands', 'ship.md'), '# ship\n');
+    return { home, project };
+  };
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.4, OFTR-003.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('builds the effective set with merge-by-ID shadowing', () => {
+    const { home, project } = buildTree();
+    const layers = discoverLayers({ homeDirectory: home, projectDirectory: project, settings: {} });
+    const set = resolveResources(layers);
+
+    const engineer = findResource(set, 'agent', 'engineer');
+    expect(engineer?.winner.layer.origin).toBe('workspace');
+    expect(engineer?.shadowed).toHaveLength(1);
+    expect(engineer?.shadowed[0]?.layer.origin).toBe('global');
+    expect(listResources(set, 'skill').map((r) => r.slug)).toEqual(['wiki']);
+    expect(listResources(set, 'knowledge').map((r) => r.slug)).toEqual(['arch/overview.md']);
+    expect(listResources(set, 'command').map((r) => r.slug)).toEqual(['ship.md']);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.7, OFTR-003.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('lists resources by kind and reports shadow warnings during validation', () => {
+    const { home, project } = buildTree();
+    const listed = executeListCommand({ homeDirectory: home, projectDirectory: project, kind: 'agents' });
+    expect(listed.messages.join('\n')).toContain('engineer  [workspace]');
+
+    const validation = executeValidateCommand({ homeDirectory: home, projectDirectory: project });
+    expect(validation.ok).toBe(true);
+    expect(validation.findings.some((f) => f.severity === 'warning' && f.resource === 'agent:engineer')).toBe(true);
+
+    const strict = executeValidateCommand({ homeDirectory: home, projectDirectory: project, strict: true });
+    expect(strict.ok).toBe(false);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.2, OFTR-003.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('flags unknown loadout slugs and name mismatches as errors', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    write(join(project, '.agents', 'agents', 'engineer', 'agent.md'), agentMd('engineer', 'skills: [missing]\n'));
+    write(join(project, '.agents', 'agents', 'mislabeled', 'agent.md'), agentMd('other'));
+
+    const set = resolveResources(
+      discoverLayers({ homeDirectory: join(root, 'home'), projectDirectory: project, settings: {} }),
+    );
+    const findings = validateEffectiveSet(set);
+
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        severity: 'error',
+        resource: 'agent:engineer',
+        message: expect.stringContaining("unknown skill 'missing'"),
+      }),
+    );
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        severity: 'error',
+        resource: 'agent:mislabeled',
+        message: expect.stringContaining('must match its directory'),
+      }),
+    );
+  });
+
+  it('rejects an unknown list kind and lists all kinds by default', () => {
+    const { home, project } = buildTree();
+    expect(() => executeListCommand({ homeDirectory: home, projectDirectory: project, kind: 'widgets' })).toThrow(
+      /Unknown resource kind/,
+    );
+    const all = executeListCommand({ homeDirectory: home, projectDirectory: project });
+    expect(all.messages).toContain('agents:');
+    expect(all.messages).toContain('skills:');
+    expect(all.messages).toContain('knowledge:');
+    expect(all.messages).toContain('commands:');
+  });
+});

--- a/code/cli/tests/unit/resolver.test.ts
+++ b/code/cli/tests/unit/resolver.test.ts
@@ -1,17 +1,18 @@
-// Tests the .agents resolver: layer ordering, merge-by-ID shadowing, agent parsing, and validation.
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+// Tests the .agents resolver: layer ordering, merge-by-ID shadowing, agent/skill parsing, validation.
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { encodeRemoteSource } from '../../src/profiles/ProfileCache.js';
 import {
+  isAgentDefinitionIssue,
   parseAgentDefinition,
   readAgentDefinition,
-  isAgentDefinitionIssue,
 } from '../../src/resolver/AgentDefinition.js';
 import { discoverLayers } from '../../src/resolver/Layer.js';
-import { findResource, listResources } from '../../src/resolver/Resource.js';
+import { compareSlugs, findResource, listResources } from '../../src/resolver/Resource.js';
 import { resolveResources } from '../../src/resolver/Resolver.js';
 import { validateEffectiveSet } from '../../src/resolver/ResolverValidation.js';
 import { executeListCommand } from '../../src/cli/commands/ListCommand.js';
@@ -33,6 +34,16 @@ const write = (path: string, content: string): void => {
 const agentMd = (name: string, extra = ''): string =>
   `---\nname: ${name}\ndescription: The ${name} agent.\n${extra}---\n\n# ${name}\n\nBody for ${name}.\n`;
 
+const setFor = (home: string, project: string, sources: { path: string }[] = []) =>
+  resolveResources(discoverLayers({ homeDirectory: home, projectDirectory: project, settings: { sources } }));
+
+const expectIssueContaining = (result: ReturnType<typeof parseAgentDefinition>, substring: string): void => {
+  expect(isAgentDefinitionIssue(result)).toBe(true);
+  if (isAgentDefinitionIssue(result)) {
+    expect(result.message).toContain(substring);
+  }
+};
+
 afterEach(() => {
   for (const root of temporaryRoots.splice(0)) {
     rmSync(root, { recursive: true, force: true });
@@ -46,9 +57,9 @@ describe('agent definition parsing', () => {
     const parsed = parseAgentDefinition(
       agentMd(
         'engineer',
-        'skills: [wiki, research]\nsubagents: [code-reviewer]\nmodel: gpt-5.2\nthinking: high\ntools:\n  allow: [read, edit]\n',
+        'skills: [wiki, research]\nsubagents: [code-reviewer]\nmodel: gpt-5.2\ntools:\n  allow: [read]\n',
       ),
-      '/nowhere',
+      [],
       '/nowhere/agent.md',
     );
 
@@ -56,44 +67,57 @@ describe('agent definition parsing', () => {
     if (isAgentDefinitionIssue(parsed)) return;
     expect(parsed.name).toBe('engineer');
     expect(parsed.loadout.skills).toEqual(['wiki', 'research']);
-    expect(parsed.loadout.subagents).toEqual(['code-reviewer']);
-    expect(parsed.loadout.model).toBe('gpt-5.2');
-    expect(parsed.loadout.tools).toEqual({ allow: ['read', 'edit'], deny: [] });
+    expect(parsed.loadout.tools).toEqual({ allow: ['read'], deny: [] });
     expect(parsed.body).toContain('# engineer');
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.4).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('merges config.json loadout over frontmatter by key', () => {
+  it('merges config.json loadout over frontmatter by key, restricted to loadout fields', () => {
     const root = createTemporaryRoot();
     const agentDir = join(root, 'agents', 'engineer');
     write(join(agentDir, 'agent.md'), agentMd('engineer', 'skills: [wiki]\nmodel: gpt-5.2\n'));
-    write(join(agentDir, 'config.json'), JSON.stringify({ model: 'gpt-5.3-mini' }));
+    // config.json attempts to also override identity `name`, which must be ignored.
+    write(join(agentDir, 'config.json'), JSON.stringify({ model: 'gpt-5.3-mini', name: 'evil' }));
 
-    const parsed = readAgentDefinition(agentDir, join(agentDir, 'agent.md'));
+    const parsed = readAgentDefinition(join(agentDir, 'agent.md'), [join(agentDir, 'config.json')]);
 
     expect(isAgentDefinitionIssue(parsed)).toBe(false);
     if (isAgentDefinitionIssue(parsed)) return;
+    expect(parsed.name).toBe('engineer'); // identity stays from frontmatter
     expect(parsed.loadout.skills).toEqual(['wiki']);
     expect(parsed.loadout.model).toBe('gpt-5.3-mini');
   });
 
-  it('reports missing frontmatter, invalid YAML, non-mapping, schema, and read errors', () => {
-    expect(parseAgentDefinition('no frontmatter', '/x', '/x/agent.md')).toMatchObject({
-      message: expect.stringContaining('frontmatter block'),
-    });
-    expect(parseAgentDefinition('---\n: bad: yaml:\n---\n', '/x', '/x/agent.md')).toMatchObject({
-      message: expect.stringContaining('not valid YAML'),
-    });
-    expect(parseAgentDefinition('---\n- 1\n- 2\n---\n', '/x', '/x/agent.md')).toMatchObject({
-      message: expect.stringContaining('YAML mapping'),
-    });
-    expect(parseAgentDefinition('---\ndescription: no name\n---\n', '/x', '/x/agent.md')).toMatchObject({
-      message: expect.stringContaining('invalid'),
-    });
-    expect(readAgentDefinition('/missing', '/missing/agent.md')).toMatchObject({
-      message: expect.stringContaining('Could not read'),
-    });
+  it('validates frontmatter independently so config cannot supply required identity', () => {
+    const root = createTemporaryRoot();
+    const agentDir = join(root, 'agents', 'x');
+    write(join(agentDir, 'agent.md'), '---\ndescription: no name\n---\n\nBody.\n');
+    write(join(agentDir, 'config.json'), JSON.stringify({ skills: ['wiki'] }));
+    expectIssueContaining(readAgentDefinition(join(agentDir, 'agent.md'), [join(agentDir, 'config.json')]), 'invalid');
+  });
+
+  it('reports malformed and non-object config.json as issues', () => {
+    const root = createTemporaryRoot();
+    const agentDir = join(root, 'agents', 'engineer');
+    write(join(agentDir, 'agent.md'), agentMd('engineer'));
+    write(join(agentDir, 'bad.json'), '{ not json');
+    write(join(agentDir, 'array.json'), '[1,2]');
+    expectIssueContaining(
+      readAgentDefinition(join(agentDir, 'agent.md'), [join(agentDir, 'bad.json')]),
+      'not readable JSON',
+    );
+    expectIssueContaining(
+      readAgentDefinition(join(agentDir, 'agent.md'), [join(agentDir, 'array.json')]),
+      'must be a JSON object',
+    );
+  });
+
+  it('reports missing frontmatter, invalid YAML, non-mapping, and read errors', () => {
+    expectIssueContaining(parseAgentDefinition('no frontmatter', [], '/x/agent.md'), 'frontmatter block');
+    expectIssueContaining(parseAgentDefinition('---\n: bad: yaml:\n---\n', [], '/x/agent.md'), 'not valid YAML');
+    expectIssueContaining(parseAgentDefinition('---\n- 1\n---\n', [], '/x/agent.md'), 'YAML mapping');
+    expectIssueContaining(readAgentDefinition('/missing/agent.md'), 'Could not read');
   });
 });
 
@@ -117,6 +141,24 @@ describe('layer discovery', () => {
 
     expect(layers.map((layer) => layer.origin)).toEqual(['workspace', 'global', 'source']);
   });
+
+  it('caches remote sources under cache_directory (default ~/.agents/cache)', () => {
+    const root = createTemporaryRoot();
+    const cache = join(root, 'cache');
+    // Materialize a fake synced remote payload under the configured cache dir, using the real encoder.
+    const encoded = encodeRemoteSource({ github: 'example/.agent', ref: 'main' });
+    write(join(cache, 'repos', encoded, 'agents', 'remote-agent', 'agent.md'), agentMd('remote-agent'));
+
+    const layers = discoverLayers({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: join(root, 'project'),
+      settings: { cacheDirectory: cache, sources: [{ github: 'example/.agent', ref: 'main' }] },
+    });
+
+    expect(layers.some((layer) => layer.origin === 'source')).toBe(true);
+    const set = resolveResources(layers);
+    expect(findResource(set, 'agent', 'remote-agent')).toBeDefined();
+  });
 });
 
 describe('resource resolution', () => {
@@ -124,7 +166,6 @@ describe('resource resolution', () => {
     const root = createTemporaryRoot();
     const home = join(root, 'home');
     const project = join(root, 'project');
-    // global defines engineer + a skill; workspace shadows engineer and adds knowledge/commands.
     write(join(home, '.agents', 'agents', 'engineer', 'agent.md'), agentMd('engineer', 'skills: [wiki]\n'));
     write(join(home, '.agents', 'skills', 'wiki', 'SKILL.md'), '---\nname: wiki\n---\n');
     write(join(project, '.agents', 'agents', 'engineer', 'agent.md'), agentMd('engineer', 'skills: [wiki]\n'));
@@ -137,16 +178,50 @@ describe('resource resolution', () => {
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('builds the effective set with merge-by-ID shadowing', () => {
     const { home, project } = buildTree();
-    const layers = discoverLayers({ homeDirectory: home, projectDirectory: project, settings: {} });
-    const set = resolveResources(layers);
-
+    const set = setFor(home, project);
     const engineer = findResource(set, 'agent', 'engineer');
     expect(engineer?.winner.layer.origin).toBe('workspace');
-    expect(engineer?.shadowed).toHaveLength(1);
     expect(engineer?.shadowed[0]?.layer.origin).toBe('global');
     expect(listResources(set, 'skill').map((r) => r.slug)).toEqual(['wiki']);
     expect(listResources(set, 'knowledge').map((r) => r.slug)).toEqual(['arch/overview.md']);
     expect(listResources(set, 'command').map((r) => r.slug)).toEqual(['ship.md']);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.4).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('merges a workspace config.json over a globally defined agent by ID', () => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    write(join(home, '.agents', 'agents', 'engineer', 'agent.md'), agentMd('engineer', 'model: gpt-5.2\n'));
+    // Workspace supplies only a config.json override — no agent.md.
+    write(join(project, '.agents', 'agents', 'engineer', 'config.json'), JSON.stringify({ model: 'gpt-5.3' }));
+
+    const set = setFor(home, project);
+    const engineer = findResource(set, 'agent', 'engineer')!;
+    expect(engineer.winner.layer.origin).toBe('global');
+    const definition = readAgentDefinition(engineer.winner.path, engineer.configPaths);
+    expect(isAgentDefinitionIssue(definition)).toBe(false);
+    if (isAgentDefinitionIssue(definition)) return;
+    expect(definition.loadout.model).toBe('gpt-5.3');
+  });
+
+  it('discovers agents behind directory symlinks and skips broken links', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    const realAgent = join(root, 'real', 'linked');
+    write(join(realAgent, 'agent.md'), agentMd('linked'));
+    mkdirSync(join(project, '.agents', 'agents'), { recursive: true });
+    symlinkSync(realAgent, join(project, '.agents', 'agents', 'linked'));
+    // Broken links (dangling dir + dangling file) must be skipped, not crash discovery.
+    symlinkSync(join(root, 'nonexistent-dir'), join(project, '.agents', 'agents', 'dangling'));
+    mkdirSync(join(project, '.agents', 'commands'), { recursive: true });
+    symlinkSync(join(root, 'nonexistent-file'), join(project, '.agents', 'commands', 'dangling.md'));
+
+    const set = setFor(join(root, 'home'), project);
+    expect(findResource(set, 'agent', 'linked')).toBeDefined();
+    expect(findResource(set, 'agent', 'dangling')).toBeUndefined();
+    expect(listResources(set, 'command').map((r) => r.slug)).toEqual([]);
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.7, OFTR-003.8).
@@ -159,38 +234,25 @@ describe('resource resolution', () => {
     const validation = executeValidateCommand({ homeDirectory: home, projectDirectory: project });
     expect(validation.ok).toBe(true);
     expect(validation.findings.some((f) => f.severity === 'warning' && f.resource === 'agent:engineer')).toBe(true);
-
-    const strict = executeValidateCommand({ homeDirectory: home, projectDirectory: project, strict: true });
-    expect(strict.ok).toBe(false);
+    expect(executeValidateCommand({ homeDirectory: home, projectDirectory: project, strict: true }).ok).toBe(false);
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.2, OFTR-003.7).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('flags unknown loadout slugs and name mismatches as errors', () => {
+  it('flags unknown loadout slugs, agent and skill name mismatches as errors', () => {
     const root = createTemporaryRoot();
     const project = join(root, 'project');
     write(join(project, '.agents', 'agents', 'engineer', 'agent.md'), agentMd('engineer', 'skills: [missing]\n'));
     write(join(project, '.agents', 'agents', 'mislabeled', 'agent.md'), agentMd('other'));
+    write(join(project, '.agents', 'skills', 'wrong', 'SKILL.md'), '---\nname: notwrong\n---\n');
 
-    const set = resolveResources(
-      discoverLayers({ homeDirectory: join(root, 'home'), projectDirectory: project, settings: {} }),
-    );
-    const findings = validateEffectiveSet(set);
+    const findings = validateEffectiveSet(setFor(join(root, 'home'), project));
+    const hasFinding = (resource: string, substring: string): boolean =>
+      findings.some((finding) => finding.resource === resource && finding.message.includes(substring));
 
-    expect(findings).toContainEqual(
-      expect.objectContaining({
-        severity: 'error',
-        resource: 'agent:engineer',
-        message: expect.stringContaining("unknown skill 'missing'"),
-      }),
-    );
-    expect(findings).toContainEqual(
-      expect.objectContaining({
-        severity: 'error',
-        resource: 'agent:mislabeled',
-        message: expect.stringContaining('must match its directory'),
-      }),
-    );
+    expect(hasFinding('agent:engineer', "unknown skill 'missing'")).toBe(true);
+    expect(hasFinding('agent:mislabeled', 'must match its directory')).toBe(true);
+    expect(hasFinding('skill:wrong', 'must match its directory')).toBe(true);
   });
 
   it('rejects an unknown list kind and lists all kinds by default', () => {
@@ -199,9 +261,12 @@ describe('resource resolution', () => {
       /Unknown resource kind/,
     );
     const all = executeListCommand({ homeDirectory: home, projectDirectory: project });
-    expect(all.messages).toContain('agents:');
-    expect(all.messages).toContain('skills:');
-    expect(all.messages).toContain('knowledge:');
-    expect(all.messages).toContain('commands:');
+    expect(all.messages).toEqual(expect.arrayContaining(['agents:', 'skills:', 'knowledge:', 'commands:']));
+  });
+
+  it('compares slugs deterministically by code unit', () => {
+    expect(compareSlugs('a', 'b')).toBe(-1);
+    expect(compareSlugs('b', 'a')).toBe(1);
+    expect(compareSlugs('a', 'a')).toBe(0);
   });
 });

--- a/docs/requirements/OFTR-003-profiles.md
+++ b/docs/requirements/OFTR-003-profiles.md
@@ -1,75 +1,66 @@
-# OFTR-003: Profiles and Inheritance
+# OFTR-003: Agents and Resolution
 
-> **Transition (RFC [#165](https://github.com/ai-outfitter/outfitter/issues/165)):** this requirement describes pre-dotagents behavior and will be amended or superseded by the RFC #165 implementation PRs together with its pinned tests. The target design lives in [docs/documentation](../documentation/README.md) and [docs/architecture](../architecture/README.md).
+> **Amendment (2026-07-17, RFC [#165](https://github.com/ai-outfitter/outfitter/issues/165)):**
+> profiles fold into agents. Authored `profile.yml` files, `inherits` inheritance, `template`
+> profiles, and `profile_export` are removed; an agent is `agents/<id>/agent.md` frontmatter plus an
+> optional `config.json`, resolved by slug across `.agents` layers with merge-by-ID. Section IDs are
+> preserved for pinned-test traceability. Target design: [docs/documentation/agents.md](../documentation/agents.md)
+> and [docs/architecture/README.md](../architecture/README.md).
 
 ## Overview
 
-Profiles describe reusable agent-CLI loadouts.
-Outfitter resolves profile definitions across settings scopes, explicit sources, and inherited profiles; the configured user default profile is selected only when no explicit profile is requested.
+An agent is the protocol's identity resource and the thing Outfitter runs. Outfitter resolves agents
+and other resources from layered `.agents` trees into one immutable effective resource set that every
+command shares.
 
 ## Requirements
 
-### OFTR-003.1: Profile Folder Layout
+### OFTR-003.1: Agent Resource Layout
 
-1. A profile MUST be represented by either a folder with a required `profile.yml` file or a flat YAML file named `<profile-id>.yml` or `<profile-id>.yaml`.
-2. Outfitter MUST provide a JSON Schema for profile YAML documents.
-3. Outfitter MUST validate every loaded profile YAML document against the profile JSON Schema.
-4. A profile folder MAY contain conventional resource folders such as `skills`, `prompts`, `extensions`, and `deepwork/jobs`.
-5. A profile folder MAY contain `cli_specific/<cli-name>/` folders for agent-specific resources and overrides.
-6. Flat profile files MUST NOT be treated as profile resource folders.
-7. Setup-source imports MUST preserve flat profile files as flat files unless the user explicitly invokes a profile-creation command.
+1. An agent MUST be represented by a directory `agents/<id>/` containing a required `agent.md` file.
+2. `agent.md` MUST begin with a `---` YAML frontmatter block declaring at least `name`.
+3. An agent directory MAY contain an optional `config.json` carrying structured loadout overrides.
+4. Outfitter MUST provide a JSON Schema for `agent.md` frontmatter and validate every loaded agent against it.
+5. Skills, knowledge, and commands are separate protocol resources under `skills/<id>/SKILL.md`, `knowledge/`, and `commands/` respectively.
 
-### OFTR-003.2: Profile Identity
+### OFTR-003.2: Agent Identity
 
-1. Profile IDs MUST be stable identifiers suitable for commands, logs, cache keys, and documentation.
-2. Profile IDs MUST match the regex `^[a-z0-9][a-z0-9._-]*[a-z0-9]$|^[a-z0-9]$`.
-3. Outfitter MUST reject profile IDs that cannot be safely referenced from the CLI.
-4. When a profile YAML document omits `id`, Outfitter MUST derive the profile ID from the containing folder name or flat filename stem.
-5. Outfitter MUST reject discovered profile folder names or flat filename stems that are not filesystem-safe profile IDs before using them as fallback IDs.
-6. Outfitter SHOULD support a separate display label if human-readable names need spaces or punctuation.
-7. Profiles MAY include a short `description` for interactive prompts and profile discovery surfaces.
-8. Interactive setup profile prompts MUST use loaded profile IDs, labels, and descriptions as their display metadata rather than hardcoding profile-repository knowledge in setup code.
+1. Agent IDs MUST be filesystem-safe slugs matching `^[a-z0-9]+(?:-[a-z0-9]+)*$`, at most 64 characters.
+2. The agent's frontmatter `name` MUST match its directory ID; a mismatch MUST be a validation error.
+3. Agents MAY include a `description` used by discovery surfaces.
 
-### OFTR-003.3: Profile Scope Precedence
+### OFTR-003.3: Layer Precedence
 
-1. Project-local profile definitions MUST take precedence over project profile definitions for the same profile name.
-2. Project profile definitions MUST take precedence over user profile definitions for the same profile name.
-3. User profile definitions MUST take precedence over cached URI profile definitions for the same profile name.
-4. Cached URI profile definitions MUST be considered according to resolved source order when multiple URI sources provide the same profile name.
+1. Outfitter MUST resolve resources from layered `.agents` trees ordered highest precedence first: workspace `<project>/.agents`, then global `~/.agents`, then configured `sources` in order.
+2. Only layers whose payload root exists on disk are included.
+3. A local `path` source's payload root is the directory itself; a remote source's root is its synced cache directory plus any configured subpath.
 
-### OFTR-003.4: Profile Inheritance
+### OFTR-003.4: Merge by ID
 
-1. `profile.yml` MAY specify an ordered `inherits` array of profile names.
-2. Inherited profiles MUST be treated as lower-precedence sources for the inheriting profile.
-3. Outfitter MUST recursively resolve inherited profiles.
-4. Outfitter MUST detect inheritance cycles and report them as validation errors.
-5. Outfitter MUST preserve inherited profile order when building the profile stack.
+1. Resources MUST merge by ID across layers: the highest-precedence definition of a slug wins and replaces lower ones. Markdown resources are not partially merged.
+2. Per-agent `config.json` MUST shallow-merge by key over the `agent.md` frontmatter loadout for the same agent directory.
+3. There is no profile inheritance; shared context lives in tree-level `system-prompt.md`/`agents.md`.
 
-### OFTR-003.5: Default Profile Selection
+### OFTR-003.5: Effective Resource Set
 
-1. Outfitter MUST use the configured `default_profile` only when no explicit profile is selected.
-2. When an explicit profile is selected, Outfitter MUST resolve only that profile and its declared `inherits` chain.
-3. Outfitter MUST NOT include the configured `default_profile` as an implicit base layer for an explicit profile.
+1. Outfitter MUST produce one immutable effective resource set per invocation mapping every slug to its winning definition.
+2. Lower-precedence definitions that a winner shadows MUST be retained for diagnostics.
+3. `list`, `validate`, `run`, and `dump` MUST consume the same effective resource set produced by a single shared resolver.
 
-### OFTR-003.6: Profile Merging
+### OFTR-003.6: Loadout
 
-1. Outfitter MUST merge resolved profile layers deterministically.
-2. YAML object values SHOULD be merged with `defu` or an equivalent controlled deep-merge utility.
-3. Array merge behavior MUST be documented per profile key before that key is treated as stable.
-4. CLI-specific profile content MUST take precedence over generic controls when both generate the same agent-specific artifact.
-5. Outfitter MUST compose `append_system_prompt` values from multiple resolved profile layers into repeated agent append-prompt inputs without requiring profiles to use raw CLI `args` for prompt composition.
-6. Outfitter MUST merge `controls.deepwork.jobs` deterministically and remove duplicate job names while preserving inherited job order.
+1. An agent's frontmatter/`config.json` MAY declare a loadout: `skills`, `subagents`, `mcp`, `extensions`, `plugins`, `model`, `thinking`, and `tools`.
+2. Loadout list entries MUST be slugs resolved against the effective resource set across layers; nothing is copied into the agent.
+3. Settings MUST NOT carry loadout selections.
 
-### OFTR-003.7: Template Profiles
+### OFTR-003.7: Resolution Validation
 
-1. A profile MAY set top-level `template: true` to indicate it is intended for inheritance by runnable profiles rather than direct launch.
-2. Outfitter MUST allow template profiles to contribute controls through `inherits` without marking the inheriting profile as a template.
-3. Outfitter MUST reject direct launches of template profiles, including launches selected through `default_profile`.
-4. `outfitter profile list` SHOULD hide template profiles by default and MUST expose them when the user explicitly requests all profiles.
+1. Outfitter MUST report an error when an agent's loadout references a `skills` or `subagents` slug that does not resolve.
+2. Outfitter MUST report a warning when a resource shadows a lower-precedence definition of the same slug.
+3. `outfitter validate --strict` MUST treat warnings as failures.
 
-### OFTR-003.8: Generated Prompt Export Preference
+### OFTR-003.8: Listing Resources
 
-1. A profile MAY set top-level `profile_export: true` to request generated prompt export for that profile.
-2. A profile MAY set top-level `profile_export: false` to disable generated prompt export even when settings enable it by default.
-3. Missing `profile_export` in a profile MUST defer to the effective settings default.
-4. Outfitter MUST validate `profile_export` as a boolean when present.
+1. `outfitter list` MUST list resolvable resources by kind from the effective resource set.
+2. `outfitter list <kind>` MUST restrict output to one kind of `agents`, `skills`, `knowledge`, or `commands` and MUST reject unknown kinds.
+3. Listed resources MUST report the winning layer for each slug deterministically.


### PR DESCRIPTION
**Stack 2/4** of the RFC #165 implementation refactor (PR 1 #172 landed). Cut from `main` head; Copilot-reviewed; squash-merged.

## This PR — the shared resolver
Amends **OFTR-003** (profiles → agents/resolution) and adds the single resolution path the target architecture requires:
- `agent.md` frontmatter schema + parser; `config.json` shallow-merges by key over the frontmatter loadout
- layered `.agents` discovery (workspace > global > sources) + `Resolver` → one immutable **effective resource set** (merge-by-ID, winning source + retained shadowed defs) for agents/skills/knowledge/commands
- `outfitter list [kind]` and `outfitter validate [--strict] [--json]` on that set; validation flags unknown loadout slugs, name mismatches, and shadowing

New resolver suite green (8); OFTR-003 pinned tests updated together (OFTR-008).

## Known-red / out of scope
Profile subcommands are unwired in favor of list/validate; `run`/`setup`/`sync` still read the old model and are retargeted in PRs 3–4. Per the agreed strategy, `main` stays partial between refactor PRs; the resolver layer is coherent and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)