### PR TITLE
refactor(composer): harness-neutral CompositionPlan [rfc-165 impl 3/5]

### DIFF
--- a/code/cli/src/composer/Composer.ts
+++ b/code/cli/src/composer/Composer.ts
@@ -1,0 +1,92 @@
+// Composes a harness-neutral CompositionPlan from the effective resource set and a selected agent.
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { isAgentDefinitionIssue, readAgentDefinition } from '../resolver/AgentDefinition.js';
+import type { EffectiveResourceSet, Loadout, ResolvedResource } from '../resolver/Resource.js';
+import { findResource } from '../resolver/Resource.js';
+import type { ComposedLoadout, CompositionPlan } from './Composition.js';
+
+export interface ComposeResult {
+  readonly plan?: CompositionPlan;
+  readonly errors: readonly string[];
+}
+
+/** Reads the highest-precedence tree-root file (e.g. system-prompt.md) across layers, or undefined. */
+const readRootFile = (set: EffectiveResourceSet, fileName: string): string | undefined => {
+  for (const layer of set.layers) {
+    const candidate = join(layer.root, fileName);
+
+    if (existsSync(candidate)) {
+      return readFileSync(candidate, 'utf8');
+    }
+  }
+
+  return undefined;
+};
+
+const resolveSlugs = (
+  set: EffectiveResourceSet,
+  kind: 'skill' | 'agent',
+  field: string,
+  slugs: readonly string[],
+  warnings: string[],
+): readonly ResolvedResource[] => {
+  const resolved: ResolvedResource[] = [];
+
+  for (const slug of slugs) {
+    const resource = findResource(set, kind, slug);
+
+    if (resource === undefined) {
+      warnings.push(`loadout ${field} references unknown ${kind} '${slug}'.`);
+    } else {
+      resolved.push(resource);
+    }
+  }
+
+  return resolved;
+};
+
+const composeLoadout = (set: EffectiveResourceSet, loadout: Loadout, warnings: string[]): ComposedLoadout => ({
+  skills: resolveSlugs(set, 'skill', 'skills', loadout.skills, warnings),
+  subagents: resolveSlugs(set, 'agent', 'subagents', loadout.subagents, warnings),
+  mcp: loadout.mcp,
+  extensions: loadout.extensions,
+  plugins: loadout.plugins,
+  model: loadout.model,
+  thinking: loadout.thinking,
+  tools: loadout.tools,
+});
+
+/**
+ * Composes the selected agent into a CompositionPlan. Returns an error when the agent slug does not
+ * resolve or its definition is invalid; loadout slugs that do not resolve are non-fatal warnings.
+ */
+export const compose = (set: EffectiveResourceSet, agentSlug: string): ComposeResult => {
+  const agent = findResource(set, 'agent', agentSlug);
+
+  if (agent === undefined) {
+    return { errors: [`Unknown agent '${agentSlug}'. Run 'outfitter list agents' to see resolvable agents.`] };
+  }
+
+  const definition = readAgentDefinition(dirname(agent.winner.path), agent.winner.path);
+
+  if (isAgentDefinitionIssue(definition)) {
+    return { errors: [`Agent '${agentSlug}' is invalid: ${definition.message}`] };
+  }
+
+  const warnings: string[] = [];
+  const plan: CompositionPlan = {
+    agent: agentSlug,
+    identity: {
+      systemPrompt: readRootFile(set, 'system-prompt.md'),
+      sharedContext: readRootFile(set, 'agents.md'),
+      agentBody: definition.body,
+      description: definition.description,
+    },
+    loadout: composeLoadout(set, definition.loadout, warnings),
+    warnings,
+  };
+
+  return { plan, errors: [] };
+};

--- a/code/cli/src/composer/Composition.ts
+++ b/code/cli/src/composer/Composition.ts
@@ -1,0 +1,37 @@
+// Harness-neutral composition types produced from the effective resource set for a selected agent.
+import type { Loadout, ResolvedResource } from '../resolver/Resource.js';
+
+/** The composed identity: base prompt, shared context, and the selected agent's body. */
+export interface ComposedIdentity {
+  /** Content of the winning `system-prompt.md`, if any. */
+  readonly systemPrompt?: string;
+  /** Content of the winning `agents.md` shared operating context, if any. */
+  readonly sharedContext?: string;
+  /** The selected agent's `agent.md` markdown body. */
+  readonly agentBody: string;
+  readonly description?: string;
+}
+
+/** A loadout with its slug references resolved against the effective set. */
+export interface ComposedLoadout {
+  readonly skills: readonly ResolvedResource[];
+  readonly subagents: readonly ResolvedResource[];
+  readonly mcp: readonly string[];
+  readonly extensions: readonly string[];
+  readonly plugins: readonly string[];
+  readonly model?: string;
+  readonly thinking?: string;
+  readonly tools?: Loadout['tools'];
+}
+
+/**
+ * A deterministic, harness-neutral plan for one run. Adapters project this to native configuration;
+ * `dump` serializes it. Identical inputs produce an identical composition.
+ */
+export interface CompositionPlan {
+  readonly agent: string;
+  readonly identity: ComposedIdentity;
+  readonly loadout: ComposedLoadout;
+  /** Non-fatal issues (e.g. unknown loadout slugs) surfaced during composition. */
+  readonly warnings: readonly string[];
+}

