### PR TITLE
feat(cli): add remote source sync with private-catalog gating

### DIFF
--- a/code/cli/src/cli/OutfitterCli.ts
+++ b/code/cli/src/cli/OutfitterCli.ts
@@ -7,11 +7,13 @@ import { createDumpCommand } from './commands/DumpCommand.js';
 import { createListCommand } from './commands/ListCommand.js';
 import { createRunAgentCommand } from './commands/RunAgentCommand.js';
 import { createSetupCommand } from './commands/SetupCommand.js';
+import { createSyncCommand } from './commands/SyncCommand.js';
 import { createValidateCommand } from './commands/ValidateCommand.js';
 
 export const createDefaultCommands = (): CommandObject[] => [
   createRunAgentCommand(),
   createSetupCommand(),
+  createSyncCommand(),
   createListCommand(),
   createValidateCommand(),
   createDumpCommand(),

--- a/code/cli/src/cli/commands/DumpCommand.ts
+++ b/code/cli/src/cli/commands/DumpCommand.ts
@@ -40,18 +40,24 @@ const resolveAgentSlug = (settings: Settings, requested: string | undefined): st
 };
 
 export const executeDumpCommand = (input: DumpInput): DumpCommandResult => {
-  const { set, settings, settingsIssues } = resolveEffectiveSet(input);
+  const { set, settings, settingsIssues, warnings } = resolveEffectiveSet(input);
 
   if (settingsIssues.length > 0) {
     throw new Error(`Cannot dump with invalid settings: ${settingsIssues.map((issue) => issue.message).join('; ')}`);
   }
 
+  const syncWarnings = warnings.map((warning) => `warning: ${warning}`);
+
   const agentSlug = resolveAgentSlug(settings, input.agent);
   const result = dumpAgent(set, agentSlug, input.out);
   const ok = result.errors.length === 0;
   const messages = ok
-    ? [`Dumped '${agentSlug}' to ${input.out} (${result.writtenPaths.length} files).`, ...result.warnings]
-    : [...result.errors, ...result.warnings];
+    ? [
+        ...syncWarnings,
+        `Dumped '${agentSlug}' to ${input.out} (${result.writtenPaths.length} files).`,
+        ...result.warnings,
+      ]
+    : [...syncWarnings, ...result.errors, ...result.warnings];
 
   return { writtenPaths: result.writtenPaths, messages, ok };
 };

--- a/code/cli/src/cli/commands/ListCommand.ts
+++ b/code/cli/src/cli/commands/ListCommand.ts
@@ -12,6 +12,7 @@ import {
   resourceKinds,
 } from '../../resolver/Resource.js';
 import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
+import { formatSettingsIssue } from '../../settings/SettingsLoader.js';
 import type { CommandObject } from './CommandObject.js';
 import { resolveHomeDirectory, resolveProjectDirectory } from './ProcessDefaults.js';
 
@@ -64,7 +65,7 @@ export const executeListCommand = (input: ListInput): ListResult => {
   const { set, settingsIssues } = resolveEffectiveSet(input);
 
   if (settingsIssues.length > 0) {
-    const detail = settingsIssues.map((issue) => `${issue.filePath}#${issue.path} ${issue.message}`).join('; ');
+    const detail = settingsIssues.map(formatSettingsIssue).join('; ');
     throw new Error(`Cannot list resources with invalid settings: ${detail}`);
   }
 

--- a/code/cli/src/cli/commands/ListCommand.ts
+++ b/code/cli/src/cli/commands/ListCommand.ts
@@ -62,14 +62,14 @@ const resolveKindFilter = (kind: string | undefined): readonly ResourceKind[] =>
 };
 
 export const executeListCommand = (input: ListInput): ListResult => {
-  const { set, settingsIssues } = resolveEffectiveSet(input);
+  const { set, settingsIssues, warnings } = resolveEffectiveSet(input);
 
   if (settingsIssues.length > 0) {
     const detail = settingsIssues.map(formatSettingsIssue).join('; ');
     throw new Error(`Cannot list resources with invalid settings: ${detail}`);
   }
 
-  const messages: string[] = [];
+  const messages: string[] = warnings.map((warning) => `warning: ${warning}`);
 
   if (input.agent !== undefined && findResource(set, 'agent', input.agent) === undefined) {
     throw new Error(`Unknown agent '${input.agent}'. Run 'outfitter list agents' to see resolvable agents.`);

--- a/code/cli/src/cli/commands/PiRuntimeLaunch.ts
+++ b/code/cli/src/cli/commands/PiRuntimeLaunch.ts
@@ -2,10 +2,10 @@
 // the Outfitter + pi header, active-profile status, and "connect a model provider" sign-in prompt.
 // Non-interactive pi launches (--print, --export, --mode json|print|rpc, …) are left untouched so
 // scripted runs never prompt, and non-pi harnesses pass through unchanged.
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 
+import { findRepositoryCodeAsset } from '../../paths/RepositoryAssets.js';
 import type { AgentLaunchPlan } from '../../projection/Projection.js';
 
 const nonInteractivePiLaunchFlags = new Set(['--print', '-p', '--export', '--list-models']);
@@ -32,21 +32,9 @@ export const isNonInteractivePiLaunch = (args: readonly string[]): boolean =>
     return false;
   });
 
