### PR TITLE
docs: stabilize the single-file persona convention

### DIFF
--- a/.outfitter/skills/outfitter/SKILL.md
+++ b/.outfitter/skills/outfitter/SKILL.md
@@ -53,7 +53,7 @@ before answering or editing configuration.
   extensions, plugins, model, thinking, tools): read `references/profiles.md`.
 - The `agents/<id>/agent.md` resource format and loadout fields: read
   `references/agents.md`.
-- Personas — the base-agent-plus-persona-documents convention: read
+- Personas — one portable persona document plus the shared reviewer: read
   `references/personas.md`.
 - Subagents and leader-agent delegation: read `references/subagents.md`.
 - Authoring or selecting skills, SKILL.md layout, skill references: read

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Managed porting and persistent harness symlinks are deferred to
   commands/            # slash commands
 ```
 
-Layers merge by ID: `<project>/.agents/` over `~/.agents/` over pinned remote [catalogs](./docs/documentation/catalogs.md). An [agent](./docs/documentation/agents.md) carries both its identity and its loadout — an [agent profile](./docs/documentation/profiles.md) — and is what you run; a [persona](./docs/documentation/personas.md) is a review convention layered on a base agent; a [subagent](./docs/documentation/subagents.md) is an agent a run delegates to, across [four delegation boundaries](./docs/documentation/subagents.md#the-four-delegation-boundaries) from an in-session helper to a Kubernetes Job.
+Layers merge by ID: `<project>/.agents/` over `~/.agents/` over pinned remote [catalogs](./docs/documentation/catalogs.md). An [agent](./docs/documentation/agents.md) carries both its identity and its loadout — an [agent profile](./docs/documentation/profiles.md) — and is what you run; a [persona](./docs/documentation/personas.md) is one portable Markdown document a shared review agent adopts at launch; a [subagent](./docs/documentation/subagents.md) is an agent a run delegates to, across [four delegation boundaries](./docs/documentation/subagents.md#the-four-delegation-boundaries) from an in-session helper to a Kubernetes Job.
 
 ## Documentation
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -227,7 +227,7 @@ Validation happens at every file boundary: settings (`settings.schema.json`), pr
 
 - Global coverage threshold: 100% for statements, branches, functions, and lines.
 - **Protocol conformance fixtures**: layered `.agents` trees with expected effective resolution output, pinned to the protocol revision.
-- Deterministic tests for settings precedence, persona composition order, task input validation, bake determinism (content-hash stability), dump byte-identity and hygiene (no credentials/state), cache path encoding, generated launch env/argv, and unsupported elements with `--strict`.
+- Deterministic tests for settings precedence, task input validation, bake determinism (content-hash stability), dump byte-identity and hygiene (no credentials/state), cache path encoding, generated launch env/argv, and unsupported elements with `--strict`.
 - Scenario fixtures for common combinations instead of one-off bespoke setup; conventions in [`./file_structure.md`](./file_structure.md).
 
 ## Settled Decisions

--- a/docs/architecture/controllable-elements.md
+++ b/docs/architecture/controllable-elements.md
@@ -34,7 +34,7 @@ The directory where conversation sessions, transcripts, or run state are stored.
 
 ### Personas
 
-Not a composed key. A persona is a convention: a base review [agent](../documentation/agents.md) plus an interchangeable persona description document fed as input (see [Personas](../documentation/personas.md)). The controllable element underneath it is the agent's composed identity — `system-prompt.md`, `agents.md`, and the selected `agents/<id>/agent.md` — not a `personas` list.
+Not a composed key. A persona is a convention: a shared review [agent](../documentation/agents.md) plus one portable persona document appended at launch (see [Personas](../documentation/personas.md)). The controllable element underneath it is harness argument passthrough — `--append-system-prompt <file>` on the launch command — not a `personas` list.
 
 - Pi name: `--system-prompt` / `--append-system-prompt` composition
 - Claude name: `--system-prompt` / `--append-system-prompt` composition

--- a/docs/documentation/README.md
+++ b/docs/documentation/README.md
@@ -15,7 +15,7 @@ Outfitter lays out conventions for iterating on and sharing agent configuration 
 - [Agents](./agents.md) — the `agents/<id>/agent.md` resource and its loadout — what you run.
 - [Agent profiles](./profiles.md) — why an agent and its loadout _is_ the profile.
 - [Skills](./skills.md) — capability packages with progressive disclosure, references, and routing.
-- [Personas](./personas.md) — the base-agent-plus-persona-documents review convention.
+- [Personas](./personas.md) — one portable Markdown file per persona; append at launch or paste anywhere.
 - [Subagents and delegation](./subagents.md) — the four delegation boundaries, from in-session helpers to Kubernetes Jobs.
 - [Settings](./settings.md) — scopes, schema, and the flat `settings.local.yml` override file.
 - [Tasks](./tasks.md) — placeholder for a separate upcoming RFC.
@@ -49,7 +49,7 @@ Each use case is a worked story — a problem, the composition that answers it, 
 - [Grafana alert investigations in-cluster](./usecases/grafana-alert-investigator.md) — a webhook turns each firing alert into one bounded investigation Job.
 - [Self-improving skills](./usecases/self-improving-skills.md) — a weekly loop that proposes skill edits and ships only measured improvements.
 - [Resident agents: a researcher wiki](./usecases/resident-agents.md) — a long-lived agent that turns an email inbox into a compounding, reviewable knowledge base.
-- [Persona reviews](./usecases/persona-reviews.md) — a base review agent plus customer-persona documents for feedback on ideas, docs, and designs.
+- [Persona reviews](./usecases/persona-reviews.md) — author one persona file, run it through the shared reviewer, paste the same file into any web agent.
 - [Organization catalog](./usecases/organization-profile-catalog.md) — publish shared org resources and defaults through an `owner/.outfitter` control repository.
 - [Engineering catalog](./usecases/engineering.md) — package engineering agents and skills for repeatable workflows.
 

--- a/docs/documentation/cli.md
+++ b/docs/documentation/cli.md
@@ -21,7 +21,7 @@ Any other arguments and unrecognized options are passed through to the launched 
 
 ```bash
 outfitter run engineer --harness claude
