### PR TITLE
fix(run): restore Pi profile identity UI

### DIFF
--- a/code/cli/src/cli/OutfitterCli.ts
+++ b/code/cli/src/cli/OutfitterCli.ts
@@ -1,8 +1,7 @@
 // Assembles the top-level Outfitter Commander program from command objects.
-import { readFileSync } from 'node:fs';
-
 import { Command } from 'commander';
 
+import { readOutfitterVersion } from '../version/OutfitterVersion.js';
 import type { CommandObject } from './commands/CommandObject.js';
 import { createDumpCommand } from './commands/DumpCommand.js';
 import { createListCommand } from './commands/ListCommand.js';
@@ -24,18 +23,11 @@ export const createOutfitterProgram = (commands: readonly CommandObject[] = crea
   program
     .name('outfitter')
     .description('Resolve, compose, and launch .agents agents in pi, Claude Code, and future harnesses.')
-    .version(readPackageVersion());
+    .version(readOutfitterVersion());
 
   for (const command of commands) {
     command.register(program);
   }
 
   return program;
-};
-
-const readPackageVersion = (): string => {
-  const packageJsonPath = new URL('../../package.json', import.meta.url);
-  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as { version: string };
-
-  return packageJson.version;
 };

--- a/code/cli/src/cli/commands/PiRuntimeLaunch.ts
+++ b/code/cli/src/cli/commands/PiRuntimeLaunch.ts
@@ -1,9 +1,9 @@
-// Attaches the Outfitter runtime pi extension to interactive profile launches. The extension
-// restores Outfitter's original "connect a model provider" sign-in prompt: when pi starts with no
-// models available it offers to connect one and opens pi's native /login. Non-interactive pi
-// launches (--print, --export, --mode json|print|rpc, …) are left untouched so scripted runs never
-// prompt, and non-pi harnesses pass through unchanged.
-import { existsSync } from 'node:fs';
+// Attaches the Outfitter runtime pi extension to interactive profile launches. The extension owns
+// the Outfitter + pi header, active-profile status, and "connect a model provider" sign-in prompt.
+// Non-interactive pi launches (--print, --export, --mode json|print|rpc, …) are left untouched so
+// scripted runs never prompt, and non-pi harnesses pass through unchanged.
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import type { AgentLaunchPlan } from '../../projection/Projection.js';
@@ -12,6 +12,17 @@ const nonInteractivePiLaunchFlags = new Set(['--print', '-p', '--export', '--lis
 const nonInteractivePiModes = new Set(['json', 'print', 'rpc']);
 
 const runtimeExtensionAsset = 'pi-extension/src/outfitter-runtime-extension.js';
+
+export interface PiRuntimeProfileIdentity {
+  readonly id: string;
+  readonly label?: string;
+}
+
+export interface PiRuntimeExtensionInput {
+  readonly outfitterVersion: string;
+  readonly profile?: PiRuntimeProfileIdentity;
+  readonly rootDirectory: string;
+}
 
 export const isNonInteractivePiLaunch = (args: readonly string[]): boolean =>
   args.some((arg, index) => {
@@ -33,17 +44,28 @@ const resolveRuntimeExtensionPath = (): string | undefined => {
   return undefined;
 };
 
-/**
- * Prepends `--extension <runtime>` to a pi launch so the auto sign-in prompt loads. The extension is
- * a no-op whenever a model is already available, so it is safe to attach to every interactive pi
- * run. Non-pi and non-interactive launches are returned unchanged.
- */
-export const attachPiRuntimeExtension = (plan: AgentLaunchPlan): AgentLaunchPlan => {
-  if (plan.command !== 'pi' || isNonInteractivePiLaunch(plan.args)) return plan;
-
+/** Stamps per-run identity metadata into the runtime extension source. */
+export const createPiRuntimeExtensionContent = (input: Omit<PiRuntimeExtensionInput, 'rootDirectory'>): string => {
   const extensionPath = resolveRuntimeExtensionPath();
   /* v8 ignore next -- defensive: the runtime extension ships with the package, so it resolves in practice. */
-  if (extensionPath === undefined) return plan;
+  if (extensionPath === undefined) throw new Error('Outfitter runtime extension was not found.');
+
+  return readFileSync(extensionPath, 'utf8')
+    .replace(/["']__OUTFITTER_VERSION__["']/gu, JSON.stringify(input.outfitterVersion))
+    .replace(/["']__OUTFITTER_ACTIVE_PROFILE__["']/gu, JSON.stringify(input.profile) ?? 'undefined');
+};
+
+/**
+ * Materializes and prepends `--extension <runtime>` to an interactive pi launch. Non-pi and
+ * non-interactive launches are returned unchanged.
+ */
+export const attachPiRuntimeExtension = (plan: AgentLaunchPlan, input: PiRuntimeExtensionInput): AgentLaunchPlan => {
+  if (plan.command !== 'pi' || isNonInteractivePiLaunch(plan.args)) return plan;
+
+  const extensionDirectory = join(input.rootDirectory, '.outfitter');
+  const extensionPath = join(extensionDirectory, 'outfitter-runtime-extension.js');
+  mkdirSync(extensionDirectory, { recursive: true });
+  writeFileSync(extensionPath, createPiRuntimeExtensionContent(input));
 
   return { ...plan, args: ['--extension', extensionPath, ...plan.args] };
 };

--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -22,6 +22,7 @@ import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
 import type { Harness } from '../../settings/Settings.js';
 import { HARNESSES } from '../../settings/Settings.js';
 import type { SetupResult } from '../../setup/Setup.js';
+import { readOutfitterVersion } from '../../version/OutfitterVersion.js';
 import type { CommandObject } from './CommandObject.js';
 import { attachPiRuntimeExtension } from './PiRuntimeLaunch.js';
 import { resolveHomeDirectory, resolveProjectDirectory } from './ProcessDefaults.js';
@@ -209,9 +210,12 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
     const messages = [...setupMessages, ...warnings];
     emit(messages);
 
-    // Attach the Outfitter runtime extension so interactive pi sessions restore the "connect a
-    // model provider" sign-in prompt when no models are available, instead of pi's raw warning.
-    const launch = attachPiRuntimeExtension(projection.launch);
+    // Attach the Outfitter runtime UI and sign-in extension to interactive pi sessions.
+    const launch = attachPiRuntimeExtension(projection.launch, {
+      outfitterVersion: readOutfitterVersion(),
+      profile: { id: agentSlug, label: composed.plan.identity.label },
+      rootDirectory,
+    });
     const exitCode = await launchWithCredentialPersistence(input, harness, rootDirectory, launch);
 
     return { launchPlan: launch, exitCode, messages };

--- a/code/cli/src/composer/Composer.ts
+++ b/code/cli/src/composer/Composer.ts
@@ -95,6 +95,7 @@ export const compose = (set: EffectiveResourceSet, agentSlug: string): ComposeRe
       systemPrompt: readRootFile(set, 'system-prompt.md'),
       sharedContext: readRootFile(set, 'agents.md'),
       agentBody: definition.body,
+      label: definition.label,
       description: definition.description,
     },
     loadout: composeLoadout(set, agentSlug, definition.loadout, warnings),

--- a/code/cli/src/composer/Composition.ts
+++ b/code/cli/src/composer/Composition.ts
@@ -9,6 +9,8 @@ export interface ComposedIdentity {
   readonly sharedContext?: string;
   /** The selected agent's `agent.md` markdown body. */
   readonly agentBody: string;
+  /** Human-readable profile name for interactive harness UI. */
+  readonly label?: string;
   readonly description?: string;
 }
 

--- a/code/cli/src/resolver/AgentDefinition.ts
+++ b/code/cli/src/resolver/AgentDefinition.ts
@@ -8,6 +8,8 @@ import { emptyLoadout } from './Resource.js';
 
 export interface AgentDefinition {
   readonly name: string;
+  /** Human-readable profile name shown in interactive harness UI. */
+  readonly label?: string;
   readonly description?: string;
   /** Markdown body after the frontmatter — the agent's identity prose. */
   readonly body: string;
@@ -71,6 +73,8 @@ const asStringArray = (value: unknown): readonly string[] =>
   Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : [];
 
 const asString = (value: unknown): string | undefined => (typeof value === 'string' ? value : undefined);
+
+const readMarkdownHeading = (body: string): string | undefined => /^#\s+(.+)$/mu.exec(body)?.[1]?.trim();
 
 const loadoutFromRecord = (record: Readonly<Record<string, unknown>>): Loadout => {
   const tools = record.tools as { readonly allow?: unknown; readonly deny?: unknown } | undefined;
@@ -166,6 +170,7 @@ export const parseAgentDefinition = (
 
   return {
     name: frontmatter.record.name as string,
+    label: asString(frontmatter.record.label)?.trim() || readMarkdownHeading(frontmatter.body),
     description: asString(frontmatter.record.description),
     body: frontmatter.body,
     loadout: loadoutFromRecord(merged),

--- a/code/cli/src/schemas/agent.schema.json
+++ b/code/cli/src/schemas/agent.schema.json
@@ -6,6 +6,7 @@
   "required": ["name"],
   "properties": {
     "name": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$", "maxLength": 64 },
+    "label": { "type": "string", "minLength": 1 },
     "description": { "type": "string" },
     "skills": {
       "$ref": "#/$defs/slugList",

--- a/code/cli/src/version/OutfitterVersion.ts
+++ b/code/cli/src/version/OutfitterVersion.ts
@@ -1,0 +1,9 @@
+// Reads the installed Outfitter package version for CLI output and runtime branding.
+import { readFileSync } from 'node:fs';
+
+export const readOutfitterVersion = (): string => {
+  const packageJsonPath = new URL('../../package.json', import.meta.url);
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as { readonly version: string };
+
+  return packageJson.version;
+};

--- a/code/cli/tests/unit/composer.test.ts
+++ b/code/cli/tests/unit/composer.test.ts
@@ -70,6 +70,16 @@ describe('composer', () => {
     expect(plan.warnings).toEqual([]);
   });
 
+  it('composes the selected profile display label', () => {
+    const { home, project } = buildTree();
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\nlabel: Engineering Lead\n---\n\n# Engineer\n',
+    );
+
+    expect(compose(resolveSet(home, project), 'engineer').plan?.identity.label).toBe('Engineering Lead');
+  });
+
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.3).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('composes an agent-local skill before a catalog-wide skill of the same slug', () => {

--- a/code/cli/tests/unit/pi-runtime-extension.test.ts
+++ b/code/cli/tests/unit/pi-runtime-extension.test.ts
@@ -1,25 +1,56 @@
-// Exercises the Outfitter runtime extension's auto sign-in prompt and the launch-time wiring that
-// attaches it. THIS TEST GUARDS OFTR-010's runtime login behavior (real pi opens /login when no
-// models are available; the isolated setup pi never does).
-import { readFileSync } from 'node:fs';
+// Exercises the Outfitter runtime extension's identity UI, auto sign-in prompt, and launch wiring.
+// THIS TEST GUARDS OFTR-010's runtime login behavior (real pi opens /login when no models are
+// available; the isolated setup pi never does).
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { Script, createContext } from 'node:vm';
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
+import {
+  attachPiRuntimeExtension,
+  createPiRuntimeExtensionContent,
+  isNonInteractivePiLaunch,
+} from '../../src/cli/commands/PiRuntimeLaunch.js';
+import type { PiRuntimeProfileIdentity } from '../../src/cli/commands/PiRuntimeLaunch.js';
 import type { AgentLaunchPlan } from '../../src/projection/Projection.js';
-import { attachPiRuntimeExtension, isNonInteractivePiLaunch } from '../../src/cli/commands/PiRuntimeLaunch.js';
 
 type Handler = (event: Record<string, unknown>, context: MockContext) => Promise<unknown>;
 type MockContext = ReturnType<typeof createMockContext>;
 
-const runtimeExtensionSource = readFileSync(
-  new URL('../../../pi-extension/src/outfitter-runtime-extension.js', import.meta.url),
-  'utf8',
-);
+interface RuntimeFixtureInput {
+  readonly outfitterVersion?: string;
+  readonly profile?: PiRuntimeProfileIdentity;
+}
 
-// Evaluates the runtime extension in a sandbox with pi-tui stubbed out, returning its factory.
-const evaluateRuntimeExtension = (): ((pi: MockPi) => void) => {
-  const executable = runtimeExtensionSource
+interface MockHeader {
+  readonly render: (width?: number) => string[];
+  readonly invalidate: () => void;
+}
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-runtime-extension-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+// Evaluates a stamped runtime extension in a sandbox with Pi's supported imports stubbed out.
+const evaluateRuntimeExtension = (input: RuntimeFixtureInput = {}): ((pi: MockPi) => void) => {
+  const executable = createPiRuntimeExtensionContent({
+    outfitterVersion: input.outfitterVersion ?? '1.2.3',
+    profile: input.profile,
+  })
+    .replace(
+      /import \{ VERSION as PI_VERSION \} from ['"]@earendil-works\/pi-coding-agent['"];/u,
+      "const PI_VERSION = '0.80.3';",
+    )
     .replace(
       /import \{ Key, matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi \} from ['"]@earendil-works\/pi-tui['"];/u,
       [
@@ -54,7 +85,10 @@ const createMockPi = () => {
 
 const createMockContext = (options: { models?: readonly unknown[]; confirm?: boolean; mode?: string } = {}) => {
   let editorText = '';
+  let header: MockHeader | undefined;
   const rendered: string[][] = [];
+  const statuses: Record<string, string> = {};
+  const theme = { fg: (_color: string, text: string) => text, bold: (text: string) => text };
   return {
     mode: options.mode ?? 'tui',
     model: options.models && options.models.length > 0 ? options.models[0] : undefined,
@@ -62,13 +96,17 @@ const createMockContext = (options: { models?: readonly unknown[]; confirm?: boo
     get editorText() {
       return editorText;
     },
+    get header() {
+      return header;
+    },
     rendered,
+    statuses,
     ui: {
       custom<T>(factory: (...args: unknown[]) => unknown): Promise<T> {
         return new Promise<T>((resolve) => {
           const component = factory(
             { requestRender: () => undefined, focusedComponent: { handleInput: () => undefined } },
-            { fg: (_color: string, text: string) => text, bold: (text: string) => text },
+            theme,
             {},
             resolve,
           ) as {
@@ -88,16 +126,67 @@ const createMockContext = (options: { models?: readonly unknown[]; confirm?: boo
       setEditorText(value: string) {
         editorText = value;
       },
+      setHeader(factory: (...args: unknown[]) => unknown) {
+        header = factory({}, theme) as MockHeader;
+      },
+      setStatus(id: string, text: string) {
+        statuses[id] = text;
+      },
+      theme,
     },
   };
 };
 
-const fireSessionStart = async (context: MockContext, event: Record<string, unknown> = { reason: 'startup' }) => {
-  const extension = evaluateRuntimeExtension();
+const fireSessionStart = async (
+  context: MockContext,
+  event: Record<string, unknown> = { reason: 'startup' },
+  fixtureInput: RuntimeFixtureInput = {},
+) => {
+  const extension = evaluateRuntimeExtension(fixtureInput);
   const pi = createMockPi();
   extension(pi);
   for (const handler of pi.handlers.session_start ?? []) await handler(event, context);
 };
+
+describe('Pi runtime extension identity UI', () => {
+  it('shows both runtime versions and the active profile label', async () => {
+    const context = createMockContext({ models: [{ id: 'm' }] });
+    await fireSessionStart(
+      context,
+      { reason: 'startup' },
+      {
+        outfitterVersion: '1.2.3',
+        profile: { id: 'engineer', label: 'Engineer' },
+      },
+    );
+
+    expect(context.header?.render(80)).toEqual(['Outfitter v1.2.3 + pi v0.80.3']);
+    expect(context.statuses['outfitter-profile']).toBe('profile: Engineer');
+  });
+
+  it('falls back to the profile id and omits the status when no profile is stamped', async () => {
+    const fallbackContext = createMockContext({ models: [{ id: 'm' }] });
+    await fireSessionStart(fallbackContext, { reason: 'startup' }, { profile: { id: 'engineer' } });
+    expect(fallbackContext.statuses['outfitter-profile']).toBe('profile: engineer');
+
+    const absentContext = createMockContext({ models: [{ id: 'm' }] });
+    await fireSessionStart(absentContext);
+    expect(absentContext.statuses['outfitter-profile']).toBeUndefined();
+  });
+
+  it('keeps the header within the terminal width and re-renders after invalidation', async () => {
+    const context = createMockContext({ models: [{ id: 'm' }] });
+    await fireSessionStart(context);
+    const header = context.header!;
+
+    const narrow = header.render(20);
+    expect(narrow.every((line) => line.length <= 20)).toBe(true);
+    expect(header.render(20)).toBe(narrow);
+    expect(header.render()).toEqual(['Outfitter v1.2.3 + pi v0.80.3']);
+    header.invalidate();
+    expect(header.render(20)).not.toBe(narrow);
+  });
+});
 
 describe('Pi runtime extension auto sign-in', () => {
   it('opens /login after confirmation when no models are available', async () => {
@@ -127,40 +216,66 @@ describe('Pi runtime extension auto sign-in', () => {
 
   it('stays inert outside a TUI session', async () => {
     const context = createMockContext({ models: [], confirm: true, mode: 'json' });
-    await fireSessionStart(context);
+    await fireSessionStart(context, { reason: 'startup' }, { profile: { id: 'engineer' } });
     expect(context.editorText).toBe('');
+    expect(context.header).toBeUndefined();
+    expect(context.statuses).toEqual({});
   });
 
-  it('only prompts on startup, not on reload', async () => {
+  it('only prompts on startup, while restoring identity UI on reload', async () => {
     const context = createMockContext({ models: [], confirm: true });
-    await fireSessionStart(context, { reason: 'reload' });
+    await fireSessionStart(context, { reason: 'reload' }, { profile: { id: 'engineer' } });
     expect(context.editorText).toBe('');
+    expect(context.header).toBeDefined();
+    expect(context.statuses['outfitter-profile']).toBe('profile: engineer');
   });
 });
 
 describe('attachPiRuntimeExtension', () => {
   const piPlan = (args: readonly string[] = []): AgentLaunchPlan => ({ command: 'pi', args, env: {} });
+  const runtimeInput = (profile?: PiRuntimeProfileIdentity) => ({
+    outfitterVersion: '1.2.3',
+    profile,
+    rootDirectory: createTemporaryRoot(),
+  });
 
-  it('prepends the runtime extension to interactive pi launches', () => {
-    const result = attachPiRuntimeExtension(piPlan(['--system-prompt', '/x']));
+  it('materializes and prepends the stamped runtime extension for interactive pi launches', () => {
+    const result = attachPiRuntimeExtension(
+      piPlan(['--system-prompt', '/x']),
+      runtimeInput({ id: 'engineer', label: 'Engineer' }),
+    );
     expect(result.args[0]).toBe('--extension');
-    expect(result.args[1]).toMatch(/outfitter-runtime-extension\.js$/u);
+    expect(result.args[1]).toMatch(/\.outfitter\/outfitter-runtime-extension\.js$/u);
     expect(result.args.slice(2)).toEqual(['--system-prompt', '/x']);
+    const extension = readFileSync(result.args[1], 'utf8');
+    expect(extension).toContain('const OUTFITTER_ACTIVE_PROFILE = {"id":"engineer","label":"Engineer"};');
+    expect(extension).toContain('const OUTFITTER_VERSION = "1.2.3";');
+    expect(extension).not.toContain('__OUTFITTER_');
+  });
+
+  it('does not reinterpret placeholder-shaped profile metadata while stamping', () => {
+    const extension = createPiRuntimeExtensionContent({
+      outfitterVersion: '1.2.3',
+      profile: { id: 'engineer', label: '__OUTFITTER_VERSION__' },
+    });
+
+    expect(extension).toContain('const OUTFITTER_ACTIVE_PROFILE = {"id":"engineer","label":"__OUTFITTER_VERSION__"};');
   });
 
   it('leaves non-pi launches untouched', () => {
     const claudePlan: AgentLaunchPlan = { command: 'claude', args: ['--model', 'x'], env: {} };
-    expect(attachPiRuntimeExtension(claudePlan)).toBe(claudePlan);
+    expect(attachPiRuntimeExtension(claudePlan, runtimeInput())).toBe(claudePlan);
   });
 
   it('does not attach to non-interactive pi launches', () => {
     for (const args of [['--print'], ['-p'], ['--export'], ['--list-models'], ['--mode', 'json'], ['--mode=rpc']]) {
-      expect(attachPiRuntimeExtension(piPlan(args)).args).toEqual(args);
+      expect(attachPiRuntimeExtension(piPlan(args), runtimeInput()).args).toEqual(args);
       expect(isNonInteractivePiLaunch(args)).toBe(true);
     }
   });
 
   it('treats a plain interactive launch as interactive', () => {
     expect(isNonInteractivePiLaunch(['--system-prompt', '/x', '--mode', 'tui'])).toBe(false);
+    expect(isNonInteractivePiLaunch(['--mode'])).toBe(false);
   });
 });

--- a/code/cli/tests/unit/resolver.test.ts
+++ b/code/cli/tests/unit/resolver.test.ts
@@ -77,6 +77,24 @@ describe('agent definition parsing', () => {
     expect(parsed.body).toContain('# engineer');
   });
 
+  it('derives the profile display label from frontmatter, then the first H1', () => {
+    const explicit = parseAgentDefinition(
+      '---\nname: engineer\nlabel: Engineering Lead\n---\n\n# Engineer\n',
+      [],
+      '/nowhere/agent.md',
+    );
+    const heading = parseAgentDefinition('---\nname: engineer\n---\n\n# Engineer\n', [], '/nowhere/agent.md');
+    const slugOnly = parseAgentDefinition('---\nname: engineer\n---\n\nNo heading.\n', [], '/nowhere/agent.md');
+
+    expect(isAgentDefinitionIssue(explicit)).toBe(false);
+    expect(isAgentDefinitionIssue(heading)).toBe(false);
+    expect(isAgentDefinitionIssue(slugOnly)).toBe(false);
+    if (isAgentDefinitionIssue(explicit) || isAgentDefinitionIssue(heading) || isAgentDefinitionIssue(slugOnly)) return;
+    expect(explicit.label).toBe('Engineering Lead');
+    expect(heading.label).toBe('Engineer');
+    expect(slugOnly.label).toBeUndefined();
+  });
+
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.4).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('merges config.json loadout over frontmatter by key, restricted to loadout fields', () => {

--- a/code/cli/tests/unit/run-agent.test.ts
+++ b/code/cli/tests/unit/run-agent.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../../src/cli/commands/RunAgentCommand.js';
 import type { AgentLaunchPlan } from '../../src/projection/Projection.js';
 import type { SetupResult } from '../../src/setup/Setup.js';
+import { readOutfitterVersion } from '../../src/version/OutfitterVersion.js';
 
 const temporaryRoots: string[] = [];
 let previousExitCode: typeof process.exitCode;
@@ -35,6 +36,7 @@ interface CapturedLaunch {
   readonly systemPrompt?: string;
   readonly skillPresent: boolean;
   readonly skillBody?: string;
+  readonly runtimeExtension?: string;
 }
 
 const captured: CapturedLaunch[] = [];
@@ -43,6 +45,9 @@ const launcher = (plan: AgentLaunchPlan): Promise<number> => {
   const runtimeDir = plan.env.PI_CODING_AGENT_DIR ?? plan.env.CLAUDE_CONFIG_DIR ?? '';
   const promptIndex = plan.args.indexOf('--system-prompt');
   const skillPath = join(runtimeDir, 'skills', 'wiki', 'SKILL.md');
+  const runtimeExtensionPath = plan.args.find(
+    (arg, index) => plan.args[index - 1] === '--extension' && arg.endsWith('outfitter-runtime-extension.js'),
+  );
   captured.push({
     plan,
     runtimeDir,
@@ -50,6 +55,7 @@ const launcher = (plan: AgentLaunchPlan): Promise<number> => {
     systemPrompt: promptIndex >= 0 ? readFileSync(plan.args[promptIndex + 1], 'utf8') : undefined,
     skillPresent: existsSync(skillPath),
     skillBody: existsSync(skillPath) ? readFileSync(skillPath, 'utf8') : undefined,
+    runtimeExtension: runtimeExtensionPath === undefined ? undefined : readFileSync(runtimeExtensionPath, 'utf8'),
   });
   return Promise.resolve(0);
 };
@@ -114,6 +120,29 @@ describe('run agent', () => {
     );
     expect(launch.systemPrompt).toBe('BASE PROMPT'); // composed identity materialized
     expect(launch.skillPresent).toBe(true); // skill content copied, not an empty dir
+  });
+
+  it('stamps the selected profile label and installed Outfitter version into the Pi runtime', async () => {
+    const { home, project } = tree();
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\nlabel: Engineering Lead\n---\n\n# Engineer\n',
+    );
+
+    await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      agent: 'engineer',
+      harness: 'pi',
+      launcher,
+    });
+
+    expect(captured[0].runtimeExtension).toContain(
+      'const OUTFITTER_ACTIVE_PROFILE = {"id":"engineer","label":"Engineering Lead"};',
+    );
+    expect(captured[0].runtimeExtension).toContain(
+      `const OUTFITTER_VERSION = ${JSON.stringify(readOutfitterVersion())};`,
+    );
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.1, OFTR-005.3).

--- a/code/pi-extension/README.md
+++ b/code/pi-extension/README.md
@@ -9,13 +9,13 @@ It brands the startup header and owns the Outfitter interactive shortcuts
 (Shift+Tab plan/build mode). Per `OFTR-010.1.4` the setup shell MUST NOT open
 `/login`, so this file is deliberately free of any credential prompt.
 
-`src/outfitter-runtime-extension.js` is the **runtime auto sign-in** extension.
-The CLI loads it into the real profile Pi session. When Pi starts with no models
-available it restores Outfitter's original "Pi does not have a model provider
-connected yet — Connect a model provider" confirmation and then delegates to
-Pi's native `/login`. It is a no-op whenever a model is already available and
-never runs for non-interactive Pi launches (`--print`, `--export`,
-`--mode json|print|rpc`).
+`src/outfitter-runtime-extension.js` is the **real-session runtime** extension.
+The CLI loads it into the selected profile's Pi session. It renders the combined
+Outfitter and Pi version header, shows the active profile in Pi's status line,
+and, when Pi starts with no models available, restores Outfitter's original
+"Pi does not have a model provider connected yet — Connect a model provider"
+confirmation before delegating to Pi's native `/login`. It never runs for
+non-interactive Pi launches (`--print`, `--export`, `--mode json|print|rpc`).
 
 ## How they are loaded
 
@@ -27,10 +27,12 @@ Pi never imports these files from the repository or the npm package directly.
   `"__OUTFITTER_HOME__"` or `"__OUTFITTER_AUTO_OPEN__"`) with the JSON-encoded
   launch-specific value, then writes the stamped file into the isolated Pi agent
   directory and passes it to pi via `--extension`.
-- The runtime extension needs no stamped values, so
-  `code/cli/src/cli/commands/PiRuntimeLaunch.ts` (`attachPiRuntimeExtension`)
-  resolves its on-disk path and passes it directly to interactive pi launches
-  via `--extension`.
+- The runtime extension is stamped by
+  `code/cli/src/cli/commands/PiRuntimeLaunch.ts` with the active profile and
+  installed Outfitter version, then written inside the ephemeral runtime tree
+  and passed to interactive pi launches via `--extension`. The Pi version is
+  imported through Pi's supported `@earendil-works/pi-coding-agent` extension
+  alias, so it describes the Pi process that is actually running.
 
 The `@ai-outfitter/outfitter` package ships this workspace's `src/` folder under
 `code/pi-extension/` (staged by `code/cli/scripts/sync-package-assets.mjs`) so
@@ -38,9 +40,10 @@ the packaged CLI can resolve the same sources after install.
 
 ## Editing notes
 
-- Keep both files dependency-free apart from `@earendil-works/pi-tui` (provided
-  by pi at runtime) and, for the setup extension, the enterprise support modules
-  copied next to the written extension (`./pi-extension/privateCatalogOnboarding.js`).
+- Keep both files dependency-free apart from Pi's supported runtime imports
+  (`@earendil-works/pi-tui` and `@earendil-works/pi-coding-agent`) and, for the
+  setup extension, the enterprise support modules copied next to the written
+  extension (`./pi-extension/privateCatalogOnboarding.js`).
 - `src/outfitter-extension.js` (setup) is intentionally excluded from Prettier so
   the stamped output stays byte-stable for the CLI's behavioral tests
   (`code/cli/tests/unit/pi-setup-extension.test.ts`), which evaluate the stamped

--- a/code/pi-extension/src/outfitter-runtime-extension.js
+++ b/code/pi-extension/src/outfitter-runtime-extension.js
@@ -1,14 +1,19 @@
+import { VERSION as PI_VERSION } from '@earendil-works/pi-coding-agent';
 import { Key, matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi } from '@earendil-works/pi-tui';
 
+const OUTFITTER_ACTIVE_PROFILE = '__OUTFITTER_ACTIVE_PROFILE__';
+const OUTFITTER_VERSION = '__OUTFITTER_VERSION__';
+
 // Outfitter runtime extension. Unlike the setup walkthrough extension
-// (outfitter-extension.js), this file is loaded into the real profile pi session. Its only job is
-// to restore Outfitter's original "no provider connected yet" sign-in prompt: when pi starts with
-// no models available, it offers to connect one and delegates to pi's native /login command, which
-// persists credentials in pi's own agent directory and selects a default model in-session.
+// (outfitter-extension.js), this file is loaded into the real profile pi session. It restores the
+// Outfitter + pi header and active-profile status, plus the original "no provider connected yet"
+// sign-in prompt: when pi starts with no models available, it offers to connect one and delegates
+// to pi's native /login command, which persists credentials in pi's own agent directory and selects
+// a default model in-session.
 //
 // The setup pi stays deliberately model-free and MUST NOT open /login (OFTR-010.1.4); that is why
-// the auto-login lives here instead. This file needs no stamped launch-time values, so the CLI
-// loads it directly by absolute path via --extension.
+// the auto-login lives here instead. The CLI stamps profile and Outfitter-version metadata into a
+// per-run copy before loading it via --extension. PI_VERSION comes from the running pi package.
 
 export default function outfitterRuntime(pi) {
   let loginSubmitted = false;
@@ -72,9 +77,43 @@ export default function outfitterRuntime(pi) {
 
   pi.on('session_start', async (event, ctx) => {
     if (ctx.mode !== 'tui') return;
+    setRuntimeHeader(ctx);
+    updateProfileStatus(ctx);
     if (event.reason === 'startup') await openLoginIfNoModels(ctx);
   });
 }
+
+const setRuntimeHeader = (ctx) => {
+  ctx.ui.setHeader((_tui, theme) => {
+    let cachedWidth;
+    let cachedLines;
+    return {
+      render: (width) => {
+        const maxWidth = typeof width === 'number' && width > 0 ? width : 120;
+        if (cachedLines === undefined || cachedWidth !== maxWidth) {
+          const line =
+            theme.bold(theme.fg('accent', 'Outfitter')) + theme.fg('dim', ` v${OUTFITTER_VERSION} + pi v${PI_VERSION}`);
+          cachedLines = [visibleWidth(line) > maxWidth ? truncateToWidth(line, maxWidth) : line];
+          cachedWidth = maxWidth;
+        }
+        return cachedLines;
+      },
+      invalidate: () => {
+        cachedWidth = undefined;
+        cachedLines = undefined;
+      },
+    };
+  });
+};
+
+const updateProfileStatus = (ctx) => {
+  // Stays a string when the source asset is loaded without Outfitter stamping and is undefined
+  // when a caller intentionally attaches the extension without a resolved profile.
+  if (typeof OUTFITTER_ACTIVE_PROFILE !== 'object' || OUTFITTER_ACTIVE_PROFILE === null) return;
+  const name = OUTFITTER_ACTIVE_PROFILE.label ?? OUTFITTER_ACTIVE_PROFILE.id;
+  if (!name) return;
+  ctx.ui.setStatus('outfitter-profile', ctx.ui.theme.fg('muted', 'profile: ' + name));
+};
 
 // Renders a described-option picker identical to the setup walkthrough's, so the runtime sign-in
 // prompt matches the rest of the Outfitter UI. Falls back to a plain label list when pi does not

--- a/docs/documentation/agents.md
+++ b/docs/documentation/agents.md
@@ -22,6 +22,7 @@ An agent is the protocol's identity resource — and, in Outfitter, the thing yo
 ```markdown
 ---
 name: engineer
+label: Engineer
 description: Implements features and fixes with a bias toward small, verifiable changes.
 skills: [wiki, research]
 subagents: [code-reviewer]
@@ -38,6 +39,10 @@ tools:
 
 You implement changes directly, keep diffs small, and verify before claiming done...
 ```
+
+`name` is the stable slug used for resolution. The optional `label` is the human-readable profile
+name shown during setup and in interactive harness UI. When `label` is omitted, Outfitter uses the
+first level-one Markdown heading, then falls back to the slug.
 
 Keep the prose focused on durable identity and behavior. Per-capability procedures belong in [skills](./skills.md); the frontmatter only _selects_ resources by slug — it never copies their content.
 


### PR DESCRIPTION
## Summary

- restore the selected Outfitter profile in Pi's status line as `profile: <label|id>`
- restore the historical `Outfitter + pi` runtime header
- add the installed Outfitter version and running Pi version to that header
- define profile display-name precedence as frontmatter `label`, first H1, then agent slug
- stamp per-run identity metadata into the ephemeral runtime extension while reading `VERSION` from the Pi process that actually loads it

## Why

The `.agents` run-path rewrite replaced the legacy launch pipeline with `RunAgentCommand`. The real-session extension was later reattached for auto sign-in, but it no longer received the selected profile identity or installed Outfitter version, and the old Outfitter-branded header was not restored.

This made interactive Pi sessions lose the `profile: ...` indicator and show only Pi's native branding/version instead of the combined Outfitter + Pi identity.

## Implementation

- carry the resolved agent display label through composition into the launch boundary
- materialize a stamped runtime extension inside the ephemeral projection tree
- render a width-safe combined header on every TUI session start/reload
- keep Claude and noninteractive Pi launches unchanged
- document the runtime extension contract and authored `label` fallback behavior

## Validation

- `npm run check-ci`
  - 227 tests passed
  - statements 99.43%, branches 98.18%, functions 98.97%, lines 99.37%
  - docs lint and production build passed
- `bash scripts/e2e-smoke.sh`
  - packed and installed `@ai-outfitter/outfitter@1.0.1` in an isolated prefix
  - verified version/help/list/validate paths
- runtime extension import/load verified against bundled Pi 0.80.3
