### PR TITLE
docs(profiles): document externally managed (symlinked) profile stores

### DIFF
--- a/docs/documentation/profiles.md
+++ b/docs/documentation/profiles.md
@@ -28,3 +28,13 @@ To share behavior across several agents, keep shared operating context in the tr
 ## Migrating from authored profiles
 
 Earlier Outfitter versions defined profiles as authored YAML files (`.outfitter/profiles/`, `profile.yml`, inheritance, `controls`). That system is removed with no compatibility mode. See the [migration reference](./migration.md) for the manual mapping from the legacy format to agents and their loadouts.
+
+### Externally managed legacy profiles
+
+While using the released profile-based CLI, operators can keep the canonical profile store outside Outfitter and symlink the user profile directory to it:
+
+```sh
+ln -s ~/.config/panopticon/secrets/<dir>/outfitter/profiles ~/.outfitter/profiles
+```
+
+Profile resolution and writes through `~/.outfitter/profiles` follow the symlink, so setup and profile edits propagate to the canonical store.


### PR DESCRIPTION
Implements #175 — audit + docs, docs-only by design.

**Audit verdict: no code change warranted.** Every write path descends through the profiles root rather than replacing it: setup/first-run creation (`copyDirectoryContentsWithoutOverwriting`, `createDefaultProfileIfMissing`, `persistFirstRunWelcomeProfile`), `profile create`, system-prompt export, and state persistence all write beneath the root; the only `.outfitter`-replacing path (local setup-source symlink mode) refuses non-empty targets, which a profiles symlink guarantees; catalog sync's recursive removals are confined to computed `~/.outfitter/cache/…` paths. No rename/delete profile flows exist. A symlinked `~/.outfitter/profiles` therefore survives all current flows, and resolution through it is live-verified on 0.11.0.

The docs note is scoped to the released profile-based CLI and placed under the migration section as "externally managed legacy profiles," given the in-flight RFC #165 transition.

Checks: targeted Prettier, `git diff --check`, `npm run docs:ci`, and the profile-create tests pass. The repo-wide gate is red on the base itself (pre-existing #165 transition drift — 45 lint errors + Settings.ts formatting), untouched here.

+10/−0. Agent-audited (gpt-5.6-sol:high) via panopticon, Fable-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)