-outfitter run reviewer -- --print "summarize this repo"
+outfitter run persona-reviewer -- --print "summarize this repo"
 ```
 
 ## `outfitter setup [source]`

--- a/docs/documentation/concepts.md
+++ b/docs/documentation/concepts.md
@@ -49,7 +49,7 @@ The protocol resources Outfitter resolves and composes:
 Three related terms, none of which is a settings key or a separate file format:
 
 - A **[profile](./profiles.md)** is just an agent and its loadout. "The engineer profile" is the `engineer` agent with everything it composes. There is no `profile.yml` and no `profiles:` map — the loadout lives on the agent.
-- A **[persona](./personas.md)** is a _convention_, not a resource: a base review agent (a base prompt plus how-to-review instructions) that reads an interchangeable persona description document — for example `docs/user-personas/coyote-road-runner-chaser.md` — as input. Swapping the input document swaps the persona.
+- A **[persona](./personas.md)** is a _convention_, not a resource: one portable, committed Markdown document per persona — for example `docs/personas/platform-lead.md` — appended at launch to a shared review agent, or pasted into any tool as stakeholder context. Swapping the file swaps the persona.
 - A **[subagent](./subagents.md)** is an agent projected into the harness's native delegation mechanism, selected in another agent's `subagents` loadout. A leader agent delegates to local coding-harness subagents or to issue- and action-backed subagents.
 
 The same agent definition can be run directly or selected as a subagent elsewhere; its loadout decides what it composes.

--- a/docs/documentation/conventions.md
+++ b/docs/documentation/conventions.md
@@ -50,6 +50,16 @@ The same convention builds a role-scoped profile — a `platform` or `marketing`
 - **Bespoke per org two ways:** as a [subagent](./subagents.md) other agents delegate role work to, or via one org-specific skill (a `brand` or `platform` skill) carrying the values — endpoints, voice, RBAC — that make the shared profile bespoke without duplicating it.
 - **Role separation is the point.** An engineer or a marketer doesn't want the other's machinery in context; they work in their own lane and delegate across lanes when needed. Cross-cutting work stays _available_ through inheritance and delegation, not by stuffing every profile.
 
+## Worked example: persona documents
+
+The [persona convention](./personas.md) is the ladder's non-technical on-ramp ([#197](https://github.com/ai-outfitter/outfitter/issues/197)): contributing a persona means committing one portable Markdown file, never touching a loadout.
+
+- **Community layer supplies the machinery** — the shared `persona-reviewer` agent and the `persona-authoring` / `persona-review` skills ship once, in [`community-profiles`](https://github.com/ai-outfitter/community-profiles).
+- **The project layer holds only the files** — a marketer or founder authors `docs/personas/platform-lead.md` (with `persona-authoring` interviewing them, or from the template by hand) and commits it as ordinary project documentation. No agent, no YAML, no `.agents` entry.
+- **Never copy** — adding a tenth persona is a tenth file, not a tenth reviewer; the same file also pastes unchanged into web agents as stakeholder context, so the artifact outlives any one harness.
+
+The full story is the [Persona reviews use case](./usecases/persona-reviews.md).
+
 ## Roadmap: a shareable prompt fragment
 
 Today the always-on vehicle is a tree's root `agents.md` / `system-prompt.md` — one file per layer. It inherits and overrides _per layer_, but you cannot yet publish one named fragment from a community catalog and override just that fragment by ID. A first-class, slug-composable shared prompt fragment is the missing primitive; until it lands, a single line per layer's shared context still deduplicates by inheritance — just not as a publishable unit. [Hooks](./hooks.md) carry the analogous gap for portable hook definitions.

--- a/docs/documentation/getting-started.md
+++ b/docs/documentation/getting-started.md
@@ -39,7 +39,7 @@ Learn how shared sources work in [Catalogs](./catalogs.md), then see [Agents](./
 
 ```bash
 outfitter run engineer
