### PR TITLE
docs(personas): prose cleanup from multi-lens review

### DIFF
--- a/docs/documentation/conventions.md
+++ b/docs/documentation/conventions.md
@@ -52,11 +52,11 @@ The same convention builds a role-scoped profile — a `platform` or `marketing`
 
 ## Worked example: persona documents
 
-The [persona convention](./personas.md) is the ladder's non-technical on-ramp ([#197](https://github.com/ai-outfitter/outfitter/issues/197)): contributing a persona means committing one portable Markdown file, never touching a loadout.
+The [persona convention](./personas.md) applies the same rule to a non-technical contribution: contributing a persona means committing one Markdown file — no loadout involved.
 
 - **Community layer supplies the machinery** — the shared `persona-reviewer` agent and the `persona-authoring` / `persona-review` skills ship once, in [`community-profiles`](https://github.com/ai-outfitter/community-profiles).
 - **The project layer holds only the files** — a marketer or founder authors `docs/personas/platform-lead.md` (with `persona-authoring` interviewing them, or from the template by hand) and commits it as ordinary project documentation. No agent, no YAML, no `.agents` entry.
-- **Never copy** — adding a tenth persona is a tenth file, not a tenth reviewer; the same file also pastes unchanged into web agents as stakeholder context, so the artifact outlives any one harness.
+- **Never copy** — a tenth persona is a tenth file, not a tenth reviewer. The same file also pastes unchanged into web agents as stakeholder context, so it is not tied to any one harness.
 
 The full story is the [Persona reviews use case](./usecases/persona-reviews.md).
 

--- a/docs/documentation/personas.md
+++ b/docs/documentation/personas.md
@@ -1,19 +1,19 @@
 # Personas
 
-A persona is not a resource or a settings key — it is a **convention** built from ordinary pieces:
+A persona is not a resource or a settings key — it is a convention built from ordinary pieces:
 
-1. A **shared review agent** — [`persona-reviewer`](https://github.com/ai-outfitter/community-profiles/blob/main/agents/persona-reviewer/agent.md), a normal [agent](./agents.md) from the community catalog whose prompt says how to review something and what a sourced report looks like. There is one reviewer for all personas, never one agent per persona.
+1. A **shared review agent** — [`persona-reviewer`](https://github.com/ai-outfitter/community-profiles/blob/main/agents/persona-reviewer/agent.md), a normal [agent](./agents.md) from the community catalog that selects the `persona-review` skill, which owns the review method and report shape. One reviewer serves all personas.
 2. **One committed Markdown file per persona** — a portable, self-contained document. The whole persona lives in that one file; swapping the file swaps the persona, and the review rules stay fixed.
 
 ## The format
 
-A persona file is plain Markdown with no frontmatter, no schema, and no classifier:
+A persona file is plain Markdown with no frontmatter and no schema:
 
-- Starts directly with an H1 naming a **generic role archetype**: `# Platform Lead`, `# Founder-operator`. (A named individual — `# Priya Nair — Platform Lead` — is an optional variant for when a specific person's voice is the point; the generic form is canonical.)
-- First-person prose: an unheaded opening paragraph that stands alone as an introduction, then the recommended sections `## My work and context`, `## What I need`, `## How I decide`, and `## How I communicate`. Sections may be renamed or combined; connected prose beats bullet stacks.
-- Everything the persona knows — role, organization, goals, concerns, constraints, decision signals, voice — is ordinary Markdown a human would read.
+- Starts directly with an H1 naming a **generic role archetype**: `# Platform Lead`, `# Founder-operator`. Use a named individual (`# Priya Nair — Platform Lead`) only when a specific person's voice is the point.
+- First-person prose: an unheaded opening paragraph, then the recommended sections `## My work and context`, `## What I need`, `## How I decide`, and `## How I communicate`. Sections may be renamed or combined; connected prose beats bullet stacks.
+- Everything the persona knows — role, goals, constraints, decision signals, voice — is ordinary Markdown.
 
-It lives in normal project documentation, deliberately **outside** `.agents/`:
+It lives in normal project documentation, deliberately outside `.agents/`:
 
 ```text
 docs/personas/
@@ -21,11 +21,11 @@ docs/personas/
   founder-operator.md
 ```
 
-A persona is project steering context, not agent configuration — which is why `outfitter dump` does not carry it, by design. The executable artifacts of this format — an authoring template and completed reference personas — ship in the community catalog's [`persona-authoring`](https://github.com/ai-outfitter/community-profiles/tree/main/skills/persona-authoring) skill.
+A persona is project steering context rather than agent configuration, which is why `outfitter dump` does not carry it. The authoring template and completed reference personas ship in the community catalog's [`persona-authoring`](https://github.com/ai-outfitter/community-profiles/tree/main/skills/persona-authoring) skill.
 
 ## Three ways to consume the same file
 
-- **Appended at launch**: `outfitter run persona-reviewer -- --append-system-prompt docs/personas/platform-lead.md …`, or the [`persona-review`](https://github.com/ai-outfitter/community-profiles/tree/main/skills/persona-review) skill's launcher script that wraps it. The reviewer adopts the file as its identity for that session only.
+- **Appended at launch**: `outfitter run persona-reviewer -- --append-system-prompt docs/personas/platform-lead.md <harness arguments>`, or the [`persona-review`](https://github.com/ai-outfitter/community-profiles/tree/main/skills/persona-review) skill's launcher script that wraps it. The reviewer adopts the file as its identity for that session only.
 - **Pasted into a web agent**: upload or paste the file unchanged into claude.ai project knowledge or a ChatGPT project as stakeholder context. Same artifact, zero conversion.
 - **Ordinary reading context**: any agent doing product planning, research, or writing can read the file to know who the work is for.
 
@@ -37,6 +37,6 @@ Organization research, interviews, and individual detail are **authoring inputs*
 
 ## Status
 
-Personas ride entirely on existing CLI behavior (`outfitter run` plus `--append-system-prompt` passthrough), so no `OFTR-*` requirement covers them — they are a documentation convention, not shipped surface. An `.agents`-native persona form (a protocol resource, or a settings layer pointing at persona documents) is a separate, deferred design; the portable file must never depend on it.
+Personas ride entirely on existing CLI behavior (`outfitter run` plus `--append-system-prompt` passthrough), so no `OFTR-*` requirement covers them. An `.agents`-native persona form (a protocol resource, or a settings layer pointing at persona documents) is a separate, deferred design; the portable file must never depend on it.
 
 See [Persona reviews](./usecases/persona-reviews.md) for the worked author → run → paste-anywhere story, and the community catalog's [persona boundary doc](https://github.com/ai-outfitter/community-profiles/blob/main/docs/persona-review.md) for the setup and runtime responsibility split.

--- a/docs/documentation/usecases/persona-reviews.md
+++ b/docs/documentation/usecases/persona-reviews.md
@@ -1,8 +1,8 @@
-# Persona Reviews
+# Persona reviews
 
 A persona review gathers structured feedback on a product, docs, onboarding flow, or UX from the point of view of the people who might use it — before asking real prospects to spend time. It uses the [persona convention](../personas.md): **one shared review agent** plus **one committed Markdown file per persona**. The same file runs under Outfitter, and pastes unchanged into any web agent.
 
-## One persona = one file
+## One persona, one file
 
 The whole persona is one portable, self-contained Markdown document — a generic role archetype, H1 first, no frontmatter, first-person prose. Abridged from the canonical [`platform-lead.md`](https://github.com/ai-outfitter/community-profiles/blob/main/skills/persona-authoring/references/personas/platform-lead.md) reference:
 
@@ -12,19 +12,14 @@ The whole persona is one portable, self-contained Markdown document — a generi
 I'm the platform lead responsible for a consistent, reproducible agent setup
 across a mid-sized engineering organization.
 
-## My work and context
-
-I own shared agent configuration for a roughly 150-engineer B2B SaaS company.
-…
-
 ## How I decide
 
 I look for clear precedence, pinned sources, documented secret boundaries,
 least-privilege access, and tests showing that credentials stay isolated
-between layers. … I check the escape hatch first.
+between layers. I check the escape hatch first.
 ```
 
-There is no `personas:` map and no agent per customer type. The review rules live in the shared [`persona-reviewer`](https://github.com/ai-outfitter/community-profiles/blob/main/agents/persona-reviewer/agent.md) agent; each persona is a cheap Markdown file you append to it.
+The review method lives in the shared [`persona-reviewer`](https://github.com/ai-outfitter/community-profiles/blob/main/agents/persona-reviewer/agent.md) agent; each persona is a Markdown file you append to it.
 
 ## Author it
 
@@ -36,7 +31,7 @@ docs/personas/
   founder-operator.md
 ```
 
-Prefer generic role archetypes over named individuals; organization research, interviews, and individual detail are authoring inputs, and the committed artifact is always the one self-contained file with nothing invented that the research does not support.
+Prefer generic role archetypes over named individuals. Research and interviews are authoring inputs; commit only the self-contained file, and invent nothing the research does not support.
 
 ## Run it under Outfitter
 
@@ -56,22 +51,22 @@ bash skills/persona-review/scripts/persona-review.sh \
   --persona docs/personas/platform-lead.md \
   -- --print "Review the onboarding flow and write the report. @README.md"
 
-# both paths reduce to:
+# the launcher resolves the persona path and runs:
 outfitter run persona-reviewer -- \
   --append-system-prompt docs/personas/platform-lead.md \
   --print "Review the onboarding flow and write the report. @README.md"
 ```
 
-One shared agent adopts the file as its identity for that session only and writes a first-person, sourced report — evidence cited to the exact page or UI moment, assumptions labeled. The catalog agent pins a model (`openai-codex/gpt-5.5`); use the launcher's `--agent` flag or a settings-layer model override to run it on whatever you have credentials for.
+One shared agent adopts the file as its identity for that session only and writes a first-person, sourced report — evidence cited to the exact page or UI moment, assumptions labeled. The catalog agent pins a model (`openai-codex/gpt-5.5`); use the launcher's `--agent` flag to run another agent that selects this skill on whatever you have credentials for.
 
 ## Take the same file to the web
 
-Paste or upload `docs/personas/platform-lead.md` unchanged into a claude.ai project's knowledge or a ChatGPT project and say: "Treat this as stakeholder context. Review the attached landing page from this persona's point of view." Same artifact, zero conversion — the file was written to read standalone, so any tool that accepts Markdown context can use it.
+Paste or upload `docs/personas/platform-lead.md` unchanged into a claude.ai project's knowledge or a ChatGPT project and say: "Treat this as stakeholder context. Review the attached landing page from this persona's point of view." The file was written to read standalone, so a tool that takes Markdown project context can use it unchanged.
 
 ## Why this shape
 
-- **No agent-per-persona fleet**: adding a persona means adding exactly one document, not maintaining another agent.
+- **One file per persona**: adding a persona adds a document, not another agent.
 - **Comparable reports**: one agent fixes the review method and output shape, so feedback from different persona files is directly comparable.
-- **Portable by construction**: the persona never depends on Outfitter, a schema, or runtime fragments — Outfitter is one optional consumer.
+- **No Outfitter dependency**: Outfitter is one optional consumer of a file that does not depend on it.
 
-See the [persona spec](../personas.md) for the format, and the community catalog's [persona boundary doc](https://github.com/ai-outfitter/community-profiles/blob/main/docs/persona-review.md) for the responsibility split between authoring, the shared reviewer, and project wrappers. The result is a reusable customer-persona review loop that reads docs or experiences a UX from many viewpoints without pretending to replace real customer discovery.
+See the [persona spec](../personas.md) for the format, and the community catalog's [persona boundary doc](https://github.com/ai-outfitter/community-profiles/blob/main/docs/persona-review.md) for the responsibility split between authoring, the shared reviewer, and project wrappers.


### PR DESCRIPTION
Follow-up to #224 from a four-lens prose review (content, language, style, duplication) of the new persona docs.

- Corrects a factual claim: the review method lives in the `persona-review` skill the reviewer selects, not in the agent's own prompt.
- Cuts the duplicated "Same artifact, zero conversion" slogan (personas.md keeps the claim in plain words; the use case makes it in its own voice), the "executable artifacts" inflation, and the sales-pitch closing sentence.
- Removes the unsupported "settings-layer model override" reference; the `--agent` escape hatch remains.
- Sentence-cases the use-case H1, removes elision ellipses from the fenced persona excerpt and the runnable command, and thins the not-X-but-Y constructions and decorative bold that repeated through personas.md.
- conventions.md: drops the repeated #197 link and the "outlives any one harness" flourish.

No structural changes; all cross-links from community-profiles and default-profiles still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)