### PR TITLE
refactor(dump): outfitter dump — deterministic self-contained tree [rfc-165 impl 4/6]

### DIFF
--- a/code/cli/src/cli/OutfitterCli.ts
+++ b/code/cli/src/cli/OutfitterCli.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 import { Command } from 'commander';
 
 import type { CommandObject } from './commands/CommandObject.js';
+import { createDumpCommand } from './commands/DumpCommand.js';
 import { createListCommand } from './commands/ListCommand.js';
 import { createRunCommand, executeRunCommand } from './commands/RunCommand.js';
 import { createSetupCommand } from './commands/SetupCommand.js';
@@ -26,6 +27,7 @@ export const createDefaultCommands = (): CommandObject[] => [
   createWelcomeCommand(),
   createListCommand(),
   createValidateCommand(),
+  createDumpCommand(),
 ];
 
 export const createOutfitterProgram = (commands: readonly CommandObject[] = createDefaultCommands()): Command => {

--- a/code/cli/src/cli/commands/DumpCommand.ts
+++ b/code/cli/src/cli/commands/DumpCommand.ts
@@ -1,0 +1,90 @@
+// Provides `outfitter dump --agent <id> --out <dir>` over the effective resource set.
+import { homedir } from 'node:os';
+
+import { Command } from 'commander';
+
+import { dumpAgent } from '../../dump/Dump.js';
+import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
+import { loadSettingsWithCachedRemoteSettings } from '../../settings/SettingsLoader.js';
+import type { CommandObject } from './CommandObject.js';
+
+export interface DumpInput {
+  readonly homeDirectory: string;
+  readonly projectDirectory: string;
+  readonly agent?: string;
+  readonly out: string;
+}
+
+export interface DumpCommandResult {
+  readonly writtenPaths: readonly string[];
+  readonly messages: readonly string[];
+  readonly ok: boolean;
+}
+
+export interface DumpCommandDependencies {
+  readonly homeDirectory?: string;
+  readonly projectDirectory?: string;
+  readonly writeLine?: (message: string) => void;
+}
+
+const resolveAgentSlug = (homeDirectory: string, projectDirectory: string, requested: string | undefined): string => {
+  if (requested !== undefined) {
+    return requested;
+  }
+
+  const { settings } = loadSettingsWithCachedRemoteSettings({ homeDirectory, projectDirectory });
+
+  if (settings.defaultAgent === undefined) {
+    throw new Error("No agent selected and no 'default_agent' in settings. Pass --agent <id>.");
+  }
+
+  return settings.defaultAgent;
+};
+
+export const executeDumpCommand = (input: DumpInput): DumpCommandResult => {
+  const { set, settingsIssues } = resolveEffectiveSet(input);
+
+  if (settingsIssues.length > 0) {
+    throw new Error(`Cannot dump with invalid settings: ${settingsIssues.map((issue) => issue.message).join('; ')}`);
+  }
+
+  const agentSlug = resolveAgentSlug(input.homeDirectory, input.projectDirectory, input.agent);
+  const result = dumpAgent(set, agentSlug, input.out);
+  const ok = result.errors.length === 0;
+  const messages = ok
+    ? [`Dumped '${agentSlug}' to ${input.out} (${result.writtenPaths.length} files).`, ...result.warnings]
+    : result.errors;
+
+  return { writtenPaths: result.writtenPaths, messages, ok };
+};
+
+export const createDumpCommand = (dependencies: DumpCommandDependencies = {}): CommandObject => ({
+  name: 'dump',
+  description: 'Write the composed .agents tree for an agent to a directory.',
+  register(program: Command): void {
+    program.addCommand(
+      new Command('dump')
+        .description('Write the composed .agents tree for an agent to a directory.')
+        .option('--agent <id>', 'Agent slug to dump (default: settings default_agent).')
+        .option('--out <dir>', 'Output directory.', './outfitter-dump')
+        .action((options: { agent?: string; out: string }) => {
+          const result = executeDumpCommand({
+            /* v8 ignore next 2 -- process defaults are exercised by the CLI entrypoint, not unit tests. */
+            homeDirectory: dependencies.homeDirectory ?? homedir(),
+            projectDirectory: dependencies.projectDirectory ?? process.cwd(),
+            agent: options.agent,
+            out: options.out,
+          });
+
+          for (const message of result.messages) {
+            /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
+            (dependencies.writeLine ?? console.log)(message);
+          }
+
+          if (!result.ok) {
+            process.exitCode = 1;
+          }
+        }),
+    );
+  },
+});

--- a/code/cli/src/cli/commands/DumpCommand.ts
+++ b/code/cli/src/cli/commands/DumpCommand.ts
@@ -53,7 +53,7 @@ export const executeDumpCommand = (input: DumpInput): DumpCommandResult => {
   const ok = result.errors.length === 0;
   const messages = ok
     ? [`Dumped '${agentSlug}' to ${input.out} (${result.writtenPaths.length} files).`, ...result.warnings]
-    : result.errors;
+    : [...result.errors, ...result.warnings];
 
   return { writtenPaths: result.writtenPaths, messages, ok };
 };

--- a/code/cli/src/dump/Containment.ts
+++ b/code/cli/src/dump/Containment.ts
@@ -1,0 +1,25 @@
+// Realpath containment helpers so a dump can never read or overwrite content outside the tree.
+import { realpathSync } from 'node:fs';
+import { isAbsolute, relative, resolve } from 'node:path';
+
+/** Resolves symlinks to a real path; falls back to a normalized absolute path when it does not exist. */
+export const realpathOrResolve = (path: string): string => {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+};
+
+/** True when `child` resolves to `parent` or somewhere inside it (symlinks followed on both sides). */
+export const isInside = (child: string, parent: string): boolean => {
+  const relativePath = relative(realpathOrResolve(parent), realpathOrResolve(child));
+  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath));
+};
+
+/** True when `path` resolves outside every provided root — i.e. it escapes the tree. */
+export const escapesRoots = (path: string, roots: readonly string[]): boolean =>
+  !roots.some((root) => isInside(path, root));
+
+/** True when two directories overlap in either direction (realpath-aware). */
+export const overlaps = (left: string, right: string): boolean => isInside(left, right) || isInside(right, left);