-outfitter run reviewer --harness claude
+outfitter run persona-reviewer --harness claude
 outfitter sync
 outfitter list agents
 outfitter validate

--- a/docs/documentation/personas.md
+++ b/docs/documentation/personas.md
@@ -2,40 +2,41 @@
 
 A persona is not a resource or a settings key — it is a **convention** built from ordinary pieces:
 
-1. A **base review agent** — a normal [agent](./agents.md) whose prompt says how to review something (an app, docs, a UX flow): what to look at, what evidence to cite, what output shape to return.
-2. Interchangeable **persona description documents** — plain markdown files with attributes in frontmatter and a short bio underneath. They come in two kinds you **mix and match**: a **role** (a reusable job archetype — goals, anxieties, buying triggers shared across a customer segment) and an **individual** (a named person with demographics — birthdate, income, education, hobbies, skills — who inherits one or more roles and adds their own voice). Give each the concreteness a [Lean Canvas](https://leanstack.com/lean-canvas) customer segment gets.
+1. A **shared review agent** — [`persona-reviewer`](https://github.com/ai-outfitter/community-profiles/blob/main/agents/persona-reviewer/agent.md), a normal [agent](./agents.md) from the community catalog whose prompt says how to review something and what a sourced report looks like. There is one reviewer for all personas, never one agent per persona.
+2. **One committed Markdown file per persona** — a portable, self-contained document. The whole persona lives in that one file; swapping the file swaps the persona, and the review rules stay fixed.
 
-You run the base agent and feed it the persona files to adopt: a role, refined by an individual. Swapping the files swaps the persona; the base agent — the review rules — stays fixed. Nothing new is added to the protocol: it is one agent plus a folder of description files. See [Persona reviews](./usecases/persona-reviews.md) for the full shape.
+## The format
+
+A persona file is plain Markdown with no frontmatter, no schema, and no classifier:
+
+- Starts directly with an H1 naming a **generic role archetype**: `# Platform Lead`, `# Founder-operator`. (A named individual — `# Priya Nair — Platform Lead` — is an optional variant for when a specific person's voice is the point; the generic form is canonical.)
+- First-person prose: an unheaded opening paragraph that stands alone as an introduction, then the recommended sections `## My work and context`, `## What I need`, `## How I decide`, and `## How I communicate`. Sections may be renamed or combined; connected prose beats bullet stacks.
+- Everything the persona knows — role, organization, goals, concerns, constraints, decision signals, voice — is ordinary Markdown a human would read.
+
+It lives in normal project documentation, deliberately **outside** `.agents/`:
 
 ```text
-customer-review/
-  agents/
-    reviewer/agent.md          # base: how to review, what to return
-  settings.yml
-docs/user-personas/
-  roles/                       # reusable job archetypes
-    staff-engineer.md
-    founder-operator.md
-  individuals/                 # named people, each naming one or more roles
-    marcus-bell.md
-    dana-okafor.md
+docs/personas/
+  platform-lead.md
+  founder-operator.md
 ```
+
+A persona is project steering context, not agent configuration — which is why `outfitter dump` does not carry it, by design. The executable artifacts of this format — an authoring template and completed reference personas — ship in the community catalog's [`persona-authoring`](https://github.com/ai-outfitter/community-profiles/tree/main/skills/persona-authoring) skill.
+
+## Three ways to consume the same file
+
+- **Appended at launch**: `outfitter run persona-reviewer -- --append-system-prompt docs/personas/platform-lead.md …`, or the [`persona-review`](https://github.com/ai-outfitter/community-profiles/tree/main/skills/persona-review) skill's launcher script that wraps it. The reviewer adopts the file as its identity for that session only.
+- **Pasted into a web agent**: upload or paste the file unchanged into claude.ai project knowledge or a ChatGPT project as stakeholder context. Same artifact, zero conversion.
+- **Ordinary reading context**: any agent doing product planning, research, or writing can read the file to know who the work is for.
 
 ## Why a convention, not a key
 
-Modeling personas as their own resource — or as a `personas:` list you compose in order — duplicates what an agent already is and grows the surface area of the system. Agents are exactly what that machinery was reaching for. Keeping personas as "base agent + description document" means a team maintains one review agent and a directory of cheap markdown files, instead of a fleet of near-identical agents.
+Modeling personas as their own resource — or as a `personas:` list you compose in order — duplicates what an agent already is and grows the surface area of the system. Keeping personas as "shared agent + one document" means a team maintains one review agent and a directory of cheap Markdown files, instead of a fleet of near-identical agents or a runtime chain of fragments.
 
-## Running a persona review
+Organization research, interviews, and individual detail are **authoring inputs**, not committed schema: interview from them, keep research notes however you like, but the committed canonical artifact is always one self-contained role file. Do not invent demographics, income, or biography the research does not support, and never generate an Outfitter agent per persona.
 
-Point the base agent at the artifact and name the persona files to adopt — a role refined by an individual:
+## Status
 
-```bash
-outfitter run reviewer -- --print \
-  "Adopt docs/user-personas/roles/founder-operator.md refined by \
-   docs/user-personas/individuals/dana-okafor.md. Review README.md and \
-   docs/getting-started.md and return the standard review shape."
-```
+Personas ride entirely on existing CLI behavior (`outfitter run` plus `--append-system-prompt` passthrough), so no `OFTR-*` requirement covers them — they are a documentation convention, not shipped surface. An `.agents`-native persona form (a protocol resource, or a settings layer pointing at persona documents) is a separate, deferred design; the portable file must never depend on it.
 
-Because the base agent fixes the output shape, feedback from different persona documents stays directly comparable.
-
-See [Persona reviews](./usecases/persona-reviews.md) for a complete catalog example.
+See [Persona reviews](./usecases/persona-reviews.md) for the worked author → run → paste-anywhere story, and the community catalog's [persona boundary doc](https://github.com/ai-outfitter/community-profiles/blob/main/docs/persona-review.md) for the setup and runtime responsibility split.

--- a/docs/documentation/profiles.md
+++ b/docs/documentation/profiles.md
@@ -23,7 +23,7 @@ Settings ([settings.md](./settings.md)) is left with just resolution and launch 
 
 ## Composing from a base
 
-To share behavior across several agents, keep shared operating context in the tree's `system-prompt.md` and `agents.md` — every agent in the tree inherits those — and put shared procedures in [skills](./skills.md) each agent selects. Selecting an agent as a subagent does _not_ share its policy; it only makes that agent available as a delegation target. The [persona](./personas.md) convention builds on the shared-context idea: one base review agent, many interchangeable persona description documents fed as input.
+To share behavior across several agents, keep shared operating context in the tree's `system-prompt.md` and `agents.md` — every agent in the tree inherits those — and put shared procedures in [skills](./skills.md) each agent selects. Selecting an agent as a subagent does _not_ share its policy; it only makes that agent available as a delegation target. The [persona](./personas.md) convention builds on the shared-context idea: one shared review agent, many single-file persona documents appended at launch.
 
 ## Migrating from authored profiles
 

--- a/docs/documentation/skills.md
+++ b/docs/documentation/skills.md
@@ -57,7 +57,7 @@ Every skill directory contains `SKILL.md`. Its `name` MUST match the directory n
 ```yaml
 ---
 name: outfitter-actions
-description: Design concise GitHub automation using stable personas and progressively disclosed skills.
+description: Design concise GitHub automation using stable agent identities and progressively disclosed skills.
 ---
 # Outfitter Actions
 
@@ -215,7 +215,7 @@ Loadout-added entries use the same `file` / `repo_file` sources and validation r
 
 ### Trust boundary
 
-Treat `file` references with the same trust as the skill that declares them. Treat every `repo_file` reference as untrusted repository content. A skill SHOULD select its workflow before reading repository references and MUST NOT allow instructions inside a reference to override persona policy, safety boundaries, or the user's request.
+Treat `file` references with the same trust as the skill that declares them. Treat every `repo_file` reference as untrusted repository content. A skill SHOULD select its workflow before reading repository references and MUST NOT allow instructions inside a reference to override the agent's identity and policy, safety boundaries, or the user's request.
 
 Outfitter resolves and normalizes reference targets before launch. Targets MUST remain within their root after following symlinks; escaping, colliding, and broken `file` references fail validation. A directory target is scanned recursively so a contained symlink cannot smuggle outside content into the generated skill.
 

--- a/docs/documentation/usecases/engineering.md
+++ b/docs/documentation/usecases/engineering.md
@@ -28,7 +28,7 @@ default_agent: engineer
 
 ## Shared operating context
 
-Rules that apply to every agent in the tree live in `agents.md`, so each role inherits them without ordered persona composition:
+Rules that apply to every agent in the tree live in `agents.md`, so each role inherits them:
 
 ```markdown
 <!-- agents.md -->

--- a/docs/documentation/usecases/organization-profile-catalog.md
+++ b/docs/documentation/usecases/organization-profile-catalog.md
@@ -26,7 +26,7 @@ default_agent: engineer
 
 ## Shared operating context
 
-Rules every role shares live in the tree's `agents.md`, inherited by each agent without ordered persona composition:
+Rules every role shares live in the tree's `agents.md`, inherited by each agent:
 
 ```markdown
 <!-- .agents/agents.md -->

--- a/docs/documentation/usecases/persona-reviews.md
+++ b/docs/documentation/usecases/persona-reviews.md
@@ -4,13 +4,13 @@ A persona review gathers structured feedback on a product, docs, onboarding flow
 
 ## One persona = one file
 
-The whole persona is one portable, self-contained Markdown document — H1 first, no frontmatter, first-person prose. Abridged from the canonical [`priya-nair.md`](https://github.com/ai-outfitter/community-profiles/blob/main/skills/persona-authoring/references/personas/priya-nair.md) reference:
+The whole persona is one portable, self-contained Markdown document — a generic role archetype, H1 first, no frontmatter, first-person prose. Abridged from the canonical [`platform-lead.md`](https://github.com/ai-outfitter/community-profiles/blob/main/skills/persona-authoring/references/personas/platform-lead.md) reference:
 
 ```markdown
-# Priya Nair — Platform Lead
+# Platform Lead
 
-I'm Priya Nair, the platform lead responsible for a consistent, reproducible
-agent setup across a mid-sized engineering organization.
+I'm the platform lead responsible for a consistent, reproducible agent setup
+across a mid-sized engineering organization.
 
 ## My work and context
 
@@ -32,10 +32,11 @@ Start from the community catalog's [`template.persona.md`](https://github.com/ai
 
 ```text
 docs/personas/
-  priya-nair.md
+  platform-lead.md
+  founder-operator.md
 ```
 
-Role archetypes and individual detail are interview inputs; the committed artifact is always the one self-contained file, with nothing invented that the research does not support.
+Prefer generic role archetypes over named individuals; organization research, interviews, and individual detail are authoring inputs, and the committed artifact is always the one self-contained file with nothing invented that the research does not support.
 
 ## Run it under Outfitter
 
@@ -52,12 +53,12 @@ Then launch the shared reviewer with the persona appended — directly, or via t
 
 ```bash
 bash skills/persona-review/scripts/persona-review.sh \
-  --persona docs/personas/priya-nair.md \
+  --persona docs/personas/platform-lead.md \
   -- --print "Review the onboarding flow and write the report. @README.md"
 
 # both paths reduce to:
 outfitter run persona-reviewer -- \
-  --append-system-prompt docs/personas/priya-nair.md \
+  --append-system-prompt docs/personas/platform-lead.md \
   --print "Review the onboarding flow and write the report. @README.md"
 ```
 
@@ -65,7 +66,7 @@ One shared agent adopts the file as its identity for that session only and write
 
 ## Take the same file to the web
 
-Paste or upload `docs/personas/priya-nair.md` unchanged into a claude.ai project's knowledge or a ChatGPT project and say: "Treat this as stakeholder context. Review the attached landing page from her point of view." Same artifact, zero conversion — the file was written to read standalone, so any tool that accepts Markdown context can use it.
+Paste or upload `docs/personas/platform-lead.md` unchanged into a claude.ai project's knowledge or a ChatGPT project and say: "Treat this as stakeholder context. Review the attached landing page from this persona's point of view." Same artifact, zero conversion — the file was written to read standalone, so any tool that accepts Markdown context can use it.
 
 ## Why this shape
 

--- a/docs/documentation/usecases/persona-reviews.md
+++ b/docs/documentation/usecases/persona-reviews.md
@@ -1,167 +1,76 @@
 # Persona Reviews
 
-A persona review catalog gathers structured feedback on a product, docs, onboarding flow, or UX from the points of view of the people who might use it — before asking real prospects to spend time. It uses the [persona convention](../personas.md): **one base review agent** plus a **directory of persona description documents**, run once per document.
+A persona review gathers structured feedback on a product, docs, onboarding flow, or UX from the point of view of the people who might use it — before asking real prospects to spend time. It uses the [persona convention](../personas.md): **one shared review agent** plus **one committed Markdown file per persona**. The same file runs under Outfitter, and pastes unchanged into any web agent.
 
-There is no `personas:` map and no agent per customer type. The review rules live in a single agent; each persona is a cheap markdown file you feed it as input.
+## One persona = one file
+
+The whole persona is one portable, self-contained Markdown document — H1 first, no frontmatter, first-person prose. Abridged from the canonical [`priya-nair.md`](https://github.com/ai-outfitter/community-profiles/blob/main/skills/persona-authoring/references/personas/priya-nair.md) reference:
+
+```markdown
+# Priya Nair — Platform Lead
+
+I'm Priya Nair, the platform lead responsible for a consistent, reproducible
+agent setup across a mid-sized engineering organization.
+
+## My work and context
+
+I own shared agent configuration for a roughly 150-engineer B2B SaaS company.
+…
+
+## How I decide
+
+I look for clear precedence, pinned sources, documented secret boundaries,
+least-privilege access, and tests showing that credentials stay isolated
+between layers. … I check the escape hatch first.
+```
+
+There is no `personas:` map and no agent per customer type. The review rules live in the shared [`persona-reviewer`](https://github.com/ai-outfitter/community-profiles/blob/main/agents/persona-reviewer/agent.md) agent; each persona is a cheap Markdown file you append to it.
+
+## Author it
+
+Start from the community catalog's [`template.persona.md`](https://github.com/ai-outfitter/community-profiles/blob/main/skills/persona-authoring/assets/template.persona.md) by hand, or let any agent that selects the [`persona-authoring`](https://github.com/ai-outfitter/community-profiles/tree/main/skills/persona-authoring) skill interview you into the file. Commit the result to normal project documentation:
 
 ```text
-customer-review/                 # standalone .agents repo; root is the payload
-  agents/
-    reviewer/agent.md            # the base review agent
-  settings.yml
-docs/user-personas/
-  roles/                         # reusable job archetypes (shared segment priorities)
-    staff-engineer.md
-    founder-operator.md
-    platform-lead.md
-  individuals/                   # specific named people, each naming one or more roles
-    marcus-bell.md               # roles: [staff-engineer]
-    dana-okafor.md               # roles: [founder-operator]
-    priya-nair.md                # roles: [platform-lead]
+docs/personas/
+  priya-nair.md
 ```
 
-Personas come in two kinds of file, and a review **mixes and matches** them: a **role** carries the priorities everyone in a customer segment shares, and an **individual** is one named person who inherits one or more roles and adds their own demographics and voice. Keep roles reusable and individuals concrete, and you can cover a lot of viewpoints from a small set of files.
+Role archetypes and individual detail are interview inputs; the committed artifact is always the one self-contained file, with nothing invented that the research does not support.
 
-## Settings
+## Run it under Outfitter
 
-Settings only names the default agent and where resources resolve from — no persona list:
+Add the community catalog as a source and sync:
 
 ```yaml
-# settings.yml
-default_agent: reviewer
+# ~/.agents/settings.yml
+sources:
+  - github: ai-outfitter/community-profiles
+    ref: <tag-or-commit>
 ```
 
-## The base review agent
-
-One agent holds the review method and the output shape. It does not name any customer type; it reads the persona files it is told to adopt, in order.
-
-```
-<!-- agents/reviewer/agent.md -->
----
-name: reviewer
-description: Reviews an artifact from the point of view of an assigned customer persona.
----
-
-Adopt the persona files named in your instructions, in order: a role file
-establishes the segment's priorities, and an individual file layers that
-person's demographics and voice on top (later files refine earlier ones). If
-an individual names roles in its frontmatter, treat those as its baseline.
-
-Read or experience the provided artifact from that persona's point of view:
-docs, screenshots, website, prototype, product flow, or onboarding path.
-Distinguish evidence from assumptions, cite the exact page or UI moment that
-shaped your reaction, and do not invent real customer research.
-
-Return feedback as: persona, artifact reviewed, first impression, top blocker,
-strongest value signal, confusing language, suggested change, and confidence.
-If you need more context, ask for the smallest missing artifact.
-```
-
-## Roles: reusable job archetypes
-
-A role captures what everyone in a customer segment shares — the job, its goals, anxieties, buying triggers, and what its feedback focuses on — with no personal detail. Roles are reused across many individuals.
-
-```
-<!-- docs/user-personas/roles/staff-engineer.md -->
----
-kind: role
-title: Staff Engineer
-segment: large-eng-org
-goals: [reduce cross-team friction, raise technical quality, adopt tools that survive scrutiny]
-anxieties: [tools that demo well but fail on a real codebase, unproven claims]
-buying_triggers: [credible examples, verifiable outcomes, a clean migration path]
-feedback_focus: [depth, verification paths, missing examples, evidence behind claims]
----
-
-Responsible for large codebases, architecture decisions, reviews, and
-cross-team technical quality. Cares whether the docs explain how the product
-improves real engineering work. Flags missing examples, weak verification
-paths, and claims that need evidence.
-```
-
-```
-<!-- docs/user-personas/roles/founder-operator.md -->
----
-kind: role
-title: Founder-operator
-segment: seed-stage-startup
-goals: [ship weekly, keep the team small, reach the next milestone before the runway ends]
-anxieties: [tool sprawl, hidden pricing, time lost to setup]
-buying_triggers: [obvious value in the first hour, no credit card to try]
-feedback_focus: [time-to-first-value, jargon, trust boundaries, pricing clarity]
----
-
-A hands-on founder who writes product specs, edits docs, ships small features,
-and manages a thin team. Cares whether the first hour feels obviously valuable.
-```
-
-## Individuals: named people who inherit roles
-
-An individual is one concrete person — with the demographics a [Lean Canvas](https://leanstack.com/lean-canvas) customer segment gets — who names one or more roles to inherit and then adds their own attributes and voice. The named person **mixes and matches** roles: usually one, but a founder who also runs the platform can list both.
-
-```
-<!-- docs/user-personas/individuals/marcus-bell.md -->
----
-kind: individual
-name: Marcus Bell
-roles: [staff-engineer]
-born: 1985-11-02
-location: Seattle, WA
-household_income: 265000
-education: MS Computer Engineering
-employer: ~400-engineer fintech
-hobbies: [rock climbing, sci-fi novels, restoring old synths]
-skills: [distributed systems, code review, architecture, mentoring]
-tone: dry, skeptical, cites sources
----
-
-Reads new tooling the way he reads a design doc: looking for the failure mode
-first. Warm once convinced, but will not take a benchmark on faith.
-```
-
-```
-<!-- docs/user-personas/individuals/dana-okafor.md -->
----
-kind: individual
-name: Dana Okafor
-roles: [founder-operator, platform-lead] # mixes two roles
-born: 1989-03-14
-location: Austin, TX
-household_income: 180000
-education: BS Computer Science
-employer: 6-person seed-stage startup (also the de facto platform owner)
-hobbies: [trail running, home espresso, mechanical keyboards]
-skills: [product specs, TypeScript, fundraising, hiring]
-tone: fast, pragmatic, allergic to jargon
----
-
-Wears the founder and the platform hat at once, so she weighs first-hour value
-against fleet-wide safety in the same breath. Impatient with setup friction.
-```
-
-Keep the role attribute set consistent so reviews stay comparable, and let individuals vary freely in demographics and tone. Add more roles (`platform-lead`, `engineering-manager`, `agency-consultant`) and more individuals the same way.
-
-## Running the reviews
-
-Run the base agent once per persona, naming the role and individual files to adopt and the artifact under review:
+Then launch the shared reviewer with the persona appended — directly, or via the `persona-review` skill's launcher:
 
 ```bash
-outfitter run reviewer -- --print \
-  "Adopt docs/user-personas/roles/staff-engineer.md refined by \
-   docs/user-personas/individuals/marcus-bell.md. Read README.md, \
-   docs/getting-started.md, and docs/pricing.md, then return the standard \
-   review shape: where the product feels credible, where it feels \
-   underspecified, and the one example that would most improve your confidence."
+bash skills/persona-review/scripts/persona-review.sh \
+  --persona docs/personas/priya-nair.md \
+  -- --print "Review the onboarding flow and write the report. @README.md"
+
+# both paths reduce to:
+outfitter run persona-reviewer -- \
+  --append-system-prompt docs/personas/priya-nair.md \
+  --print "Review the onboarding flow and write the report. @README.md"
 ```
 
-```bash
-outfitter run reviewer -- --print \
-  "Adopt docs/user-personas/individuals/dana-okafor.md and the roles it names. \
-   Browse the local docs site and try the first-run setup flow. Report the \
-   first confusing moment, the first moment that felt valuable, and whether \
-   you would keep using it."
-```
+One shared agent adopts the file as its identity for that session only and writes a first-person, sourced report — evidence cited to the exact page or UI moment, assumptions labeled. The catalog agent pins a model (`openai-codex/gpt-5.5`); use the launcher's `--agent` flag or a settings-layer model override to run it on whatever you have credentials for.
 
-Model and thinking choices — cheaper models for high-volume routing reviews, deeper reasoning for platform-risk reviews — live in the reviewer agent's loadout, or a machine-local override, rather than being duplicated per persona.
+## Take the same file to the web
 
-Because the base agent fixes the output shape, feedback from every persona document is directly comparable. The result is a reusable customer-persona review catalog that reads docs or experiences a UX from many viewpoints without pretending to replace real customer discovery.
+Paste or upload `docs/personas/priya-nair.md` unchanged into a claude.ai project's knowledge or a ChatGPT project and say: "Treat this as stakeholder context. Review the attached landing page from her point of view." Same artifact, zero conversion — the file was written to read standalone, so any tool that accepts Markdown context can use it.
+
+## Why this shape
+
+- **No agent-per-persona fleet**: adding a persona means adding exactly one document, not maintaining another agent.
+- **Comparable reports**: one agent fixes the review method and output shape, so feedback from different persona files is directly comparable.
+- **Portable by construction**: the persona never depends on Outfitter, a schema, or runtime fragments — Outfitter is one optional consumer.
+
+See the [persona spec](../personas.md) for the format, and the community catalog's [persona boundary doc](https://github.com/ai-outfitter/community-profiles/blob/main/docs/persona-review.md) for the responsibility split between authoring, the shared reviewer, and project wrappers. The result is a reusable customer-persona review loop that reads docs or experiences a UX from many viewpoints without pretending to replace real customer discovery.


### PR DESCRIPTION
## Summary

Makes the single portable Markdown file the canonical persona primitive across the docs, replacing the roles/individuals frontmatter layout and the `reviewer` agent naming.

- `docs/documentation/personas.md` is now the format spec: one committed file per persona, H1-first generic role archetype (`# Platform Lead`), no frontmatter/schema, first-person prose with the four recommended sections; lives in `docs/personas/` outside `.agents/`; consumed by appending at launch (`outfitter run persona-reviewer -- --append-system-prompt <file>`), pasting unchanged into web agents (claude.ai project knowledge, ChatGPT), or as ordinary reading context. Explicit no-OFTR status note: personas ride on existing CLI passthrough.
- `docs/documentation/usecases/persona-reviews.md` rewritten as the demo story: author (community-profiles `persona-authoring` template) → run under Outfitter (the `persona-review` launcher) → paste the same file into any web agent.
- Remaining mentions reconciled: concepts, profiles, conventions (new "Worked example: persona documents" section — the non-technical on-ramp from #197), controllable-elements, READMEs, skills.md wording, stale "ordered persona composition" clauses, bundled outfitter skill routing, and `outfitter run reviewer` examples renamed to `persona-reviewer`.

Canonical catalog implementation: ai-outfitter/community-profiles#7 and ai-outfitter/community-profiles#18 (generic role-named reference personas).

Progresses #185 (persona-era docs refresh) and documents the #197 persona on-ramp. Supersedes the roles/individuals layout; `docs/user-personas` no longer appears anywhere.

## Verification

- `grep -rn "docs/user-personas|persona composition|outfitter run reviewer " docs README.md .outfitter` returns nothing.
- Docs-only change; no pinned OFTR tests touched, no tests reference persona docs.
- Cross-repo links point at merged community-profiles main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)