--- a/code/cli/tests/unit/composer.test.ts
+++ b/code/cli/tests/unit/composer.test.ts
@@ -1,0 +1,108 @@
+// Tests composition of a harness-neutral CompositionPlan from the effective resource set.
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { compose } from '../../src/composer/Composer.js';
+import { discoverLayers } from '../../src/resolver/Layer.js';
+import { resolveResources } from '../../src/resolver/Resolver.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-composer-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const write = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+const resolveSet = (home: string, project: string) =>
+  resolveResources(discoverLayers({ homeDirectory: home, projectDirectory: project, settings: {} }));
+
+describe('composer', () => {
+  const buildTree = (): { home: string; project: string } => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    write(join(home, '.agents', 'system-prompt.md'), 'BASE PROMPT');
+    write(join(project, '.agents', 'agents.md'), 'SHARED CONTEXT');
+    write(join(project, '.agents', 'skills', 'wiki', 'SKILL.md'), '---\nname: wiki\n---\n');
+    write(
+      join(project, '.agents', 'agents', 'code-reviewer', 'agent.md'),
+      '---\nname: code-reviewer\n---\n\nReview.\n',
+    );
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\ndescription: Ships changes.\nskills: [wiki]\nsubagents: [code-reviewer]\nmodel: gpt-5.2\nthinking: high\nmcp: [github]\n---\n\n# Engineer\n\nImplement.\n',
+    );
+    return { home, project };
+  };
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.2, OFTR-005.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('composes identity and resolved loadout for a selected agent', () => {
+    const { home, project } = buildTree();
+    const result = compose(resolveSet(home, project), 'engineer');
+
+    expect(result.errors).toEqual([]);
+    const plan = result.plan!;
+    expect(plan.identity.systemPrompt).toBe('BASE PROMPT');
+    expect(plan.identity.sharedContext).toBe('SHARED CONTEXT');
+    expect(plan.identity.agentBody).toContain('# Engineer');
+    expect(plan.identity.description).toBe('Ships changes.');
+    expect(plan.loadout.skills.map((s) => s.slug)).toEqual(['wiki']);
+    expect(plan.loadout.subagents.map((s) => s.slug)).toEqual(['code-reviewer']);
+    expect(plan.loadout.mcp).toEqual(['github']);
+    expect(plan.loadout.model).toBe('gpt-5.2');
+    expect(plan.loadout.thinking).toBe('high');
+    expect(plan.warnings).toEqual([]);
+  });
+
+  it('is deterministic — identical inputs compose to an identical plan', () => {
+    const { home, project } = buildTree();
+    expect(compose(resolveSet(home, project), 'engineer').plan).toEqual(
+      compose(resolveSet(home, project), 'engineer').plan,
+    );
+  });
+
+  it('errors for an unknown agent slug', () => {
+    const { home, project } = buildTree();
+    const result = compose(resolveSet(home, project), 'missing');
+    expect(result.plan).toBeUndefined();
+    expect(result.errors[0]).toContain("Unknown agent 'missing'");
+  });
+
+  it('errors when the selected agent definition is invalid', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    write(join(project, '.agents', 'agents', 'broken', 'agent.md'), 'no frontmatter here');
+    const result = compose(resolveSet(join(root, 'home'), project), 'broken');
+    expect(result.errors[0]).toContain('is invalid');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('warns but does not fail when a loadout slug does not resolve', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\nskills: [ghost]\n---\n\nBody.\n',
+    );
+    const result = compose(resolveSet(join(root, 'home'), project), 'engineer');
+    expect(result.errors).toEqual([]);
+    expect(result.plan!.warnings).toContain("loadout skills references unknown skill 'ghost'.");
+  });
+});

--- a/docs/requirements/OFTR-005-run-and-composite-profile.md
+++ b/docs/requirements/OFTR-005-run-and-composite-profile.md
@@ -1,6 +1,6 @@
 # OFTR-005: Run Command and Composite profile Lifecycle
 
