### PR TITLE
feat(resolver): agent-local knowledge/commands + mcp/hooks stubs

### DIFF
--- a/code/cli/src/cli/commands/ListCommand.ts
+++ b/code/cli/src/cli/commands/ListCommand.ts
@@ -4,6 +4,7 @@ import { Command } from 'commander';
 
 import type { ResourceKind } from '../../resolver/Resource.js';
 import {
+  agentLocalKinds,
   compareSlugs,
   findResource,
   listAgentResources,
@@ -74,7 +75,7 @@ export const executeListCommand = (input: ListInput): ListResult => {
   }
 
   for (const kind of resolveKindFilter(input.kind)) {
-    const hasAgentContext = input.agent !== undefined && kind === 'skill';
+    const hasAgentContext = input.agent !== undefined && agentLocalKinds.includes(kind);
     const globalResources = listResources(set, kind);
     const localResources = hasAgentContext ? listAgentResources(set, input.agent, kind) : [];
     const resources = new Map(globalResources.map((resource) => [resource.slug, resource]));
@@ -106,7 +107,10 @@ export const createListCommand = (dependencies: ListCommandDependencies = {}): C
       new Command('list')
         .description('List resolvable resources (agents, skills, knowledge, commands).')
         .argument('[kind]', 'Restrict to one kind: agents, skills, knowledge, or commands.')
-        .option('--agent <id>', 'Resolve resources in an agent context, including its local skills.')
+        .option(
+          '--agent <id>',
+          'Resolve resources in an agent context, including its agent-local skills/knowledge/commands.',
+        )
         .action((kind: string | undefined, options: { agent?: string }) => {
           const result = executeListCommand({
             /* v8 ignore next 2 -- process defaults are exercised by the CLI entrypoint, not unit tests. */

--- a/code/cli/src/resolver/Resolver.ts
+++ b/code/cli/src/resolver/Resolver.ts
@@ -3,7 +3,7 @@ import { existsSync, readdirSync, statSync } from 'node:fs';
 import { join, posix, relative, sep } from 'node:path';
 
 import type { EffectiveResourceSet, Layer, ResourceDefinition, ResourceKind, ResolvedResource } from './Resource.js';
-import { compareSlugs, resourceKinds } from './Resource.js';
+import { agentLocalKinds, compareSlugs, resourceKinds } from './Resource.js';
 
 /** True when the path resolves (following symlinks) to a directory; false for broken links. */
 const resolvesToDirectory = (path: string): boolean => {
@@ -71,8 +71,14 @@ const listFilesRecursively = (root: string): readonly string[] => {
 
 const toSlug = (root: string, entryPath: string): string => relative(root, entryPath).split(sep).join(posix.sep);
 
-const discoverDirectoryResources = (layer: Layer, kind: ResourceKind): readonly ResourceDefinition[] => {
-  const container = join(layer.root, directoryResourceKinds.get(kind)!);
+// `base` is the directory the kind's container sits under: a layer root for catalog-wide resources,
+// or `<layer.root>/agents/<owner>` for agent-local ones. Attribution (`layer`) is separate from it.
+const discoverDirectoryResources = (
+  layer: Layer,
+  kind: ResourceKind,
+  base: string = layer.root,
+): readonly ResourceDefinition[] => {
+  const container = join(base, directoryResourceKinds.get(kind)!);
   const entryFile = entryFileByKind.get(kind)!;
 
   return listSubdirectories(container)
@@ -80,49 +86,70 @@ const discoverDirectoryResources = (layer: Layer, kind: ResourceKind): readonly 
     .map((slug) => ({ kind, slug, layer, path: join(container, slug, entryFile) }));
 };
 
-// Per-agent config.json paths across every layer that defines the agent, highest precedence first.
-const collectAgentConfigPaths = (layers: readonly Layer[], slug: string): readonly string[] =>
-  layers
-    .map((layer) => join(layer.root, 'agents', slug, 'config.json'))
-    .filter((configPath) => resolvesToFile(configPath));
+// Existing `agents/<slug>/<...>` files across every layer that defines the agent, highest first.
+const collectAgentFiles = (layers: readonly Layer[], slug: string, ...segments: string[]): readonly string[] =>
+  layers.map((layer) => join(layer.root, 'agents', slug, ...segments)).filter((path) => resolvesToFile(path));
 
-const withAgentConfigPaths = (
+const isNonEmptyDirectory = (directory: string): boolean => {
+  try {
+    return statSync(directory).isDirectory() && readdirSync(directory).length > 0;
+  } catch {
+    return false;
+  }
+};
+
+// Non-empty `agents/<slug>/hooks/` directories across layers (reserved namespace; surfaced, not resolved).
+const collectAgentHookDirs = (layers: readonly Layer[], slug: string): readonly string[] =>
+  layers.map((layer) => join(layer.root, 'agents', slug, 'hooks')).filter(isNonEmptyDirectory);
+
+const withAgentResourcePaths = (
   layers: readonly Layer[],
   agents: ReadonlyMap<string, ResolvedResource>,
 ): ReadonlyMap<string, ResolvedResource> =>
   new Map(
     [...agents.entries()].map(([slug, resource]) => [
       slug,
-      { ...resource, configPaths: collectAgentConfigPaths(layers, slug) },
+      {
+        ...resource,
+        configPaths: collectAgentFiles(layers, slug, 'config.json'),
+        mcpPaths: collectAgentFiles(layers, slug, 'mcp.json'),
+        hookPaths: collectAgentHookDirs(layers, slug),
+      },
     ]),
   );
 
-const discoverFileResources = (layer: Layer, kind: ResourceKind): readonly ResourceDefinition[] => {
-  const container = join(layer.root, fileTreeResourceKinds.get(kind)!);
+const discoverFileResources = (
+  layer: Layer,
+  kind: ResourceKind,
+  base: string = layer.root,
+): readonly ResourceDefinition[] => {
+  const container = join(base, fileTreeResourceKinds.get(kind)!);
 
   return listFilesRecursively(container).map((path) => ({ kind, slug: toSlug(container, path), layer, path }));
 };
 
-const discoverLayerResources = (layer: Layer, kind: ResourceKind): readonly ResourceDefinition[] =>
-  directoryResourceKinds.has(kind) ? discoverDirectoryResources(layer, kind) : discoverFileResources(layer, kind);
+const discoverLayerResources = (
+  layer: Layer,
+  kind: ResourceKind,
+  base: string = layer.root,
+): readonly ResourceDefinition[] =>
+  directoryResourceKinds.has(kind)
+    ? discoverDirectoryResources(layer, kind, base)
+    : discoverFileResources(layer, kind, base);
 
 type AgentResourceDefinition = ResourceDefinition & { readonly ownerAgent: string };
 
-const discoverAgentSkills = (layer: Layer): readonly AgentResourceDefinition[] => {
+// Agent-local discovery of kind K = catalog discovery of K, re-rooted under `agents/<owner>/` and
+// attributed to the real layer. One generic path serves skills, knowledge, and commands.
+const discoverAgentResources = (layer: Layer): readonly AgentResourceDefinition[] => {
   const agentsDirectory = join(layer.root, 'agents');
 
   return listSubdirectories(agentsDirectory).flatMap((ownerAgent) => {
-    const skillsDirectory = join(agentsDirectory, ownerAgent, 'skills');
+    const agentBase = join(agentsDirectory, ownerAgent);
 
-    return listSubdirectories(skillsDirectory)
-      .filter((slug) => resolvesToFile(join(skillsDirectory, slug, 'SKILL.md')))
-      .map((slug) => ({
-        kind: 'skill' as const,
-        slug,
-        layer,
-        path: join(skillsDirectory, slug, 'SKILL.md'),
-        ownerAgent,
-      }));
+    return agentLocalKinds.flatMap((kind) =>
+      discoverLayerResources(layer, kind, agentBase).map((definition) => ({ ...definition, ownerAgent })),
+    );
   });
 };
 
@@ -152,13 +179,28 @@ const resolveKind = (layers: readonly Layer[], kind: ResourceKind): ReadonlyMap<
   return resolveDefinitions(layers.flatMap((layer) => discoverLayerResources(layer, kind)));
 };
 
+// Groups one agent's local definitions by kind, then resolves each kind's slug precedence.
+const resolveAgentKinds = (
+  definitions: readonly AgentResourceDefinition[],
+): ReadonlyMap<ResourceKind, ReadonlyMap<string, ResolvedResource>> => {
+  const byKind = new Map<ResourceKind, ResourceDefinition[]>();
+
+  for (const definition of definitions) {
+    const kindDefinitions = byKind.get(definition.kind) ?? [];
+    kindDefinitions.push(definition);
+    byKind.set(definition.kind, kindDefinitions);
+  }
+
+  return new Map([...byKind.entries()].map(([kind, kindDefinitions]) => [kind, resolveDefinitions(kindDefinitions)]));
+};
+
 const resolveAgentResources = (
   layers: readonly Layer[],
 ): ReadonlyMap<string, ReadonlyMap<ResourceKind, ReadonlyMap<string, ResolvedResource>>> => {
   const definitionsByAgent = new Map<string, AgentResourceDefinition[]>();
 
   for (const layer of layers) {
-    for (const definition of discoverAgentSkills(layer)) {
+    for (const definition of discoverAgentResources(layer)) {
       const definitions = definitionsByAgent.get(definition.ownerAgent) ?? [];
       definitions.push(definition);
       definitionsByAgent.set(definition.ownerAgent, definitions);
@@ -168,10 +210,7 @@ const resolveAgentResources = (
   return new Map(
     [...definitionsByAgent.entries()]
       .sort(([left], [right]) => compareSlugs(left, right))
-      .map(([agentSlug, definitions]) => [
-        agentSlug,
-        new Map<ResourceKind, ReadonlyMap<string, ResolvedResource>>([['skill', resolveDefinitions(definitions)]]),
-      ]),
+      .map(([agentSlug, definitions]) => [agentSlug, resolveAgentKinds(definitions)]),
   );
 };
 
@@ -181,7 +220,7 @@ export const resolveResources = (layers: readonly Layer[]): EffectiveResourceSet
 
   for (const kind of resourceKinds) {
     const resolved = resolveKind(layers, kind);
-    resources.set(kind, kind === 'agent' ? withAgentConfigPaths(layers, resolved) : resolved);
+    resources.set(kind, kind === 'agent' ? withAgentResourcePaths(layers, resolved) : resolved);
   }
 
   return { layers, resources, agentResources: resolveAgentResources(layers) };

--- a/code/cli/src/resolver/ResolverValidation.ts
+++ b/code/cli/src/resolver/ResolverValidation.ts
@@ -2,7 +2,7 @@
 import { isSkillDocumentIssue, readSkillDocument } from '../skills/SkillDocument.js';
 import { isAgentDefinitionIssue, readAgentDefinition } from './AgentDefinition.js';
 import type { EffectiveResourceSet, ResolvedResource } from './Resource.js';
-import { findLoadoutResource, findResource, listAgentResources, listResources } from './Resource.js';
+import { agentLocalKinds, findLoadoutResource, findResource, listAgentResources, listResources } from './Resource.js';
 
 export interface ValidationFinding {
   readonly severity: 'error' | 'warning';
@@ -81,6 +81,30 @@ const shadowFindings = (resource: ResolvedResource): readonly ValidationFinding[
     message: `shadowed definition in ${definition.layer.label} is overridden by ${resource.winner.layer.label}.`,
   }));
 
+// Agent-local resource shapes that resolver discovers but does not yet project into a run. Surfaced
+// as warnings (fatal only under --strict) so a selection placed here is never silently dropped.
+const reservedNamespaceFindings = (agent: ResolvedResource): readonly ValidationFinding[] => {
+  const findings: ValidationFinding[] = [];
+
+  if ((agent.mcpPaths ?? []).length > 0) {
+    findings.push({
+      severity: 'warning',
+      resource: `agent:${agent.slug}`,
+      message: "agent-local 'mcp.json' is discovered but not yet projected into the run (adapter parity, #183).",
+    });
+  }
+
+  if ((agent.hookPaths ?? []).length > 0) {
+    findings.push({
+      severity: 'warning',
+      resource: `agent:${agent.slug}`,
+      message: "agent-local 'hooks/' is a reserved namespace and is not yet resolved.",
+    });
+  }
+
+  return findings;
+};
+
 /**
  * Collects validation findings across the effective set. `error` findings always fail validation;
  * `warning` findings (such as shadowed definitions) fail only under `--strict`.
@@ -89,7 +113,7 @@ export const validateEffectiveSet = (set: EffectiveResourceSet): readonly Valida
   const findings: ValidationFinding[] = [];
 
   for (const agent of listResources(set, 'agent')) {
-    findings.push(...validateAgent(set, agent));
+    findings.push(...validateAgent(set, agent), ...reservedNamespaceFindings(agent));
   }
 
   for (const skill of listResources(set, 'skill')) {
@@ -105,8 +129,12 @@ export const validateEffectiveSet = (set: EffectiveResourceSet): readonly Valida
       });
     }
 
-    for (const skill of listAgentResources(set, agentSlug, 'skill')) {
-      findings.push(...validateSkill(skill), ...shadowFindings(skill));
+    for (const kind of agentLocalKinds) {
+      for (const resource of listAgentResources(set, agentSlug, kind)) {
+        findings.push(...shadowFindings(resource));
+        // Only skills have a document reader today; knowledge/commands are opaque file trees.
+        if (kind === 'skill') findings.push(...validateSkill(resource));
+      }
     }
   }
 

--- a/code/cli/src/resolver/Resource.ts
+++ b/code/cli/src/resolver/Resource.ts
@@ -5,6 +5,14 @@ export type ResourceKind = 'agent' | 'skill' | 'knowledge' | 'command';
 
 export const resourceKinds: readonly ResourceKind[] = ['agent', 'skill', 'knowledge', 'command'];
 
+/**
+ * Kinds that also resolve **agent-local** — discovered under `agents/<agent>/<container>/` and
+ * resolved local-first before catalog fallback. Excludes `agent` (no nested subagents; a delegate is
+ * a shared catalog agent). mcp/hooks are handled separately (config file / reserved namespace), not
+ * as slug-container kinds.
+ */
+export const agentLocalKinds: readonly ResourceKind[] = ['skill', 'knowledge', 'command'];
+
 /** Where a layer originates, highest precedence first. */
 export type LayerOrigin = 'workspace' | 'global' | 'source';
 
@@ -59,6 +67,17 @@ export interface ResolvedResource {
    * override one loadout field of a globally defined agent.
    */
   readonly configPaths?: readonly string[];
+  /**
+   * For agents: existing `agents/<slug>/mcp.json` paths across all layers, highest precedence first.
+   * Discovered here so a later projection pass (#183) can merge them over the tree-root `mcp.json`.
+   * Config merges by server id — it does not shadow whole like slug resources.
+   */
+  readonly mcpPaths?: readonly string[];
+  /**
+   * For agents: existing `agents/<slug>/hooks/` directories across all layers. The hooks namespace is
+   * reserved (no protocol hooks entity yet); presence is surfaced as a diagnostic, not resolved.
+   */
+  readonly hookPaths?: readonly string[];
 }
 
 /** Locale-independent, deterministic slug ordering (code-unit comparison). */

--- a/code/cli/src/schemas/agent.schema.json
+++ b/code/cli/src/schemas/agent.schema.json
@@ -11,10 +11,22 @@
       "$ref": "#/$defs/slugList",
       "description": "Skill slugs resolved from agents/<name>/skills first, then catalog-wide skills."
     },
-    "subagents": { "$ref": "#/$defs/slugList" },
-    "mcp": { "$ref": "#/$defs/slugList" },
-    "extensions": { "$ref": "#/$defs/slugList" },
-    "plugins": { "$ref": "#/$defs/slugList" },
+    "subagents": {
+      "$ref": "#/$defs/slugList",
+      "description": "Agent slugs delegated to. Resolved catalog-wide (a delegate is a shared agent, not nested under agents/<name>)."
+    },
+    "mcp": {
+      "$ref": "#/$defs/slugList",
+      "description": "MCP server ids. Per-agent agents/<name>/mcp.json is discovered and merges by id over the tree-root mcp.json; projection into the run is deferred (adapter parity, #183)."
+    },
+    "extensions": {
+      "$ref": "#/$defs/slugList",
+      "description": "Harness-native extension selections passed through to the launch; no on-disk agent-local namespace."
+    },
+    "plugins": {
+      "$ref": "#/$defs/slugList",
+      "description": "Harness-native plugin selections passed through to the launch; no on-disk agent-local namespace."
+    },
     "model": { "type": "string", "minLength": 1 },
     "thinking": { "type": "string", "minLength": 1 },
     "tools": {

--- a/code/cli/tests/unit/resolver.test.ts
+++ b/code/cli/tests/unit/resolver.test.ts
@@ -242,6 +242,79 @@ describe('resource resolution', () => {
     expect(localShadowWarnings).toHaveLength(1); // local-over-local only; catalog fallback is not a collision
   });
 
+  it('resolves agent-local knowledge and commands local-first, and lists them in agent context', () => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+
+    write(join(home, '.agents', 'knowledge', 'shared.md'), 'catalog-wide shared knowledge');
+    write(join(home, '.agents', 'commands', 'deploy.md'), 'catalog-wide deploy');
+    write(join(home, '.agents', 'agents', 'engineer', 'knowledge', 'shared.md'), 'home-local knowledge');
+    write(join(project, '.agents', 'agents', 'engineer', 'agent.md'), agentMd('engineer'));
+    write(join(project, '.agents', 'agents', 'engineer', 'knowledge', 'shared.md'), 'workspace-local knowledge');
+    write(join(project, '.agents', 'agents', 'engineer', 'knowledge', 'private.md'), 'workspace-local private');
+    write(join(project, '.agents', 'agents', 'engineer', 'commands', 'deploy.md'), 'workspace-local deploy');
+
+    const set = setFor(home, project);
+    // Agent-local knowledge shadows the catalog-wide slug for its owner and keeps private entries.
+    const shared = findLoadoutResource(set, 'engineer', 'knowledge', 'shared.md')!;
+    expect(shared.winner.layer.origin).toBe('workspace');
+    expect(shared.winner.ownerAgent).toBe('engineer');
+    expect(shared.shadowed.map((definition) => definition.layer.origin)).toEqual(['global']); // local-over-local
+    expect(listAgentResources(set, 'engineer', 'knowledge').map((resource) => resource.slug)).toEqual([
+      'private.md',
+      'shared.md',
+    ]);
+    expect(listAgentResources(set, 'engineer', 'command').map((resource) => resource.slug)).toEqual(['deploy.md']);
+    // Catalog-wide copies remain resolvable without an agent context.
+    expect(findResource(set, 'knowledge', 'shared.md')?.winner.ownerAgent).toBeUndefined();
+
+    // Generalized shadow finding fires for a non-skill agent-local kind (local-over-local only).
+    const shadowWarnings = validateEffectiveSet(set).filter(
+      (finding) => finding.resource === 'agent:engineer/knowledge:shared.md',
+    );
+    expect(shadowWarnings).toHaveLength(1);
+
+    const listed = executeListCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      kind: 'knowledge',
+      agent: 'engineer',
+    });
+    expect(listed.messages).toEqual([
+      'knowledge (agent engineer):',
+      '  private.md  [workspace; agent-local]',
+      '  shared.md  [workspace; agent-local]',
+    ]);
+  });
+
+  it('discovers per-agent mcp.json and reserved hooks, warning that they are not yet projected', () => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+
+    write(join(home, '.agents', 'agents', 'engineer', 'agent.md'), agentMd('engineer'));
+    write(join(home, '.agents', 'agents', 'engineer', 'mcp.json'), JSON.stringify({ servers: { gh: {} } }));
+    write(join(home, '.agents', 'agents', 'engineer', 'hooks', 'pre', 'run.sh'), 'echo hi');
+    // A second agent with an empty hooks dir and no mcp.json — neither should be collected.
+    write(join(home, '.agents', 'agents', 'plain', 'agent.md'), agentMd('plain'));
+    mkdirSync(join(home, '.agents', 'agents', 'plain', 'hooks'), { recursive: true });
+
+    const set = setFor(home, project);
+    const engineer = findResource(set, 'agent', 'engineer')!;
+    expect(engineer.mcpPaths).toHaveLength(1);
+    expect(engineer.hookPaths).toHaveLength(1);
+    const plain = findResource(set, 'agent', 'plain')!;
+    expect(plain.mcpPaths).toEqual([]);
+    expect(plain.hookPaths).toEqual([]); // empty hooks/ is not collected
+
+    const findings = validateEffectiveSet(set);
+    expect(findings.some((f) => f.resource === 'agent:engineer' && /mcp\.json/.test(f.message))).toBe(true);
+    expect(findings.some((f) => f.resource === 'agent:engineer' && /hooks/.test(f.message))).toBe(true);
+    // Stubs surface as warnings (fatal only under --strict), never as errors.
+    expect(findings.filter((f) => f.severity === 'error')).toHaveLength(0);
+  });
+
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.4).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('merges a workspace config.json over a globally defined agent by ID', () => {

--- a/docs/documentation/agents.md
+++ b/docs/documentation/agents.md
@@ -56,6 +56,10 @@ Keep the prose focused on durable identity and behavior. Per-capability procedur
 
 Every value is a slug resolved across layers. Skills first check `agents/<agent>/skills/<slug>/` across layer precedence, then fall back to catalog-wide `skills/<slug>/`. This lets an agent own private implementation capabilities without exposing them to every agent in the catalog. See [Skills](./skills.md#agent-local-skills).
 
+`knowledge` and `commands` resolve the same way — an agent may keep private files under `agents/<agent>/knowledge/` and `agents/<agent>/commands/`, local-first over the catalog-wide trees. `subagents` are always catalog-wide (a delegate is a shared agent). `extensions`/`plugins` are harness-native passthroughs with no on-disk namespace, and `model`/`thinking`/`tools` are per-agent already via `config.json` merge — none of these have an `agents/<agent>/` directory.
+
+Two per-agent surfaces are **discovered but not yet projected** (adapter parity is tracked in [#183](https://github.com/ai-outfitter/outfitter/issues/183)): `agents/<agent>/mcp.json` (merges by server id over the tree-root `mcp.json`) and the reserved `agents/<agent>/hooks/` namespace (see [Hooks](./hooks.md)). Both surface a validation warning when present so a selection placed there is never silently dropped.
+
 ## config.json
 
 The optional `config.json` carries structured or harness-specific configuration that is awkward in frontmatter, following the protocol's schema for the pinned revision. JSON files merge across layers per the protocol's JSON merge behavior, so a workspace layer can adjust one field of a globally defined agent — swap the model, add an extension — without copying the whole definition.

--- a/docs/documentation/concepts.md
+++ b/docs/documentation/concepts.md
@@ -25,7 +25,9 @@ Outfitter stores and exchanges all agent configuration in the vendor-neutral [Do
   mcp.json             # MCP server configuration
   models.json          # model configuration
   agents/<id>/agent.md # agent definitions (+ optional config.json)
-  agents/<id>/skills/  # skills private to one agent
+  agents/<id>/skills/  # skills private to one agent (also knowledge/, commands/)
+  agents/<id>/mcp.json # per-agent MCP config (discovered; projection deferred, #183)
+  agents/<id>/hooks/   # reserved namespace (not yet resolved)
   skills/<id>/...      # Agent Skills packages
   tasks/<id>/task.md   # named execution contracts
   knowledge/...        # reference documents


### PR DESCRIPTION
Stacked on #189 (base = `agent/agent-local-resources`). Extends the agent-local mechanism from **skills-only** to the full per-agent resource surface — as resolution/layout scaffolding. **Projection stays deferred to #183.**

## What this adds
- **One generic agent-local container.** Agent-local discovery of kind K = catalog discovery of K re-rooted under `agents/<owner>/`, attributed to the real layer. Replaces the skill-special `discoverAgentSkills`; introduces `agentLocalKinds = [skill, knowledge, command]`.
- **`knowledge` + `commands` resolve agent-local** — local-first with catalog fallback, isolated per agent. Terminal behavior (no loadout field / no projection), so this is complete, not a stub.
- **`mcp.json` + `hooks/` stubs.** Per-agent `agents/<slug>/mcp.json` and reserved `agents/<slug>/hooks/` are discovered onto the agent resource (`mcpPaths` / `hookPaths`) and each surfaces a **validation warning** ("discovered/reserved, not yet projected") so a selection is never silently dropped. `mcp` merges by server id (config), not slug-shadow; `hooks` is a reserved namespace (no protocol entity yet).
- **`list <kind> --agent <id>`** works for all agent-local kinds; `agent.schema.json` + docs document the layout, resolution model, and what stays catalog-wide (`subagents`) / harness-native (`extensions`, `plugins`) / config-merged (`model`, `thinking`, `tools`).

## Stub seam for #183
Discovery populates `agentResources` / `mcpPaths`; when adapter parity lands, each kind flips from *discovered/reserved* to *projected* (composer resolves it into `ComposedLoadout`, materialize copies it, it moves from `unsupportedElements` to `supportedElements`) **without re-plumbing resolution**.

## Validation
- typecheck / lint / prettier clean
- `npm run coverage`: 177 tests, branch coverage 98.07% (gate 98%)

Refs #189, #188, #183.