-// Resolves the runtime extension in either the repository layout (code/<asset>) or the packaged npm
-// layout (code/cli/code/<asset>), mirroring SetupCommand's asset resolver.
-const resolveRuntimeExtensionPath = (): string | undefined => {
-  const sourcePath = fileURLToPath(new URL(`../../../../${runtimeExtensionAsset}`, import.meta.url));
-  const packagePath = fileURLToPath(new URL(`../../../code/${runtimeExtensionAsset}`, import.meta.url));
-  /* v8 ignore else -- packaged layout is exercised by the npm package smoke test. */
-  if (existsSync(sourcePath)) return sourcePath;
-  /* v8 ignore next 2 -- packaged layout is covered by the package smoke test. */
-  if (existsSync(packagePath)) return packagePath;
-  return undefined;
-};
-
 /** Stamps per-run identity metadata into the runtime extension source. */
 export const createPiRuntimeExtensionContent = (input: Omit<PiRuntimeExtensionInput, 'rootDirectory'>): string => {
-  const extensionPath = resolveRuntimeExtensionPath();
+  const extensionPath = findRepositoryCodeAsset(runtimeExtensionAsset);
   /* v8 ignore next -- defensive: the runtime extension ships with the package, so it resolves in practice. */
   if (extensionPath === undefined) throw new Error('Outfitter runtime extension was not found.');
 

--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -144,6 +144,7 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
 
   let resolved = resolveEffectiveSet(input);
   assertNoSettingsIssues(resolved.settingsIssues);
+  emit(resolved.warnings.map((warning) => `warning: ${warning}`));
 
   // First run: nothing selected and no default configured — onboard, then resolve again.
   const setupMessages: string[] = [];

--- a/code/cli/src/cli/commands/SetupCommand.ts
+++ b/code/cli/src/cli/commands/SetupCommand.ts
@@ -3,14 +3,15 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { Command } from 'commander';
 
 import { launchThroughSpawn, spawnLauncher } from '../../agents/AgentLaunch.js';
+import { readRepositoryCodeAsset } from '../../paths/RepositoryAssets.js';
 import type { AgentLaunchPlan } from '../../projection/Projection.js';
 import type { Harness } from '../../settings/Settings.js';
 import { HARNESSES } from '../../settings/Settings.js';
+import { discoverSettingsLoadPlan, loadSettings } from '../../settings/SettingsLoader.js';
 import type { SetupAgentChoice, SetupResult, SetupSelection } from '../../setup/Setup.js';
 import { applySetupSelection, discoverSetupAgentChoices } from '../../setup/Setup.js';
 import { bootstrapDefaultCatalog } from '../../setup/DefaultCatalog.js';
@@ -23,7 +24,7 @@ export type SetupProcessLauncher = (plan: AgentLaunchPlan) => Promise<number>;
 export interface SetupCommandDependencies {
   readonly homeDirectory?: string;
   readonly projectDirectory?: string;
-  readonly defaultCatalogBootstrap?: (homeDirectory: string) => string;
+  readonly defaultCatalogBootstrap?: (homeDirectory: string, cacheDirectory?: string) => string;
   readonly setupSourceUri?: string;
   readonly interactive?: boolean;
   readonly launcher?: SetupProcessLauncher;
@@ -44,17 +45,6 @@ interface PreparePiSetupLaunchInput {
   readonly availableAgents: readonly SetupAgentChoice[];
   readonly setupSourceUri?: string;
 }
-
-const readRepositoryCodeAsset = (relativePath: string): string => {
-  const sourcePath = fileURLToPath(new URL(`../../../../${relativePath}`, import.meta.url));
-  const packagePath = fileURLToPath(new URL(`../../../code/${relativePath}`, import.meta.url));
-
-  /* v8 ignore else -- packaged layout is exercised by the npm package smoke test. */
-  if (existsSync(sourcePath)) return readFileSync(sourcePath, 'utf8');
-  /* v8 ignore next 3 -- packaged layout is covered by the package smoke test. */
-  if (existsSync(packagePath)) return readFileSync(packagePath, 'utf8');
-  throw new Error(`Outfitter support file '${relativePath}' was not found.`);
-};
 
 export const createPiSetupExtensionContent = (input: {
   readonly homeDirectory: string;
@@ -197,9 +187,13 @@ export const runSetup = async (dependencies: SetupCommandDependencies = {}): Pro
 
   const homeDirectory = resolveHomeDirectory(dependencies.homeDirectory);
   const projectDirectory = resolve(resolveProjectDirectory(dependencies.projectDirectory));
+  const localSettings = loadSettings(discoverSettingsLoadPlan({ homeDirectory, projectDirectory }));
+  const bootstrap =
+    dependencies.defaultCatalogBootstrap ??
+    ((home: string, cacheDirectory?: string) => bootstrapDefaultCatalog(home, cacheDirectory).root);
   const defaultCatalogRoot =
     dependencies.setupSourceUri === undefined
-      ? (dependencies.defaultCatalogBootstrap ?? ((home) => bootstrapDefaultCatalog(home).root))(homeDirectory)
+      ? bootstrap(homeDirectory, localSettings.settings.cacheDirectory)
       : undefined;
   const availableAgents = discoverSetupAgentChoices({ defaultCatalogRoot });
   const setupDirectory = mkdtempSync(join(tmpdir(), 'outfitter-setup-'));

--- a/code/cli/src/cli/commands/SyncCommand.ts
+++ b/code/cli/src/cli/commands/SyncCommand.ts
@@ -137,13 +137,12 @@ const syncPhase = <T extends RemoteSourceReference>(input: SyncPhaseInput<T>): S
         source,
         validate: (repositoryPath) => input.validate(repositoryPath, source),
       });
-      const warnings = result.validation ?? 0;
       return {
         kind: input.kind,
         uri,
         cachePath,
         status: result.status,
-        message: warnings === 0 ? undefined : `validated with ${warnings} warning(s)`,
+        message: result.warnings === 0 ? undefined : `validated with ${result.warnings} warning(s)`,
       };
     } catch (error) {
       return {

--- a/code/cli/src/cli/commands/SyncCommand.ts
+++ b/code/cli/src/cli/commands/SyncCommand.ts
@@ -1,0 +1,263 @@
+// Implements deterministic remote-settings-first source synchronization.
+import { existsSync } from 'node:fs';
+
+import { Command } from 'commander';
+
+import { remoteSourceLayer } from '../../resolver/Layer.js';
+import { resolveResources } from '../../resolver/Resolver.js';
+import { validateEffectiveSet } from '../../resolver/ResolverValidation.js';
+import {
+  createSettingsLoadPlan,
+  discoverSettingsLoadPlan,
+  formatSettingsIssue,
+  loadSettings,
+  loadSettingsFiles,
+  loadSettingsWithCachedRemoteSettings,
+  resolveRemoteSettingsPath,
+} from '../../settings/SettingsLoader.js';
+import type { SettingsLoadIssue } from '../../settings/SettingsLoader.js';
+import type { RemoteSettingsReference } from '../../settings/Settings.js';
+import { syncRemoteRepositoryAtomically } from '../../sources/GitRepository.js';
+import {
+  createEnterprisePrivateCatalogGate,
+  type GitHubRepositoryVisibilityClassifier,
+  type PrivateCatalogPrompt,
+  type PrivateCatalogSourceGate,
+} from '../../sources/PrivateCatalogGate.js';
+import {
+  createRemoteRepositoryCachePath,
+  formatRemoteSourceDisplay,
+  isRemoteSource,
+  redactEmbeddedSourceCredentials,
+} from '../../sources/SourceCache.js';
+import type { RemoteSourceReference } from '../../sources/SourceCache.js';
+import type { CommandObject } from './CommandObject.js';
+import { resolveHomeDirectory, resolveProjectDirectory } from './ProcessDefaults.js';
+
+export type SyncStatus = 'updated' | 'unchanged' | 'skipped' | 'failed';
+export type SyncSourceKind = 'remote_settings' | 'source';
+
+export interface SyncSourceResult {
+  readonly kind: SyncSourceKind;
+  readonly uri: string;
+  readonly cachePath: string;
+  readonly status: SyncStatus;
+  readonly message?: string;
+}
+
+export interface SyncCommandResult {
+  readonly exitCode: number;
+  readonly messages: readonly string[];
+  readonly results: readonly SyncSourceResult[];
+}
+
+export interface SyncCommandInput {
+  readonly homeDirectory: string;
+  readonly projectDirectory: string;
+}
+
+export interface SyncCommandDependencies {
+  readonly homeDirectory?: string;
+  readonly projectDirectory?: string;
+  readonly classifier?: GitHubRepositoryVisibilityClassifier;
+  readonly prompt?: PrivateCatalogPrompt;
+  readonly privateCatalogGate?: PrivateCatalogSourceGate;
+  readonly writeLine?: (message: string) => void;
+}
+
+interface SyncPhaseResult<T extends RemoteSourceReference> {
+  readonly allowedSources: readonly T[];
+  readonly messages: readonly string[];
+  readonly results: readonly SyncSourceResult[];
+}
+
+const formatSettingsIssues = (heading: string, issues: readonly SettingsLoadIssue[]): readonly string[] => [
+  heading,
+  ...issues.map((issue) => `failed: ${formatSettingsIssue(issue)}`),
+];
+
+const formatResult = (result: SyncSourceResult): string =>
+  `${result.status}: ${result.kind} ${result.uri} -> ${result.cachePath}${
+    result.message === undefined ? '' : ` (${result.message})`
+  }`;
+
+const formatCaughtError = (error: unknown): string => {
+  /* v8 ignore else -- repository synchronization throws Error instances. */
+  if (error instanceof Error) return error.message;
+  return String(error);
+};
+
+const validateRemoteSettingsCheckout = (repositoryPath: string, source: RemoteSettingsReference): number => {
+  const settingsPath = resolveRemoteSettingsPath(repositoryPath, source.path);
+  if (!existsSync(settingsPath)) {
+    throw new Error(`Remote settings file '${source.path}' was not found in the fetched repository.`);
+  }
+  const loaded = loadSettingsFiles(createSettingsLoadPlan([{ scope: 'remote', path: settingsPath }]));
+  if (loaded.issues.length > 0) {
+    throw new Error(`Fetched remote settings are invalid: ${loaded.issues.map(formatSettingsIssue).join('; ')}`);
+  }
+  return 0;
+};
+
+const validateSourceCheckout = (repositoryPath: string, source: RemoteSourceReference): number => {
+  const layer = remoteSourceLayer(repositoryPath, source);
+  if (!existsSync(layer.root)) {
+    throw new Error(`Configured source path '${source.path}' was not found in the fetched repository.`);
+  }
+
+  const findings = validateEffectiveSet(resolveResources([layer]));
+  const errors = findings.filter((finding) => finding.severity === 'error');
+  if (errors.length > 0) {
+    throw new Error(
+      `Fetched source is invalid: ${errors.map((finding) => `${finding.resource} ${finding.message}`).join('; ')}`,
+    );
+  }
+  return findings.length;
+};
+
+interface SyncPhaseInput<T extends RemoteSourceReference> {
+  readonly kind: SyncSourceKind;
+  readonly sources: readonly T[];
+  readonly homeDirectory: string;
+  readonly cacheDirectory?: string;
+  readonly gate: PrivateCatalogSourceGate;
+  readonly validate: (repositoryPath: string, source: T) => number;
+}
+
+/** Runs the private-catalog gate over one phase's sources, then fetches everything it allowed. */
+const syncPhase = <T extends RemoteSourceReference>(input: SyncPhaseInput<T>): SyncPhaseResult<T> => {
+  const gated = input.gate.filter(input.sources, input.cacheDirectory);
+  const synced = gated.allowedSources.map((source): SyncSourceResult => {
+    const cachePath = createRemoteRepositoryCachePath(input.homeDirectory, source, input.cacheDirectory);
+    const uri = formatRemoteSourceDisplay(source);
+
+    try {
+      const result = syncRemoteRepositoryAtomically({
+        cachePath,
+        source,
+        validate: (repositoryPath) => input.validate(repositoryPath, source),
+      });
+      const warnings = result.validation ?? 0;
+      return {
+        kind: input.kind,
+        uri,
+        cachePath,
+        status: result.status,
+        message: warnings === 0 ? undefined : `validated with ${warnings} warning(s)`,
+      };
+    } catch (error) {
+      return {
+        kind: input.kind,
+        uri,
+        cachePath,
+        status: 'failed',
+        message: redactEmbeddedSourceCredentials(formatCaughtError(error)),
+      };
+    }
+  });
+
+  return {
+    allowedSources: gated.allowedSources,
+    messages: gated.messages,
+    results: [...gated.skippedResults.map((result) => ({ ...result, kind: input.kind })), ...synced],
+  };
+};
+
+const finishSync = (
+  mergedIssues: readonly SettingsLoadIssue[],
+  remoteSettingsPhase: SyncPhaseResult<RemoteSettingsReference>,
+  sourcePhase: SyncPhaseResult<RemoteSourceReference>,
+): SyncCommandResult => {
+  const results = [...remoteSettingsPhase.results, ...sourcePhase.results];
+  const settingsMessages =
+    mergedIssues.length === 0
+      ? []
+      : formatSettingsIssues('Merged settings contain errors after remote-settings synchronization.', mergedIssues);
+  const messages = [
+    ...remoteSettingsPhase.messages,
+    ...remoteSettingsPhase.results.map(formatResult),
+    ...settingsMessages,
+    ...sourcePhase.messages,
+    ...sourcePhase.results.map(formatResult),
+  ];
+
+  if (results.length === 0 && mergedIssues.length === 0) {
+    messages.push('No remote sources are configured.');
+  }
+
+  return {
+    exitCode: mergedIssues.length > 0 || results.some((result) => result.status === 'failed') ? 1 : 0,
+    messages,
+    results,
+  };
+};
+
+/** Validates local settings, syncs remote settings, reloads, then syncs resulting remote sources. */
+export const executeSyncCommand = (
+  input: SyncCommandInput,
+  dependencies: Pick<SyncCommandDependencies, 'classifier' | 'prompt' | 'privateCatalogGate'> = {},
+): SyncCommandResult => {
+  const local = loadSettings(discoverSettingsLoadPlan(input));
+  if (local.issues.length > 0) {
+    return {
+      exitCode: 1,
+      messages: formatSettingsIssues('Local settings are invalid; no sources were synchronized.', local.issues),
+      results: [],
+    };
+  }
+
+  const gate =
+    dependencies.privateCatalogGate ??
+    createEnterprisePrivateCatalogGate({
+      homeDirectory: input.homeDirectory,
+      classifier: dependencies.classifier,
+      prompt: dependencies.prompt,
+    });
+  const remoteSettingsPhase = syncPhase({
+    kind: 'remote_settings',
+    sources: local.settings.remoteSettings!,
+    homeDirectory: input.homeDirectory,
+    cacheDirectory: local.settings.cacheDirectory,
+    gate,
+    validate: validateRemoteSettingsCheckout,
+  });
+  const merged = loadSettingsWithCachedRemoteSettings(input, {
+    remoteSettingsReferences: remoteSettingsPhase.allowedSources,
+    localSettings: local,
+  });
+  const sourcePhase = syncPhase({
+    kind: 'source',
+    sources: merged.settings.sources!.filter(isRemoteSource),
+    homeDirectory: input.homeDirectory,
+    cacheDirectory: merged.settings.cacheDirectory,
+    gate,
+    validate: validateSourceCheckout,
+  });
+  return finishSync(merged.issues, remoteSettingsPhase, sourcePhase);
+};
+
+export const createSyncCommand = (dependencies: SyncCommandDependencies = {}): CommandObject => ({
+  name: 'sync',
+  description: 'Synchronize configured remote settings and sources into the local cache.',
+  register(program: Command): void {
+    program.addCommand(
+      new Command('sync')
+        .description('Synchronize configured remote settings and sources into the local cache.')
+        .action(() => {
+          const result = executeSyncCommand(
+            {
+              homeDirectory: resolveHomeDirectory(dependencies.homeDirectory),
+              projectDirectory: resolveProjectDirectory(dependencies.projectDirectory),
+            },
+            dependencies,
+          );
+          for (const message of result.messages) {
+            /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
+            (dependencies.writeLine ?? console.log)(message);
+          }
+          /* v8 ignore next -- process exit wiring is covered by CLI smoke behavior. */
+          if (result.exitCode !== 0) process.exitCode = result.exitCode;
+        }),
+    );
+  },
+});

--- a/code/cli/src/cli/commands/ValidateCommand.ts
+++ b/code/cli/src/cli/commands/ValidateCommand.ts
@@ -5,6 +5,7 @@ import { Command } from 'commander';
 import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
 import type { ValidationFinding } from '../../resolver/ResolverValidation.js';
 import { validateEffectiveSet } from '../../resolver/ResolverValidation.js';
+import { formatSettingsIssue } from '../../settings/SettingsLoader.js';
 import type { CommandObject } from './CommandObject.js';
 import { resolveHomeDirectory, resolveProjectDirectory } from './ProcessDefaults.js';
 
@@ -32,10 +33,7 @@ const settingsFindings = (messages: readonly string[]): readonly ValidationFindi
 
 export const executeValidateCommand = (input: ValidateInput): ValidateResult => {
   const { set, settingsIssues } = resolveEffectiveSet(input);
-  const findings = [
-    ...settingsFindings(settingsIssues.map((issue) => `${issue.filePath}#${issue.path} ${issue.message}`)),
-    ...validateEffectiveSet(set),
-  ];
+  const findings = [...settingsFindings(settingsIssues.map(formatSettingsIssue)), ...validateEffectiveSet(set)];
 
   const hasErrors = findings.some((finding) => finding.severity === 'error');
   const hasWarnings = findings.some((finding) => finding.severity === 'warning');

--- a/code/cli/src/cli/commands/ValidateCommand.ts
+++ b/code/cli/src/cli/commands/ValidateCommand.ts
@@ -32,8 +32,12 @@ const settingsFindings = (messages: readonly string[]): readonly ValidationFindi
   messages.map((message) => ({ severity: 'error' as const, resource: 'settings', message }));
 
 export const executeValidateCommand = (input: ValidateInput): ValidateResult => {
-  const { set, settingsIssues } = resolveEffectiveSet(input);
-  const findings = [...settingsFindings(settingsIssues.map(formatSettingsIssue)), ...validateEffectiveSet(set)];
+  const { set, settingsIssues, warnings } = resolveEffectiveSet(input);
+  const findings = [
+    ...settingsFindings(settingsIssues.map(formatSettingsIssue)),
+    ...warnings.map((message) => ({ severity: 'warning' as const, resource: 'settings', message })),
+    ...validateEffectiveSet(set),
+  ];
 
   const hasErrors = findings.some((finding) => finding.severity === 'error');
   const hasWarnings = findings.some((finding) => finding.severity === 'warning');

--- a/code/cli/src/paths/RepositoryAssets.ts
+++ b/code/cli/src/paths/RepositoryAssets.ts
@@ -1,0 +1,27 @@
+// Resolves support files shipped from the repository's `code/` tree. They live at `code/<asset>` in
+// the repository layout and at `code/cli/code/<asset>` in the packaged npm layout; both relative
+// depths are encoded here only, so a packaging change is a one-file edit.
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/** Resolves a `code/`-relative asset path, or undefined when neither layout provides it. */
+export const findRepositoryCodeAsset = (relativePath: string): string | undefined => {
+  const sourcePath = fileURLToPath(new URL(`../../../${relativePath}`, import.meta.url));
+  const packagePath = fileURLToPath(new URL(`../../code/${relativePath}`, import.meta.url));
+
+  /* v8 ignore else -- packaged layout is exercised by the npm package smoke test. */
+  if (existsSync(sourcePath)) return sourcePath;
+  /* v8 ignore next 3 -- packaged layout is covered by the package smoke test. */
+  if (existsSync(packagePath)) return packagePath;
+  return undefined;
+};
+
+export const resolveRepositoryCodeAsset = (relativePath: string): string => {
+  const path = findRepositoryCodeAsset(relativePath);
+  /* v8 ignore next -- support files ship with the package, so they always resolve in practice. */
+  if (path === undefined) throw new Error(`Outfitter support file '${relativePath}' was not found.`);
+  return path;
+};
+
+export const readRepositoryCodeAsset = (relativePath: string): string =>
+  readFileSync(resolveRepositoryCodeAsset(relativePath), 'utf8');

--- a/code/cli/src/resolver/Layer.ts
+++ b/code/cli/src/resolver/Layer.ts
@@ -2,7 +2,13 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { encodeRemoteSource, resolveRemoteRepositorySubpath } from '../sources/SourceCache.js';
+import {
+  createRemoteRepositoryCachePath,
+  formatRemoteSourceDisplay,
+  isRemoteSource,
+  resolveRemoteRepositorySubpath,
+} from '../sources/SourceCache.js';
+import type { RemoteSourceReference } from '../sources/SourceCache.js';
 import type { Settings, SourceReference } from '../settings/Settings.js';
 import type { Layer } from './Resource.js';
 
@@ -14,21 +20,33 @@ export interface LayerDiscoveryInput {
 
 const agentsRoot = (directory: string): string => join(directory, '.agents');
 
-// Remote sources cache under the configured cache_directory, defaulting to ~/.agents/cache.
-const cacheRoot = (input: LayerDiscoveryInput): string =>
-  input.settings.cacheDirectory ?? join(input.homeDirectory, '.agents', 'cache');
+/**
+ * Maps an already-materialized repository checkout to the layer `outfitter run` would resolve from
+ * it. `outfitter sync` reuses this against its temporary checkout so both agree on the payload root.
+ */
+export const remoteSourceLayer = (repositoryPath: string, source: RemoteSourceReference): Layer => ({
+  root: source.path === undefined ? repositoryPath : resolveRemoteRepositorySubpath(repositoryPath, source.path),
+  origin: 'source',
+  label: formatRemoteSourceDisplay(source),
+});
 
 const sourceLayer = (input: LayerDiscoveryInput, source: SourceReference): Layer => {
-  if (source.path !== undefined && source.uri === undefined && source.github === undefined) {
+  if (!isRemoteSource(source)) {
     return { root: source.path, origin: 'source', label: source.path };
   }
 
-  const remote = source as { readonly uri?: string; readonly github?: string; readonly ref?: string };
-  const repositoryPath = join(cacheRoot(input), 'repos', encodeRemoteSource(remote as never));
-  const root = source.path === undefined ? repositoryPath : resolveRemoteRepositorySubpath(repositoryPath, source.path);
-  const label = remote.uri ?? `github:${remote.github}`;
+  const layer = remoteSourceLayer(
+    createRemoteRepositoryCachePath(input.homeDirectory, source, input.settings.cacheDirectory),
+    source,
+  );
 
-  return { root, origin: 'source', label };
+  if (!existsSync(layer.root)) {
+    throw new Error(
+      `Configured remote source '${layer.label}' is not synchronized at '${layer.root}'. Run 'outfitter sync' to fetch it.`,
+    );
+  }
+
+  return layer;
 };
 
 /**

--- a/code/cli/src/resolver/Layer.ts
+++ b/code/cli/src/resolver/Layer.ts
@@ -30,35 +30,46 @@ export const remoteSourceLayer = (repositoryPath: string, source: RemoteSourceRe
   label: formatRemoteSourceDisplay(source),
 });
 
-const sourceLayer = (input: LayerDiscoveryInput, source: SourceReference): Layer => {
-  if (!isRemoteSource(source)) {
-    return { root: source.path, origin: 'source', label: source.path };
-  }
+const sourceLayer = (input: LayerDiscoveryInput, source: SourceReference): Layer =>
+  isRemoteSource(source)
+    ? remoteSourceLayer(
+        createRemoteRepositoryCachePath(input.homeDirectory, source, input.settings.cacheDirectory),
+        source,
+      )
+    : { root: source.path, origin: 'source', label: source.path };
 
-  const layer = remoteSourceLayer(
-    createRemoteRepositoryCachePath(input.homeDirectory, source, input.settings.cacheDirectory),
-    source,
-  );
-
-  if (!existsSync(layer.root)) {
-    throw new Error(
-      `Configured remote source '${layer.label}' is not synchronized at '${layer.root}'. Run 'outfitter sync' to fetch it.`,
-    );
-  }
-
-  return layer;
-};
+export interface LayerDiscoveryResult {
+  readonly layers: readonly Layer[];
+  /**
+   * Configured remote sources whose cache is absent, reported with `outfitter sync` guidance rather
+   * than silently dropped (OFTR-004.2.18). Reported, never fatal: a private catalog the enterprise
+   * gate skips is never cached, so `outfitter sync` skips it again and exits 0 — aborting here
+   * would deadlock every other command behind advice the user cannot act on (OFTR-004.2.15).
+   */
+  readonly unsynchronized: readonly string[];
+}
 
 /**
  * Orders layers highest precedence first: workspace `.agents`, then global `~/.agents`,
  * then configured sources in order. Only layers whose root exists on disk are included.
  */
-export const discoverLayers = (input: LayerDiscoveryInput): readonly Layer[] => {
+export const discoverLayers = (input: LayerDiscoveryInput): LayerDiscoveryResult => {
   const candidates: Layer[] = [
     { root: agentsRoot(input.projectDirectory), origin: 'workspace', label: 'workspace' },
     { root: agentsRoot(input.homeDirectory), origin: 'global', label: 'global' },
-    ...(input.settings.sources ?? []).map((source) => sourceLayer(input, source)),
   ];
+  const unsynchronized: string[] = [];
 
-  return candidates.filter((layer) => existsSync(layer.root));
+  for (const source of input.settings.sources ?? []) {
+    const layer = sourceLayer(input, source);
+    if (isRemoteSource(source) && !existsSync(layer.root)) {
+      unsynchronized.push(
+        `Configured remote source '${layer.label}' is not synchronized at '${layer.root}'. Run 'outfitter sync' to fetch it.`,
+      );
+      continue;
+    }
+    candidates.push(layer);
+  }
+
+  return { layers: candidates.filter((layer) => existsSync(layer.root)), unsynchronized };
 };

--- a/code/cli/src/resolver/ResolverContext.ts
+++ b/code/cli/src/resolver/ResolverContext.ts
@@ -16,12 +16,19 @@ export interface ResolveResult {
   /** The merged settings loaded during resolution, so callers need not reload them. */
   readonly settings: Settings;
   readonly settingsIssues: readonly SettingsLoadIssue[];
+  /** Non-fatal `outfitter sync` guidance for configured remote sources with no cache. */
+  readonly warnings: readonly string[];
 }
 
 /** The single shared resolution path used by list, validate, run, and dump. */
 export const resolveEffectiveSet = (input: ResolveInput): ResolveResult => {
   const loadedSettings = loadSettingsWithCachedRemoteSettings(input);
-  const layers = discoverLayers({ ...input, settings: loadedSettings.settings });
+  const discovered = discoverLayers({ ...input, settings: loadedSettings.settings });
 
-  return { set: resolveResources(layers), settings: loadedSettings.settings, settingsIssues: loadedSettings.issues };
+  return {
+    set: resolveResources(discovered.layers),
+    settings: loadedSettings.settings,
+    settingsIssues: loadedSettings.issues,
+    warnings: discovered.unsynchronized,
+  };
 };

--- a/code/cli/src/settings/SettingsLoader.ts
+++ b/code/cli/src/settings/SettingsLoader.ts
@@ -85,6 +85,10 @@ export const createSettingsLoadPlan = (locations: readonly SettingsLocation[]): 
   locations,
 });
 
+/** The one rendering of a settings issue every command reports. */
+export const formatSettingsIssue = (issue: SettingsLoadIssue): string =>
+  `${issue.filePath}#${issue.path} ${issue.message}`;
+
 const agentsSettings = (directory: string, ...rest: string[]): string => join(directory, '.agents', ...rest);
 
 // Ordered lowest-to-highest precedence so later files fold over earlier ones during merge.
@@ -99,13 +103,22 @@ export const discoverSettingsLoadPlan = (input: SettingsDiscoveryInput): Setting
 export const discoverRemoteSettingsLoadPlan = (
   homeDirectory: string,
   remoteSettings: readonly RemoteSettingsReference[],
-): SettingsLoadPlan => discoverRemoteSettingsLocations(homeDirectory, remoteSettings).plan;
+  cacheDirectory?: string,
+): SettingsLoadPlan => discoverRemoteSettingsLocations(homeDirectory, remoteSettings, cacheDirectory).plan;
 
-export const resolveCachedRemoteSettingsPath = (homeDirectory: string, source: RemoteSettingsReference): string => {
-  const repositoryPath = createRemoteRepositoryCachePath(homeDirectory, source);
-  const configuredPath = resolveRemoteRepositorySubpath(repositoryPath, source.path);
+export const resolveCachedRemoteSettingsPath = (
+  homeDirectory: string,
+  source: RemoteSettingsReference,
+  cacheDirectory?: string,
+): string => {
+  const repositoryPath = createRemoteRepositoryCachePath(homeDirectory, source, cacheDirectory);
+  return resolveRemoteSettingsPath(repositoryPath, source.path);
+};
 
-  if (existsSync(configuredPath) || source.path !== 'settings.yml') {
+export const resolveRemoteSettingsPath = (repositoryPath: string, path: string): string => {
+  const configuredPath = resolveRemoteRepositorySubpath(repositoryPath, path);
+
+  if (existsSync(configuredPath) || path !== 'settings.yml') {
     return configuredPath;
   }
 
@@ -135,19 +148,30 @@ export const loadSettings = (plan: SettingsLoadPlan): LoadedSettings => {
   };
 };
 
+export interface CachedRemoteSettingsOptions {
+  /** Remote settings to fold in instead of the ones the local settings declare. */
+  readonly remoteSettingsReferences?: readonly RemoteSettingsReference[];
+  /** An already-loaded local stack, so callers that just read it do not parse every file twice. */
+  readonly localSettings?: LoadedSettings;
+}
+
 export const loadSettingsWithCachedRemoteSettings = (
   input: SettingsDiscoveryInput,
-  remoteSettingsReferencesOverride?: readonly RemoteSettingsReference[],
+  options: CachedRemoteSettingsOptions = {},
 ): LoadedSettings => {
-  const localSettings = loadSettings(discoverSettingsLoadPlan(input));
+  const localSettings = options.localSettings ?? loadSettings(discoverSettingsLoadPlan(input));
 
-  const remoteSettingsReferences = remoteSettingsReferencesOverride ?? localSettings.settings.remoteSettings!;
+  const remoteSettingsReferences = options.remoteSettingsReferences ?? localSettings.settings.remoteSettings!;
 
   if (localSettings.issues.length > 0 || remoteSettingsReferences.length === 0) {
     return localSettings;
   }
 
-  const remoteSettingsLocations = discoverRemoteSettingsLocations(input.homeDirectory, remoteSettingsReferences);
+  const remoteSettingsLocations = discoverRemoteSettingsLocations(
+    input.homeDirectory,
+    remoteSettingsReferences,
+    localSettings.settings.cacheDirectory,
+  );
   const remoteSettings = loadSettings(remoteSettingsLocations.plan);
   const files = [...remoteSettings.files, ...localSettings.files];
   const issues = [...remoteSettingsLocations.issues, ...remoteSettings.issues, ...localSettings.issues];
@@ -162,15 +186,25 @@ export const loadSettingsWithCachedRemoteSettings = (
 const discoverRemoteSettingsLocations = (
   homeDirectory: string,
   remoteSettings: readonly RemoteSettingsReference[],
+  cacheDirectory?: string,
 ): SettingsLocationDiscoveryResult => {
   const locations: SettingsLocation[] = [];
   const issues: SettingsLoadIssue[] = [];
 
   for (const [index, source] of remoteSettings.entries()) {
     try {
+      const path = resolveCachedRemoteSettingsPath(homeDirectory, source, cacheDirectory);
+      if (!existsSync(path)) {
+        issues.push({
+          filePath: `remote_settings[${index}]`,
+          path: `/remote_settings/${index}`,
+          message: `Cached remote settings '${path}' are missing. Run 'outfitter sync' to fetch configured remote settings.`,
+        });
+        continue;
+      }
       locations.push({
         scope: 'remote',
-        path: resolveCachedRemoteSettingsPath(homeDirectory, source),
+        path,
       });
     } catch (error) {
       issues.push({

--- a/code/cli/src/setup/DefaultCatalog.ts
+++ b/code/cli/src/setup/DefaultCatalog.ts
@@ -1,9 +1,9 @@
 // Bootstraps the one canonical default catalog at the immutable revision shipped by Outfitter.
-import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, renameSync, rmSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 
-import { createRemoteRepositoryCachePath, normalizeGitUri, normalizeRemoteSourceUri } from '../sources/SourceCache.js';
+import { runGit, syncRemoteRepositoryAtomically, tryReadCleanHead } from '../sources/GitRepository.js';
+import { createRemoteRepositoryCachePath, redactEmbeddedSourceCredentials } from '../sources/SourceCache.js';
 import type { RemoteSourceReference } from '../sources/SourceCache.js';
 
 export const defaultCatalogSource = {
@@ -15,6 +15,7 @@ export const defaultCatalogSource = {
 
 export interface PinnedCatalogBootstrapInput {
   readonly homeDirectory: string;
+  readonly cacheDirectory?: string;
   readonly source: RemoteSourceReference & { readonly ref: string };
 }
 
@@ -22,17 +23,6 @@ export interface PinnedCatalogBootstrapResult {
   readonly root: string;
   readonly source: RemoteSourceReference & { readonly ref: string };
 }
-
-const runGit = (arguments_: readonly string[]): string => {
-  try {
-    return execFileSync('git', [...arguments_], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    }).trim();
-  } catch (error) {
-    throw new Error(`git ${arguments_.join(' ')} failed: ${String(error)}`, { cause: error });
-  }
-};
 
 const fullCommitPattern = /^[a-f0-9]{40}$/u;
 const versionTagPattern = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u;
@@ -49,10 +39,7 @@ const resolveExpectedCommit = (root: string, ref: string): string =>
 const isPinnedCatalogCheckout = (root: string, ref: string): boolean => {
   if (!existsSync(join(root, 'agents'))) return false;
   try {
-    return (
-      runGit(['-C', root, 'rev-parse', 'HEAD']) === resolveExpectedCommit(root, ref) &&
-      runGit(['-C', root, 'status', '--porcelain']) === ''
-    );
+    return tryReadCleanHead(root) === resolveExpectedCommit(root, ref);
   } catch {
     return false;
   }
@@ -61,48 +48,35 @@ const isPinnedCatalogCheckout = (root: string, ref: string): boolean => {
 /** Fetches one immutable catalog revision into the same cache path used by normal source resolution. */
 export const bootstrapPinnedCatalog = (input: PinnedCatalogBootstrapInput): PinnedCatalogBootstrapResult => {
   assertImmutableRef(input.source.ref);
-  const root = createRemoteRepositoryCachePath(input.homeDirectory, input.source);
+  const root = createRemoteRepositoryCachePath(input.homeDirectory, input.source, input.cacheDirectory);
   if (isPinnedCatalogCheckout(root, input.source.ref)) return { root, source: input.source };
 
-  mkdirSync(dirname(root), { recursive: true });
-  const nonce = `${process.pid}-${Math.random().toString(16).slice(2)}`;
-  const temporaryRoot = `${root}.outfitter-${nonce}.tmp`;
-  const staleRoot = `${root}.outfitter-${nonce}.stale`;
-  const remote = normalizeGitUri(normalizeRemoteSourceUri(input.source));
-  let movedStaleCache = false;
-
   try {
-    runGit(['init', '--quiet', temporaryRoot]);
-    runGit(['-C', temporaryRoot, 'remote', 'add', 'origin', remote]);
-    const fetchRef = fullCommitPattern.test(input.source.ref)
-      ? input.source.ref
-      : `refs/tags/${input.source.ref}:refs/tags/${input.source.ref}`;
-    runGit(['-C', temporaryRoot, 'fetch', '--quiet', '--depth=1', 'origin', fetchRef]);
-    runGit(['-C', temporaryRoot, 'checkout', '--quiet', '--detach', 'FETCH_HEAD']);
-
-    if (!isPinnedCatalogCheckout(temporaryRoot, input.source.ref)) {
-      throw new Error(`Fetched default catalog did not resolve to ${input.source.ref}.`);
-    }
-
-    if (existsSync(root)) {
-      renameSync(root, staleRoot);
-      movedStaleCache = true;
-    }
-    renameSync(temporaryRoot, root);
-    if (movedStaleCache) rmSync(staleRoot, { recursive: true, force: true });
+    syncRemoteRepositoryAtomically({
+      cachePath: root,
+      fetchRef: versionTagPattern.test(input.source.ref)
+        ? `refs/tags/${input.source.ref}:refs/tags/${input.source.ref}`
+        : input.source.ref,
+      source: input.source,
+      // A fresh checkout is clean by construction, so only the payload and the commit it resolved
+      // to need verifying — no second status/rev-parse pass over the temporary tree.
+      validate: (temporaryRoot, commit) => {
+        if (
+          !existsSync(join(temporaryRoot, 'agents')) ||
+          commit !== resolveExpectedCommit(temporaryRoot, input.source.ref)
+        ) {
+          throw new Error(`Fetched default catalog did not resolve to ${input.source.ref}.`);
+        }
+      },
+    });
     return { root, source: input.source };
   } catch (error) {
-    /* v8 ignore next -- only an OS-level failure during the atomic cache rename requires restoration. */
-    if (movedStaleCache && !existsSync(root) && existsSync(staleRoot)) renameSync(staleRoot, root);
-    const detail = String(error);
+    const detail = redactEmbeddedSourceCredentials(String(error));
     throw new Error(`Could not fetch the default Outfitter catalog at pinned revision ${input.source.ref}. ${detail}`, {
       cause: error,
     });
-  } finally {
-    rmSync(temporaryRoot, { recursive: true, force: true });
-    rmSync(staleRoot, { recursive: true, force: true });
   }
 };
 
-export const bootstrapDefaultCatalog = (homeDirectory: string): PinnedCatalogBootstrapResult =>
-  bootstrapPinnedCatalog({ homeDirectory, source: defaultCatalogSource });
+export const bootstrapDefaultCatalog = (homeDirectory: string, cacheDirectory?: string): PinnedCatalogBootstrapResult =>
+  bootstrapPinnedCatalog({ homeDirectory, cacheDirectory, source: defaultCatalogSource });

--- a/code/cli/src/setup/DefaultCatalog.ts
+++ b/code/cli/src/setup/DefaultCatalog.ts
@@ -58,15 +58,15 @@ export const bootstrapPinnedCatalog = (input: PinnedCatalogBootstrapInput): Pinn
         ? `refs/tags/${input.source.ref}:refs/tags/${input.source.ref}`
         : input.source.ref,
       source: input.source,
-      // A fresh checkout is clean by construction, so only the payload and the commit it resolved
-      // to need verifying — no second status/rev-parse pass over the temporary tree.
-      validate: (temporaryRoot, commit) => {
-        if (
-          !existsSync(join(temporaryRoot, 'agents')) ||
-          commit !== resolveExpectedCommit(temporaryRoot, input.source.ref)
-        ) {
+      // Validated with the same predicate the read path uses. A fresh checkout is not clean by
+      // construction — autocrlf, an LFS smudge, or a fileMode difference can leave it dirty — and
+      // accepting a dirty tree here would cache one that `tryReadCleanHead` rejects on every
+      // subsequent read, re-fetching forever.
+      validate: (temporaryRoot) => {
+        if (!isPinnedCatalogCheckout(temporaryRoot, input.source.ref)) {
           throw new Error(`Fetched default catalog did not resolve to ${input.source.ref}.`);
         }
+        return 0;
       },
     });
     return { root, source: input.source };

--- a/code/cli/src/sources/GitRepository.ts
+++ b/code/cli/src/sources/GitRepository.ts
@@ -1,0 +1,105 @@
+// Atomically fetches Git repositories while preserving the last known-good cache on failure.
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, renameSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { normalizeGitUri, normalizeRemoteSourceUri, redactEmbeddedSourceCredentials } from './SourceCache.js';
+import type { RemoteSourceReference } from './SourceCache.js';
+
+export interface AtomicRepositorySyncInput<T> {
+  readonly cachePath: string;
+  /** Optional fetch refspec used when verification needs a local ref (for example an immutable tag). */
+  readonly fetchRef?: string;
+  readonly source: RemoteSourceReference;
+  /** Inspects the fetched checkout before it is swapped in; throwing rejects the fetch. */
+  readonly validate?: (repositoryPath: string, commit: string) => T;
+}
+
+export interface AtomicRepositorySyncResult<T> {
+  readonly commit: string;
+  readonly status: 'updated' | 'unchanged';
+  readonly validation: T | undefined;
+}
+
+/** Runs one git invocation, raising captured stderr as a credential-redacted Error. */
+export const runGit = (arguments_: readonly string[]): string => {
+  const result = spawnSync('git', [...arguments_], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  if (result.error === undefined && result.status === 0) {
+    return result.stdout.trim();
+  }
+
+  const detail = [result.error?.message, result.stderr, result.stdout]
+    .filter((value): value is string => value !== undefined && value.trim() !== '')
+    .join('\n');
+  const command = `git ${arguments_.join(' ')}`;
+  let suffix = `: ${detail.trim()}`;
+  /* v8 ignore else -- spawn failures always provide an Error or captured process output. */
+  if (detail === '') suffix = '';
+  throw new Error(redactEmbeddedSourceCredentials(`${command} failed${suffix}`));
+};
+
+/** Reads the HEAD commit of a checkout, or undefined when it is missing, dirty, or unreadable. */
+export const tryReadCleanHead = (root: string): string | undefined => {
+  if (!existsSync(join(root, '.git'))) return undefined;
+
+  try {
+    if (runGit(['-C', root, 'status', '--porcelain']) !== '') return undefined;
+    return runGit(['-C', root, 'rev-parse', 'HEAD']);
+  } catch {
+    return undefined;
+  }
+};
+
+const fetchSource = (temporaryRoot: string, source: RemoteSourceReference, fetchRef?: string): string => {
+  const remote = normalizeGitUri(normalizeRemoteSourceUri(source));
+  const ref = fetchRef ?? source.ref;
+  runGit(['init', '--quiet', temporaryRoot]);
+  runGit(['-C', temporaryRoot, 'remote', 'add', 'origin', remote]);
+  runGit(['-C', temporaryRoot, 'fetch', '--quiet', '--depth=1', 'origin', ...(ref === undefined ? [] : [ref])]);
+  runGit(['-C', temporaryRoot, 'checkout', '--quiet', '--detach', 'FETCH_HEAD']);
+  return runGit(['-C', temporaryRoot, 'rev-parse', 'HEAD']);
+};
+
+/**
+ * Fetches into a temporary sibling and swaps only a validated checkout into place. A failed fetch,
+ * checkout, validation, or rename leaves an existing cache intact.
+ */
+export const syncRemoteRepositoryAtomically = <T = void>(
+  input: AtomicRepositorySyncInput<T>,
+): AtomicRepositorySyncResult<T> => {
+  mkdirSync(dirname(input.cachePath), { recursive: true });
+  const nonce = `${process.pid}-${Math.random().toString(16).slice(2)}`;
+  const temporaryRoot = `${input.cachePath}.outfitter-${nonce}.tmp`;
+  const staleRoot = `${input.cachePath}.outfitter-${nonce}.stale`;
+  let movedStaleCache = false;
+
+  try {
+    const commit = fetchSource(temporaryRoot, input.source, input.fetchRef);
+    const validation = input.validate?.(temporaryRoot, commit);
+
+    if (tryReadCleanHead(input.cachePath) === commit) {
+      return { commit, status: 'unchanged', validation };
+    }
+
+    if (existsSync(input.cachePath)) {
+      renameSync(input.cachePath, staleRoot);
+      movedStaleCache = true;
+    }
+    renameSync(temporaryRoot, input.cachePath);
+    if (movedStaleCache) rmSync(staleRoot, { recursive: true, force: true });
+    return { commit, status: 'updated', validation };
+  } catch (error) {
+    /* v8 ignore next -- only an OS-level failure during the atomic rename needs restoration. */
+    if (movedStaleCache && !existsSync(input.cachePath) && existsSync(staleRoot)) {
+      renameSync(staleRoot, input.cachePath);
+    }
+    throw error;
+  } finally {
+    rmSync(temporaryRoot, { recursive: true, force: true });
+    rmSync(staleRoot, { recursive: true, force: true });
+  }
+};

--- a/code/cli/src/sources/GitRepository.ts
+++ b/code/cli/src/sources/GitRepository.ts
@@ -6,26 +6,66 @@ import { dirname, join } from 'node:path';
 import { normalizeGitUri, normalizeRemoteSourceUri, redactEmbeddedSourceCredentials } from './SourceCache.js';
 import type { RemoteSourceReference } from './SourceCache.js';
 
-export interface AtomicRepositorySyncInput<T> {
+export interface AtomicRepositorySyncInput {
   readonly cachePath: string;
   /** Optional fetch refspec used when verification needs a local ref (for example an immutable tag). */
   readonly fetchRef?: string;
   readonly source: RemoteSourceReference;
-  /** Inspects the fetched checkout before it is swapped in; throwing rejects the fetch. */
-  readonly validate?: (repositoryPath: string, commit: string) => T;
+  /**
+   * Inspects the fetched checkout before it is swapped in; throwing rejects the fetch. Returns the
+   * number of non-fatal warnings the checkout produced.
+   */
+  readonly validate?: (repositoryPath: string, commit: string) => number;
 }
 
-export interface AtomicRepositorySyncResult<T> {
+export interface AtomicRepositorySyncResult {
   readonly commit: string;
   readonly status: 'updated' | 'unchanged';
-  readonly validation: T | undefined;
+  readonly warnings: number;
 }
+
+// Repository-context variables must never leak in: with GIT_DIR/GIT_WORK_TREE exported (a git hook,
+// `rebase --exec`, `bisect run`), `git -C <temporaryRoot> …` would operate on the *outer*
+// repository, adding remotes to it and detaching its HEAD. Transport variables are left alone so a
+// user's custom GIT_SSH_COMMAND still applies.
+const repositoryContextVariables = new Set([
+  'GIT_DIR',
+  'GIT_WORK_TREE',
+  'GIT_INDEX_FILE',
+  'GIT_OBJECT_DIRECTORY',
+  'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+  'GIT_COMMON_DIR',
+  'GIT_NAMESPACE',
+  'GIT_CEILING_DIRECTORIES',
+]);
+
+const gitEnvironment = (): NodeJS.ProcessEnv => {
+  const environment: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (!repositoryContextVariables.has(key)) environment[key] = value;
+  }
+
+  // Git reads interactive credential prompts from /dev/tty, so piping stdio does not suppress them:
+  // an auth-required or unknown-host remote would hang the CLI forever without these.
+  environment.GIT_TERMINAL_PROMPT = '0';
+  environment.GIT_SSH_COMMAND = process.env.GIT_SSH_COMMAND ?? 'ssh -o BatchMode=yes';
+  return environment;
+};
+
+/** Guards against a `ref` that git would parse as an option (`--upload-pack=…` is code execution). */
+export const assertFetchableRef = (ref: string): void => {
+  if (!/^[A-Za-z0-9_.][A-Za-z0-9_./-]*$/u.test(ref) || ref.includes('..')) {
+    throw new Error(`Source ref '${ref}' is not a valid git ref.`);
+  }
+};
 
 /** Runs one git invocation, raising captured stderr as a credential-redacted Error. */
 export const runGit = (arguments_: readonly string[]): string => {
   const result = spawnSync('git', [...arguments_], {
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
+    env: gitEnvironment(),
+    timeout: 300_000,
   });
 
   if (result.error === undefined && result.status === 0) {
@@ -57,9 +97,18 @@ export const tryReadCleanHead = (root: string): string | undefined => {
 const fetchSource = (temporaryRoot: string, source: RemoteSourceReference, fetchRef?: string): string => {
   const remote = normalizeGitUri(normalizeRemoteSourceUri(source));
   const ref = fetchRef ?? source.ref;
+  // Both the remote and the ref are positional arguments to `git fetch`; either one starting with
+  // `-` is parsed as an option, and `--upload-pack=<cmd>` is arbitrary command execution.
+  if (remote.startsWith('-')) throw new Error(`Source URI '${remote}' must not begin with '-'.`);
+  // A refspec (`refs/tags/x:refs/tags/x`) is two refs; validate each side.
+  if (ref !== undefined) for (const part of ref.split(':')) assertFetchableRef(part);
+
   runGit(['init', '--quiet', temporaryRoot]);
-  runGit(['-C', temporaryRoot, 'remote', 'add', 'origin', remote]);
-  runGit(['-C', temporaryRoot, 'fetch', '--quiet', '--depth=1', 'origin', ...(ref === undefined ? [] : [ref])]);
+  // Fetch by URL rather than `remote add origin <url>`: a credential-bearing URL written into
+  // .git/config would be renamed into the long-lived cache and persist there in plaintext.
+  // An omitted ref must resolve the remote's default branch — with no refspec at all, FETCH_HEAD
+  // holds every branch tip and `rev-parse FETCH_HEAD` would take whichever sorts first.
+  runGit(['-C', temporaryRoot, 'fetch', '--quiet', '--depth=1', remote, ref ?? 'HEAD']);
   runGit(['-C', temporaryRoot, 'checkout', '--quiet', '--detach', 'FETCH_HEAD']);
   return runGit(['-C', temporaryRoot, 'rev-parse', 'HEAD']);
 };
@@ -68,9 +117,7 @@ const fetchSource = (temporaryRoot: string, source: RemoteSourceReference, fetch
  * Fetches into a temporary sibling and swaps only a validated checkout into place. A failed fetch,
  * checkout, validation, or rename leaves an existing cache intact.
  */
-export const syncRemoteRepositoryAtomically = <T = void>(
-  input: AtomicRepositorySyncInput<T>,
-): AtomicRepositorySyncResult<T> => {
+export const syncRemoteRepositoryAtomically = (input: AtomicRepositorySyncInput): AtomicRepositorySyncResult => {
   mkdirSync(dirname(input.cachePath), { recursive: true });
   const nonce = `${process.pid}-${Math.random().toString(16).slice(2)}`;
   const temporaryRoot = `${input.cachePath}.outfitter-${nonce}.tmp`;
@@ -79,10 +126,10 @@ export const syncRemoteRepositoryAtomically = <T = void>(
 
   try {
     const commit = fetchSource(temporaryRoot, input.source, input.fetchRef);
-    const validation = input.validate?.(temporaryRoot, commit);
+    const warnings = input.validate?.(temporaryRoot, commit) ?? 0;
 
     if (tryReadCleanHead(input.cachePath) === commit) {
-      return { commit, status: 'unchanged', validation };
+      return { commit, status: 'unchanged', warnings };
     }
 
     if (existsSync(input.cachePath)) {
@@ -91,7 +138,7 @@ export const syncRemoteRepositoryAtomically = <T = void>(
     }
     renameSync(temporaryRoot, input.cachePath);
     if (movedStaleCache) rmSync(staleRoot, { recursive: true, force: true });
-    return { commit, status: 'updated', validation };
+    return { commit, status: 'updated', warnings };
   } catch (error) {
     /* v8 ignore next -- only an OS-level failure during the atomic rename needs restoration. */
     if (movedStaleCache && !existsSync(input.cachePath) && existsSync(staleRoot)) {

--- a/code/cli/src/sources/GitRepository.ts
+++ b/code/cli/src/sources/GitRepository.ts
@@ -94,14 +94,24 @@ export const tryReadCleanHead = (root: string): string | undefined => {
   }
 };
 
+/**
+ * Rejects a remote or ref that git would parse as an option. Runs before any filesystem work so a
+ * hostile ref always reports as an invalid ref, rather than as whatever incidental error the cache
+ * path happens to raise first (a long encoded name exceeds the macOS filename limit, for example).
+ */
+const assertFetchableSource = (source: RemoteSourceReference, fetchRef?: string): void => {
+  // Both the remote and the ref are positional arguments to `git fetch`; either one starting with
+  // `-` is parsed as an option, and `--upload-pack=<cmd>` is arbitrary command execution.
+  const remote = normalizeGitUri(normalizeRemoteSourceUri(source));
+  if (remote.startsWith('-')) throw new Error(`Source URI '${remote}' must not begin with '-'.`);
+  // A refspec (`refs/tags/x:refs/tags/x`) is two refs; validate each side.
+  const ref = fetchRef ?? source.ref;
+  if (ref !== undefined) for (const part of ref.split(':')) assertFetchableRef(part);
+};
+
 const fetchSource = (temporaryRoot: string, source: RemoteSourceReference, fetchRef?: string): string => {
   const remote = normalizeGitUri(normalizeRemoteSourceUri(source));
   const ref = fetchRef ?? source.ref;
-  // Both the remote and the ref are positional arguments to `git fetch`; either one starting with
-  // `-` is parsed as an option, and `--upload-pack=<cmd>` is arbitrary command execution.
-  if (remote.startsWith('-')) throw new Error(`Source URI '${remote}' must not begin with '-'.`);
-  // A refspec (`refs/tags/x:refs/tags/x`) is two refs; validate each side.
-  if (ref !== undefined) for (const part of ref.split(':')) assertFetchableRef(part);
 
   runGit(['init', '--quiet', temporaryRoot]);
   // Fetch by URL rather than `remote add origin <url>`: a credential-bearing URL written into
@@ -118,6 +128,7 @@ const fetchSource = (temporaryRoot: string, source: RemoteSourceReference, fetch
  * checkout, validation, or rename leaves an existing cache intact.
  */
 export const syncRemoteRepositoryAtomically = (input: AtomicRepositorySyncInput): AtomicRepositorySyncResult => {
+  assertFetchableSource(input.source, input.fetchRef);
   mkdirSync(dirname(input.cachePath), { recursive: true });
   const nonce = `${process.pid}-${Math.random().toString(16).slice(2)}`;
   const temporaryRoot = `${input.cachePath}.outfitter-${nonce}.tmp`;

--- a/code/cli/src/sources/PrivateCatalogGate.ts
+++ b/code/cli/src/sources/PrivateCatalogGate.ts
@@ -1,0 +1,80 @@
+// Loads the enterprise-licensed private-catalog policy boundary for CLI source synchronization.
+import { createRequire } from 'node:module';
+
+import { resolveRepositoryCodeAsset } from '../paths/RepositoryAssets.js';
+import type { RemoteSourceReference } from './SourceCache.js';
+import { createRemoteRepositoryCachePath, formatRemoteSourceDisplay } from './SourceCache.js';
+
+export interface GitHubRepositoryVisibilityClassifier {
+  classify(repository: string): 'private' | 'public' | 'unknown';
+}
+
+export interface PrivateCatalogPrompt {
+  readonly interactive: boolean;
+  confirm(repository: string): boolean;
+}
+
+export interface PrivateCatalogSkippedResult {
+  readonly uri: string;
+  readonly cachePath: string;
+  readonly status: 'skipped';
+  readonly message: string;
+}
+
+export interface PrivateCatalogGateResult<T extends RemoteSourceReference> {
+  readonly allowedSources: readonly T[];
+  readonly skippedResults: readonly PrivateCatalogSkippedResult[];
+  readonly messages: readonly string[];
+}
+
+export interface PrivateCatalogSourceGate {
+  filter<T extends RemoteSourceReference>(sources: readonly T[], cacheDirectory?: string): PrivateCatalogGateResult<T>;
+}
+
+interface EnterpriseGateModule {
+  createGitHubRepositoryVisibilityClassifier(): GitHubRepositoryVisibilityClassifier;
+  createPrivateCatalogGate(input: {
+    readonly homeDirectory: string;
+    readonly classifier: GitHubRepositoryVisibilityClassifier;
+    readonly prompt?: PrivateCatalogPrompt;
+  }): unknown;
+  gatePrivateCatalogSources<T extends RemoteSourceReference>(
+    sources: readonly T[],
+    gate: unknown,
+    helpers: {
+      readonly formatDisplayUri: (source: RemoteSourceReference) => string;
+      readonly resolveCachePath: (source: RemoteSourceReference) => string;
+    },
+  ): PrivateCatalogGateResult<T>;
+}
+
+const loadEnterpriseGateModule = (): EnterpriseGateModule =>
+  createRequire(import.meta.url)(
+    resolveRepositoryCodeAsset('enterprise/cli/privateCatalogGate.cjs'),
+  ) as EnterpriseGateModule;
+
+export const createEnterprisePrivateCatalogGate = (input: {
+  readonly homeDirectory: string;
+  readonly classifier?: GitHubRepositoryVisibilityClassifier;
+  readonly prompt?: PrivateCatalogPrompt;
+}): PrivateCatalogSourceGate => {
+  const enterprise = loadEnterpriseGateModule();
+  const { homeDirectory } = input;
+  const gate = enterprise.createPrivateCatalogGate({
+    homeDirectory,
+    classifier: input.classifier ?? enterprise.createGitHubRepositoryVisibilityClassifier(),
+    prompt: input.prompt,
+  });
+
+  return {
+    filter<T extends RemoteSourceReference>(
+      sources: readonly T[],
+      cacheDirectory?: string,
+    ): PrivateCatalogGateResult<T> {
+      return enterprise.gatePrivateCatalogSources(sources, gate, {
+        formatDisplayUri: formatRemoteSourceDisplay,
+        resolveCachePath: (source) => createRemoteRepositoryCachePath(homeDirectory, source, cacheDirectory),
+      });
+    },
+  };
+};

--- a/code/cli/src/sources/SourceCache.ts
+++ b/code/cli/src/sources/SourceCache.ts
@@ -6,6 +6,11 @@ export type RemoteSourceReference =
   | { readonly uri: string; readonly github?: never; readonly ref?: string; readonly path?: string }
   | { readonly github: string; readonly uri?: never; readonly ref?: string; readonly path?: string };
 
+/** Distinguishes remote (`uri`/`github`) sources from local `path` sources. */
+export const isRemoteSource = <T extends { readonly uri?: string; readonly github?: string }>(
+  source: T,
+): source is T & RemoteSourceReference => source.uri !== undefined || source.github !== undefined;
+
 export const normalizeGitUri = (uri: string): string => (uri.startsWith('git+') ? uri.slice('git+'.length) : uri);
 
 export const normalizeRemoteSourceUri = (source: RemoteSourceReference): string => {
@@ -15,6 +20,11 @@ export const normalizeRemoteSourceUri = (source: RemoteSourceReference): string 
 
   return `git+https://github.com/${source.github}.git`;
 };
+
+export const formatRemoteSourceDisplay = (source: RemoteSourceReference): string =>
+  source.github === undefined
+    ? redactSourceUriCredentials(source.uri)
+    : `github:${source.github}${source.ref === undefined ? '' : `#${source.ref}`}`;
 
 export const redactSourceUriCredentials = (uri: string): string => {
   const prefix = uri.startsWith('git+') ? 'git+' : '';
@@ -31,9 +41,13 @@ export const redactSourceUriCredentials = (uri: string): string => {
     parsedUri.password = '';
     return `${prefix}${parsedUri.toString()}`;
   } catch {
-    return uri.replace(/\/\/[^/@\s]+@/u, '//REDACTED@');
+    return uri.replace(/\/\/[^/@\s]+@/gu, '//REDACTED@');
   }
 };
+
+/** Redacts credentials from every URI embedded in arbitrary command or stderr text. */
+export const redactEmbeddedSourceCredentials = (value: string): string =>
+  value.replace(/((?:git\+)?[A-Za-z][A-Za-z0-9+.-]*:\/\/)[^/@\s]+@/gu, '$1REDACTED@');
 
 export const encodeSourceUri = (uri: string): string =>
   Buffer.from(redactSourceUriCredentials(uri), 'utf8').toString('base64url');
@@ -41,8 +55,15 @@ export const encodeSourceUri = (uri: string): string =>
 export const encodeRemoteSource = (source: RemoteSourceReference): string =>
   encodeSourceUri(`${normalizeRemoteSourceUri(source)}#${source.ref ?? ''}`);
 
-export const createRemoteRepositoryCachePath = (homeDirectory: string, source: RemoteSourceReference): string =>
-  join(homeDirectory, '.agents', 'cache', 'repos', encodeRemoteSource(source));
+/** Resolves the one cache root used by sync, settings, layer discovery, and setup bootstrap. */
+export const resolveRemoteRepositoryCacheRoot = (homeDirectory: string, cacheDirectory?: string): string =>
+  cacheDirectory ?? join(homeDirectory, '.agents', 'cache');
+
+export const createRemoteRepositoryCachePath = (
+  homeDirectory: string,
+  source: RemoteSourceReference,
+  cacheDirectory?: string,
+): string => join(resolveRemoteRepositoryCacheRoot(homeDirectory, cacheDirectory), 'repos', encodeRemoteSource(source));
 
 export const resolveRemoteRepositorySubpath = (repositoryPath: string, subpath = ''): string => {
   if (isAbsolute(subpath)) {

--- a/code/cli/tests/unit/composer.test.ts
+++ b/code/cli/tests/unit/composer.test.ts
@@ -29,7 +29,7 @@ afterEach(() => {
 });
 
 const resolveSet = (home: string, project: string) =>
-  resolveResources(discoverLayers({ homeDirectory: home, projectDirectory: project, settings: {} }));
+  resolveResources(discoverLayers({ homeDirectory: home, projectDirectory: project, settings: {} }).layers);
 
 describe('composer', () => {
   const buildTree = (): { home: string; project: string } => {

--- a/code/cli/tests/unit/default-catalog.test.ts
+++ b/code/cli/tests/unit/default-catalog.test.ts
@@ -85,6 +85,21 @@ describe('default catalog bootstrap', () => {
     expect(bootstrapPinnedCatalog({ homeDirectory, source }).root).toBe(first.root);
   });
 
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.4).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('honors a configured remote repository cache directory', () => {
+    const sourceRepository = createCatalogRepository();
+    const homeDirectory = mkdtempSync(join(tmpdir(), 'outfitter-default-catalog-home-'));
+    const cacheDirectory = join(homeDirectory, 'selected-cache');
+    temporaryRoots.push(homeDirectory);
+    const source = { uri: sourceRepository.root, ref: sourceRepository.ref } as const;
+
+    const result = bootstrapPinnedCatalog({ homeDirectory, cacheDirectory, source });
+
+    expect(result.root).toBe(createRemoteRepositoryCachePath(homeDirectory, source, cacheDirectory));
+    expect(readFileSync(join(result.root, 'agents', 'founder', 'agent.md'), 'utf8')).toContain('name: founder');
+  });
+
   it('replaces locally modified cache content with the pinned checkout', () => {
     const sourceRepository = createCatalogRepository();
     const homeDirectory = mkdtempSync(join(tmpdir(), 'outfitter-default-catalog-home-'));

--- a/code/cli/tests/unit/resolver-cli.test.ts
+++ b/code/cli/tests/unit/resolver-cli.test.ts
@@ -109,6 +109,29 @@ describe('resolver command objects', () => {
     expect(result.messages).toContain('✓ No issues found.');
   });
 
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.18).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('surfaces unsynchronized remote sources as non-fatal guidance in list and validate', async () => {
+    const root = createTemporaryRoot();
+    write(join(root, 'project', '.agents', 'agents', 'ok', 'agent.md'), '---\nname: ok\n---\n\nBody.\n');
+    write(join(root, 'project', '.agents', 'settings.yml'), 'sources:\n  - uri: https://example.com/catalog.git\n');
+    const lines: string[] = [];
+
+    // list still resolves the workspace layer and exits normally; the missing cache only warns.
+    await buildProgram(root, lines).parseAsync(['node', 'outfitter', 'list', 'agents']);
+    expect(process.exitCode).not.toBe(1);
+    expect(lines.join('\n')).toContain("Run 'outfitter sync'");
+    expect(lines.join('\n')).toContain('ok  [workspace]');
+
+    const validation = executeValidateCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: join(root, 'project'),
+    });
+    // A warning, never an error: an unsynchronized source must not fail a clean workspace.
+    expect(validation.ok).toBe(true);
+    expect(validation.findings.some((f) => f.severity === 'warning' && /outfitter sync/u.test(f.message))).toBe(true);
+  });
+
   it('validate through parseAsync prints clean text output and leaves the exit code unset', async () => {
     const root = createTemporaryRoot();
     write(join(root, 'project', '.agents', 'agents', 'ok', 'agent.md'), '---\nname: ok\n---\n\nBody.\n');

--- a/code/cli/tests/unit/resolver.test.ts
+++ b/code/cli/tests/unit/resolver.test.ts
@@ -184,6 +184,38 @@ describe('layer discovery', () => {
     const set = resolveResources(layers);
     expect(findResource(set, 'agent', 'remote-agent')).toBeDefined();
   });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.3, OFTR-004.2.4).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('resolves a configured payload subpath inside a cached remote repository', () => {
+    const root = createTemporaryRoot();
+    const cache = join(root, 'cache');
+    const source = { github: 'example/colocated', ref: 'main', path: '.agents' } as const;
+    const encoded = encodeRemoteSource(source);
+    write(join(cache, 'repos', encoded, '.agents', 'agents', 'nested', 'agent.md'), agentMd('nested'));
+
+    const layers = discoverLayers({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: join(root, 'project'),
+      settings: { cacheDirectory: cache, sources: [source] },
+    });
+
+    expect(layers.find((layer) => layer.origin === 'source')?.root).toBe(join(cache, 'repos', encoded, '.agents'));
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.3, OFTR-004.2.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('reports a missing configured remote cache before agent lookup', () => {
+    const root = createTemporaryRoot();
+
+    expect(() =>
+      discoverLayers({
+        homeDirectory: join(root, 'home'),
+        projectDirectory: join(root, 'project'),
+        settings: { sources: [{ github: 'example/missing', ref: 'main' }] },
+      }),
+    ).toThrow(/Run 'outfitter sync'/u);
+  });
 });
 
 describe('resource resolution', () => {

--- a/code/cli/tests/unit/resolver.test.ts
+++ b/code/cli/tests/unit/resolver.test.ts
@@ -41,7 +41,7 @@ const agentMd = (name: string, extra = ''): string =>
   `---\nname: ${name}\ndescription: The ${name} agent.\n${extra}---\n\n# ${name}\n\nBody for ${name}.\n`;
 
 const setFor = (home: string, project: string, sources: { path: string }[] = []) =>
-  resolveResources(discoverLayers({ homeDirectory: home, projectDirectory: project, settings: { sources } }));
+  resolveResources(discoverLayers({ homeDirectory: home, projectDirectory: project, settings: { sources } }).layers);
 
 const expectIssueContaining = (result: ReturnType<typeof parseAgentDefinition>, substring: string): void => {
   expect(isAgentDefinitionIssue(result)).toBe(true);
@@ -164,7 +164,7 @@ describe('layer discovery', () => {
       settings: { sources: [{ path: shared }, { path: join(root, 'absent') }] },
     });
 
-    expect(layers.map((layer) => layer.origin)).toEqual(['workspace', 'global', 'source']);
+    expect(layers.layers.map((layer) => layer.origin)).toEqual(['workspace', 'global', 'source']);
   });
 
   it('caches remote sources under cache_directory (default ~/.agents/cache)', () => {
@@ -180,8 +180,8 @@ describe('layer discovery', () => {
       settings: { cacheDirectory: cache, sources: [{ github: 'example/.agent', ref: 'main' }] },
     });
 
-    expect(layers.some((layer) => layer.origin === 'source')).toBe(true);
-    const set = resolveResources(layers);
+    expect(layers.layers.some((layer) => layer.origin === 'source')).toBe(true);
+    const set = resolveResources(layers.layers);
     expect(findResource(set, 'agent', 'remote-agent')).toBeDefined();
   });
 
@@ -200,21 +200,46 @@ describe('layer discovery', () => {
       settings: { cacheDirectory: cache, sources: [source] },
     });
 
-    expect(layers.find((layer) => layer.origin === 'source')?.root).toBe(join(cache, 'repos', encoded, '.agents'));
+    expect(layers.layers.find((layer) => layer.origin === 'source')?.root).toBe(
+      join(cache, 'repos', encoded, '.agents'),
+    );
   });
 
-  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.3, OFTR-004.2.3).
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.3, OFTR-004.2.18).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('reports a missing configured remote cache before agent lookup', () => {
+  // Reported, not raised: OFTR-004.2.15 requires a gate-skipped private catalog to leave other
+  // sources working, and such a catalog is never cached, so aborting resolution would deadlock
+  // every command behind guidance the user cannot act on.
+  it('reports a missing configured remote cache instead of silently dropping it', () => {
     const root = createTemporaryRoot();
 
-    expect(() =>
-      discoverLayers({
-        homeDirectory: join(root, 'home'),
-        projectDirectory: join(root, 'project'),
-        settings: { sources: [{ github: 'example/missing', ref: 'main' }] },
-      }),
-    ).toThrow(/Run 'outfitter sync'/u);
+    const discovered = discoverLayers({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: join(root, 'project'),
+      settings: { sources: [{ github: 'example/missing', ref: 'main' }] },
+    });
+
+    expect(discovered.unsynchronized).toHaveLength(1);
+    expect(discovered.unsynchronized[0]).toMatch(/Run 'outfitter sync'/u);
+    expect(discovered.layers.some((layer) => layer.origin === 'source')).toBe(false);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.15).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('keeps other sources resolvable when one remote source is unsynchronized', () => {
+    const root = createTemporaryRoot();
+    const cache = join(root, 'cache');
+    const present = { github: 'example/present', ref: 'main' } as const;
+    write(join(cache, 'repos', encodeRemoteSource(present), 'agents', 'ok', 'agent.md'), agentMd('ok'));
+
+    const discovered = discoverLayers({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: join(root, 'project'),
+      settings: { cacheDirectory: cache, sources: [{ github: 'example/skipped', ref: 'main' }, present] },
+    });
+
+    expect(discovered.unsynchronized).toHaveLength(1);
+    expect(findResource(resolveResources(discovered.layers), 'agent', 'ok')).toBeDefined();
   });
 });
 

--- a/code/cli/tests/unit/settings-loader.test.ts
+++ b/code/cli/tests/unit/settings-loader.test.ts
@@ -327,6 +327,46 @@ describe('settings loading', () => {
     expect(localOverrideLoaded.settings.sources).toEqual([{ path: join(homeDirectory, '.agents', 'local-agents') }]);
   });
 
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.6, OFTR-004.2.4).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('loads remote settings from the configured cache directory', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    const cacheDirectory = join(root, 'selected-cache');
+    const source = { github: 'example/configured-cache', path: 'settings.yml' } as const;
+    writeSettings(
+      join(homeDirectory, '.agents', 'settings.yml'),
+      `cache_directory: ${cacheDirectory}\nremote_settings:\n  - github: ${source.github}\n    path: settings.yml\n`,
+    );
+    writeSettings(
+      join(createRemoteRepositoryCachePath(homeDirectory, source, cacheDirectory), 'settings.yml'),
+      'default_agent: from-remote\n',
+    );
+
+    const loaded = loadSettingsWithCachedRemoteSettings({ homeDirectory, projectDirectory });
+
+    expect(loaded.issues).toEqual([]);
+    expect(loaded.settings.defaultAgent).toBe('from-remote');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.6, OFTR-004.2.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('reports an actionable issue when a configured remote settings cache is missing', () => {
+    const root = createTemporaryRoot();
+    const homeDirectory = join(root, 'home');
+    const projectDirectory = join(root, 'project');
+    writeSettings(
+      join(homeDirectory, '.agents', 'settings.yml'),
+      'remote_settings:\n  - github: example/missing\n    path: settings.yml\n',
+    );
+
+    const loaded = loadSettingsWithCachedRemoteSettings({ homeDirectory, projectDirectory });
+
+    expect(loaded.issues).toHaveLength(1);
+    expect(loaded.issues[0]?.message).toContain("Run 'outfitter sync'");
+  });
+
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.6).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('reports invalid cached remote settings subpaths as settings issues', () => {

--- a/code/cli/tests/unit/setup.test.ts
+++ b/code/cli/tests/unit/setup.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 // Tests the renderer-independent setup state machine and Pi-hosted command handoff.
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
@@ -11,6 +11,7 @@ import { createSetupCommand, preparePiSetupLaunch, runSetup } from '../../src/cl
 import type { AgentLaunchPlan } from '../../src/projection/Projection.js';
 import { defaultCatalogSource } from '../../src/setup/DefaultCatalog.js';
 import { applySetupSelection, discoverSetupAgentChoices, sanitizeAgentSlug } from '../../src/setup/Setup.js';
+import { createRemoteRepositoryCachePath } from '../../src/sources/SourceCache.js';
 
 const temporaryRoots: string[] = [];
 
@@ -500,12 +501,20 @@ describe('Pi setup launch', () => {
     expect(extension).toContain('const OUTFITTER_SETUP_SOURCE_URI = "https://example.test/catalog.git";');
   });
 
-  it('runs the Pi walkthrough and applies a custom-profile handoff', async () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.4, OFTR-010.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('passes the selected cache root into setup bootstrap and applies a custom-profile handoff', async () => {
     const { catalog, home, project } = createTree();
+    const selectedCache = join(home, '.agents', 'selected-cache');
+    let bootstrapCache: string | undefined;
+    write(join(home, '.agents', 'settings.yml'), 'cache_directory: ./selected-cache\n');
     const result = await runSetup({
       homeDirectory: home,
       projectDirectory: project,
-      defaultCatalogBootstrap: () => catalog,
+      defaultCatalogBootstrap: (_bootstrapHome, cacheDirectory) => {
+        bootstrapCache = cacheDirectory;
+        return catalog;
+      },
       interactive: true,
       launcher: (plan) => {
         writeFileSync(
@@ -522,6 +531,7 @@ describe('Pi setup launch', () => {
       },
     });
     expect(result?.defaultAgent).toBe('walkthrough');
+    expect(bootstrapCache).toBe(selectedCache);
     expect(existsSync(join(project, '.agents', 'agents', 'walkthrough', 'agent.md'))).toBe(true);
   });
 
@@ -651,7 +661,12 @@ describe('Pi setup launch', () => {
     createSetupCommand({
       homeDirectory: home,
       projectDirectory: project,
-      defaultCatalogBootstrap: () => catalog,
+      defaultCatalogBootstrap: (bootstrapHome, cacheDirectory) => {
+        const cachePath = createRemoteRepositoryCachePath(bootstrapHome, defaultCatalogSource, cacheDirectory);
+        mkdirSync(dirname(cachePath), { recursive: true });
+        cpSync(catalog, cachePath, { recursive: true });
+        return cachePath;
+      },
       interactive: true,
       launcher: (plan) => {
         writeFileSync(

--- a/code/cli/tests/unit/source-cache.test.ts
+++ b/code/cli/tests/unit/source-cache.test.ts
@@ -4,9 +4,12 @@ import { describe, expect, it } from 'vitest';
 import {
   createRemoteRepositoryCachePath,
   encodeRemoteSource,
+  formatRemoteSourceDisplay,
   normalizeGitUri,
   normalizeRemoteSourceUri,
+  redactEmbeddedSourceCredentials,
   redactSourceUriCredentials,
+  resolveRemoteRepositoryCacheRoot,
   resolveRemoteRepositorySubpath,
 } from '../../src/sources/SourceCache.js';
 
@@ -27,12 +30,23 @@ describe('source cache', () => {
     expect(redactSourceUriCredentials('https://example.test/a.git')).toBe('https://example.test/a.git');
     // Unparseable URIs fall back to a regex redaction.
     expect(redactSourceUriCredentials('git+ssh://user@example.test:a.git')).toContain('REDACTED@');
+    expect(
+      redactEmbeddedSourceCredentials('fatal: https://first:one@example.test/a and ssh://second:two@example.test/b'),
+    ).toBe('fatal: https://REDACTED@example.test/a and ssh://REDACTED@example.test/b');
+    expect(formatRemoteSourceDisplay({ uri: 'https://user:secret@example.test/a.git' })).toBe(
+      'https://REDACTED@example.test/a.git',
+    );
   });
 
-  it('encodes remote sources and repository cache paths under ~/.agents/cache', () => {
+  it('encodes remote sources under the selected repository cache root', () => {
     const path = createRemoteRepositoryCachePath('/home/x', { github: 'example/.agent', ref: 'main' });
     expect(path).toContain('/home/x/.agents/cache/repos/');
     expect(path.endsWith(encodeRemoteSource({ github: 'example/.agent', ref: 'main' }))).toBe(true);
+    expect(createRemoteRepositoryCachePath('/home/x', { github: 'example/.agent' }, '/var/cache/agents')).toContain(
+      '/var/cache/agents/repos/',
+    );
+    expect(resolveRemoteRepositoryCacheRoot('/home/x')).toBe('/home/x/.agents/cache');
+    expect(resolveRemoteRepositoryCacheRoot('/home/x', '/custom')).toBe('/custom');
   });
 
   it('rejects absolute and escaping repository subpaths', () => {

--- a/code/cli/tests/unit/sync-command.test.ts
+++ b/code/cli/tests/unit/sync-command.test.ts
@@ -35,6 +35,9 @@ const createRepository = (
   git(['init', '--quiet', root]);
   git(['-C', root, 'config', 'user.name', 'Outfitter Tests']);
   git(['-C', root, 'config', 'user.email', 'tests@outfitter.dev']);
+  // Isolate from the developer's global config; a global commit.gpgsign would fail every commit.
+  git(['-C', root, 'config', 'commit.gpgsign', 'false']);
+  git(['-C', root, 'config', 'tag.gpgsign', 'false']);
   for (const [path, content] of Object.entries(files)) write(join(root, path), content);
   git(['-C', root, 'add', '.']);
   git(['-C', root, 'commit', '--quiet', '-m', 'initial']);
@@ -363,5 +366,88 @@ describe('private catalog gate', () => {
     expect(result.skippedResults[0]?.status).toBe('skipped');
     expect(result.skippedResults[0]?.cachePath).toContain(join(input.root, 'cache', 'repos'));
     expect(result.messages.join('\n')).toContain('~/.agents/settings.yml');
+  });
+});
+
+describe('remote fetch hardening', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.9).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  // A ref beginning with `-` is parsed by git as an option, not a refspec: `--upload-pack=<cmd>`
+  // is arbitrary command execution on every machine that syncs a hostile catalog.
+  it('rejects a ref that git would parse as an option instead of fetching it', () => {
+    const catalog = createRepository({ 'agents/remote/agent.md': agent('remote') });
+    const input = createInvocation();
+    const marker = join(input.root, 'INJECTED');
+    writeHomeSettings(
+      input.homeDirectory,
+      `sources:\n  - uri: ${catalog.root}\n    ref: "--upload-pack=touch ${marker}; git-upload-pack"\n`,
+    );
+
+    const result = executeSyncCommand(input);
+
+    expect(existsSync(marker)).toBe(false);
+    expect(result.results[0]?.status).toBe('failed');
+    expect(result.results[0]?.message).toContain('is not a valid git ref');
+    expect(result.exitCode).toBe(1);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.9).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('never persists credentials from a source URI into the cached repository config', () => {
+    const catalog = createRepository({ 'agents/remote/agent.md': agent('remote') });
+    const input = createInvocation();
+    // A credentialed URI whose host is the local path form git can actually reach.
+    writeHomeSettings(input.homeDirectory, `sources:\n  - uri: ${catalog.root}\n`);
+
+    const result = executeSyncCommand(input);
+    expect(result.results[0]?.status).toBe('updated');
+
+    const config = readFileSync(join(result.results[0].cachePath, '.git', 'config'), 'utf8');
+    expect(config).not.toContain('[remote "origin"]');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.9).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  // An exported GIT_DIR/GIT_WORK_TREE (a git hook, `rebase --exec`, `bisect run`) would otherwise
+  // redirect every `git -C <temp> …` at the *outer* repository and detach its HEAD.
+  it('ignores inherited repository-context variables instead of operating on the outer repository', () => {
+    const catalog = createRepository({ 'agents/remote/agent.md': agent('remote') });
+    const outer = createRepository({ 'agents/outer/agent.md': agent('outer') });
+    const input = createInvocation();
+    writeHomeSettings(input.homeDirectory, `sources:\n  - uri: ${catalog.root}\n`);
+    const outerHeadBefore = git(['-C', outer.root, 'rev-parse', 'HEAD']);
+
+    const previous = { dir: process.env.GIT_DIR, workTree: process.env.GIT_WORK_TREE };
+    process.env.GIT_DIR = join(outer.root, '.git');
+    process.env.GIT_WORK_TREE = outer.root;
+    let result;
+    try {
+      result = executeSyncCommand(input);
+    } finally {
+      if (previous.dir === undefined) delete process.env.GIT_DIR;
+      else process.env.GIT_DIR = previous.dir;
+      if (previous.workTree === undefined) delete process.env.GIT_WORK_TREE;
+      else process.env.GIT_WORK_TREE = previous.workTree;
+    }
+
+    expect(result.results[0]?.status).toBe('updated');
+    expect(git(['-C', outer.root, 'rev-parse', 'HEAD'])).toBe(outerHeadBefore);
+    expect(git(['-C', outer.root, 'remote'])).toBe('');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  // With no refspec, FETCH_HEAD holds every branch tip and rev-parse takes whichever sorts first.
+  it('resolves the remote default branch for an unpinned source, not the first branch by name', () => {
+    const catalog = createRepository({ 'agents/remote/agent.md': agent('remote') });
+    git(['-C', catalog.root, 'branch', 'aaa-decoy']);
+    const defaultCommit = commitFile(catalog.root, 'agents/remote/agent.md', agent('remote', 'updated'), 'update');
+    const input = createInvocation();
+    writeHomeSettings(input.homeDirectory, `sources:\n  - uri: ${catalog.root}\n`);
+
+    const result = executeSyncCommand(input);
+
+    expect(result.results[0]?.status).toBe('updated');
+    expect(git(['-C', result.results[0].cachePath, 'rev-parse', 'HEAD'])).toBe(defaultCommit);
   });
 });

--- a/code/cli/tests/unit/sync-command.test.ts
+++ b/code/cli/tests/unit/sync-command.test.ts
@@ -1,0 +1,367 @@
+// Tests .agents-native remote synchronization, sequencing, safety, status, and enterprise gating.
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { Command } from 'commander';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createSyncCommand, executeSyncCommand } from '../../src/cli/commands/SyncCommand.js';
+import { createEnterprisePrivateCatalogGate } from '../../src/sources/PrivateCatalogGate.js';
+import { createRemoteRepositoryCachePath } from '../../src/sources/SourceCache.js';
+
+const temporaryRoots: string[] = [];
+
+const git = (arguments_: readonly string[]): string =>
+  execFileSync('git', [...arguments_], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+
+const write = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+
+const agent = (name: string, body = ''): string =>
+  `---\nname: ${name}\ndescription: ${name} test agent.\n---\n\n# ${name}\n\n${body}\n`;
+
+const createRepository = (
+  files: Readonly<Record<string, string>>,
+): { readonly root: string; readonly commit: string } => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-sync-source-'));
+  temporaryRoots.push(root);
+  git(['init', '--quiet', root]);
+  git(['-C', root, 'config', 'user.name', 'Outfitter Tests']);
+  git(['-C', root, 'config', 'user.email', 'tests@outfitter.dev']);
+  for (const [path, content] of Object.entries(files)) write(join(root, path), content);
+  git(['-C', root, 'add', '.']);
+  git(['-C', root, 'commit', '--quiet', '-m', 'initial']);
+  return { root, commit: git(['-C', root, 'rev-parse', 'HEAD']) };
+};
+
+const commitFile = (repository: string, path: string, content: string, message: string): string => {
+  write(join(repository, path), content);
+  git(['-C', repository, 'add', path]);
+  git(['-C', repository, 'commit', '--quiet', '-m', message]);
+  return git(['-C', repository, 'rev-parse', 'HEAD']);
+};
+
+const createInvocation = (): {
+  readonly homeDirectory: string;
+  readonly projectDirectory: string;
+  readonly root: string;
+} => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-sync-invocation-'));
+  temporaryRoots.push(root);
+  return {
+    root,
+    homeDirectory: join(root, 'home'),
+    projectDirectory: join(root, 'project'),
+  };
+};
+
+const writeHomeSettings = (homeDirectory: string, content: string): void =>
+  write(join(homeDirectory, '.agents', 'settings.yml'), content);
+
+afterEach(() => {
+  process.exitCode = undefined;
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('sync command', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.1, OFTR-004.2.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('registers the command object and reports an empty configuration successfully', async () => {
+    const input = createInvocation();
+    writeHomeSettings(input.homeDirectory, 'sources:\n  - path: ./local-catalog\n');
+    const lines: string[] = [];
+    const program = new Command();
+    createSyncCommand({
+      ...input,
+      writeLine: (line) => lines.push(line),
+    }).register(program);
+
+    await program.parseAsync(['node', 'outfitter', 'sync']);
+
+    expect(lines).toEqual(['No remote sources are configured.']);
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('fails before synchronization when local settings are invalid', () => {
+    const input = createInvocation();
+    writeHomeSettings(input.homeDirectory, 'default_harness: invalid\n');
+
+    const result = executeSyncCommand(input);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.results).toEqual([]);
+    expect(result.messages.join('\n')).toContain('Local settings are invalid');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('sets the command exit status and prints diagnostics for required failures', async () => {
+    const input = createInvocation();
+    const lines: string[] = [];
+    writeHomeSettings(input.homeDirectory, 'default_harness: invalid\n');
+    const program = new Command();
+    createSyncCommand({
+      ...input,
+      writeLine: (line) => lines.push(line),
+    }).register(program);
+
+    await program.parseAsync(['node', 'outfitter', 'sync']);
+
+    expect(process.exitCode).toBe(1);
+    expect(lines.join('\n')).toContain('Local settings are invalid');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.6, OFTR-004.2.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('fails missing or invalid remote settings before making either checkout active', () => {
+    const input = createInvocation();
+    const missing = createRepository({ 'README.md': '# no settings\n' });
+    const invalid = createRepository({ 'settings.yml': 'default_harness: invalid\n' });
+    writeHomeSettings(
+      input.homeDirectory,
+      `remote_settings:\n  - uri: ${JSON.stringify(
+        missing.root,
+      )}\n    path: settings.yml\n  - uri: ${JSON.stringify(invalid.root)}\n    path: settings.yml\n`,
+    );
+
+    const result = executeSyncCommand(input);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.results.map((entry) => entry.status)).toEqual(['failed', 'failed']);
+    expect(result.messages.join('\n')).toContain('Remote settings file');
+    expect(result.messages.join('\n')).toContain('Fetched remote settings are invalid');
+    expect(result.messages.join('\n')).toContain('Merged settings contain errors');
+    expect(result.results.every((entry) => !existsSync(entry.cachePath))).toBe(true);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.2, OFTR-004.2.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('syncs remote settings first, reloads them, then discovers sources in a configured cache', () => {
+    const input = createInvocation();
+    const cacheDirectory = join(input.root, 'configured-cache');
+    const catalog = createRepository({
+      'agents/remote/agent.md': agent('remote'),
+    });
+    const control = createRepository({
+      'settings.yml': `sources:\n  - uri: ${JSON.stringify(catalog.root)}\n`,
+    });
+    writeHomeSettings(
+      input.homeDirectory,
+      `cache_directory: ${cacheDirectory}\nremote_settings:\n  - uri: ${JSON.stringify(
+        control.root,
+      )}\n    path: settings.yml\n`,
+    );
+
+    const result = executeSyncCommand(input);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.results.map(({ kind, status }) => ({ kind, status }))).toEqual([
+      { kind: 'remote_settings', status: 'updated' },
+      { kind: 'source', status: 'updated' },
+    ]);
+    expect(result.results.every((entry) => entry.cachePath.startsWith(cacheDirectory))).toBe(true);
+    expect(
+      existsSync(
+        join(
+          createRemoteRepositoryCachePath(input.homeDirectory, { uri: catalog.root }, cacheDirectory),
+          'agents',
+          'remote',
+          'agent.md',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.3, OFTR-004.2.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('checks out pinned refs, updates unpinned refs, and reports unchanged repeat syncs', () => {
+    const input = createInvocation();
+    const catalog = createRepository({
+      'agents/old/agent.md': agent('old'),
+    });
+    git(['-C', catalog.root, 'tag', 'v1.0.0']);
+    const latestCommit = commitFile(catalog.root, 'agents/latest/agent.md', agent('latest'), 'add latest agent');
+    writeHomeSettings(
+      input.homeDirectory,
+      `sources:\n  - uri: ${JSON.stringify(catalog.root)}\n    ref: v1.0.0\n  - uri: ${JSON.stringify(catalog.root)}\n`,
+    );
+
+    const first = executeSyncCommand(input);
+    const pinnedPath = createRemoteRepositoryCachePath(input.homeDirectory, {
+      uri: catalog.root,
+      ref: 'v1.0.0',
+    });
+    const movingPath = createRemoteRepositoryCachePath(input.homeDirectory, { uri: catalog.root });
+
+    expect(first.results.map((result) => result.status)).toEqual(['updated', 'updated']);
+    expect(git(['-C', pinnedPath, 'rev-parse', 'HEAD'])).toBe(catalog.commit);
+    expect(git(['-C', movingPath, 'rev-parse', 'HEAD'])).toBe(latestCommit);
+
+    const second = executeSyncCommand(input);
+    expect(second.results.map((result) => result.status)).toEqual(['unchanged', 'unchanged']);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.6, OFTR-004.2.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('validates repository subpaths and reports non-fatal payload warnings', () => {
+    const input = createInvocation();
+    const catalog = createRepository({
+      'payload/agents/warned/agent.md': agent('warned'),
+      'payload/agents/warned/mcp.json': '{}\n',
+    });
+    writeHomeSettings(
+      input.homeDirectory,
+      `sources:\n  - uri: ${JSON.stringify(catalog.root)}\n    path: missing\n  - uri: ${JSON.stringify(
+        catalog.root,
+      )}\n    path: payload\n`,
+    );
+
+    const result = executeSyncCommand(input);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.results.map((entry) => entry.status)).toEqual(['failed', 'updated']);
+    expect(result.results[0]?.message).toContain('was not found');
+    expect(result.results[1]?.message).toContain('validated with 1 warning');
+  });
+
+  it('replaces a malformed non-Git cache with a valid fetched checkout', () => {
+    const input = createInvocation();
+    const catalog = createRepository({
+      'agents/fresh/agent.md': agent('fresh'),
+    });
+    const source = { uri: catalog.root } as const;
+    const cachePath = createRemoteRepositoryCachePath(input.homeDirectory, source);
+    mkdirSync(join(cachePath, '.git'), { recursive: true });
+    writeHomeSettings(input.homeDirectory, `sources:\n  - uri: ${JSON.stringify(catalog.root)}\n`);
+
+    const result = executeSyncCommand(input);
+
+    expect(result.results[0]?.status).toBe('updated');
+    expect(git(['-C', cachePath, 'rev-parse', 'HEAD'])).toBe(catalog.commit);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.7, OFTR-004.2.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('preserves the last valid cache when a fetched update fails validation', () => {
+    const input = createInvocation();
+    const catalog = createRepository({
+      'agents/stable/agent.md': agent('stable', 'last good'),
+    });
+    writeHomeSettings(input.homeDirectory, `sources:\n  - uri: ${JSON.stringify(catalog.root)}\n`);
+    const first = executeSyncCommand(input);
+    const cachePath = first.results[0].cachePath;
+    const cachedCommit = git(['-C', cachePath, 'rev-parse', 'HEAD']);
+
+    commitFile(catalog.root, 'agents/stable/agent.md', agent('wrong-name', 'invalid update'), 'invalid agent identity');
+    const second = executeSyncCommand(input);
+
+    expect(second.exitCode).toBe(1);
+    expect(second.results[0]?.status).toBe('failed');
+    expect(git(['-C', cachePath, 'rev-parse', 'HEAD'])).toBe(cachedCommit);
+    expect(readFileSync(join(cachePath, 'agents', 'stable', 'agent.md'), 'utf8')).toContain('last good');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.7, OFTR-004.2.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('preserves the last valid cache when the remote can no longer be fetched', () => {
+    const input = createInvocation();
+    const catalog = createRepository({
+      'agents/stable/agent.md': agent('stable', 'available'),
+    });
+    writeHomeSettings(input.homeDirectory, `sources:\n  - uri: ${JSON.stringify(catalog.root)}\n`);
+    const first = executeSyncCommand(input);
+    const cachePath = first.results[0].cachePath;
+    const unavailablePath = `${catalog.root}-offline`;
+    renameSync(catalog.root, unavailablePath);
+    temporaryRoots[temporaryRoots.indexOf(catalog.root)] = unavailablePath;
+
+    const second = executeSyncCommand(input);
+
+    expect(second.exitCode).toBe(1);
+    expect(second.results[0]?.status).toBe('failed');
+    expect(readFileSync(join(cachePath, 'agents', 'stable', 'agent.md'), 'utf8')).toContain('available');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.9).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('redacts embedded credentials from result URIs, errors, and cache paths', () => {
+    const input = createInvocation();
+    const credentialedUri = 'https://user:super-secret@127.0.0.1:9/catalog.git';
+    writeHomeSettings(input.homeDirectory, `sources:\n  - uri: ${JSON.stringify(credentialedUri)}\n`);
+
+    const result = executeSyncCommand(input);
+    const output = JSON.stringify(result);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.results[0]?.status).toBe('failed');
+    expect(output).not.toContain('super-secret');
+    expect(output).not.toContain('user:');
+    expect(output).toContain('REDACTED');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.7, OFTR-004.2.15).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('returns a successful skipped result for a gated private source', () => {
+    const input = createInvocation();
+    writeHomeSettings(input.homeDirectory, 'sources:\n  - github: acme/private\n');
+
+    const result = executeSyncCommand(input, {
+      classifier: { classify: () => 'private' },
+      prompt: { interactive: false, confirm: () => false },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.results).toMatchObject([{ kind: 'source', status: 'skipped' }]);
+    expect(result.messages.join('\n')).toContain('~/.agents/settings.yml');
+  });
+});
+
+describe('private catalog gate', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.10, OFTR-004.2.13).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('enables accepted private catalogs in ~/.agents/settings.yml', () => {
+    const input = createInvocation();
+    const gate = createEnterprisePrivateCatalogGate({
+      homeDirectory: input.homeDirectory,
+      classifier: { classify: () => 'private' },
+      prompt: { interactive: true, confirm: () => true },
+    });
+
+    const result = gate.filter([{ github: 'acme/private' }]);
+    const settingsPath = join(input.homeDirectory, '.agents', 'settings.yml');
+
+    expect(result.allowedSources).toEqual([{ github: 'acme/private' }]);
+    expect(result.messages).toContain('info: Enabled private profile catalogs in ~/.agents/settings.yml.');
+    expect(readFileSync(settingsPath, 'utf8')).toContain('private_catalogs: true');
+    expect(existsSync(join(input.homeDirectory, '.outfitter', 'settings.yml'))).toBe(false);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.14, OFTR-004.2.15).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('returns skipped status and guidance for a declined or non-interactive private catalog', () => {
+    const input = createInvocation();
+    const gate = createEnterprisePrivateCatalogGate({
+      homeDirectory: input.homeDirectory,
+      classifier: { classify: () => 'private' },
+      prompt: { interactive: false, confirm: () => false },
+    });
+
+    const result = gate.filter([{ github: 'acme/private' }], join(input.root, 'cache'));
+
+    expect(result.allowedSources).toEqual([]);
+    expect(result.skippedResults[0]?.status).toBe('skipped');
+    expect(result.skippedResults[0]?.cachePath).toContain(join(input.root, 'cache', 'repos'));
+    expect(result.messages.join('\n')).toContain('~/.agents/settings.yml');
+  });
+});

--- a/code/enterprise/cli/privateCatalogGate.cjs
+++ b/code/enterprise/cli/privateCatalogGate.cjs
@@ -1,5 +1,5 @@
 const { spawnSync } = require('node:child_process');
-const { dirname, join } = require('node:path');
+const { join } = require('node:path');
 
 const {
   formatPrivateCatalogCliPrompt,
@@ -10,7 +10,7 @@ const {
 const { enablePrivateProfileCatalogs, isPrivateProfileCatalogsEnabled } = require('./privateCatalogSettings.cjs');
 
 const createPrivateCatalogGate = ({ homeDirectory, classifier, prompt }) => {
-  const settingsPath = join(homeDirectory, '.outfitter', 'settings.yml');
+  const settingsPath = join(homeDirectory, '.agents', 'settings.yml');
 
   return {
     classifier,
@@ -50,7 +50,7 @@ const gatePrivateCatalogSources = (sources, gate, helpers) => {
     }
     skippedResults.push({
       uri: helpers.formatDisplayUri(source),
-      cachePath: helpers.createRemoteRepositoryCachePath(dirname(dirname(gate.settingsPath)), source),
+      cachePath: helpers.resolveCachePath(source),
       status: 'skipped',
       message: formatPrivateCatalogSkipResultMessage(repository),
     });

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -127,6 +127,7 @@ Rules:
 - `default_agent` names the agent plain `outfitter` runs; `default_harness` selects the harness (`pi` or `claude`).
 - `sources` entries MUST specify a local `path`, a remote `uri`, or a `github` shorthand; remote entries accept `ref` and payload-subdirectory `path`. Relative `path` values resolve relative to the settings file containing them.
 - `remote_settings` entries point at settings-style YAML files inside synced remote repositories; fetched by `outfitter sync` and loaded at lower precedence.
+- `cache_directory` selects the repository cache root for sync, remote-settings loading, remote layer discovery, and default-catalog bootstrap. Its default is `~/.agents/cache`.
 - `custom_settings` may contain arbitrary YAML-compatible nested data, deep-merged by precedence.
 
 ## Composition
@@ -207,7 +208,7 @@ Outfitter launches `claude` with `CLAUDE_CONFIG_DIR` pointing at the projection 
 
 - **`outfitter run [agent]`** (default command): resolve → compose → project → launch. A positional agent slug selects what to run (default from settings `default_agent`); `--harness <pi|claude>` selects the harness (default from settings `default_harness`, then `pi`); unknown args pass through to the child CLI; `--strict` makes warnings fatal. Interactive clean-home launches start Pi-native onboarding; non-interactive clean-home launches require `outfitter setup` first.
 - **`outfitter setup [source]`**: launch the bundled, model-free Pi walkthrough with the original three setup modes (default catalog, create a profile, or another catalog), original profile/target wording, and optional direct-source path; append only the default CLI-agent choice (Pi/Outfitter preselected); then atomically apply the result through the CLI state machine.
-- **`outfitter sync`**: fetch/update remote sources and remote settings into the cache (`~/.agents/cache/repos/<encoded-uri-and-ref>/`), validate payloads, report per-source status, redact embedded credentials from output.
+- **`outfitter sync`**: validate local settings; atomically fetch configured remote settings; reload the merged settings; then atomically fetch every resulting remote source into `<cache_directory>/repos/<encoded-uri-and-ref>/`. Validate before swapping, preserve the last good checkout on failure, report per-source status, and redact embedded credentials from all output. Required-source failures exit nonzero. Network synchronization never runs implicitly during `outfitter run`.
 - **`outfitter list [kind]`**: report the effective resource set — slugs, winning sources, shadowed definitions — deterministically.
 - **`outfitter validate [--strict] [--json]`**: protocol layout, frontmatter and JSON schemas, unresolved loadout slugs, skill reference escapes/collisions, settings schema.
 - **`outfitter dump [--agent <id>] [--out]`**: write the deterministic tree, optionally restricted to one agent's transitive closure.

--- a/docs/architecture/file_structure.md
+++ b/docs/architecture/file_structure.md
@@ -49,6 +49,7 @@ Outfitter is organized around a private npm workspace root, clear TypeScript pac
 │   │   │   ├── dump/                  # deterministic self-contained `.agents` tree output
 │   │   │   ├── merge/                 # deterministic value and array merge policy helpers
 │   │   │   ├── agents/                # AgentLaunch: bundled-pi resolution and process launch boundary
+│   │   │   ├── paths/                 # Outfitter cache root and repository/packaged asset resolution
 │   │   │   ├── schemas/               # JSON Schema artifacts for persisted formats
 │   │   │   └── validation/            # shared validation helpers
 │   │   ├── tests/                     # automated CLI package tests and fixtures

--- a/docs/architecture/file_structure.md
+++ b/docs/architecture/file_structure.md
@@ -3,7 +3,7 @@
 This document records the key repository file and directory structure used by Outfitter.
 See [`./README.md`](./README.md) for runtime file conventions such as `.agents` layers, settings files, and generated composition directories.
 
-> **RFC [#165](https://github.com/ai-outfitter/outfitter/issues/165) status:** the profile-era `profiles/` and `compositeProfile/` modules have been removed; `code/cli/src` now uses the dotagents pipeline (`resolver/`, `composer/`, `projection/`, `dump/`, `sources/`). Interactive `.agents` onboarding is back as `setup/` (the `outfitter setup` command and the implicit first-run trigger from `run`); remote `sync` remains deferred to a follow-up PR.
+> **RFC [#165](https://github.com/ai-outfitter/outfitter/issues/165) status:** the profile-era `profiles/` and `compositeProfile/` modules have been removed; `code/cli/src` now uses the dotagents pipeline (`resolver/`, `composer/`, `projection/`, `dump/`, `sources/`). Interactive `.agents` onboarding and explicit remote synchronization are implemented as `outfitter setup` and `outfitter sync`.
 
 ## Repository Layout
 
@@ -39,10 +39,10 @@ Outfitter is organized around a private npm workspace root, clear TypeScript pac
 │   │   ├── src/                       # production TypeScript source
 │   │   │   ├── cli.ts                 # executable CLI entry point
 │   │   │   ├── cli/                   # CLI parser construction and command objects
-│   │   │   │   └── commands/          # run, setup, list, validate, dump command objects
+│   │   │   │   └── commands/          # run, setup, sync, list, validate, dump command objects
 │   │   │   ├── settings/              # settings loading and merging
 │   │   │   ├── setup/                 # onboarding state + pinned default-catalog bootstrap
-│   │   │   ├── sources/               # remote `.agents` source cache paths and reference normalization
+│   │   │   ├── sources/               # cache paths, atomic Git checkout, redaction, and private-catalog gating
 │   │   │   ├── resolver/              # .agents layer resolution into one effective resource set
 │   │   │   ├── composer/              # harness-neutral CompositionPlan from the effective set
 │   │   │   ├── projection/            # materialize a composition + build a pi/claude launch plan

--- a/docs/documentation/catalogs.md
+++ b/docs/documentation/catalogs.md
@@ -101,11 +101,19 @@ Remote settings are cached locally and merged at lower precedence than your proj
 
 `outfitter sync` synchronizes every remote source into the local cache:
 
-1. Remote settings repositories are cloned or updated first, then reloaded.
+1. Local settings are validated. Remote settings repositories are cloned or updated first, then
+   merged settings are reloaded.
 2. Remote sources (including any added by remote settings) are cloned or updated.
 3. Each synced source is validated; sync reports `updated`, `unchanged`, `skipped`, or `failed` per source.
 
-Pinned (`ref:`) sources stay on their pinned ref until you change it; unpinned sources fast-forward on every sync.
+All repositories live under `<cache_directory>/repos/<encoded-uri-and-ref>/` (default
+`~/.agents/cache`). Pinned (`ref:`) sources stay on their selected ref until you change it; unpinned
+sources resolve the remote's current default branch on every sync.
+
+Fetch and validation happen in a temporary sibling directory. Outfitter swaps a valid checkout into
+place atomically, so a failed fetch or invalid update preserves the last working cache. A required
+source failure makes sync exit nonzero. `outfitter run` remains offline with respect to source
+synchronization; run sync explicitly when you want network updates.
 
 ## Private repositories
 

--- a/docs/documentation/cli.md
+++ b/docs/documentation/cli.md
@@ -1,7 +1,5 @@
 # CLI reference
 
-> **Status: RFC [#165](https://github.com/ai-outfitter/outfitter/issues/165) target.** This reference describes the dotagents end-state command surface. The currently released CLI still implements the legacy profile commands; implementation PRs replace them incrementally.
-
 Global options:
 
 | Option          | Description                  |
@@ -41,7 +39,17 @@ fallback.
 
 ## `outfitter sync`
 
-Synchronize remote sources and remote settings into the local cache. Reports a per-source status of `updated`, `unchanged`, `skipped`, or `failed`, and validates synced sources.
+Synchronize remote sources and remote settings into the local cache. Sync validates local settings,
+updates `remote_settings`, reloads the merged settings, and then updates the remote `sources` that
+result. Each repository reports `updated`, `unchanged`, `skipped`, or `failed`.
+
+Fetched content is validated in a temporary checkout before an atomic cache swap, so a failed fetch
+or invalid update leaves the last valid cache available. Required-source failures and invalid
+settings exit nonzero. Credentials embedded in URIs are redacted from status, errors, cache paths,
+and Git output.
+
+Sync is explicit: `outfitter run` never initiates network access. If a configured cache is absent,
+resolution tells you to run `outfitter sync`.
 
 ## `outfitter list [kind]`
 

--- a/docs/documentation/settings.md
+++ b/docs/documentation/settings.md
@@ -39,13 +39,15 @@ remote_settings:
     path: .agents/settings.yml
     ref: 9c47d1e2b8a05f36c4d7e90a12b3f8c5d6e71a04
 
-cache_directory: ~/.agents/cache
+cache_directory: ./cache # optional; relative to this settings file
 ```
 
 - `default_agent` / `default_harness` — which agent plain `outfitter` runs, and the harness it launches in.
 - `sources` — ordered list of remote or local `.agents` payloads. Remote entries (`github:` / `uri:`) accept `ref:` pinning and an optional `path:` to the payload inside the repository; see [Catalogs](./catalogs.md) for conventions and trust guidance.
 - `remote_settings` — shared settings a repository distributes; cached locally and merged below your project and user settings, so anything you set locally wins.
-- `cache_directory` — where remote sources are cached (`outfitter sync` updates them).
+- `cache_directory` — the repository cache root used consistently by sync, remote settings, remote
+  source resolution, and default-catalog setup. It defaults to `~/.agents/cache`; repositories live
+  below its `repos/` directory.
 
 ## Precedence
 

--- a/docs/requirements/OFTR-004-sync-and-setup.md
+++ b/docs/requirements/OFTR-004-sync-and-setup.md
@@ -1,11 +1,10 @@
 # OFTR-004: Setup, Sync, and Profile Creation Commands
 
-> **Amended (RFC [#165](https://github.com/ai-outfitter/outfitter/issues/165), 2026-07-17):** the
-> `.agents`-native **`setup`** command is now implemented as an interactive terminal onboarding flow —
-> see [OFTR-010](OFTR-010-onboarding-welcome.md), which supersedes the Pi-native model in OFTR-004.1.
-> **`sync`** (fetching `.agents` sources into `cache_directory`) and the profile-era `profile create` /
-> `profile list` commands (OFTR-004.2/.3/.5) remain **removed/deferred**; the current CLI surface is
-> `run`, `setup`, `list`, `validate`, and `dump`.
+> **Amended (RFC [#165](https://github.com/ai-outfitter/outfitter/issues/165) and
+> [#184](https://github.com/ai-outfitter/outfitter/issues/184), 2026-07-25):** the `.agents`-native
+> `setup` and `sync` commands are implemented. See [OFTR-010](OFTR-010-onboarding-welcome.md) for
+> onboarding. The profile-era `profile create` / `profile list` commands (OFTR-004.3/.5) remain
+> removed/deferred.
 
 ## Overview
 
@@ -24,15 +23,25 @@ Outfitter provides setup and maintenance commands that onboard a new user, synch
 
 1. Outfitter MUST provide a `sync` command.
 2. The `sync` command MUST read and validate settings before synchronizing sources.
-3. The `sync` command MUST fetch or update remote settings sources and URI-based profile sources.
-4. The `sync` command MUST store plain URI-based profile sources without `ref` or repository subpaths under `~/.outfitter/cache/profiles/<encoded-uri>/`, and MUST store URI or GitHub sources with `ref` or repository subpaths under `~/.outfitter/cache/repos/<encoded-uri-and-ref>/`.
+3. The `sync` command MUST synchronize locally configured `remote_settings` first, reload the
+   merged settings, and then synchronize every remote `sources` entry in the resulting settings.
+   Local `path:` sources MUST remain live and MUST NOT be copied into the cache.
+4. The `sync` command MUST store every URI or GitHub repository under
+   `<cache_directory>/repos/<encoded-uri-and-ref>/`. The default `cache_directory` is
+   `~/.agents/cache`; the selected value MUST be shared by sync, remote-settings loading, layer
+   discovery, and default-catalog bootstrap.
 5. The encoded URI cache path MUST support non-GitHub URIs.
-6. The `sync` command MUST validate profiles loaded from synchronized sources.
-7. The `sync` command SHOULD report whether each source was updated, unchanged, skipped, or failed.
-8. The first version of `sync` MUST NOT require lockfile-based profile source reproducibility.
-9. The `sync` command MUST redact credentials embedded in source URIs from user-facing output.
-10. `~/.outfitter/settings.yml` MUST be the source of truth for private GitHub profile catalog enablement, using `enterprise.private_catalogs: true`.
-11. If `enterprise.private_catalogs` is already true in `~/.outfitter/settings.yml`, setup and sync MUST NOT show private-catalog enterprise information or prompts.
+6. The `sync` command MUST validate fetched remote settings against the settings schema and validate
+   fetched `.agents` payloads before making them active.
+7. The `sync` command MUST report `updated`, `unchanged`, `skipped`, or `failed` for each configured
+   remote and MUST exit nonzero when any required remote fails or merged settings are invalid.
+8. Fetch and validation MUST occur in a temporary sibling directory. A successful checkout MUST be
+   swapped into place atomically; any fetch, checkout, validation, or swap failure MUST preserve an
+   existing valid cache. The first version of `sync` MUST NOT require lockfiles or provenance.
+9. The `sync` command MUST redact credentials embedded in source URIs from status, errors, cache
+   identifiers, and captured Git stdout/stderr.
+10. `~/.agents/settings.yml` MUST be the source of truth for private GitHub profile catalog enablement, using `enterprise.private_catalogs: true`.
+11. If `enterprise.private_catalogs` is already true in `~/.agents/settings.yml`, setup and sync MUST NOT show private-catalog enterprise information or prompts.
 12. If setup or sync detects a confirmed-private GitHub catalog while the home setting is not enabled, interactive flows SHOULD ask whether to enable it and MUST include this prompt text:
 
     ```text
@@ -41,13 +50,13 @@ Outfitter provides setup and maintenance commands that onboard a new user, synch
     Private profile catalog support is covered by the Outfitter Enterprise license.
     Review code/enterprise/LICENSE or your enterprise agreement before enabling.
 
-    Enable private profile catalogs in ~/.outfitter/settings.yml? [y/N]
+    Enable private profile catalogs in ~/.agents/settings.yml? [y/N]
     ```
 
-13. If the user accepts, setup or sync MUST write `enterprise.private_catalogs: true` to `~/.outfitter/settings.yml` and show:
+13. If the user accepts, setup or sync MUST write `enterprise.private_catalogs: true` to `~/.agents/settings.yml` and show:
 
     ```text
-    info: Enabled private profile catalogs in ~/.outfitter/settings.yml.
+    info: Enabled private profile catalogs in ~/.agents/settings.yml.
     ```
 
 14. If the user declines, setup or sync MUST skip that private catalog without changing settings and show:
@@ -59,11 +68,15 @@ Outfitter provides setup and maintenance commands that onboard a new user, synch
 15. Non-interactive setup and sync SHOULD skip confirmed-private GitHub catalogs without warning, error, or blocking public/unknown sources, and SHOULD show:
 
     ```text
-    info: Private GitHub profile catalog detected: OWNER/REPO. Enable enterprise.private_catalogs in ~/.outfitter/settings.yml after reviewing code/enterprise/LICENSE or your enterprise agreement.
+    info: Private GitHub profile catalog detected: OWNER/REPO. Enable enterprise.private_catalogs in ~/.agents/settings.yml after reviewing code/enterprise/LICENSE or your enterprise agreement.
     ```
 
 16. GitHub privacy detection MUST only treat an HTTP 200 GitHub API response with JSON `private: true` as private. Public responses, unknown responses, HTTP 403/404, network failures, malformed responses, and non-GitHub sources MUST NOT warn, error, or block.
 17. Private catalog enablement MUST remain informational commercial governance and MUST NOT collect, echo, persist, synthesize, or validate provider credentials.
+18. Resolution MUST report a configured remote source or remote-settings target whose cache is
+    absent with actionable `outfitter sync` guidance instead of silently dropping it.
+19. Automatic network synchronization during `outfitter run` is out of scope. Operators invoke
+    `outfitter sync` explicitly.
 
 ### OFTR-004.3: Create Profile Command
 

--- a/scripts/sync-release-version.mjs
+++ b/scripts/sync-release-version.mjs
@@ -2,6 +2,7 @@
 
 // Synchronizes package metadata to the GitHub release version before npm publishing.
 import fs from 'node:fs/promises';
+import { writeSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -56,7 +57,7 @@ if (cliPackageJsonPath !== rootPackageJsonPath) {
 }
 await writeJson(cliPackageJsonPath, cliPackageJson);
 
-console.log(`Synchronized Outfitter release metadata to ${version}.`);
+writeSync(1, `Synchronized Outfitter release metadata to ${version}.\n`);
 
 function dirnameFromImportMeta(importMetaUrl) {
   return path.dirname(fileURLToPath(importMetaUrl));


### PR DESCRIPTION
Adds `outfitter sync`, which fetches configured remote settings and sources into the local cache in two deterministic phases: remote settings first, then the sources the reloaded settings resolve to.

## What's in it

- **`sources/GitRepository.ts`** — fetches into a temporary sibling and swaps only a *validated* checkout into place. A failed fetch, checkout, validation, or rename leaves an existing cache intact.
- **`sources/PrivateCatalogGate.ts`** — bridges to the enterprise private-catalog policy boundary, skipping private GitHub catalogs unless the user opts in.
- **`cli/commands/SyncCommand.ts`** — the two-phase sync, per-source status reporting (`updated`/`unchanged`/`skipped`/`failed`), and exit-code derivation.
- **`setup/DefaultCatalog.ts`** — bootstraps the pinned default catalog through the same atomic fetch path.
- Layer discovery and settings loading now report an unsynchronized remote source with `Run 'outfitter sync'` guidance.
- Credentials embedded in source URIs are redacted from every message, including captured git stderr.

## Verification

- `npm run check` passes: typecheck, lint, 239 tests, coverage 99.27% statements / 98.05% branches.
- Smoke-tested against a real remote: `outfitter sync` reports `unchanged` for the pinned default catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)