### PR TITLE
cleanup: post-release simplifications (run/dump/resolver)

### DIFF
--- a/code/cli/src/cli/commands/DumpCommand.ts
+++ b/code/cli/src/cli/commands/DumpCommand.ts
@@ -4,7 +4,7 @@ import { Command } from 'commander';
 
 import { dumpAgent } from '../../dump/Dump.js';
 import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
-import { loadSettingsWithCachedRemoteSettings } from '../../settings/SettingsLoader.js';
+import type { Settings } from '../../settings/Settings.js';
 import type { CommandObject } from './CommandObject.js';
 import { resolveHomeDirectory, resolveProjectDirectory } from './ProcessDefaults.js';
 
@@ -27,12 +27,10 @@ export interface DumpCommandDependencies {
   readonly writeLine?: (message: string) => void;
 }
 
-const resolveAgentSlug = (homeDirectory: string, projectDirectory: string, requested: string | undefined): string => {
+const resolveAgentSlug = (settings: Settings, requested: string | undefined): string => {
   if (requested !== undefined) {
     return requested;
   }
-
-  const { settings } = loadSettingsWithCachedRemoteSettings({ homeDirectory, projectDirectory });
 
   if (settings.defaultAgent === undefined) {
     throw new Error("No agent selected and no 'default_agent' in settings. Pass --agent <id>.");
@@ -42,13 +40,13 @@ const resolveAgentSlug = (homeDirectory: string, projectDirectory: string, reque
 };
 
 export const executeDumpCommand = (input: DumpInput): DumpCommandResult => {
-  const { set, settingsIssues } = resolveEffectiveSet(input);
+  const { set, settings, settingsIssues } = resolveEffectiveSet(input);
 
   if (settingsIssues.length > 0) {
     throw new Error(`Cannot dump with invalid settings: ${settingsIssues.map((issue) => issue.message).join('; ')}`);
   }
 
-  const agentSlug = resolveAgentSlug(input.homeDirectory, input.projectDirectory, input.agent);
+  const agentSlug = resolveAgentSlug(settings, input.agent);
   const result = dumpAgent(set, agentSlug, input.out);
   const ok = result.errors.length === 0;
   const messages = ok

--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -125,10 +125,11 @@ const spawnLauncher = {
   },
 };
 
-const makeDefaultLauncher =
-  (agentId: Harness): AgentProcessLauncher =>
-  (plan) =>
-    launchAgentProcess(spawnLauncher, resolveAgentLaunchExecutable(plan), agentId);
+// The install-hint agentId is derived from the logical launch command ('pi' | 'claude') so a
+// missing-CLI failure always names the harness actually being launched, regardless of how the
+// harness was selected (flag, settings default, or built-in fallback).
+const defaultLauncher: AgentProcessLauncher = (plan) =>
+  launchAgentProcess(spawnLauncher, resolveAgentLaunchExecutable(plan), plan.command);
 /* v8 ignore stop */
 
 export const createRunAgentCommand = (dependencies: RunAgentDependencies = {}): CommandObject => ({
@@ -152,7 +153,7 @@ export const createRunAgentCommand = (dependencies: RunAgentDependencies = {}): 
           /* v8 ignore next 3 -- process/launcher defaults are exercised by the CLI entrypoint, not unit tests. */
           const homeDirectory = resolveHomeDirectory(dependencies.homeDirectory);
           const projectDirectory = resolveProjectDirectory(dependencies.projectDirectory);
-          const launcher = dependencies.launcher ?? makeDefaultLauncher(resolveHarness(undefined, options.harness));
+          const launcher = dependencies.launcher ?? defaultLauncher;
           const result = await executeRunAgentCommand({
             homeDirectory,
             projectDirectory,

--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -10,7 +10,6 @@ import { compose } from '../../composer/Composer.js';
 import { projectComposition } from '../../projection/ProjectHarness.js';
 import type { AgentLaunchPlan } from '../../projection/Projection.js';
 import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
-import { loadSettingsWithCachedRemoteSettings } from '../../settings/SettingsLoader.js';
 import type { Harness } from '../../settings/Settings.js';
 import type { CommandObject } from './CommandObject.js';
 import { resolveHomeDirectory, resolveProjectDirectory } from './ProcessDefaults.js';
@@ -65,8 +64,7 @@ const resolveHarness = (settingsDefault: Harness | undefined, requested: string 
 };
 
 export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunAgentResult> => {
-  const { settings } = loadSettingsWithCachedRemoteSettings(input);
-  const { set, settingsIssues } = resolveEffectiveSet(input);
+  const { set, settings, settingsIssues } = resolveEffectiveSet(input);
 
   if (settingsIssues.length > 0) {
     throw new Error(`Cannot run with invalid settings: ${settingsIssues.map((issue) => issue.message).join('; ')}`);

--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -112,7 +112,7 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
 };
 
 /* v8 ignore start -- real process spawn is covered by end-to-end smoke usage, not unit tests. */
-const spawnLauncher = {
+const spawnLauncher: SpawnLauncher = {
   async launch(plan: AgentLaunchPlan): Promise<number> {
     const { default: spawn } = await import('cross-spawn');
     return await new Promise<number>((resolve, reject) => {
@@ -122,13 +122,23 @@ const spawnLauncher = {
     });
   },
 };
-
-// The install-hint agentId is derived from the logical launch command ('pi' | 'claude') so a
-// missing-CLI failure always names the harness actually being launched, regardless of how the
-// harness was selected (flag, settings default, or built-in fallback).
-const defaultLauncher: AgentProcessLauncher = (plan) =>
-  launchAgentProcess(spawnLauncher, resolveAgentLaunchExecutable(plan), plan.command);
 /* v8 ignore stop */
+
+interface SpawnLauncher {
+  launch(plan: AgentLaunchPlan): Promise<number>;
+}
+
+/**
+ * Launches a resolved plan through the given spawn boundary. The install-hint agentId is derived
+ * from the logical launch command ('pi' | 'claude') so a missing-CLI failure always names the
+ * harness actually being launched, regardless of how the harness was selected (flag, settings
+ * default, or built-in fallback).
+ */
+export const launchThroughSpawn = (spawn: SpawnLauncher, plan: AgentLaunchPlan): Promise<number> =>
+  launchAgentProcess(spawn, resolveAgentLaunchExecutable(plan), plan.command);
+
+/* v8 ignore next -- wiring to the real spawn boundary; launchThroughSpawn itself is unit-tested. */
+const defaultLauncher: AgentProcessLauncher = (plan) => launchThroughSpawn(spawnLauncher, plan);
 
 export const createRunAgentCommand = (dependencies: RunAgentDependencies = {}): CommandObject => ({
   name: 'run',

--- a/code/cli/src/dump/Dump.ts
+++ b/code/cli/src/dump/Dump.ts
@@ -12,6 +12,7 @@ import {
 import { dirname, join } from 'node:path';
 
 import { compose } from '../composer/Composer.js';
+import { pickLoadoutKeys } from '../resolver/AgentDefinition.js';
 import { compareSlugs, findResource } from '../resolver/Resource.js';
 import type { EffectiveResourceSet, Layer, ResolvedResource } from '../resolver/Resource.js';
 import { escapesRoots, overlaps } from './Containment.js';
@@ -21,8 +22,6 @@ export interface DumpResult {
   readonly warnings: readonly string[];
   readonly errors: readonly string[];
 }
-
-const loadoutKeys = ['skills', 'subagents', 'mcp', 'extensions', 'plugins', 'model', 'thinking', 'tools'] as const;
 
 // Tree-root files carried into the dump so loadout selections (mcp/models) are not dangling.
 const rootFileNames = ['system-prompt.md', 'agents.md', 'mcp.json', 'models.json'] as const;
@@ -66,8 +65,7 @@ const mergeEffectiveConfig = (configPaths: readonly string[]): Record<string, un
 
   for (const configPath of [...configPaths].reverse()) {
     const parsed = JSON.parse(readFileSync(configPath, 'utf8')) as Record<string, unknown>;
-    const loadout = Object.fromEntries(loadoutKeys.filter((key) => key in parsed).map((key) => [key, parsed[key]]));
-    merged = { ...merged, ...loadout };
+    merged = { ...merged, ...pickLoadoutKeys(parsed) };
   }
 
   return merged;

--- a/code/cli/src/dump/Dump.ts
+++ b/code/cli/src/dump/Dump.ts
@@ -123,13 +123,8 @@ const composeClosure = (set: EffectiveResourceSet, rootSlug: string): ClosureCom
     }
     seen.add(slug);
 
-    const agent = findResource(set, 'agent', slug);
-
-    /* v8 ignore next 3 -- compose only queues resolvable subagents, so a queued slug always resolves. */
-    if (agent === undefined) {
-      continue;
-    }
-
+    // compose surfaces an unknown/invalid root agent as an error; every queued subagent is already
+    // resolved by the composer, so a plan implies findResource returns the agent.
     const composed = compose(set, slug);
 
     if (composed.plan === undefined) {
@@ -137,7 +132,7 @@ const composeClosure = (set: EffectiveResourceSet, rootSlug: string): ClosureCom
       continue;
     }
 
-    agents.push(agent);
+    agents.push(findResource(set, 'agent', slug)!);
     warnings.push(...composed.plan.warnings);
     for (const skill of composed.plan.loadout.skills) {
       skillSlugs.add(skill.slug);
@@ -193,12 +188,7 @@ const failure = (errors: readonly string[], warnings: readonly string[] = []): D
 
 /** Writes the composed closure of `agentSlug` into a freshly cleaned `<outDirectory>/.agents/`. */
 export const dumpAgent = (set: EffectiveResourceSet, agentSlug: string, outDirectory: string): DumpResult => {
-  const root = compose(set, agentSlug);
-
-  if (root.plan === undefined) {
-    return failure(root.errors);
-  }
-
+  // composeClosure composes the root once and surfaces an unknown/invalid root agent as an error.
   const closure = composeClosure(set, agentSlug);
 
   if (closure.errors.length > 0) {

--- a/code/cli/src/dump/Dump.ts
+++ b/code/cli/src/dump/Dump.ts
@@ -73,35 +73,6 @@ const mergeEffectiveConfig = (configPaths: readonly string[]): Record<string, un
   return merged;
 };
 
-/** BFS over the selected agent and its subagents to form the transitive agent closure. */
-const agentClosure = (set: EffectiveResourceSet, rootSlug: string): readonly ResolvedResource[] => {
-  const seen = new Set<string>();
-  const ordered: ResolvedResource[] = [];
-  const queue = [rootSlug];
-
-  while (queue.length > 0) {
-    const slug = queue.shift()!;
-
-    if (seen.has(slug)) {
-      continue;
-    }
-    seen.add(slug);
-
-    const agent = findResource(set, 'agent', slug);
-
-    /* v8 ignore next 3 -- compose only queues resolvable subagents, so a queued slug always resolves. */
-    if (agent === undefined) {
-      continue;
-    }
-
-    ordered.push(agent);
-    const composed = compose(set, slug);
-    queue.push(...(composed.plan?.loadout.subagents ?? []).map((subagent) => subagent.slug).sort(compareSlugs));
-  }
-
-  return ordered;
-};
-
 // Copies the highest-precedence tree-root file, matching what the composer reads; escaping targets error.
 const writeRootFiles = (set: EffectiveResourceSet, outRoot: string, written: string[]): readonly string[] => {
   const errors: string[] = [];
@@ -134,25 +105,46 @@ interface ClosureCompose {
   readonly errors: readonly string[];
 }
 
-/** Composes every closure member, collecting skills, warnings, and any composition errors. */
+/**
+ * BFS over the selected agent and its subagents, composing each closure member exactly once to
+ * collect the transitive agent list, its skills, warnings, and any composition errors.
+ */
 const composeClosure = (set: EffectiveResourceSet, rootSlug: string): ClosureCompose => {
-  const agents = agentClosure(set, rootSlug);
+  const seen = new Set<string>();
+  const agents: ResolvedResource[] = [];
   const skillSlugs = new Set<string>();
   const warnings: string[] = [];
   const errors: string[] = [];
+  const queue = [rootSlug];
 
-  for (const agent of agents) {
-    const composed = compose(set, agent.slug);
+  while (queue.length > 0) {
+    const slug = queue.shift()!;
+
+    if (seen.has(slug)) {
+      continue;
+    }
+    seen.add(slug);
+
+    const agent = findResource(set, 'agent', slug);
+
+    /* v8 ignore next 3 -- compose only queues resolvable subagents, so a queued slug always resolves. */
+    if (agent === undefined) {
+      continue;
+    }
+
+    const composed = compose(set, slug);
 
     if (composed.plan === undefined) {
       errors.push(...composed.errors);
       continue;
     }
 
+    agents.push(agent);
     warnings.push(...composed.plan.warnings);
     for (const skill of composed.plan.loadout.skills) {
       skillSlugs.add(skill.slug);
     }
+    queue.push(...composed.plan.loadout.subagents.map((subagent) => subagent.slug).sort(compareSlugs));
   }
 
   return { agents, skillSlugs: [...skillSlugs].sort(compareSlugs), warnings, errors };
@@ -203,8 +195,10 @@ const failure = (errors: readonly string[], warnings: readonly string[] = []): D
 
 /** Writes the composed closure of `agentSlug` into a freshly cleaned `<outDirectory>/.agents/`. */
 export const dumpAgent = (set: EffectiveResourceSet, agentSlug: string, outDirectory: string): DumpResult => {
-  if (compose(set, agentSlug).plan === undefined) {
-    return failure(compose(set, agentSlug).errors);
+  const root = compose(set, agentSlug);
+
+  if (root.plan === undefined) {
+    return failure(root.errors);
   }
 
   const closure = composeClosure(set, agentSlug);

--- a/code/cli/src/resolver/AgentDefinition.ts
+++ b/code/cli/src/resolver/AgentDefinition.ts
@@ -24,7 +24,20 @@ export const isAgentDefinitionIssue = <T extends object>(
 ): value is AgentDefinitionIssue => 'message' in value;
 
 /** Loadout fields a per-agent config.json may override; identity fields (`name`) are frontmatter-only. */
-const loadoutKeys = ['skills', 'subagents', 'mcp', 'extensions', 'plugins', 'model', 'thinking', 'tools'] as const;
+export const loadoutKeys = [
+  'skills',
+  'subagents',
+  'mcp',
+  'extensions',
+  'plugins',
+  'model',
+  'thinking',
+  'tools',
+] as const;
+
+/** Restricts an arbitrary record to the loadout keys config.json is allowed to supply. */
+export const pickLoadoutKeys = (record: Readonly<Record<string, unknown>>): Record<string, unknown> =>
+  Object.fromEntries(loadoutKeys.filter((key) => key in record).map((key) => [key, record[key]]));
 
 interface FrontmatterSplit {
   readonly frontmatter: string;
@@ -89,8 +102,7 @@ const readConfigLoadout = (configPath: string): Readonly<Record<string, unknown>
     return { path: configPath, message: 'config.json must be a JSON object of loadout overrides.' };
   }
 
-  const record = parsed as Record<string, unknown>;
-  return Object.fromEntries(loadoutKeys.filter((key) => key in record).map((key) => [key, record[key]]));
+  return pickLoadoutKeys(parsed as Record<string, unknown>);
 };
 
 const parseFrontmatterRecord = (

--- a/code/cli/src/resolver/ResolverContext.ts
+++ b/code/cli/src/resolver/ResolverContext.ts
@@ -1,6 +1,7 @@
 // Shared entry point that turns a home/project location into one effective resource set.
 import { loadSettingsWithCachedRemoteSettings } from '../settings/SettingsLoader.js';
 import type { SettingsLoadIssue } from '../settings/SettingsLoader.js';
+import type { Settings } from '../settings/Settings.js';
 import { discoverLayers } from './Layer.js';
 import type { EffectiveResourceSet } from './Resource.js';
 import { resolveResources } from './Resolver.js';
@@ -12,6 +13,8 @@ export interface ResolveInput {
 
 export interface ResolveResult {
   readonly set: EffectiveResourceSet;
+  /** The merged settings loaded during resolution, so callers need not reload them. */
+  readonly settings: Settings;
   readonly settingsIssues: readonly SettingsLoadIssue[];
 }
 
@@ -20,5 +23,5 @@ export const resolveEffectiveSet = (input: ResolveInput): ResolveResult => {
   const loadedSettings = loadSettingsWithCachedRemoteSettings(input);
   const layers = discoverLayers({ ...input, settings: loadedSettings.settings });
 
-  return { set: resolveResources(layers), settingsIssues: loadedSettings.issues };
+  return { set: resolveResources(layers), settings: loadedSettings.settings, settingsIssues: loadedSettings.issues };
 };

--- a/code/cli/tests/unit/run-agent.test.ts
+++ b/code/cli/tests/unit/run-agent.test.ts
@@ -6,7 +6,11 @@ import { dirname, join } from 'node:path';
 import { Command } from 'commander';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { createRunAgentCommand, executeRunAgentCommand } from '../../src/cli/commands/RunAgentCommand.js';
+import {
+  createRunAgentCommand,
+  executeRunAgentCommand,
+  launchThroughSpawn,
+} from '../../src/cli/commands/RunAgentCommand.js';
 import type { AgentLaunchPlan } from '../../src/projection/Projection.js';
 
 const temporaryRoots: string[] = [];
@@ -300,5 +304,17 @@ describe('run agent', () => {
     await program.parseAsync(['node', 'outfitter', 'run', 'engineer', '--harness', 'pi']);
     expect(captured[0]?.plan.command).toBe('pi');
     expect(captured[0]?.dirExisted).toBe(true);
+  });
+
+  // A missing CLI must be reported for the harness actually launched, not the built-in pi fallback
+  // (regression: the default launcher's agentId once ignored the resolved harness).
+  it('reports the launched harness and its install hint when the CLI is missing', async () => {
+    const enoent = Object.assign(new Error('spawn claude ENOENT'), { code: 'ENOENT' });
+    const failingSpawn = { launch: (): Promise<number> => Promise.reject(enoent) };
+    const claudePlan: AgentLaunchPlan = { command: 'claude', args: [], env: { CLAUDE_CONFIG_DIR: '/tmp/x' } };
+
+    await expect(launchThroughSpawn(failingSpawn, claudePlan)).rejects.toThrow(
+      /Could not launch the 'claude' agent CLI.*claude\.com\/claude-code/s,
+    );
   });
 });


### PR DESCRIPTION
Post-release cleanup pass over the RFC #165 pipeline (four discrete commits). One real correctness fix, three efficiency/reuse cleanups. No intended behavior changes.

## Commits
- **fix(run)** — the default launcher derived its install-hint agent from `resolveHarness(undefined, options.harness)`, which ignores `settings.default_harness` and falls back to `pi`. With `default_harness: claude` and no `--harness`, a missing `claude` CLI was reported as "Could not launch the 'pi' agent CLI" with pi's install hint. Now derives the agent from the logical launch command.
- **perf(cli)** — `resolveEffectiveSet` already loads+merges settings; `run` and `dump` reloaded them. It now returns the merged settings and both executors reuse them (settings stack read once).
- **perf(dump)** — `dumpAgent` composed the root agent 3× (double entry guard + `agentClosure` + `composeClosure`). Merged into one BFS that composes each closure agent once.
- **refactor** — `loadoutKeys` + the config.json loadout-key filter were duplicated in `AgentDefinition.ts` and `Dump.ts`; exported `loadoutKeys`/`pickLoadoutKeys` from the canonical `AgentDefinition` and reused them.

## Verification
- `vitest --coverage`: 109 tests pass; 99.88% stmts / 98.18% branches / 100% functions / 99.87% lines (≥98% gate)
- `tsc --noEmit` clean · `eslint .` clean · `prettier@3.9.4 --check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)