--- a/code/cli/src/dump/Dump.ts
+++ b/code/cli/src/dump/Dump.ts
@@ -1,9 +1,18 @@
 // Writes a deterministic, self-contained `.agents/` tree for one agent's transitive closure.
-import { copyFileSync, existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { dirname, join } from 'node:path';
 
 import { compose } from '../composer/Composer.js';
-import { findResource } from '../resolver/Resource.js';
+import { compareSlugs, findResource } from '../resolver/Resource.js';
 import type { EffectiveResourceSet, ResolvedResource } from '../resolver/Resource.js';
 
 export interface DumpResult {
@@ -12,9 +21,31 @@ export interface DumpResult {
   readonly errors: readonly string[];
 }
 
+const loadoutKeys = ['skills', 'subagents', 'mcp', 'extensions', 'plugins', 'model', 'thinking', 'tools'] as const;
+
+/** True when the path is a symlink; a symlinked resource directory cannot be safely dumped. */
+const isSymlink = (path: string): boolean => {
+  try {
+    return lstatSync(path).isSymbolicLink();
+  } catch {
+    return false;
+  }
+};
+
 /** Recursively copies a resource directory, skipping symlinks so no path escapes the tree. */
-const copyResourceDirectory = (sourceDir: string, targetDir: string, written: string[]): void => {
-  for (const entry of readdirSync(sourceDir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+const copyResourceDirectory = (
+  sourceDir: string,
+  targetDir: string,
+  written: string[],
+  excludeNames: readonly string[] = [],
+): void => {
+  const entries = readdirSync(sourceDir, { withFileTypes: true }).sort((a, b) => compareSlugs(a.name, b.name));
+
+  for (const entry of entries) {
+    if (excludeNames.includes(entry.name)) {
+      continue;
+    }
+
     const sourcePath = join(sourceDir, entry.name);
     const targetPath = join(targetDir, entry.name);
 
@@ -30,6 +61,19 @@ const copyResourceDirectory = (sourceDir: string, targetDir: string, written: st
       written.push(targetPath);
     }
   }
+};
+
+/** Shallow-merges the effective per-agent config.json (loadout keys) across layers, highest wins. */
+const mergeEffectiveConfig = (configPaths: readonly string[]): Record<string, unknown> => {
+  let merged: Record<string, unknown> = {};
+
+  for (const configPath of [...configPaths].reverse()) {
+    const parsed = JSON.parse(readFileSync(configPath, 'utf8')) as Record<string, unknown>;
+    const loadout = Object.fromEntries(loadoutKeys.filter((key) => key in parsed).map((key) => [key, parsed[key]]));
+    merged = { ...merged, ...loadout };
+  }
+
+  return merged;
 };
 
 /** BFS over the selected agent and its subagents to form the transitive agent closure. */
@@ -54,17 +98,18 @@ const agentClosure = (set: EffectiveResourceSet, rootSlug: string): readonly Res
 
     ordered.push(agent);
     const composed = compose(set, slug);
-    queue.push(...(composed.plan?.loadout.subagents ?? []).map((subagent) => subagent.slug).sort());
+    queue.push(...(composed.plan?.loadout.subagents ?? []).map((subagent) => subagent.slug).sort(compareSlugs));
   }
 
   return ordered;
 };
 
+// Only regular files are dumped for identity roots; a symlinked root file is skipped to a lower layer.
 const writeRootFile = (set: EffectiveResourceSet, fileName: string, outRoot: string, written: string[]): void => {
   for (const layer of set.layers) {
     const candidate = join(layer.root, fileName);
 
-    if (existsSync(candidate)) {
+    if (existsSync(candidate) && !isSymlink(candidate) && lstatSync(candidate).isFile()) {
       const target = join(outRoot, fileName);
       writeFileSync(target, readFileSync(candidate, 'utf8'));
       written.push(target);
@@ -73,35 +118,93 @@ const writeRootFile = (set: EffectiveResourceSet, fileName: string, outRoot: str
   }
 };
 
-/** Writes the composed closure of `agentSlug` into `<outDirectory>/.agents/`. */
-export const dumpAgent = (set: EffectiveResourceSet, agentSlug: string, outDirectory: string): DumpResult => {
-  const composed = compose(set, agentSlug);
+interface ClosureCompose {
+  readonly agents: readonly ResolvedResource[];
+  readonly skillSlugs: readonly string[];
+  readonly warnings: readonly string[];
+  readonly errors: readonly string[];
+}
 
-  if (composed.plan === undefined) {
-    return { writtenPaths: [], warnings: [], errors: composed.errors };
+/** Composes every closure member, collecting skills, warnings, and any composition errors. */
+const composeClosure = (set: EffectiveResourceSet, rootSlug: string): ClosureCompose => {
+  const agents = agentClosure(set, rootSlug);
+  const skillSlugs = new Set<string>();
+  const warnings: string[] = [];
+  const errors: string[] = [];
+
+  for (const agent of agents) {
+    const composed = compose(set, agent.slug);
+
+    if (composed.plan === undefined) {
+      errors.push(...composed.errors);
+      continue;
+    }
+
+    warnings.push(...composed.plan.warnings);
+    for (const skill of composed.plan.loadout.skills) {
+      skillSlugs.add(skill.slug);
+    }
+  }
+
+  return { agents, skillSlugs: [...skillSlugs].sort(compareSlugs), warnings, errors };
+};
+
+const symlinkResourceError = (resource: ResolvedResource): string =>
+  `${resource.kind} '${resource.slug}' is a directory symlink and cannot be safely dumped.`;
+
+const writeMergedConfig = (agent: ResolvedResource, agentTarget: string, written: string[]): void => {
+  const mergedConfig = mergeEffectiveConfig(agent.configPaths ?? []);
+
+  if (Object.keys(mergedConfig).length > 0) {
+    const configTarget = join(agentTarget, 'config.json');
+    mkdirSync(agentTarget, { recursive: true });
+    writeFileSync(configTarget, `${JSON.stringify(mergedConfig, null, 2)}\n`);
+    written.push(configTarget);
+  }
+};
+
+/** Writes the composed closure of `agentSlug` into a freshly cleaned `<outDirectory>/.agents/`. */
+export const dumpAgent = (set: EffectiveResourceSet, agentSlug: string, outDirectory: string): DumpResult => {
+  const rootCompose = compose(set, agentSlug);
+
+  if (rootCompose.plan === undefined) {
+    return { writtenPaths: [], warnings: [], errors: rootCompose.errors };
+  }
+
+  const closure = composeClosure(set, agentSlug);
+
+  if (closure.errors.length > 0) {
+    return { writtenPaths: [], warnings: closure.warnings, errors: closure.errors };
+  }
+
+  const resources = [...closure.agents, ...closure.skillSlugs.map((slug) => findResource(set, 'skill', slug)!)];
+  const symlinked = resources.filter((resource) => isSymlink(dirname(resource.winner.path)));
+
+  if (symlinked.length > 0) {
+    return { writtenPaths: [], warnings: closure.warnings, errors: symlinked.map(symlinkResourceError) };
   }
 
   const outRoot = join(outDirectory, '.agents');
+  rmSync(outRoot, { recursive: true, force: true }); // clean destination so the dump is closure-scoped
   mkdirSync(outRoot, { recursive: true });
   const written: string[] = [];
 
   writeRootFile(set, 'system-prompt.md', outRoot, written);
   writeRootFile(set, 'agents.md', outRoot, written);
 
-  const agents = agentClosure(set, agentSlug);
-  const skillSlugs = new Set<string>();
-
-  for (const agent of agents) {
-    copyResourceDirectory(dirname(agent.winner.path), join(outRoot, 'agents', agent.slug), written);
-    for (const skill of compose(set, agent.slug).plan?.loadout.skills ?? []) {
-      skillSlugs.add(skill.slug);
-    }
+  for (const agent of closure.agents) {
+    const agentTarget = join(outRoot, 'agents', agent.slug);
+    copyResourceDirectory(dirname(agent.winner.path), agentTarget, written, ['config.json']);
+    writeMergedConfig(agent, agentTarget, written);
   }
 
-  for (const slug of [...skillSlugs].sort()) {
-    const skill = findResource(set, 'skill', slug)!;
-    copyResourceDirectory(dirname(skill.winner.path), join(outRoot, 'skills', slug), written);
+  for (const slug of closure.skillSlugs) {
+    copyResourceDirectory(
+      dirname(findResource(set, 'skill', slug)!.winner.path),
+      join(outRoot, 'skills', slug),
+      written,
+    );
   }
 
-  return { writtenPaths: written.sort(), warnings: composed.plan.warnings, errors: [] };
+  return { writtenPaths: written.sort(compareSlugs), warnings: closure.warnings, errors: [] };
 };

--- a/code/cli/src/dump/Dump.ts
+++ b/code/cli/src/dump/Dump.ts
@@ -1,0 +1,107 @@
+// Writes a deterministic, self-contained `.agents/` tree for one agent's transitive closure.
+import { copyFileSync, existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { compose } from '../composer/Composer.js';
+import { findResource } from '../resolver/Resource.js';
+import type { EffectiveResourceSet, ResolvedResource } from '../resolver/Resource.js';
+
+export interface DumpResult {
+  readonly writtenPaths: readonly string[];
+  readonly warnings: readonly string[];
+  readonly errors: readonly string[];
+}
+
+/** Recursively copies a resource directory, skipping symlinks so no path escapes the tree. */
+const copyResourceDirectory = (sourceDir: string, targetDir: string, written: string[]): void => {
+  for (const entry of readdirSync(sourceDir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    const sourcePath = join(sourceDir, entry.name);
+    const targetPath = join(targetDir, entry.name);
+
+    if (lstatSync(sourcePath).isSymbolicLink()) {
+      continue;
+    }
+
+    if (entry.isDirectory()) {
+      copyResourceDirectory(sourcePath, targetPath, written);
+    } else if (entry.isFile()) {
+      mkdirSync(dirname(targetPath), { recursive: true });
+      copyFileSync(sourcePath, targetPath);
+      written.push(targetPath);
+    }
+  }
+};
+
+/** BFS over the selected agent and its subagents to form the transitive agent closure. */
+const agentClosure = (set: EffectiveResourceSet, rootSlug: string): readonly ResolvedResource[] => {
+  const seen = new Set<string>();
+  const ordered: ResolvedResource[] = [];
+  const queue = [rootSlug];
+
+  while (queue.length > 0) {
+    const slug = queue.shift()!;
+
+    if (seen.has(slug)) {
+      continue;
+    }
+    seen.add(slug);
+
+    const agent = findResource(set, 'agent', slug);
+
+    if (agent === undefined) {
+      continue;
+    }
+
+    ordered.push(agent);
+    const composed = compose(set, slug);
+    queue.push(...(composed.plan?.loadout.subagents ?? []).map((subagent) => subagent.slug).sort());
+  }
+
+  return ordered;
+};
+
+const writeRootFile = (set: EffectiveResourceSet, fileName: string, outRoot: string, written: string[]): void => {
+  for (const layer of set.layers) {
+    const candidate = join(layer.root, fileName);
+
+    if (existsSync(candidate)) {
+      const target = join(outRoot, fileName);
+      writeFileSync(target, readFileSync(candidate, 'utf8'));
+      written.push(target);
+      return;
+    }
+  }
+};
+
+/** Writes the composed closure of `agentSlug` into `<outDirectory>/.agents/`. */
+export const dumpAgent = (set: EffectiveResourceSet, agentSlug: string, outDirectory: string): DumpResult => {
+  const composed = compose(set, agentSlug);
+
+  if (composed.plan === undefined) {
+    return { writtenPaths: [], warnings: [], errors: composed.errors };
+  }
+
+  const outRoot = join(outDirectory, '.agents');
+  mkdirSync(outRoot, { recursive: true });
+  const written: string[] = [];
+
+  writeRootFile(set, 'system-prompt.md', outRoot, written);
+  writeRootFile(set, 'agents.md', outRoot, written);
+
+  const agents = agentClosure(set, agentSlug);
+  const skillSlugs = new Set<string>();
+
+  for (const agent of agents) {
+    copyResourceDirectory(dirname(agent.winner.path), join(outRoot, 'agents', agent.slug), written);
+    for (const skill of compose(set, agent.slug).plan?.loadout.skills ?? []) {
+      skillSlugs.add(skill.slug);
+    }
+  }
+
+  for (const slug of [...skillSlugs].sort()) {
+    const skill = findResource(set, 'skill', slug)!;
+    copyResourceDirectory(dirname(skill.winner.path), join(outRoot, 'skills', slug), written);
+  }
+
+  return { writtenPaths: written.sort(), warnings: composed.plan.warnings, errors: [] };
+};

--- a/code/cli/src/dump/Dump.ts
+++ b/code/cli/src/dump/Dump.ts
@@ -13,7 +13,8 @@ import { dirname, join } from 'node:path';
 
 import { compose } from '../composer/Composer.js';
 import { compareSlugs, findResource } from '../resolver/Resource.js';
-import type { EffectiveResourceSet, ResolvedResource } from '../resolver/Resource.js';
+import type { EffectiveResourceSet, Layer, ResolvedResource } from '../resolver/Resource.js';
+import { escapesRoots, overlaps } from './Containment.js';
 
 export interface DumpResult {
   readonly writtenPaths: readonly string[];
@@ -23,16 +24,12 @@ export interface DumpResult {
 
 const loadoutKeys = ['skills', 'subagents', 'mcp', 'extensions', 'plugins', 'model', 'thinking', 'tools'] as const;
 
-/** True when the path is a symlink; a symlinked resource directory cannot be safely dumped. */
-const isSymlink = (path: string): boolean => {
-  try {
-    return lstatSync(path).isSymbolicLink();
-  } catch {
-    return false;
-  }
-};
+// Tree-root files carried into the dump so loadout selections (mcp/models) are not dangling.
+const rootFileNames = ['system-prompt.md', 'agents.md', 'mcp.json', 'models.json'] as const;
 
-/** Recursively copies a resource directory, skipping symlinks so no path escapes the tree. */
+const layerRoots = (set: EffectiveResourceSet): readonly string[] => set.layers.map((layer) => layer.root);
+
+/** Recursively copies a directory, skipping symlinked entries so no path escapes the tree. */
 const copyResourceDirectory = (
   sourceDir: string,
   targetDir: string,
@@ -104,18 +101,29 @@ const agentClosure = (set: EffectiveResourceSet, rootSlug: string): readonly Res
   return ordered;
 };
 
-// Only regular files are dumped for identity roots; a symlinked root file is skipped to a lower layer.
-const writeRootFile = (set: EffectiveResourceSet, fileName: string, outRoot: string, written: string[]): void => {
-  for (const layer of set.layers) {
-    const candidate = join(layer.root, fileName);
+// Copies the highest-precedence tree-root file, matching what the composer reads; escaping targets error.
+const writeRootFiles = (set: EffectiveResourceSet, outRoot: string, written: string[]): readonly string[] => {
+  const errors: string[] = [];
+  const roots = layerRoots(set);
 
-    if (existsSync(candidate) && !isSymlink(candidate) && lstatSync(candidate).isFile()) {
-      const target = join(outRoot, fileName);
-      writeFileSync(target, readFileSync(candidate, 'utf8'));
-      written.push(target);
-      return;
+  for (const fileName of rootFileNames) {
+    const source = set.layers.map((layer) => join(layer.root, fileName)).find((candidate) => existsSync(candidate));
+
+    if (source === undefined) {
+      continue;
     }
+
+    if (escapesRoots(source, roots)) {
+      errors.push(`root file '${fileName}' resolves outside the tree and cannot be safely dumped.`);
+      continue;
+    }
+
+    const target = join(outRoot, fileName);
+    writeFileSync(target, readFileSync(source, 'utf8'));
+    written.push(target);
   }
+
+  return errors;
 };
 
 interface ClosureCompose {
@@ -149,8 +157,31 @@ const composeClosure = (set: EffectiveResourceSet, rootSlug: string): ClosureCom
   return { agents, skillSlugs: [...skillSlugs].sort(compareSlugs), warnings, errors };
 };
 
-const symlinkResourceError = (resource: ResolvedResource): string =>
-  `${resource.kind} '${resource.slug}' is a directory symlink and cannot be safely dumped.`;
+const closureResources = (set: EffectiveResourceSet, closure: ClosureCompose): readonly ResolvedResource[] => [
+  ...closure.agents,
+  ...closure.skillSlugs.map((slug) => findResource(set, 'skill', slug)!),
+];
+
+// A defining file or its config that resolves outside every layer root cannot be safely dumped.
+const containmentErrors = (resources: readonly ResolvedResource[], roots: readonly string[]): readonly string[] => {
+  const errors: string[] = [];
+
+  for (const resource of resources) {
+    const files = [resource.winner.path, ...(resource.configPaths ?? [])];
+    if (files.some((file) => escapesRoots(file, roots))) {
+      errors.push(`${resource.kind} '${resource.slug}' resolves outside the tree and cannot be safely dumped.`);
+    }
+  }
+
+  return errors;
+};
+
+const overlapError = (outRoot: string, layers: readonly Layer[]): string | undefined => {
+  const clash = layers.find((layer) => overlaps(outRoot, layer.root));
+  return clash === undefined
+    ? undefined
+    : `dump output ${outRoot} overlaps source layer '${clash.label}'; choose an --out outside the tree.`;
+};
 
 const writeMergedConfig = (agent: ResolvedResource, agentTarget: string, written: string[]): void => {
   const mergedConfig = mergeEffectiveConfig(agent.configPaths ?? []);
@@ -163,34 +194,46 @@ const writeMergedConfig = (agent: ResolvedResource, agentTarget: string, written
   }
 };
 
+const failure = (errors: readonly string[], warnings: readonly string[] = []): DumpResult => ({
+  writtenPaths: [],
+  warnings,
+  errors,
+});
+
 /** Writes the composed closure of `agentSlug` into a freshly cleaned `<outDirectory>/.agents/`. */
 export const dumpAgent = (set: EffectiveResourceSet, agentSlug: string, outDirectory: string): DumpResult => {
-  const rootCompose = compose(set, agentSlug);
-
-  if (rootCompose.plan === undefined) {
-    return { writtenPaths: [], warnings: [], errors: rootCompose.errors };
+  if (compose(set, agentSlug).plan === undefined) {
+    return failure(compose(set, agentSlug).errors);
   }
 
   const closure = composeClosure(set, agentSlug);
 
   if (closure.errors.length > 0) {
-    return { writtenPaths: [], warnings: closure.warnings, errors: closure.errors };
+    return failure(closure.errors, closure.warnings);
   }
 
-  const resources = [...closure.agents, ...closure.skillSlugs.map((slug) => findResource(set, 'skill', slug)!)];
-  const symlinked = resources.filter((resource) => isSymlink(dirname(resource.winner.path)));
+  const roots = layerRoots(set);
+  const safety = containmentErrors(closureResources(set, closure), roots);
 
-  if (symlinked.length > 0) {
-    return { writtenPaths: [], warnings: closure.warnings, errors: symlinked.map(symlinkResourceError) };
+  if (safety.length > 0) {
+    return failure(safety, closure.warnings);
   }
 
   const outRoot = join(outDirectory, '.agents');
+  const clash = overlapError(outRoot, set.layers);
+
+  if (clash !== undefined) {
+    return failure([clash], closure.warnings);
+  }
+
   rmSync(outRoot, { recursive: true, force: true }); // clean destination so the dump is closure-scoped
   mkdirSync(outRoot, { recursive: true });
   const written: string[] = [];
+  const rootErrors = writeRootFiles(set, outRoot, written);
 
-  writeRootFile(set, 'system-prompt.md', outRoot, written);
-  writeRootFile(set, 'agents.md', outRoot, written);
+  if (rootErrors.length > 0) {
+    return failure(rootErrors, closure.warnings);
+  }
 
   for (const agent of closure.agents) {
     const agentTarget = join(outRoot, 'agents', agent.slug);

--- a/code/cli/tests/unit/dump.test.ts
+++ b/code/cli/tests/unit/dump.test.ts
@@ -118,4 +118,97 @@ describe('dump command', () => {
     expect(result.ok).toBe(false);
     expect(result.messages[0]).toContain("Unknown agent 'ghost'");
   });
+
+  it('materializes the merged effective config.json across layers', () => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    write(
+      join(home, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\nmodel: gpt-5.2\n---\n\nBody.\n',
+    );
+    write(join(project, '.agents', 'agents', 'engineer', 'config.json'), JSON.stringify({ model: 'gpt-5.3' }));
+    const out = join(createTemporaryRoot(), 'merged');
+
+    executeDumpCommand({ homeDirectory: home, projectDirectory: project, agent: 'engineer', out });
+
+    const config = JSON.parse(readFileSync(join(out, '.agents', 'agents', 'engineer', 'config.json'), 'utf8'));
+    expect(config).toEqual({ model: 'gpt-5.3' });
+  });
+
+  it('rejects a dump whose resource directory is a symlink', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    const external = join(root, 'external-skill');
+    write(join(external, 'SKILL.md'), '---\nname: wiki\n---\n');
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\nskills: [wiki]\n---\n\nBody.\n',
+    );
+    mkdirSync(join(project, '.agents', 'skills'), { recursive: true });
+    symlinkSync(external, join(project, '.agents', 'skills', 'wiki'));
+    const out = join(createTemporaryRoot(), 'unsafe');
+
+    const result = executeDumpCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+      agent: 'engineer',
+      out,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.messages.join(' ')).toContain('directory symlink');
+  });
+
+  it('cleans the destination so a smaller closure leaves no stale files', () => {
+    const { home, project } = buildTree();
+    const out = join(createTemporaryRoot(), 'reuse');
+    // First dump: engineer pulls in reviewer + wiki.
+    executeDumpCommand({ homeDirectory: home, projectDirectory: project, agent: 'engineer', out });
+    // Second dump into the same dir: reviewer has no skills/subagents.
+    executeDumpCommand({ homeDirectory: home, projectDirectory: project, agent: 'reviewer', out });
+
+    const tree = relativeTree(join(out, '.agents'));
+    expect(tree).toContain('agents/reviewer/agent.md');
+    expect(tree).not.toContain('agents/engineer/agent.md');
+    expect(tree).not.toContain('skills/wiki/SKILL.md');
+  });
+
+  it('fails the whole dump when a transitive subagent is invalid', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    write(
+      join(project, '.agents', 'agents', 'lead', 'agent.md'),
+      '---\nname: lead\nsubagents: [broken]\n---\n\nBody.\n',
+    );
+    write(join(project, '.agents', 'agents', 'broken', 'agent.md'), '---\nname: mismatch\n---\n\nBody.\n');
+    const out = join(createTemporaryRoot(), 'closure');
+
+    const result = executeDumpCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+      agent: 'lead',
+      out,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.messages.join(' ')).toContain('must match its directory');
+  });
+
+  it('propagates non-fatal loadout warnings from closure members', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\nskills: [ghost]\n---\n\nBody.\n',
+    );
+    const out = join(createTemporaryRoot(), 'warn');
+
+    const result = executeDumpCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+      agent: 'engineer',
+      out,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.messages.join(' ')).toContain("unknown skill 'ghost'");
+  });
 });

--- a/code/cli/tests/unit/dump.test.ts
+++ b/code/cli/tests/unit/dump.test.ts
@@ -156,7 +156,75 @@ describe('dump command', () => {
       out,
     });
     expect(result.ok).toBe(false);
-    expect(result.messages.join(' ')).toContain('directory symlink');
+    expect(result.messages.join(' ')).toContain('cannot be safely dumped');
+  });
+
+  it('rejects a resource reached through a symlinked ancestor directory', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    const externalAgents = join(root, 'external-agents');
+    write(join(externalAgents, 'engineer', 'agent.md'), '---\nname: engineer\n---\n\nBody.\n');
+    mkdirSync(join(project, '.agents'), { recursive: true });
+    symlinkSync(externalAgents, join(project, '.agents', 'agents')); // whole agents/ dir is an escaping link
+    const out = join(createTemporaryRoot(), 'ancestor');
+
+    const result = executeDumpCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+      agent: 'engineer',
+      out,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.messages.join(' ')).toContain('cannot be safely dumped');
+  });
+
+  it('rejects an --out that overlaps a source layer', () => {
+    const { home, project } = buildTree();
+    const result = executeDumpCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      agent: 'engineer',
+      out: project,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.messages.join(' ')).toContain('overlaps source layer');
+    // the source .agents tree must still be intact
+    expect(relativeTree(join(project, '.agents'))).toContain('agents/engineer/agent.md');
+  });
+
+  it('materializes tree-root mcp.json and models.json so selections are self-contained', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    write(join(project, '.agents', 'mcp.json'), '{"github":{}}');
+    write(join(project, '.agents', 'models.json'), '{"gpt-5.2":{}}');
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\nmcp: [github]\n---\n\nBody.\n',
+    );
+    const out = join(createTemporaryRoot(), 'roots');
+
+    executeDumpCommand({ homeDirectory: join(root, 'home'), projectDirectory: project, agent: 'engineer', out });
+    const tree = relativeTree(join(out, '.agents'));
+    expect(tree).toContain('mcp.json');
+    expect(tree).toContain('models.json');
+  });
+
+  it('errors when a tree-root file resolves outside the tree', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    write(join(root, 'outside', 'system-prompt.md'), 'EXTERNAL');
+    write(join(project, '.agents', 'agents', 'engineer', 'agent.md'), '---\nname: engineer\n---\n\nBody.\n');
+    symlinkSync(join(root, 'outside', 'system-prompt.md'), join(project, '.agents', 'system-prompt.md'));
+    const out = join(createTemporaryRoot(), 'escape');
+
+    const result = executeDumpCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+      agent: 'engineer',
+      out,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.messages.join(' ')).toContain('resolves outside the tree');
   });
 
   it('cleans the destination so a smaller closure leaves no stale files', () => {
@@ -178,7 +246,7 @@ describe('dump command', () => {
     const project = join(root, 'project');
     write(
       join(project, '.agents', 'agents', 'lead', 'agent.md'),
-      '---\nname: lead\nsubagents: [broken]\n---\n\nBody.\n',
+      '---\nname: lead\nskills: [ghost]\nsubagents: [broken]\n---\n\nBody.\n',
     );
     write(join(project, '.agents', 'agents', 'broken', 'agent.md'), '---\nname: mismatch\n---\n\nBody.\n');
     const out = join(createTemporaryRoot(), 'closure');
@@ -191,6 +259,8 @@ describe('dump command', () => {
     });
     expect(result.ok).toBe(false);
     expect(result.messages.join(' ')).toContain('must match its directory');
+    // warnings from closure members are surfaced even on a fatal failure
+    expect(result.messages.join(' ')).toContain("unknown skill 'ghost'");
   });
 
   it('propagates non-fatal loadout warnings from closure members', () => {

--- a/code/cli/tests/unit/dump.test.ts
+++ b/code/cli/tests/unit/dump.test.ts
@@ -1,0 +1,121 @@
+// Tests `outfitter dump`: deterministic, self-contained, closure-scoped .agents output.
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { executeDumpCommand } from '../../src/cli/commands/DumpCommand.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-dump-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const write = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+
+const relativeTree = (root: string): string[] => {
+  const files: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else files.push(relative(root, full).split(/[/\\]/).join('/'));
+    }
+  };
+  walk(root);
+  return files.sort();
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+const buildTree = (): { home: string; project: string } => {
+  const root = createTemporaryRoot();
+  const home = join(root, 'home');
+  const project = join(root, 'project');
+  write(join(project, '.agents', 'system-prompt.md'), 'BASE');
+  write(join(project, '.agents', 'skills', 'wiki', 'SKILL.md'), '---\nname: wiki\n---\n');
+  write(join(project, '.agents', 'skills', 'unused', 'SKILL.md'), '---\nname: unused\n---\n');
+  write(join(project, '.agents', 'agents', 'reviewer', 'agent.md'), '---\nname: reviewer\n---\n\nReview.\n');
+  write(
+    join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+    '---\nname: engineer\nskills: [wiki]\nsubagents: [reviewer]\n---\n\n# Engineer\n',
+  );
+  return { home, project };
+};
+
+describe('dump command', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('writes the transitive closure of an agent as a self-contained .agents tree', () => {
+    const { home, project } = buildTree();
+    const out = join(createTemporaryRoot(), 'review');
+
+    const result = executeDumpCommand({ homeDirectory: home, projectDirectory: project, agent: 'engineer', out });
+
+    expect(result.ok).toBe(true);
+    expect(relativeTree(join(out, '.agents'))).toEqual([
+      'agents/engineer/agent.md',
+      'agents/reviewer/agent.md',
+      'skills/wiki/SKILL.md',
+      'system-prompt.md',
+    ]);
+    // 'unused' skill is not in engineer's closure.
+    expect(relativeTree(join(out, '.agents'))).not.toContain('skills/unused/SKILL.md');
+  });
+
+  it('is deterministic — two dumps produce identical trees and contents', () => {
+    const { home, project } = buildTree();
+    const outA = join(createTemporaryRoot(), 'a');
+    const outB = join(createTemporaryRoot(), 'b');
+
+    executeDumpCommand({ homeDirectory: home, projectDirectory: project, agent: 'engineer', out: outA });
+    executeDumpCommand({ homeDirectory: home, projectDirectory: project, agent: 'engineer', out: outB });
+
+    const treeA = relativeTree(join(outA, '.agents'));
+    expect(treeA).toEqual(relativeTree(join(outB, '.agents')));
+    for (const file of treeA) {
+      expect(readFileSync(join(outA, '.agents', file), 'utf8')).toBe(readFileSync(join(outB, '.agents', file), 'utf8'));
+    }
+  });
+
+  it('never copies symlinks into the dump', () => {
+    const { home, project } = buildTree();
+    symlinkSync('/etc/passwd', join(project, '.agents', 'agents', 'engineer', 'secret-link'));
+    const out = join(createTemporaryRoot(), 'safe');
+
+    executeDumpCommand({ homeDirectory: home, projectDirectory: project, agent: 'engineer', out });
+
+    expect(relativeTree(join(out, '.agents'))).not.toContain('agents/engineer/secret-link');
+  });
+
+  it('uses default_agent when --agent is omitted and errors when neither is available', () => {
+    const { home, project } = buildTree();
+    write(join(project, '.agents', 'settings.yml'), 'default_agent: engineer\n');
+    const out = join(createTemporaryRoot(), 'def');
+    expect(executeDumpCommand({ homeDirectory: home, projectDirectory: project, out }).ok).toBe(true);
+
+    const bare = createTemporaryRoot();
+    expect(() =>
+      executeDumpCommand({ homeDirectory: join(bare, 'home'), projectDirectory: join(bare, 'project'), out }),
+    ).toThrow(/No agent selected/);
+  });
+
+  it('reports an error for an unknown agent', () => {
+    const { home, project } = buildTree();
+    const out = join(createTemporaryRoot(), 'x');
+    const result = executeDumpCommand({ homeDirectory: home, projectDirectory: project, agent: 'ghost', out });
+    expect(result.ok).toBe(false);
+    expect(result.messages[0]).toContain("Unknown agent 'ghost'");
+  });
+});

--- a/code/cli/tests/unit/source-layout.test.ts
+++ b/code/cli/tests/unit/source-layout.test.ts
@@ -58,13 +58,19 @@ describe('source layout scaffolding', () => {
       'setup',
       'sync',
       'welcome',
-      'profile',
-      'profile list',
-      'profile create',
-      'profile lint',
+      'list',
+      'validate',
+      'dump',
     ]);
-    expect(program.commands.map((command) => command.name())).toEqual(['run', 'setup', 'sync', 'welcome', 'profile']);
-    expect(program.commands.at(4)?.commands.map((command) => command.name())).toEqual(['list', 'create', 'lint']);
+    expect(program.commands.map((command) => command.name())).toEqual([
+      'run',
+      'setup',
+      'sync',
+      'welcome',
+      'list',
+      'validate',
+      'dump',
+    ]);
     expect(describeCommandObject(createRunCommand())).toEqual({
       name: 'run',
       description: 'Assemble a profile compositeProfile and launch the selected agent CLI.',

--- a/docs/architecture/file_structure.md
+++ b/docs/architecture/file_structure.md
@@ -43,10 +43,13 @@ Outfitter is organized around a private npm workspace root, clear TypeScript pac
 │   │   │   │   ├── commands/run/      # run command helper modules (profile resolution, launch summary)
 │   │   │   │   └── commands/setup/    # setup command helper modules (types, starter sources, imports, prompts, launch)
 │   │   │   ├── settings/              # settings loading and merging
-│   │   │   ├── profiles/              # profile loading, validation, resolution, and merging
+│   │   │   ├── resolver/              # .agents layer resolution into one effective resource set (RFC #165)
+│   │   │   ├── composer/              # harness-neutral CompositionPlan from the effective set (RFC #165)
+│   │   │   ├── dump/                  # deterministic self-contained `.agents` tree output (RFC #165)
+│   │   │   ├── profiles/              # legacy profile loading/resolution (removed by the RFC #165 cleanup PR)
 │   │   │   │   └── PromptIncludes.ts  # typed append_system_prompt include resolution and diagnostics
 │   │   │   ├── merge/                 # deterministic value and array merge policy helpers
-│   │   │   ├── compositeProfile/      # generated runtime composite profile assembly and watching
+│   │   │   ├── compositeProfile/      # legacy composite profile assembly (removed by the RFC #165 cleanup PR)
 │   │   │   ├── agents/                # agent adapter boundary and CLI-specific adapters
 │   │   │   ├── schemas/               # JSON Schema artifacts for persisted formats
 │   │   │   └── validation/            # shared validation helpers


### PR DESCRIPTION
**Stack 4/6** of the RFC #165 implementation refactor (settings #172, resolver #173, composer #176 landed). Cut from `main`. (Supersedes auto-closed #177; Copilot review from #177 already addressed in the latest commit.)

## This PR — `outfitter dump`
`outfitter dump --agent <id> --out <dir>` writes an agent's transitive closure as a **deterministic**, **closure-scoped**, **symlink-safe** `.agents/` tree, with the **merged effective config.json** materialized per agent and closure-wide compose errors/warnings surfaced. Dump suite green (10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)