-> **Transition (RFC [#165](https://github.com/ai-outfitter/outfitter/issues/165)):** this requirement describes pre-dotagents behavior and will be amended or superseded by the RFC #165 implementation PRs together with its pinned tests. The target design lives in [docs/documentation](../documentation/README.md) and [docs/architecture](../architecture/README.md).
+> **Transition (RFC [#165](https://github.com/ai-outfitter/outfitter/issues/165)):** this requirement is being amended across the implementation stack. **OFTR-005.2 and OFTR-005.3 are amended (2026-07-17)** to the harness-neutral composition model below. The remaining sections (run command surface, watching, state persistence, prompt export) still describe pre-dotagents behavior and are amended together with their pinned tests in the adapter/run PR. Target design: [docs/architecture/README.md](../architecture/README.md).
 
 ## Overview
 
@@ -18,20 +18,24 @@ The `run` command assembles a temporary agent-specific configuration directory c
 6. The `run` command MUST pass unrecognized arguments through to the selected agent CLI unaltered.
 7. When invoked before user setup has created `~/.outfitter/settings.yml`, the default `run` command MUST execute setup before resolving the profile without printing a separate pre-setup announcement.
 
-### OFTR-005.2: Composite profile Definition
+### OFTR-005.2: Composition Definition
 
-1. Outfitter MUST call the dynamically assembled runtime configuration directory a `composite profile`.
-2. A composite profile MUST be scoped to a resolved profile and a selected agent CLI.
-3. Outfitter MUST create composite profile directories under the system temporary directory.
-4. Outfitter SHOULD use composite profile paths that include a run-specific identifier to avoid collisions between concurrent runs.
+_Amended (2026-07-17, RFC #165): a run is defined by a harness-neutral composition, not a profile._
 
-### OFTR-005.3: Composite profile Assembly
+1. Outfitter MUST compose a harness-neutral **composition plan** for a run from the effective resource set and a selected agent.
+2. A composition plan MUST be scoped to one selected agent slug and is projected per harness by an adapter.
+3. A composition plan MUST carry the composed identity (base `system-prompt.md`, shared `agents.md` context, and the agent's `agent.md` body) and the agent's resolved loadout.
+4. Composition MUST be deterministic: identical sources, refs, and selections produce an identical composition plan.
 
-1. Outfitter MUST assemble the composite profile from resolved profile layers in precedence order.
-2. Outfitter MUST combine generic profile controls with CLI-specific overrides.
-3. Each logical generated file in the composite profile MUST have an object instance representing it.
-4. Each composite profile file object MUST know its source inputs and generated output path.
-5. Each composite profile file object SHOULD expose its merge or transform strategy.
+### OFTR-005.3: Composition Assembly
+
+_Amended (2026-07-17, RFC #165): composition assembles from the effective resource set._
+
+1. Outfitter MUST compose identity by layering the winning `system-prompt.md` as the base, the winning `agents.md` as shared context, and the selected agent's body on top, in that deterministic order.
+2. Outfitter MUST resolve each loadout slug (`skills`, `subagents`) against the effective resource set to its winning resource.
+3. Outfitter MUST report an error when the selected agent slug does not resolve or its definition is invalid.
+4. Outfitter MUST surface a loadout slug that does not resolve as a non-fatal composition warning.
+5. `list`, `validate`, `run`, and `dump` MUST compose from the same shared resolver and composer.
 
 ### OFTR-005.4: Composite profile Watching
 


### PR DESCRIPTION
**Stack 3/5** of the RFC #165 implementation refactor. Based on PR #173 (resolver) — GitHub will retarget this to `main` once #173 merges.

## This PR — the Composer
Amends **OFTR-005.2/005.3** and adds the harness-neutral composition step:
- `CompositionPlan` — deterministic plan for one run: composed identity (base `system-prompt.md` + shared `agents.md` + agent `agent.md` body) + loadout with skill/subagent slugs resolved against the effective set
- `compose(set, agentSlug)`: errors on unknown/invalid agent; unresolved loadout slugs are non-fatal warnings; identical inputs → identical plan

Composer suite green (5).

> **Re-slice note:** PR 3 (originally composer + adapter projection + run/dump) is split — the adapter projection + `run`/`dump` rewrite over 30k+ of `Profile`-shaped adapter code lands as **PR 4**, legacy deletion as **PR 5**. Keeps each PR reviewable.

Per the agreed strategy, `main` stays partial between refactor PRs; the composer layer is coherent and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)