### PR TITLE
refactor(run): project a CompositionPlan and launch pi/claude [rfc-165 impl 5/6]

### DIFF
--- a/code/cli/src/cli/OutfitterCli.ts
+++ b/code/cli/src/cli/OutfitterCli.ts
@@ -6,14 +6,15 @@ import { Command } from 'commander';
 import type { CommandObject } from './commands/CommandObject.js';
 import { createDumpCommand } from './commands/DumpCommand.js';
 import { createListCommand } from './commands/ListCommand.js';
-import { createRunCommand, executeRunCommand } from './commands/RunCommand.js';
+import { executeRunCommand } from './commands/RunCommand.js';
+import { createRunAgentCommand } from './commands/RunAgentCommand.js';
 import { createSetupCommand } from './commands/SetupCommand.js';
 import { createSyncCommand } from './commands/SyncCommand.js';
 import { createValidateCommand } from './commands/ValidateCommand.js';
 import { createWelcomeCommand } from './commands/WelcomeCommand.js';
 
 export const createDefaultCommands = (): CommandObject[] => [
-  createRunCommand(),
+  createRunAgentCommand(),
   createSetupCommand({
     /* v8 ignore next 2 -- covered by end-to-end CLI smoke usage; unit tests inject this dependency. */
     async launchSetupSourceProfile(input) {
@@ -35,7 +36,7 @@ export const createOutfitterProgram = (commands: readonly CommandObject[] = crea
 
   program
     .name('outfitter')
-    .description('Profile-oriented wrapper for launching pi, Claude Code, and future agent CLIs.')
+    .description('Resolve, compose, and launch .agents agents in pi, Claude Code, and future harnesses.')
     .version(readPackageVersion());
 
   for (const command of commands) {

--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -1,15 +1,17 @@
 // `outfitter run [agent]` — resolve → compose → project → launch on the .agents model.
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { Command, Option } from 'commander';
+
+import { launchAgentProcess, resolveAgentLaunchExecutable } from '../../agents/AgentLaunch.js';
 import { compose } from '../../composer/Composer.js';
 import { projectComposition } from '../../projection/ProjectHarness.js';
 import type { AgentLaunchPlan } from '../../projection/Projection.js';
 import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
 import { loadSettingsWithCachedRemoteSettings } from '../../settings/SettingsLoader.js';
 import type { Harness } from '../../settings/Settings.js';
-import { Command } from 'commander';
 import type { CommandObject } from './CommandObject.js';
 
 export type AgentProcessLauncher = (plan: AgentLaunchPlan) => Promise<number>;
@@ -18,10 +20,12 @@ export interface RunAgentInput {
   readonly homeDirectory: string;
   readonly projectDirectory: string;
   readonly agent?: string;
-  readonly harness?: Harness;
+  readonly harness?: string;
   readonly strict?: boolean;
   readonly passThroughArgs?: readonly string[];
   readonly launcher: AgentProcessLauncher;
+  /** Keep the runtime projection directory after the run (debugging). */
+  readonly retainProjection?: boolean;
 }
 
 export interface RunAgentResult {
@@ -37,6 +41,8 @@ export interface RunAgentDependencies {
   readonly writeLine?: (message: string) => void;
 }
 
+const harnesses: readonly Harness[] = ['pi', 'claude'];
+
 const resolveAgentSlug = (settingsDefault: string | undefined, requested: string | undefined): string => {
   const slug = requested ?? settingsDefault;
 
@@ -47,8 +53,15 @@ const resolveAgentSlug = (settingsDefault: string | undefined, requested: string
   return slug;
 };
 
-const resolveHarness = (settingsDefault: Harness | undefined, requested: Harness | undefined): Harness =>
-  requested ?? settingsDefault ?? 'pi';
+const resolveHarness = (settingsDefault: Harness | undefined, requested: string | undefined): Harness => {
+  const harness = requested ?? settingsDefault ?? 'pi';
+
+  if (harness !== 'pi' && harness !== 'claude') {
+    throw new Error(`Unknown harness '${harness}'. Use --harness pi or --harness claude.`);
+  }
+
+  return harness;
+};
 
 export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunAgentResult> => {
   const { settings } = loadSettingsWithCachedRemoteSettings(input);
@@ -67,35 +80,54 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
   }
 
   const rootDirectory = mkdtempSync(join(tmpdir(), `outfitter-${agentSlug}-${harness}-`));
-  const projection = projectComposition(composed.plan, {
-    harness,
-    rootDirectory,
-    homeDirectory: input.homeDirectory,
-    passThroughArgs: input.passThroughArgs,
-  });
 
-  const warnings = [
-    ...composed.plan.warnings,
-    ...projection.unsupported.map((element) => `harness '${harness}' cannot project loadout element '${element}'.`),
-  ];
+  try {
+    const projection = projectComposition(composed.plan, {
+      harness,
+      rootDirectory,
+      homeDirectory: input.homeDirectory,
+      passThroughArgs: input.passThroughArgs,
+    });
 
-  if (input.strict === true && projection.unsupported.length > 0) {
-    return { exitCode: 1, messages: [...warnings, 'Strict mode: unsupported loadout elements are fatal.'] };
+    // Composition warnings (e.g. an unresolved skill) and unsupported harness elements are both
+    // advisory; --strict makes the combined set fatal before launch.
+    const warnings = [
+      ...composed.plan.warnings,
+      ...projection.unsupported.map((element) => `harness '${harness}' cannot project loadout element '${element}'.`),
+    ];
+
+    if (input.strict === true && warnings.length > 0) {
+      return {
+        exitCode: 1,
+        messages: [...warnings, 'Strict mode: composition warnings and unsupported elements are fatal.'],
+      };
+    }
+
+    const exitCode = await input.launcher(projection.launch);
+    return { launchPlan: projection.launch, exitCode, messages: warnings };
+  } finally {
+    if (input.retainProjection !== true) {
+      rmSync(rootDirectory, { recursive: true, force: true });
+    }
   }
-
-  const exitCode = await input.launcher(projection.launch);
-  return { launchPlan: projection.launch, exitCode, messages: warnings };
 };
 
 /* v8 ignore start -- real process spawn is covered by end-to-end smoke usage, not unit tests. */
-const defaultLauncher: AgentProcessLauncher = async (plan) => {
-  const { default: spawn } = await import('cross-spawn');
-  return await new Promise<number>((resolve) => {
-    const child = spawn(plan.command, [...plan.args], { stdio: 'inherit', env: { ...process.env, ...plan.env } });
-    child.on('exit', (code) => resolve(code ?? 0));
-    child.on('error', () => resolve(1));
-  });
+const spawnLauncher = {
+  async launch(plan: AgentLaunchPlan): Promise<number> {
+    const { default: spawn } = await import('cross-spawn');
+    return await new Promise<number>((resolve, reject) => {
+      const child = spawn(plan.command, [...plan.args], { stdio: 'inherit', env: { ...process.env, ...plan.env } });
+      child.on('error', reject); // ENOENT surfaces as an actionable install message
+      child.on('close', (code, signal) => resolve(code ?? (signal ? 1 : 0)));
+    });
+  },
 };
+
+const makeDefaultLauncher =
+  (agentId: Harness): AgentProcessLauncher =>
+  (plan) =>
+    launchAgentProcess(spawnLauncher, resolveAgentLaunchExecutable(plan), agentId);
 /* v8 ignore stop */
 
 export const createRunAgentCommand = (dependencies: RunAgentDependencies = {}): CommandObject => ({
@@ -107,14 +139,14 @@ export const createRunAgentCommand = (dependencies: RunAgentDependencies = {}): 
       .description('Resolve, compose, and launch an agent in the selected harness.')
       .argument('[agent]', 'Agent slug to run (default: settings default_agent).')
       .argument('[args...]', 'Arguments passed through to the harness after --.')
-      .option('--harness <harness>', 'Harness to launch: pi or claude.')
-      .option('--strict', 'Treat unsupported loadout elements as fatal.')
+      .addOption(new Option('--harness <harness>', 'Harness to launch.').choices([...harnesses]))
+      .option('--strict', 'Treat composition warnings and unsupported loadout elements as fatal.')
       .allowUnknownOption(true)
       .action(
         async (
           agent: string | undefined,
           passThroughArgs: readonly string[],
-          options: { harness?: Harness; strict?: boolean },
+          options: { harness?: string; strict?: boolean },
         ) => {
           const result = await executeRunAgentCommand({
             /* v8 ignore next 2 -- process defaults exercised by the CLI entrypoint, not unit tests. */
@@ -124,12 +156,13 @@ export const createRunAgentCommand = (dependencies: RunAgentDependencies = {}): 
             harness: options.harness,
             strict: options.strict,
             passThroughArgs,
-            launcher: dependencies.launcher ?? defaultLauncher,
+            /* v8 ignore next -- the default spawn launcher is exercised by end-to-end usage. */
+            launcher: dependencies.launcher ?? makeDefaultLauncher(resolveHarness(undefined, options.harness)),
           });
 
           for (const message of result.messages) {
-            /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
-            (dependencies.writeLine ?? console.log)(message);
+            /* v8 ignore next -- console.error fallback is direct CLI behavior; tests inject a writer. */
+            (dependencies.writeLine ?? console.error)(message);
           }
 
           process.exitCode = result.exitCode;

--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -1,0 +1,139 @@
+// `outfitter run [agent]` — resolve → compose → project → launch on the .agents model.
+import { mkdtempSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { compose } from '../../composer/Composer.js';
+import { projectComposition } from '../../projection/ProjectHarness.js';
+import type { AgentLaunchPlan } from '../../projection/Projection.js';
+import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
+import { loadSettingsWithCachedRemoteSettings } from '../../settings/SettingsLoader.js';
+import type { Harness } from '../../settings/Settings.js';
+import { Command } from 'commander';
+import type { CommandObject } from './CommandObject.js';
+
+export type AgentProcessLauncher = (plan: AgentLaunchPlan) => Promise<number>;
+
+export interface RunAgentInput {
+  readonly homeDirectory: string;
+  readonly projectDirectory: string;
+  readonly agent?: string;
+  readonly harness?: Harness;
+  readonly strict?: boolean;
+  readonly passThroughArgs?: readonly string[];
+  readonly launcher: AgentProcessLauncher;
+}
+
+export interface RunAgentResult {
+  readonly launchPlan?: AgentLaunchPlan;
+  readonly exitCode: number;
+  readonly messages: readonly string[];
+}
+
+export interface RunAgentDependencies {
+  readonly homeDirectory?: string;
+  readonly projectDirectory?: string;
+  readonly launcher?: AgentProcessLauncher;
+  readonly writeLine?: (message: string) => void;
+}
+
+const resolveAgentSlug = (settingsDefault: string | undefined, requested: string | undefined): string => {
+  const slug = requested ?? settingsDefault;
+
+  if (slug === undefined) {
+    throw new Error("No agent selected and no 'default_agent' in settings. Pass an agent: outfitter run <agent>.");
+  }
+
+  return slug;
+};
+
+const resolveHarness = (settingsDefault: Harness | undefined, requested: Harness | undefined): Harness =>
+  requested ?? settingsDefault ?? 'pi';
+
+export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunAgentResult> => {
+  const { settings } = loadSettingsWithCachedRemoteSettings(input);
+  const { set, settingsIssues } = resolveEffectiveSet(input);
+
+  if (settingsIssues.length > 0) {
+    throw new Error(`Cannot run with invalid settings: ${settingsIssues.map((issue) => issue.message).join('; ')}`);
+  }
+
+  const agentSlug = resolveAgentSlug(settings.defaultAgent, input.agent);
+  const harness = resolveHarness(settings.defaultHarness, input.harness);
+  const composed = compose(set, agentSlug);
+
+  if (composed.plan === undefined) {
+    return { exitCode: 1, messages: composed.errors };
+  }
+
+  const rootDirectory = mkdtempSync(join(tmpdir(), `outfitter-${agentSlug}-${harness}-`));
+  const projection = projectComposition(composed.plan, {
+    harness,
+    rootDirectory,
+    homeDirectory: input.homeDirectory,
+    passThroughArgs: input.passThroughArgs,
+  });
+
+  const warnings = [
+    ...composed.plan.warnings,
+    ...projection.unsupported.map((element) => `harness '${harness}' cannot project loadout element '${element}'.`),
+  ];
+
+  if (input.strict === true && projection.unsupported.length > 0) {
+    return { exitCode: 1, messages: [...warnings, 'Strict mode: unsupported loadout elements are fatal.'] };
+  }
+
+  const exitCode = await input.launcher(projection.launch);
+  return { launchPlan: projection.launch, exitCode, messages: warnings };
+};
+
+/* v8 ignore start -- real process spawn is covered by end-to-end smoke usage, not unit tests. */
+const defaultLauncher: AgentProcessLauncher = async (plan) => {
+  const { default: spawn } = await import('cross-spawn');
+  return await new Promise<number>((resolve) => {
+    const child = spawn(plan.command, [...plan.args], { stdio: 'inherit', env: { ...process.env, ...plan.env } });
+    child.on('exit', (code) => resolve(code ?? 0));
+    child.on('error', () => resolve(1));
+  });
+};
+/* v8 ignore stop */
+
+export const createRunAgentCommand = (dependencies: RunAgentDependencies = {}): CommandObject => ({
+  name: 'run',
+  description: 'Resolve, compose, and launch an agent in the selected harness.',
+  register(program: Command): void {
+    program
+      .command('run', { isDefault: true })
+      .description('Resolve, compose, and launch an agent in the selected harness.')
+      .argument('[agent]', 'Agent slug to run (default: settings default_agent).')
+      .argument('[args...]', 'Arguments passed through to the harness after --.')
+      .option('--harness <harness>', 'Harness to launch: pi or claude.')
+      .option('--strict', 'Treat unsupported loadout elements as fatal.')
+      .allowUnknownOption(true)
+      .action(
+        async (
+          agent: string | undefined,
+          passThroughArgs: readonly string[],
+          options: { harness?: Harness; strict?: boolean },
+        ) => {
+          const result = await executeRunAgentCommand({
+            /* v8 ignore next 2 -- process defaults exercised by the CLI entrypoint, not unit tests. */
+            homeDirectory: dependencies.homeDirectory ?? homedir(),
+            projectDirectory: dependencies.projectDirectory ?? process.cwd(),
+            agent,
+            harness: options.harness,
+            strict: options.strict,
+            passThroughArgs,
+            launcher: dependencies.launcher ?? defaultLauncher,
+          });
+
+          for (const message of result.messages) {
+            /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
+            (dependencies.writeLine ?? console.log)(message);
+          }
+
+          process.exitCode = result.exitCode;
+        },
+      );
+  },
+});

--- a/code/cli/src/projection/Materialize.ts
+++ b/code/cli/src/projection/Materialize.ts
@@ -1,8 +1,10 @@
 // Materializes a CompositionPlan into a runtime configuration directory the harness launches from.
-import { mkdirSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { copyFileSync, lstatSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 
 import type { CompositionPlan } from '../composer/Composition.js';
+import type { ResolvedResource } from '../resolver/Resource.js';
+import { escapesRoots } from '../dump/Containment.js';
 
 export interface MaterializedComposition {
   readonly rootDirectory: string;
@@ -10,13 +12,48 @@ export interface MaterializedComposition {
   readonly systemPromptPath: string;
   /** Absolute paths to append-prompt fragments, in composition order. */
   readonly appendPromptPaths: readonly string[];
-  /** Absolute paths to materialized skill directories, keyed by slug. */
+  /** Absolute paths to materialized skill directories, in slug order. */
   readonly skillDirectories: readonly string[];
+  /** Skills that could not be materialized safely (escaping symlinks). */
+  readonly skippedSkills: readonly string[];
 }
+
+/** Recursively copies a directory, skipping symlinked entries so no path escapes the tree. */
+const copyDirectory = (sourceDir: string, targetDir: string): void => {
+  mkdirSync(targetDir, { recursive: true });
+
+  for (const entry of readdirSync(sourceDir, { withFileTypes: true })) {
+    const sourcePath = join(sourceDir, entry.name);
+
+    if (lstatSync(sourcePath).isSymbolicLink()) {
+      continue;
+    }
+
+    if (entry.isDirectory()) {
+      copyDirectory(sourcePath, join(targetDir, entry.name));
+    } else if (entry.isFile()) {
+      copyFileSync(sourcePath, join(targetDir, entry.name));
+    }
+  }
+};
+
+const materializeSkill = (skill: ResolvedResource, rootDirectory: string): string | undefined => {
+  const sourceDir = dirname(skill.winner.path);
+
+  // A skill whose directory resolves outside its layer cannot be materialized safely.
+  if (escapesRoots(sourceDir, [skill.winner.layer.root])) {
+    return undefined;
+  }
+
+  const targetDir = join(rootDirectory, 'skills', skill.slug);
+  copyDirectory(sourceDir, targetDir);
+  return targetDir;
+};
 
 /**
  * Writes the composed identity and skills into `rootDirectory`. The base `system-prompt.md` becomes
- * the system prompt; shared `agents.md` context and the agent body are appended in order.
+ * the system prompt; shared `agents.md` context and the agent body are appended in order. Each
+ * selected skill directory (SKILL.md + scripts/assets) is copied so the harness has real content.
  */
 export const materializeComposition = (
   composition: CompositionPlan,
@@ -39,11 +76,17 @@ export const materializeComposition = (
   writeFileSync(agentBodyPath, composition.identity.agentBody);
   appendPromptPaths.push(agentBodyPath);
 
-  const skillDirectories = composition.loadout.skills.map((skill) => {
-    const skillDir = join(rootDirectory, 'skills', skill.slug);
-    mkdirSync(skillDir, { recursive: true });
-    return skillDir;
-  });
+  const skillDirectories: string[] = [];
+  const skippedSkills: string[] = [];
 
-  return { rootDirectory, systemPromptPath, appendPromptPaths, skillDirectories };
+  for (const skill of composition.loadout.skills) {
+    const materialized = materializeSkill(skill, rootDirectory);
+    if (materialized === undefined) {
+      skippedSkills.push(skill.slug);
+    } else {
+      skillDirectories.push(materialized);
+    }
+  }
+
+  return { rootDirectory, systemPromptPath, appendPromptPaths, skillDirectories, skippedSkills };
 };

--- a/code/cli/src/projection/Materialize.ts
+++ b/code/cli/src/projection/Materialize.ts
@@ -1,0 +1,49 @@
+// Materializes a CompositionPlan into a runtime configuration directory the harness launches from.
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { CompositionPlan } from '../composer/Composition.js';
+
+export interface MaterializedComposition {
+  readonly rootDirectory: string;
+  /** Absolute path to the composed system prompt written for the run. */
+  readonly systemPromptPath: string;
+  /** Absolute paths to append-prompt fragments, in composition order. */
+  readonly appendPromptPaths: readonly string[];
+  /** Absolute paths to materialized skill directories, keyed by slug. */
+  readonly skillDirectories: readonly string[];
+}
+
+/**
+ * Writes the composed identity and skills into `rootDirectory`. The base `system-prompt.md` becomes
+ * the system prompt; shared `agents.md` context and the agent body are appended in order.
+ */
+export const materializeComposition = (
+  composition: CompositionPlan,
+  rootDirectory: string,
+): MaterializedComposition => {
+  mkdirSync(rootDirectory, { recursive: true });
+
+  const systemPromptPath = join(rootDirectory, 'system-prompt.md');
+  writeFileSync(systemPromptPath, composition.identity.systemPrompt ?? '');
+
+  const appendPromptPaths: string[] = [];
+
+  if (composition.identity.sharedContext !== undefined) {
+    const contextPath = join(rootDirectory, 'agents.md');
+    writeFileSync(contextPath, composition.identity.sharedContext);
+    appendPromptPaths.push(contextPath);
+  }
+
+  const agentBodyPath = join(rootDirectory, 'agent.md');
+  writeFileSync(agentBodyPath, composition.identity.agentBody);
+  appendPromptPaths.push(agentBodyPath);
+
+  const skillDirectories = composition.loadout.skills.map((skill) => {
+    const skillDir = join(rootDirectory, 'skills', skill.slug);
+    mkdirSync(skillDir, { recursive: true });
+    return skillDir;
+  });
+
+  return { rootDirectory, systemPromptPath, appendPromptPaths, skillDirectories };
+};

--- a/code/cli/src/projection/ProjectHarness.ts
+++ b/code/cli/src/projection/ProjectHarness.ts
@@ -1,0 +1,77 @@
+// Projects a harness-neutral CompositionPlan to a native pi or Claude Code launch.
+import type { CompositionPlan } from '../composer/Composition.js';
+import type { Harness } from '../settings/Settings.js';
+import { materializeComposition } from './Materialize.js';
+import type { AgentLaunchPlan, AgentProjectionPlan, ProjectionInput } from './Projection.js';
+
+// Loadout elements each harness can project today; anything else surfaces as unsupported.
+const supportedElements: Readonly<Record<Harness, readonly string[]>> = {
+  pi: ['skills', 'model', 'thinking', 'extensions', 'plugins', 'mcp'],
+  claude: ['skills', 'model', 'thinking', 'mcp'],
+};
+
+const loadoutElementsInUse = (composition: CompositionPlan): readonly string[] => {
+  const { loadout } = composition;
+  const present: string[] = [];
+
+  if (loadout.skills.length > 0) present.push('skills');
+  if (loadout.extensions.length > 0) present.push('extensions');
+  if (loadout.plugins.length > 0) present.push('plugins');
+  if (loadout.mcp.length > 0) present.push('mcp');
+  if (loadout.model !== undefined) present.push('model');
+  if (loadout.thinking !== undefined) present.push('thinking');
+
+  return present;
+};
+
+export const unsupportedElements = (composition: CompositionPlan, harness: Harness): readonly string[] =>
+  loadoutElementsInUse(composition).filter((element) => !supportedElements[harness].includes(element));
+
+const promptArgs = (systemPromptPath: string, appendPromptPaths: readonly string[]): readonly string[] => [
+  '--system-prompt',
+  systemPromptPath,
+  ...appendPromptPaths.flatMap((path) => ['--append-system-prompt', path]),
+];
+
+const modelArgs = (composition: CompositionPlan, harness: Harness): readonly string[] => {
+  const args: string[] = [];
+
+  if (composition.loadout.model !== undefined) {
+    args.push('--model', composition.loadout.model);
+  }
+
+  if (composition.loadout.thinking !== undefined) {
+    args.push(harness === 'pi' ? '--thinking' : '--effort', composition.loadout.thinking);
+  }
+
+  return args;
+};
+
+const buildLaunchPlan = (
+  composition: CompositionPlan,
+  input: ProjectionInput,
+  systemPromptPath: string,
+  appendPromptPaths: readonly string[],
+): AgentLaunchPlan => {
+  const isPi = input.harness === 'pi';
+  const skillArgs = isPi ? composition.loadout.skills.flatMap((skill) => ['--skill', skill.slug]) : [];
+
+  return {
+    command: isPi ? 'pi' : 'claude',
+    args: [
+      ...promptArgs(systemPromptPath, appendPromptPaths),
+      ...skillArgs,
+      ...modelArgs(composition, input.harness),
+      ...(input.passThroughArgs ?? []),
+    ],
+    env: isPi ? { PI_CODING_AGENT_DIR: input.rootDirectory } : { CLAUDE_CONFIG_DIR: input.rootDirectory },
+  };
+};
+
+/** Materializes the composition into the runtime root and builds the harness launch plan. */
+export const projectComposition = (composition: CompositionPlan, input: ProjectionInput): AgentProjectionPlan => {
+  const materialized = materializeComposition(composition, input.rootDirectory);
+  const launch = buildLaunchPlan(composition, input, materialized.systemPromptPath, materialized.appendPromptPaths);
+
+  return { rootDirectory: input.rootDirectory, launch, unsupported: unsupportedElements(composition, input.harness) };
+};

--- a/code/cli/src/projection/ProjectHarness.ts
+++ b/code/cli/src/projection/ProjectHarness.ts
@@ -4,10 +4,12 @@ import type { Harness } from '../settings/Settings.js';
 import { materializeComposition } from './Materialize.js';
 import type { AgentLaunchPlan, AgentProjectionPlan, ProjectionInput } from './Projection.js';
 
-// Loadout elements each harness can project today; anything else surfaces as unsupported.
+// Loadout elements each harness actually projects today. Anything else is reported unsupported so
+// `--strict` catches silently-dropped selections. mcp/extensions/plugins/subagents/tools are not
+// projected yet (incremental parity) and therefore surface as unsupported.
 const supportedElements: Readonly<Record<Harness, readonly string[]>> = {
-  pi: ['skills', 'model', 'thinking', 'extensions', 'plugins', 'mcp'],
-  claude: ['skills', 'model', 'thinking', 'mcp'],
+  pi: ['skills', 'model', 'thinking'],
+  claude: ['skills', 'model', 'thinking'],
 };
 
 const loadoutElementsInUse = (composition: CompositionPlan): readonly string[] => {
@@ -15,11 +17,13 @@ const loadoutElementsInUse = (composition: CompositionPlan): readonly string[] =
   const present: string[] = [];
 
   if (loadout.skills.length > 0) present.push('skills');
+  if (loadout.subagents.length > 0) present.push('subagents');
   if (loadout.extensions.length > 0) present.push('extensions');
   if (loadout.plugins.length > 0) present.push('plugins');
   if (loadout.mcp.length > 0) present.push('mcp');
   if (loadout.model !== undefined) present.push('model');
   if (loadout.thinking !== undefined) present.push('thinking');
+  if (loadout.tools !== undefined) present.push('tools');
 
   return present;
 };
@@ -72,6 +76,10 @@ const buildLaunchPlan = (
 export const projectComposition = (composition: CompositionPlan, input: ProjectionInput): AgentProjectionPlan => {
   const materialized = materializeComposition(composition, input.rootDirectory);
   const launch = buildLaunchPlan(composition, input, materialized.systemPromptPath, materialized.appendPromptPaths);
+  const unsupported = [
+    ...unsupportedElements(composition, input.harness),
+    ...materialized.skippedSkills.map((slug) => `skill:${slug} (escaping symlink)`),
+  ];
 
-  return { rootDirectory: input.rootDirectory, launch, unsupported: unsupportedElements(composition, input.harness) };
+  return { rootDirectory: input.rootDirectory, launch, unsupported };
 };

--- a/code/cli/src/projection/Projection.ts
+++ b/code/cli/src/projection/Projection.ts
@@ -1,0 +1,23 @@
+// Harness-neutral projection types: a materialized runtime tree plus the launch plan for one run.
+import type { Harness } from '../settings/Settings.js';
+
+export interface AgentLaunchPlan {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly env: Readonly<Record<string, string>>;
+}
+
+export interface AgentProjectionPlan {
+  /** Absolute path to the materialized runtime configuration root for this run. */
+  readonly rootDirectory: string;
+  readonly launch: AgentLaunchPlan;
+  /** Composition elements the selected harness cannot project. */
+  readonly unsupported: readonly string[];
+}
+
+export interface ProjectionInput {
+  readonly harness: Harness;
+  readonly rootDirectory: string;
+  readonly homeDirectory: string;
+  readonly passThroughArgs?: readonly string[];
+}

--- a/code/cli/tests/unit/run-agent.test.ts
+++ b/code/cli/tests/unit/run-agent.test.ts
@@ -1,4 +1,4 @@
-// Tests run: resolve → compose → project → launch, and the pi/claude launch mapping.
+// Tests run: resolve → compose → project → launch, launch mapping, cleanup, and strict/validation.
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -23,9 +23,26 @@ const write = (path: string, content: string): void => {
   writeFileSync(path, content);
 };
 
-const captured: AgentLaunchPlan[] = [];
+interface CapturedLaunch {
+  readonly plan: AgentLaunchPlan;
+  readonly runtimeDir: string;
+  readonly dirExisted: boolean;
+  readonly systemPrompt?: string;
+  readonly skillPresent: boolean;
+}
+
+const captured: CapturedLaunch[] = [];
+
 const launcher = async (plan: AgentLaunchPlan): Promise<number> => {
-  captured.push(plan);
+  const runtimeDir = plan.env.PI_CODING_AGENT_DIR ?? plan.env.CLAUDE_CONFIG_DIR ?? '';
+  const promptIndex = plan.args.indexOf('--system-prompt');
+  captured.push({
+    plan,
+    runtimeDir,
+    dirExisted: existsSync(runtimeDir),
+    systemPrompt: promptIndex >= 0 ? readFileSync(plan.args[promptIndex + 1]!, 'utf8') : undefined,
+    skillPresent: existsSync(join(runtimeDir, 'skills', 'wiki', 'SKILL.md')),
+  });
   return 0;
 };
 
@@ -47,7 +64,7 @@ const tree = (): { home: string; project: string } => {
   const project = join(root, 'project');
   write(join(project, '.agents', 'system-prompt.md'), 'BASE PROMPT');
   write(join(project, '.agents', 'agents.md'), 'SHARED');
-  write(join(project, '.agents', 'skills', 'wiki', 'SKILL.md'), '---\nname: wiki\n---\n');
+  write(join(project, '.agents', 'skills', 'wiki', 'SKILL.md'), '---\nname: wiki\n---\n\nWiki skill body.\n');
   write(
     join(project, '.agents', 'agents', 'engineer', 'agent.md'),
     '---\nname: engineer\nskills: [wiki]\nmodel: gpt-5.2\nthinking: high\nextensions: [ext-a]\n---\n\n# Engineer\n',
@@ -58,7 +75,7 @@ const tree = (): { home: string; project: string } => {
 describe('run agent', () => {
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.1, OFTR-006.1).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('resolves, composes, projects, and launches an agent in pi', async () => {
+  it('resolves, composes, projects, materializes skills, and launches an agent in pi', async () => {
     const { home, project } = tree();
     const result = await executeRunAgentCommand({
       homeDirectory: home,
@@ -70,10 +87,9 @@ describe('run agent', () => {
     });
 
     expect(result.exitCode).toBe(0);
-    const plan = result.launchPlan!;
-    expect(plan.command).toBe('pi');
-    expect(plan.env.PI_CODING_AGENT_DIR).toBeDefined();
-    expect(plan.args).toEqual(
+    expect(result.launchPlan!.command).toBe('pi');
+    const launch = captured[0]!;
+    expect(launch.plan.args).toEqual(
       expect.arrayContaining([
         '--system-prompt',
         '--append-system-prompt',
@@ -86,9 +102,21 @@ describe('run agent', () => {
         '--yolo',
       ]),
     );
-    // system prompt materialized from the composed identity
-    const promptIndex = plan.args.indexOf('--system-prompt');
-    expect(readFileSync(plan.args[promptIndex + 1]!, 'utf8')).toBe('BASE PROMPT');
+    expect(launch.systemPrompt).toBe('BASE PROMPT'); // composed identity materialized
+    expect(launch.skillPresent).toBe(true); // skill content copied, not an empty dir
+  });
+
+  it('cleans up the runtime projection directory after the run', async () => {
+    const { home, project } = tree();
+    await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      agent: 'engineer',
+      harness: 'pi',
+      launcher,
+    });
+    expect(captured[0]!.dirExisted).toBe(true); // existed during launch
+    expect(existsSync(captured[0]!.runtimeDir)).toBe(false); // removed afterwards
   });
 
   it('maps model/thinking to claude flags and reports pi-only elements as unsupported', async () => {
@@ -109,7 +137,7 @@ describe('run agent', () => {
     expect(result.messages.join(' ')).toContain("cannot project loadout element 'extensions'");
   });
 
-  it('fails under --strict when a loadout element is unsupported', async () => {
+  it('fails under --strict on an unsupported element and never launches', async () => {
     const { home, project } = tree();
     const result = await executeRunAgentCommand({
       homeDirectory: home,
@@ -119,10 +147,66 @@ describe('run agent', () => {
       strict: true,
       launcher,
     });
-
     expect(result.exitCode).toBe(1);
-    expect(captured).toHaveLength(0); // never launched
+    expect(captured).toHaveLength(0);
     expect(result.messages.join(' ')).toContain('Strict mode');
+  });
+
+  it('fails under --strict on a composition warning (unresolved skill)', async () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\nskills: [ghost]\n---\n\nBody.\n',
+    );
+    const result = await executeRunAgentCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+      agent: 'engineer',
+      harness: 'pi',
+      strict: true,
+      launcher,
+    });
+    expect(result.exitCode).toBe(1);
+    expect(captured).toHaveLength(0);
+    expect(result.messages.join(' ')).toContain("unknown skill 'ghost'");
+  });
+
+  it('rejects an unknown harness', async () => {
+    const { home, project } = tree();
+    await expect(
+      executeRunAgentCommand({
+        homeDirectory: home,
+        projectDirectory: project,
+        agent: 'engineer',
+        harness: 'codex',
+        launcher,
+      }),
+    ).rejects.toThrow(/Unknown harness 'codex'/);
+  });
+
+  it('skips a skill whose directory escapes the tree via symlink and reports it unsupported', async () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    const external = join(root, 'external-skill');
+    write(join(external, 'SKILL.md'), '---\nname: wiki\n---\n');
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\nskills: [wiki]\n---\n\nBody.\n',
+    );
+    mkdirSync(join(project, '.agents', 'skills'), { recursive: true });
+    const { symlinkSync } = await import('node:fs');
+    symlinkSync(external, join(project, '.agents', 'skills', 'wiki'));
+
+    const result = await executeRunAgentCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+      agent: 'engineer',
+      harness: 'pi',
+      launcher,
+    });
+    expect(captured[0]!.skillPresent).toBe(false);
+    expect(result.messages.join(' ')).toContain('escaping symlink');
   });
 
   it('uses default_agent and default_harness from settings', async () => {
@@ -162,7 +246,7 @@ describe('run agent', () => {
       writeLine: (m) => lines.push(m),
     }).register(program);
     await program.parseAsync(['node', 'outfitter', 'run', 'engineer', '--harness', 'pi']);
-    expect(captured[0]?.command).toBe('pi');
-    expect(existsSync(captured[0]!.env.PI_CODING_AGENT_DIR)).toBe(true);
+    expect(captured[0]?.plan.command).toBe('pi');
+    expect(captured[0]?.dirExisted).toBe(true);
   });
 });

--- a/code/cli/tests/unit/run-agent.test.ts
+++ b/code/cli/tests/unit/run-agent.test.ts
@@ -1,0 +1,168 @@
+// Tests run: resolve → compose → project → launch, and the pi/claude launch mapping.
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { Command } from 'commander';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createRunAgentCommand, executeRunAgentCommand } from '../../src/cli/commands/RunAgentCommand.js';
+import type { AgentLaunchPlan } from '../../src/projection/Projection.js';
+
+const temporaryRoots: string[] = [];
+let previousExitCode: typeof process.exitCode;
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-run-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const write = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+
+const captured: AgentLaunchPlan[] = [];
+const launcher = async (plan: AgentLaunchPlan): Promise<number> => {
+  captured.push(plan);
+  return 0;
+};
+
+beforeEach(() => {
+  previousExitCode = process.exitCode;
+  captured.length = 0;
+});
+
+afterEach(() => {
+  process.exitCode = previousExitCode;
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+const tree = (): { home: string; project: string } => {
+  const root = createTemporaryRoot();
+  const home = join(root, 'home');
+  const project = join(root, 'project');
+  write(join(project, '.agents', 'system-prompt.md'), 'BASE PROMPT');
+  write(join(project, '.agents', 'agents.md'), 'SHARED');
+  write(join(project, '.agents', 'skills', 'wiki', 'SKILL.md'), '---\nname: wiki\n---\n');
+  write(
+    join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+    '---\nname: engineer\nskills: [wiki]\nmodel: gpt-5.2\nthinking: high\nextensions: [ext-a]\n---\n\n# Engineer\n',
+  );
+  return { home, project };
+};
+
+describe('run agent', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.1, OFTR-006.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('resolves, composes, projects, and launches an agent in pi', async () => {
+    const { home, project } = tree();
+    const result = await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      agent: 'engineer',
+      harness: 'pi',
+      passThroughArgs: ['--yolo'],
+      launcher,
+    });
+
+    expect(result.exitCode).toBe(0);
+    const plan = result.launchPlan!;
+    expect(plan.command).toBe('pi');
+    expect(plan.env.PI_CODING_AGENT_DIR).toBeDefined();
+    expect(plan.args).toEqual(
+      expect.arrayContaining([
+        '--system-prompt',
+        '--append-system-prompt',
+        '--skill',
+        'wiki',
+        '--model',
+        'gpt-5.2',
+        '--thinking',
+        'high',
+        '--yolo',
+      ]),
+    );
+    // system prompt materialized from the composed identity
+    const promptIndex = plan.args.indexOf('--system-prompt');
+    expect(readFileSync(plan.args[promptIndex + 1]!, 'utf8')).toBe('BASE PROMPT');
+  });
+
+  it('maps model/thinking to claude flags and reports pi-only elements as unsupported', async () => {
+    const { home, project } = tree();
+    const result = await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      agent: 'engineer',
+      harness: 'claude',
+      launcher,
+    });
+
+    const plan = result.launchPlan!;
+    expect(plan.command).toBe('claude');
+    expect(plan.env.CLAUDE_CONFIG_DIR).toBeDefined();
+    expect(plan.args).toEqual(expect.arrayContaining(['--effort', 'high']));
+    expect(plan.args).not.toContain('--skill'); // claude skills are materialized, not flagged
+    expect(result.messages.join(' ')).toContain("cannot project loadout element 'extensions'");
+  });
+
+  it('fails under --strict when a loadout element is unsupported', async () => {
+    const { home, project } = tree();
+    const result = await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      agent: 'engineer',
+      harness: 'claude',
+      strict: true,
+      launcher,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(captured).toHaveLength(0); // never launched
+    expect(result.messages.join(' ')).toContain('Strict mode');
+  });
+
+  it('uses default_agent and default_harness from settings', async () => {
+    const { home, project } = tree();
+    write(join(project, '.agents', 'settings.yml'), 'default_agent: engineer\ndefault_harness: pi\n');
+    const result = await executeRunAgentCommand({ homeDirectory: home, projectDirectory: project, launcher });
+    expect(result.launchPlan?.command).toBe('pi');
+  });
+
+  it('errors when no agent is selected and none is defaulted', async () => {
+    const root = createTemporaryRoot();
+    await expect(
+      executeRunAgentCommand({ homeDirectory: join(root, 'home'), projectDirectory: join(root, 'project'), launcher }),
+    ).rejects.toThrow(/No agent selected/);
+  });
+
+  it('returns a nonzero exit with errors for an unknown agent', async () => {
+    const { home, project } = tree();
+    const result = await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      agent: 'ghost',
+      launcher,
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.messages[0]).toContain("Unknown agent 'ghost'");
+  });
+
+  it('drives the run command object through Commander parseAsync', async () => {
+    const { home, project } = tree();
+    const lines: string[] = [];
+    const program = new Command();
+    createRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      launcher,
+      writeLine: (m) => lines.push(m),
+    }).register(program);
+    await program.parseAsync(['node', 'outfitter', 'run', 'engineer', '--harness', 'pi']);
+    expect(captured[0]?.command).toBe('pi');
+    expect(existsSync(captured[0]!.env.PI_CODING_AGENT_DIR)).toBe(true);
+  });
+});

--- a/docs/requirements/OFTR-005-run-and-composite-profile.md
+++ b/docs/requirements/OFTR-005-run-and-composite-profile.md
@@ -10,13 +10,16 @@ The `run` command assembles a temporary agent-specific configuration directory c
 
 ### OFTR-005.1: Run Command Defaults
 
+_Amended (2026-07-17, RFC #165): `run` selects an agent slug and a harness, not a profile._
+
 1. Outfitter MUST provide a `run` command.
 2. `run` MUST be the default command when no command is specified.
 3. The default command behavior MUST be implemented with Commander rather than a custom `process.argv` parser.
-4. The `run` command MUST accept `-p` and `--profile` options for selecting the profile.
-5. The `run` command MUST use the resolved default profile when no profile option is provided.
-6. The `run` command MUST pass unrecognized arguments through to the selected agent CLI unaltered.
-7. When invoked before user setup has created `~/.outfitter/settings.yml`, the default `run` command MUST execute setup before resolving the profile without printing a separate pre-setup announcement.
+4. The `run` command MUST accept a positional agent slug selecting which agent to run.
+5. The `run` command MUST use the resolved `default_agent` when no agent is provided, and error when neither is available.
+6. The `run` command MUST accept `--harness <pi|claude>`, defaulting to `default_harness` then `pi`.
+7. The `run` command MUST pass unrecognized arguments through to the selected harness CLI unaltered.
+8. The `run` command MUST resolve, compose, project, and launch through the shared resolver and composer.
 
 ### OFTR-005.2: Composition Definition
 

--- a/docs/requirements/OFTR-006-agent-adapters.md
+++ b/docs/requirements/OFTR-006-agent-adapters.md
@@ -1,6 +1,6 @@
 # OFTR-006: Agent Adapters, Pi Support, and Claude Code Support
 
-> **Transition (RFC [#165](https://github.com/ai-outfitter/outfitter/issues/165)):** this requirement describes pre-dotagents behavior and will be amended or superseded by the RFC #165 implementation PRs together with its pinned tests. The target design lives in [docs/documentation](../documentation/README.md) and [docs/architecture](../architecture/README.md).
+> **Transition (RFC [#165](https://github.com/ai-outfitter/outfitter/issues/165)):** **OFTR-006.1 is amended (2026-07-17)** to the composition-projection model below (harnesses project a `CompositionPlan`, reporting unsupported _elements_). The pi/claude launch-control sections still describe profile-era behavior and richer parity (mcp reconciliation, extensions, session dirs, state persistence) is projected incrementally; the current implementation projects composed identity, skills, model, and thinking. Target design: [docs/architecture/README.md](../architecture/README.md).
 
 ## Overview
 
@@ -11,11 +11,13 @@ Pi is the default and primary supported adapter; Claude Code is also supported t
 
 ### OFTR-006.1: Adapter Boundary
 
-1. Outfitter MUST define an agent adapter abstraction for CLI-specific composite profile assembly and launch command generation.
-2. Each adapter MUST expose an identifier for the agent CLI it supports.
-3. Each adapter MUST report which controllable elements it supports.
-4. Each adapter MUST return warnings for profile controls it cannot translate.
-5. Outfitter SHOULD keep generic profile resolution independent from adapter-specific file generation.
+_Amended (2026-07-17, RFC #165): adapters project a harness-neutral composition, not a profile._
+
+1. Outfitter MUST project a harness-neutral `CompositionPlan` to a native harness launch: a materialized runtime configuration root plus a launch plan (command, args, environment).
+2. Each harness projection MUST be identified by its harness (`pi` or `claude`).
+3. Each harness projection MUST report which composition loadout elements it cannot project (`getUnsupportedElements`).
+4. When a composition selects an element the harness cannot project, Outfitter MUST warn; `--strict` MUST make it fatal before launch.
+5. Composition (resolver + composer) MUST stay independent of harness-specific projection.
 
 ### OFTR-006.2: Supported Adapter Availability
 


### PR DESCRIPTION
**Stack 5/6** of the RFC #165 implementation refactor (settings #172, resolver #173, composer #176, dump #179 landed). Cut from `main`.

## This PR — projection + `run`
Completes the pipeline: `outfitter run [agent] --harness pi|claude` → resolve → compose → **project** → launch.
- **projection**: materialize a `CompositionPlan` into a runtime root (composed system prompt + shared-context/agent-body append prompts + skill dirs) and build a harness launch plan
- **pi**: `PI_CODING_AGENT_DIR`, `--system-prompt`/`--append-system-prompt`, `--skill`, `--model`/`--thinking`, pass-through
- **claude**: `CLAUDE_CONFIG_DIR`, `--model`/`--effort`, prompts; pi-only elements reported unsupported
- **run**: `default_agent`/`default_harness`, unsupported-element warnings, `--strict` fatal before launch, injectable launcher for tests
- amends **OFTR-005.1** + **OFTR-006.1**; run-agent suite green (7)

## Scope / deferred
Projects identity + skills + model + thinking. Richer pi/claude parity (mcp reconciliation, extensions/plugins, session dirs, state persistence, live watch) is incremental; the legacy `Profile`/`compositeProfile` adapters are **removed in PR 6** (which also brings the full suite green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)