### PR TITLE
refactor(dump): outfitter dump — deterministic self-contained tree [rfc-165 impl 4/6]

### DIFF
--- a/code/cli/src/cli/OutfitterCli.ts
+++ b/code/cli/src/cli/OutfitterCli.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 import { Command } from 'commander';
 
 import type { CommandObject } from './commands/CommandObject.js';
+import { createDumpCommand } from './commands/DumpCommand.js';
 import { createListCommand } from './commands/ListCommand.js';
 import { createRunCommand, executeRunCommand } from './commands/RunCommand.js';
 import { createSetupCommand } from './commands/SetupCommand.js';
@@ -26,6 +27,7 @@ export const createDefaultCommands = (): CommandObject[] => [
   createWelcomeCommand(),
   createListCommand(),
   createValidateCommand(),
+  createDumpCommand(),
 ];
 
 export const createOutfitterProgram = (commands: readonly CommandObject[] = createDefaultCommands()): Command => {

--- a/code/cli/src/cli/commands/DumpCommand.ts
+++ b/code/cli/src/cli/commands/DumpCommand.ts
@@ -1,0 +1,90 @@
+// Provides `outfitter dump --agent <id> --out <dir>` over the effective resource set.
+import { homedir } from 'node:os';
+
+import { Command } from 'commander';
+
+import { dumpAgent } from '../../dump/Dump.js';
+import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
+import { loadSettingsWithCachedRemoteSettings } from '../../settings/SettingsLoader.js';
+import type { CommandObject } from './CommandObject.js';
+
+export interface DumpInput {
+  readonly homeDirectory: string;
+  readonly projectDirectory: string;
+  readonly agent?: string;
+  readonly out: string;
+}
+
+export interface DumpCommandResult {
+  readonly writtenPaths: readonly string[];
+  readonly messages: readonly string[];
+  readonly ok: boolean;
+}
+
+export interface DumpCommandDependencies {
+  readonly homeDirectory?: string;
+  readonly projectDirectory?: string;
+  readonly writeLine?: (message: string) => void;
+}
+
+const resolveAgentSlug = (homeDirectory: string, projectDirectory: string, requested: string | undefined): string => {
+  if (requested !== undefined) {
+    return requested;
+  }
+
+  const { settings } = loadSettingsWithCachedRemoteSettings({ homeDirectory, projectDirectory });
+
+  if (settings.defaultAgent === undefined) {
+    throw new Error("No agent selected and no 'default_agent' in settings. Pass --agent <id>.");
+  }
+
+  return settings.defaultAgent;
+};
+
+export const executeDumpCommand = (input: DumpInput): DumpCommandResult => {
+  const { set, settingsIssues } = resolveEffectiveSet(input);
+
+  if (settingsIssues.length > 0) {
+    throw new Error(`Cannot dump with invalid settings: ${settingsIssues.map((issue) => issue.message).join('; ')}`);
+  }
+
+  const agentSlug = resolveAgentSlug(input.homeDirectory, input.projectDirectory, input.agent);
+  const result = dumpAgent(set, agentSlug, input.out);
+  const ok = result.errors.length === 0;
+  const messages = ok
+    ? [`Dumped '${agentSlug}' to ${input.out} (${result.writtenPaths.length} files).`, ...result.warnings]
+    : result.errors;
+
+  return { writtenPaths: result.writtenPaths, messages, ok };
+};
+
+export const createDumpCommand = (dependencies: DumpCommandDependencies = {}): CommandObject => ({
+  name: 'dump',
+  description: 'Write the composed .agents tree for an agent to a directory.',
+  register(program: Command): void {
+    program.addCommand(
+      new Command('dump')
+        .description('Write the composed .agents tree for an agent to a directory.')
+        .option('--agent <id>', 'Agent slug to dump (default: settings default_agent).')
+        .option('--out <dir>', 'Output directory.', './outfitter-dump')
+        .action((options: { agent?: string; out: string }) => {
+          const result = executeDumpCommand({
+            /* v8 ignore next 2 -- process defaults are exercised by the CLI entrypoint, not unit tests. */
+            homeDirectory: dependencies.homeDirectory ?? homedir(),
+            projectDirectory: dependencies.projectDirectory ?? process.cwd(),
+            agent: options.agent,
+            out: options.out,
+          });
+
+          for (const message of result.messages) {
+            /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
+            (dependencies.writeLine ?? console.log)(message);
+          }
+
+          if (!result.ok) {
+            process.exitCode = 1;
+          }
+        }),
+    );
+  },
+});

--- a/code/cli/src/dump/Dump.ts
+++ b/code/cli/src/dump/Dump.ts
@@ -1,0 +1,107 @@
+// Writes a deterministic, self-contained `.agents/` tree for one agent's transitive closure.
+import { copyFileSync, existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { compose } from '../composer/Composer.js';
+import { findResource } from '../resolver/Resource.js';
+import type { EffectiveResourceSet, ResolvedResource } from '../resolver/Resource.js';
+
+export interface DumpResult {
+  readonly writtenPaths: readonly string[];
+  readonly warnings: readonly string[];
+  readonly errors: readonly string[];
+}
+
+/** Recursively copies a resource directory, skipping symlinks so no path escapes the tree. */
+const copyResourceDirectory = (sourceDir: string, targetDir: string, written: string[]): void => {
+  for (const entry of readdirSync(sourceDir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    const sourcePath = join(sourceDir, entry.name);
+    const targetPath = join(targetDir, entry.name);
+
+    if (lstatSync(sourcePath).isSymbolicLink()) {
+      continue;
+    }
+
+    if (entry.isDirectory()) {
+      copyResourceDirectory(sourcePath, targetPath, written);
+    } else if (entry.isFile()) {
+      mkdirSync(dirname(targetPath), { recursive: true });
+      copyFileSync(sourcePath, targetPath);
+      written.push(targetPath);
+    }
+  }
+};
+
+/** BFS over the selected agent and its subagents to form the transitive agent closure. */
+const agentClosure = (set: EffectiveResourceSet, rootSlug: string): readonly ResolvedResource[] => {
+  const seen = new Set<string>();
+  const ordered: ResolvedResource[] = [];
+  const queue = [rootSlug];
+
+  while (queue.length > 0) {
+    const slug = queue.shift()!;
+
+    if (seen.has(slug)) {
+      continue;
+    }
+    seen.add(slug);
+
+    const agent = findResource(set, 'agent', slug);
+
+    if (agent === undefined) {
+      continue;
+    }
+
+    ordered.push(agent);
+    const composed = compose(set, slug);
+    queue.push(...(composed.plan?.loadout.subagents ?? []).map((subagent) => subagent.slug).sort());
+  }
+
+  return ordered;
+};
+
+const writeRootFile = (set: EffectiveResourceSet, fileName: string, outRoot: string, written: string[]): void => {
+  for (const layer of set.layers) {
+    const candidate = join(layer.root, fileName);
+
+    if (existsSync(candidate)) {
+      const target = join(outRoot, fileName);
+      writeFileSync(target, readFileSync(candidate, 'utf8'));
+      written.push(target);
+      return;
+    }
+  }
+};
+
+/** Writes the composed closure of `agentSlug` into `<outDirectory>/.agents/`. */
+export const dumpAgent = (set: EffectiveResourceSet, agentSlug: string, outDirectory: string): DumpResult => {
+  const composed = compose(set, agentSlug);
+
+  if (composed.plan === undefined) {
+    return { writtenPaths: [], warnings: [], errors: composed.errors };
+  }
+
+  const outRoot = join(outDirectory, '.agents');
+  mkdirSync(outRoot, { recursive: true });
+  const written: string[] = [];
+
+  writeRootFile(set, 'system-prompt.md', outRoot, written);
+  writeRootFile(set, 'agents.md', outRoot, written);
+
+  const agents = agentClosure(set, agentSlug);
+  const skillSlugs = new Set<string>();
+
+  for (const agent of agents) {
+    copyResourceDirectory(dirname(agent.winner.path), join(outRoot, 'agents', agent.slug), written);
+    for (const skill of compose(set, agent.slug).plan?.loadout.skills ?? []) {
+      skillSlugs.add(skill.slug);
+    }
+  }
+
+  for (const slug of [...skillSlugs].sort()) {
+    const skill = findResource(set, 'skill', slug)!;
+    copyResourceDirectory(dirname(skill.winner.path), join(outRoot, 'skills', slug), written);
+  }
+
+  return { writtenPaths: written.sort(), warnings: composed.plan.warnings, errors: [] };
+};

--- a/code/cli/tests/unit/dump.test.ts
+++ b/code/cli/tests/unit/dump.test.ts
@@ -1,0 +1,121 @@
+// Tests `outfitter dump`: deterministic, self-contained, closure-scoped .agents output.
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { executeDumpCommand } from '../../src/cli/commands/DumpCommand.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-dump-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const write = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+
+const relativeTree = (root: string): string[] => {
+  const files: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else files.push(relative(root, full).split(/[/\\]/).join('/'));
+    }
+  };
+  walk(root);
+  return files.sort();
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+const buildTree = (): { home: string; project: string } => {
+  const root = createTemporaryRoot();
+  const home = join(root, 'home');
+  const project = join(root, 'project');
+  write(join(project, '.agents', 'system-prompt.md'), 'BASE');
+  write(join(project, '.agents', 'skills', 'wiki', 'SKILL.md'), '---\nname: wiki\n---\n');
+  write(join(project, '.agents', 'skills', 'unused', 'SKILL.md'), '---\nname: unused\n---\n');
+  write(join(project, '.agents', 'agents', 'reviewer', 'agent.md'), '---\nname: reviewer\n---\n\nReview.\n');
+  write(
+    join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+    '---\nname: engineer\nskills: [wiki]\nsubagents: [reviewer]\n---\n\n# Engineer\n',
+  );
+  return { home, project };
+};
+
+describe('dump command', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('writes the transitive closure of an agent as a self-contained .agents tree', () => {
+    const { home, project } = buildTree();
+    const out = join(createTemporaryRoot(), 'review');
+
+    const result = executeDumpCommand({ homeDirectory: home, projectDirectory: project, agent: 'engineer', out });
+
+    expect(result.ok).toBe(true);
+    expect(relativeTree(join(out, '.agents'))).toEqual([
+      'agents/engineer/agent.md',
+      'agents/reviewer/agent.md',
+      'skills/wiki/SKILL.md',
+      'system-prompt.md',
+    ]);
+    // 'unused' skill is not in engineer's closure.
+    expect(relativeTree(join(out, '.agents'))).not.toContain('skills/unused/SKILL.md');
+  });
+
+  it('is deterministic — two dumps produce identical trees and contents', () => {
+    const { home, project } = buildTree();
+    const outA = join(createTemporaryRoot(), 'a');
+    const outB = join(createTemporaryRoot(), 'b');
+
+    executeDumpCommand({ homeDirectory: home, projectDirectory: project, agent: 'engineer', out: outA });
+    executeDumpCommand({ homeDirectory: home, projectDirectory: project, agent: 'engineer', out: outB });
+
+    const treeA = relativeTree(join(outA, '.agents'));
+    expect(treeA).toEqual(relativeTree(join(outB, '.agents')));
+    for (const file of treeA) {
+      expect(readFileSync(join(outA, '.agents', file), 'utf8')).toBe(readFileSync(join(outB, '.agents', file), 'utf8'));
+    }
+  });
+
+  it('never copies symlinks into the dump', () => {
+    const { home, project } = buildTree();
+    symlinkSync('/etc/passwd', join(project, '.agents', 'agents', 'engineer', 'secret-link'));
+    const out = join(createTemporaryRoot(), 'safe');
+
+    executeDumpCommand({ homeDirectory: home, projectDirectory: project, agent: 'engineer', out });
+
+    expect(relativeTree(join(out, '.agents'))).not.toContain('agents/engineer/secret-link');
+  });
+
+  it('uses default_agent when --agent is omitted and errors when neither is available', () => {
+    const { home, project } = buildTree();
+    write(join(project, '.agents', 'settings.yml'), 'default_agent: engineer\n');
+    const out = join(createTemporaryRoot(), 'def');
+    expect(executeDumpCommand({ homeDirectory: home, projectDirectory: project, out }).ok).toBe(true);
+
+    const bare = createTemporaryRoot();
+    expect(() =>
+      executeDumpCommand({ homeDirectory: join(bare, 'home'), projectDirectory: join(bare, 'project'), out }),
+    ).toThrow(/No agent selected/);
+  });
+
+  it('reports an error for an unknown agent', () => {
+    const { home, project } = buildTree();
+    const out = join(createTemporaryRoot(), 'x');
+    const result = executeDumpCommand({ homeDirectory: home, projectDirectory: project, agent: 'ghost', out });
+    expect(result.ok).toBe(false);
+    expect(result.messages[0]).toContain("Unknown agent 'ghost'");
+  });
+});


### PR DESCRIPTION
**Stack 4/6** of the RFC #165 implementation refactor. Based on the composer PR #176 (will retarget to `main` once that merges).

## This PR — `outfitter dump`
`outfitter dump --agent <id> --out <dir>` writes an agent's transitive closure (identity root files, the agent + its subagents, and referenced skills) as a plain `.agents/` tree:
- **deterministic** — byte-identical across runs
- **closure-scoped** — only what the agent composes
- **safe** — never copies symlinks out of the tree

Dump suite green (5).

> Re-slice: the big adapter-projection + `run` rewrite (over `Profile`-shaped pi/claude adapters) is now **PR 5**; legacy deletion **PR 6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)