### PR TITLE
fix(pi): project selected subagents and MCP servers

### DIFF
--- a/code/cli/src/composer/Composer.ts
+++ b/code/cli/src/composer/Composer.ts
@@ -2,6 +2,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { escapesRoots } from '../dump/Containment.js';
 import { isAgentDefinitionIssue, readAgentDefinition } from '../resolver/AgentDefinition.js';
 import type { EffectiveResourceSet, Loadout, ResolvedResource } from '../resolver/Resource.js';
 import { findLoadoutResource, findResource } from '../resolver/Resource.js';
@@ -29,7 +30,7 @@ const resolveSlugs = (
   set: EffectiveResourceSet,
   agentSlug: string,
   kind: 'skill' | 'agent',
-  field: string,
+  reference: string,
   slugs: readonly string[],
   warnings: string[],
 ): readonly ResolvedResource[] => {
@@ -39,7 +40,7 @@ const resolveSlugs = (
     const resource = findLoadoutResource(set, agentSlug, kind, slug);
 
     if (resource === undefined) {
-      warnings.push(`loadout ${field} references unknown ${kind} '${slug}'.`);
+      warnings.push(`${reference} references unknown ${kind} '${slug}'.`);
     } else {
       resolved.push(resource);
     }
@@ -48,21 +49,135 @@ const resolveSlugs = (
   return resolved;
 };
 
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  value !== null && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+
+const readMcpServers = (path: string, warnings: string[]): Readonly<Record<string, unknown>> => {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    warnings.push(`MCP configuration '${path}' is not readable JSON: ${String(error)}`);
+    return {};
+  }
+
+  const document = asRecord(parsed);
+  const servers = document === undefined ? undefined : asRecord(document.mcpServers);
+
+  if (servers === undefined) {
+    warnings.push(`MCP configuration '${path}' must contain an object-valued 'mcpServers' map.`);
+    return {};
+  }
+
+  return servers;
+};
+
+const composeMcpServers = (
+  set: EffectiveResourceSet,
+  agent: ResolvedResource,
+  selectedIds: readonly string[],
+  warnings: string[],
+): Readonly<Record<string, unknown>> => {
+  if (selectedIds.length === 0) {
+    return {};
+  }
+
+  const rootPaths = set.layers.map((layer) => join(layer.root, 'mcp.json')).filter((path) => existsSync(path));
+  const pathsByPrecedence = [
+    ...rootPaths.reverse(),
+    // Resolver annotates every agent resource with mcpPaths, including an empty array.
+    ...[...agent.mcpPaths!].reverse(),
+  ];
+  const available: Record<string, unknown> = {};
+  const roots = set.layers.map((layer) => layer.root);
+
+  for (const path of pathsByPrecedence) {
+    if (escapesRoots(path, roots)) {
+      warnings.push(`MCP configuration '${path}' resolves outside the resource layers and was skipped.`);
+      continue;
+    }
+    Object.assign(available, readMcpServers(path, warnings));
+  }
+
+  const selected: Record<string, unknown> = {};
+  for (const id of selectedIds) {
+    if (Object.hasOwn(available, id)) {
+      selected[id] = available[id];
+    } else {
+      warnings.push(`loadout mcp references unknown server '${id}'.`);
+    }
+  }
+
+  return selected;
+};
+
+const resolveDelegateSkills = (
+  set: EffectiveResourceSet,
+  subagents: readonly ResolvedResource[],
+  leaderSkills: readonly ResolvedResource[],
+  warnings: string[],
+): readonly ResolvedResource[] => {
+  const skills = new Map(leaderSkills.map((skill) => [skill.slug, skill]));
+  const delegateSkills: ResolvedResource[] = [];
+  const roots = set.layers.map((layer) => layer.root);
+
+  for (const subagent of subagents) {
+    const definitionPaths = [subagent.winner.path, ...(subagent.configPaths ?? [])];
+    if (definitionPaths.some((path) => escapesRoots(path, roots))) continue;
+
+    const definition = readAgentDefinition(subagent.winner.path, subagent.configPaths);
+
+    if (isAgentDefinitionIssue(definition) || definition.name !== subagent.slug) {
+      continue;
+    }
+
+    for (const skill of resolveSlugs(
+      set,
+      subagent.slug,
+      'skill',
+      `subagent '${subagent.slug}' loadout skills`,
+      definition.loadout.skills,
+      warnings,
+    )) {
+      const selected = skills.get(skill.slug);
+
+      if (selected === undefined) {
+        skills.set(skill.slug, skill);
+        delegateSkills.push(skill);
+      } else if (selected.winner.path !== skill.winner.path) {
+        warnings.push(
+          `delegate skill '${skill.slug}' resolves to conflicting definitions; using '${selected.winner.path}'.`,
+        );
+      }
+    }
+  }
+
+  return delegateSkills;
+};
+
 const composeLoadout = (
   set: EffectiveResourceSet,
-  agentSlug: string,
+  agent: ResolvedResource,
   loadout: Loadout,
   warnings: string[],
-): ComposedLoadout => ({
-  skills: resolveSlugs(set, agentSlug, 'skill', 'skills', loadout.skills, warnings),
-  subagents: resolveSlugs(set, agentSlug, 'agent', 'subagents', loadout.subagents, warnings),
-  mcp: loadout.mcp,
-  extensions: loadout.extensions,
-  plugins: loadout.plugins,
-  model: loadout.model,
-  thinking: loadout.thinking,
-  tools: loadout.tools,
-});
+): ComposedLoadout => {
+  const subagents = resolveSlugs(set, agent.slug, 'agent', 'loadout subagents', loadout.subagents, warnings);
+  const skills = resolveSlugs(set, agent.slug, 'skill', 'loadout skills', loadout.skills, warnings);
+
+  return {
+    skills,
+    delegateSkills: resolveDelegateSkills(set, subagents, skills, warnings),
+    subagents,
+    mcp: loadout.mcp,
+    mcpServers: composeMcpServers(set, agent, loadout.mcp, warnings),
+    extensions: loadout.extensions,
+    plugins: loadout.plugins,
+    model: loadout.model,
+    thinking: loadout.thinking,
+    tools: loadout.tools,
+  };
+};
 
 /**
  * Composes the selected agent into a CompositionPlan. Returns an error when the agent slug does not
@@ -98,7 +213,7 @@ export const compose = (set: EffectiveResourceSet, agentSlug: string): ComposeRe
       label: definition.label,
       description: definition.description,
     },
-    loadout: composeLoadout(set, agentSlug, definition.loadout, warnings),
+    loadout: composeLoadout(set, agent, definition.loadout, warnings),
     warnings,
   };
 

--- a/code/cli/src/composer/Composition.ts
+++ b/code/cli/src/composer/Composition.ts
@@ -17,8 +17,12 @@ export interface ComposedIdentity {
 /** A loadout with its slug references resolved against the effective set. */
 export interface ComposedLoadout {
   readonly skills: readonly ResolvedResource[];
+  /** Skills selected by delegates, materialized for them without loading them into the leader. */
+  readonly delegateSkills: readonly ResolvedResource[];
   readonly subagents: readonly ResolvedResource[];
   readonly mcp: readonly string[];
+  /** Selected MCP server definitions after layer and per-agent precedence are applied. */
+  readonly mcpServers: Readonly<Record<string, unknown>>;
   readonly extensions: readonly string[];
   readonly plugins: readonly string[];
   readonly model?: string;

--- a/code/cli/src/projection/Materialize.ts
+++ b/code/cli/src/projection/Materialize.ts
@@ -1,10 +1,12 @@
 // Materializes a CompositionPlan into a runtime configuration directory the harness launches from.
-import { copyFileSync, lstatSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs';
+import { copyFileSync, lstatSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 import type { CompositionPlan } from '../composer/Composition.js';
 import { escapesRoots } from '../dump/Containment.js';
 import { removeTargetTypeConflict } from '../fs/TypeConflict.js';
+import type { AgentDefinition } from '../resolver/AgentDefinition.js';
+import { isAgentDefinitionIssue, readAgentDefinition } from '../resolver/AgentDefinition.js';
 import type { ResolvedResource } from '../resolver/Resource.js';
 
 export interface MaterializedComposition {
@@ -17,6 +19,8 @@ export interface MaterializedComposition {
   readonly skillDirectories: readonly string[];
   /** Skills that could not be materialized safely (escaping symlinks). */
   readonly skippedSkills: readonly string[];
+  /** Subagents whose merged agent definition could not be materialized. */
+  readonly skippedSubagents: readonly string[];
 }
 
 /** Recursively copies a directory, skipping symlinked entries so no path escapes the tree. */
@@ -73,10 +77,78 @@ const materializeSkill = (skill: ResolvedResource, rootDirectory: string): strin
   return targetDir;
 };
 
+const optionalScalar = (name: string, value: string | undefined): readonly string[] =>
+  value === undefined ? [] : [`${name}: ${JSON.stringify(value)}`];
+
+const optionalList = (name: string, values: readonly string[]): readonly string[] =>
+  values.length === 0 ? [] : [`${name}: ${JSON.stringify(values.join(', '))}`];
+
+const subagentEscapesRoots = (subagent: ResolvedResource): boolean => {
+  const roots = [
+    subagent.winner.layer.root,
+    ...subagent.shadowed.map((definition) => definition.layer.root),
+    ...(subagent.configLayerRoots ?? []),
+  ];
+  const paths = [subagent.winner.path, ...(subagent.configPaths ?? [])];
+  return paths.some((path) => escapesRoots(path, roots));
+};
+
+const readValidSubagentDefinition = (subagent: ResolvedResource): AgentDefinition | undefined => {
+  if (subagentEscapesRoots(subagent)) {
+    return undefined;
+  }
+
+  const definition = readAgentDefinition(subagent.winner.path, subagent.configPaths);
+
+  return isAgentDefinitionIssue(definition) || definition.name !== subagent.slug ? undefined : definition;
+};
+
+const serializeSubagent = (subagent: ResolvedResource): string | undefined => {
+  const definition = readValidSubagentDefinition(subagent);
+
+  if (definition === undefined) return undefined;
+
+  const denied = new Set(definition.loadout.tools?.deny ?? []);
+  const tools = definition.loadout.tools?.allow?.filter((tool) => !denied.has(tool));
+  const frontmatter = [
+    `name: ${JSON.stringify(subagent.slug)}`,
+    `description: ${JSON.stringify(definition.description ?? definition.label ?? `Delegated ${subagent.slug} agent.`)}`,
+    ...optionalScalar('model', definition.loadout.model),
+    ...optionalScalar('thinking', definition.loadout.thinking),
+    ...optionalList('tools', tools ?? []),
+    ...optionalList('skills', definition.loadout.skills),
+    ...optionalList('extensions', definition.loadout.extensions),
+  ];
+
+  return `---\n${frontmatter.join('\n')}\n---\n\n${definition.body}`;
+};
+
+const materializeSubagents = (subagents: readonly ResolvedResource[], rootDirectory: string): readonly string[] => {
+  if (subagents.length === 0) {
+    return [];
+  }
+
+  const agentsDirectory = join(rootDirectory, 'agents');
+  rmSync(agentsDirectory, { recursive: true, force: true });
+  mkdirSync(agentsDirectory, { recursive: true });
+  const skipped: string[] = [];
+
+  for (const subagent of subagents) {
+    const content = serializeSubagent(subagent);
+    if (content === undefined) {
+      skipped.push(subagent.slug);
+    } else {
+      writeGeneratedFile(join(agentsDirectory, `${subagent.slug}.md`), content);
+    }
+  }
+
+  return skipped;
+};
+
 /**
- * Writes the composed identity and skills into `rootDirectory`. The base `system-prompt.md` becomes
- * the system prompt; shared `agents.md` context and the agent body are appended in order. Each
- * selected skill directory (SKILL.md + scripts/assets) is copied so the harness has real content.
+ * Writes the composed identity, skills, subagents, and selected MCP servers into
+ * `rootDirectory`. The base `system-prompt.md` becomes the system prompt; shared `agents.md`
+ * context and the agent body are appended in order.
  */
 export const materializeComposition = (
   composition: CompositionPlan,
@@ -102,7 +174,7 @@ export const materializeComposition = (
   const skillDirectories: string[] = [];
   const skippedSkills: string[] = [];
 
-  for (const skill of composition.loadout.skills) {
+  for (const skill of [...composition.loadout.skills, ...composition.loadout.delegateSkills]) {
     const materialized = materializeSkill(skill, rootDirectory);
     if (materialized === undefined) {
       skippedSkills.push(skill.slug);
@@ -111,5 +183,21 @@ export const materializeComposition = (
     }
   }
 
-  return { rootDirectory, systemPromptPath, appendPromptPaths, skillDirectories, skippedSkills };
+  const skippedSubagents = materializeSubagents(composition.loadout.subagents, rootDirectory);
+
+  if (composition.loadout.mcp.length > 0) {
+    writeGeneratedFile(
+      join(rootDirectory, 'mcp.json'),
+      `${JSON.stringify({ mcpServers: composition.loadout.mcpServers }, null, 2)}\n`,
+    );
+  }
+
+  return {
+    rootDirectory,
+    systemPromptPath,
+    appendPromptPaths,
+    skillDirectories,
+    skippedSkills,
+    skippedSubagents,
+  };
 };

--- a/code/cli/src/projection/ProjectHarness.ts
+++ b/code/cli/src/projection/ProjectHarness.ts
@@ -6,12 +6,15 @@ import type { AgentLaunchPlan, AgentProjectionPlan, ProjectionInput } from './Pr
 
 // Loadout elements a projection actually maps to native config. Anything else is reported
 // unsupported so `--strict` catches silently-dropped selections. Baseline for both harnesses is
-// identity + skills + model + thinking; pi additionally projects `extensions` once the run path has
-// resolved their install dirs (`extensionLoadDirs`). subagents/mcp/plugins/tools remain unsupported
-// pending incremental parity (#183).
+// identity + skills + model + thinking. Pi also projects selected subagents and MCP servers into
+// its runtime config directory, and projects `extensions` once the run path has resolved their
+// install dirs (`extensionLoadDirs`). plugins/tools remain unsupported pending incremental parity
+// (#183).
 const supportedElements = (input: ProjectionInput): readonly string[] => {
   const baseline = ['skills', 'model', 'thinking'];
-  return input.harness === 'pi' && input.extensionLoadDirs !== undefined ? [...baseline, 'extensions'] : baseline;
+  if (input.harness !== 'pi') return baseline;
+  const pi = [...baseline, 'subagents', 'mcp'];
+  return input.extensionLoadDirs === undefined ? pi : [...pi, 'extensions'];
 };
 
 const loadoutElementsInUse = (composition: CompositionPlan): readonly string[] => {
@@ -86,6 +89,7 @@ export const projectComposition = (composition: CompositionPlan, input: Projecti
   const unsupported = [
     ...unsupportedElements(composition, input),
     ...materialized.skippedSkills.map((slug) => `skill:${slug} (escaping symlink)`),
+    ...materialized.skippedSubagents.map((slug) => `subagent:${slug} (invalid definition)`),
   ];
 
   return { rootDirectory: input.rootDirectory, launch, unsupported };

--- a/code/cli/src/resolver/Resolver.ts
+++ b/code/cli/src/resolver/Resolver.ts
@@ -90,6 +90,9 @@ const discoverDirectoryResources = (
 const collectAgentFiles = (layers: readonly Layer[], slug: string, ...segments: string[]): readonly string[] =>
   layers.map((layer) => join(layer.root, 'agents', slug, ...segments)).filter((path) => resolvesToFile(path));
 
+const collectAgentFileLayerRoots = (layers: readonly Layer[], slug: string, ...segments: string[]): readonly string[] =>
+  layers.filter((layer) => resolvesToFile(join(layer.root, 'agents', slug, ...segments))).map((layer) => layer.root);
+
 const isNonEmptyDirectory = (directory: string): boolean => {
   try {
     return statSync(directory).isDirectory() && readdirSync(directory).length > 0;
@@ -117,6 +120,7 @@ const withAgentResourcePaths = (
       {
         ...resource,
         configPaths: collectAgentFiles(layers, slug, 'config.json'),
+        configLayerRoots: collectAgentFileLayerRoots(layers, slug, 'config.json'),
         mcpPaths: collectAgentFiles(layers, slug, 'mcp.json'),
         hookPaths: collectAgentHookDirs(layers, slug),
         piConfigDirectories: collectAgentPiConfigDirs(layers, slug),

--- a/code/cli/src/resolver/ResolverValidation.ts
+++ b/code/cli/src/resolver/ResolverValidation.ts
@@ -81,18 +81,10 @@ const shadowFindings = (resource: ResolvedResource): readonly ValidationFinding[
     message: `shadowed definition in ${definition.layer.label} is overridden by ${resource.winner.layer.label}.`,
   }));
 
-// Agent-local resource shapes that resolver discovers but does not yet project into a run. Surfaced
-// as warnings (fatal only under --strict) so a selection placed here is never silently dropped.
+// Reserved agent-local resource shapes that resolver discovers but does not yet project into a run.
+// Surfaced as warnings (fatal only under --strict) so content placed here is never silently dropped.
 const reservedNamespaceFindings = (agent: ResolvedResource): readonly ValidationFinding[] => {
   const findings: ValidationFinding[] = [];
-
-  if ((agent.mcpPaths ?? []).length > 0) {
-    findings.push({
-      severity: 'warning',
-      resource: `agent:${agent.slug}`,
-      message: "agent-local 'mcp.json' is discovered but not yet projected into the run (adapter parity, #183).",
-    });
-  }
 
   if ((agent.hookPaths ?? []).length > 0) {
     findings.push({

--- a/code/cli/src/resolver/Resource.ts
+++ b/code/cli/src/resolver/Resource.ts
@@ -68,6 +68,11 @@ export interface ResolvedResource {
    */
   readonly configPaths?: readonly string[];
   /**
+   * For agents: layer roots corresponding to `configPaths`. Config-only overlay layers do not
+   * appear in `winner` or `shadowed`, so projection retains this provenance for containment checks.
+   */
+  readonly configLayerRoots?: readonly string[];
+  /**
    * For agents: existing `agents/<slug>/mcp.json` paths across all layers, highest precedence first.
    * Discovered here so a later projection pass (#183) can merge them over the tree-root `mcp.json`.
    * Config merges by server id — it does not shadow whole like slug resources.

--- a/code/cli/src/schemas/agent.schema.json
+++ b/code/cli/src/schemas/agent.schema.json
@@ -18,7 +18,7 @@
     },
     "mcp": {
       "$ref": "#/$defs/slugList",
-      "description": "MCP server ids. Per-agent agents/<name>/mcp.json is discovered and merges by id over the tree-root mcp.json; projection into the run is deferred (adapter parity, #183)."
+      "description": "MCP server ids. Per-agent agents/<name>/mcp.json merges by id over layered tree-root mcp.json files before selected servers are projected into the run."
     },
     "extensions": {
       "$ref": "#/$defs/slugList",

--- a/code/cli/tests/unit/composer.test.ts
+++ b/code/cli/tests/unit/composer.test.ts
@@ -1,5 +1,5 @@
 // Tests composition of a harness-neutral CompositionPlan from the effective resource set.
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
@@ -40,8 +40,16 @@ describe('composer', () => {
     write(join(project, '.agents', 'agents.md'), 'SHARED CONTEXT');
     write(join(project, '.agents', 'skills', 'wiki', 'SKILL.md'), '---\nname: wiki\n---\n');
     write(
+      join(project, '.agents', 'mcp.json'),
+      JSON.stringify({ mcpServers: { github: { command: 'github-mcp-server' } } }),
+    );
+    write(
       join(project, '.agents', 'agents', 'code-reviewer', 'agent.md'),
-      '---\nname: code-reviewer\n---\n\nReview.\n',
+      '---\nname: code-reviewer\nskills: [review-only]\n---\n\nReview.\n',
+    );
+    write(
+      join(project, '.agents', 'agents', 'code-reviewer', 'skills', 'review-only', 'SKILL.md'),
+      '---\nname: review-only\n---\n',
     );
     write(
       join(project, '.agents', 'agents', 'engineer', 'agent.md'),
@@ -63,8 +71,11 @@ describe('composer', () => {
     expect(plan.identity.agentBody).toContain('# Engineer');
     expect(plan.identity.description).toBe('Ships changes.');
     expect(plan.loadout.skills.map((s) => s.slug)).toEqual(['wiki']);
+    expect(plan.loadout.delegateSkills.map((s) => s.slug)).toEqual(['review-only']);
+    expect(plan.loadout.delegateSkills[0]?.winner.ownerAgent).toBe('code-reviewer');
     expect(plan.loadout.subagents.map((s) => s.slug)).toEqual(['code-reviewer']);
     expect(plan.loadout.mcp).toEqual(['github']);
+    expect(plan.loadout.mcpServers).toEqual({ github: { command: 'github-mcp-server' } });
     expect(plan.loadout.model).toBe('gpt-5.2');
     expect(plan.loadout.thinking).toBe('high');
     expect(plan.warnings).toEqual([]);
@@ -78,6 +89,68 @@ describe('composer', () => {
     );
 
     expect(compose(resolveSet(home, project), 'engineer').plan?.identity.label).toBe('Engineering Lead');
+  });
+
+  it('merges layered and agent-local MCP servers by id, then keeps only selected servers', () => {
+    const { home, project } = buildTree();
+    write(
+      join(home, '.agents', 'mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          github: { command: 'home-github' },
+          unused: { command: 'home-unused' },
+        },
+      }),
+    );
+    write(
+      join(project, '.agents', 'mcp.json'),
+      JSON.stringify({ mcpServers: { github: { command: 'project-github' } } }),
+    );
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'mcp.json'),
+      JSON.stringify({ mcpServers: { github: { command: 'agent-github' } } }),
+    );
+
+    const result = compose(resolveSet(home, project), 'engineer');
+
+    expect(result.plan?.loadout.mcpServers).toEqual({ github: { command: 'agent-github' } });
+    expect(result.plan?.warnings).toEqual([]);
+  });
+
+  it('warns when selected MCP configuration is invalid or does not contain the selected server', () => {
+    const { home, project } = buildTree();
+    write(join(home, '.agents', 'mcp.json'), 'not json');
+    write(join(project, '.agents', 'mcp.json'), JSON.stringify({ mcpServers: [] }));
+    write(join(project, '.agents', 'agents', 'engineer', 'mcp.json'), JSON.stringify([]));
+
+    const result = compose(resolveSet(home, project), 'engineer');
+
+    expect(result.plan?.loadout.mcpServers).toEqual({});
+    expect(result.plan?.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('not readable JSON'),
+        expect.stringContaining("object-valued 'mcpServers'"),
+        expect.stringContaining("unknown server 'github'"),
+      ]),
+    );
+  });
+
+  it('does not read selected MCP configuration through a symlink that escapes its layer', () => {
+    const { home, project } = buildTree();
+    const external = join(createTemporaryRoot(), 'outside-mcp.json');
+    write(external, JSON.stringify({ mcpServers: { github: { command: 'outside' } } }));
+    rmSync(join(project, '.agents', 'mcp.json'));
+    symlinkSync(external, join(project, '.agents', 'mcp.json'));
+
+    const result = compose(resolveSet(home, project), 'engineer');
+
+    expect(result.plan?.loadout.mcpServers).toEqual({});
+    expect(result.plan?.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('resolves outside the resource layers'),
+        expect.stringContaining("unknown server 'github'"),
+      ]),
+    );
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.3).
@@ -144,5 +217,88 @@ describe('composer', () => {
     const result = compose(resolveSet(join(root, 'home'), project), 'engineer');
     expect(result.errors).toEqual([]);
     expect(result.plan!.warnings).toContain("loadout skills references unknown skill 'ghost'.");
+  });
+
+  it('warns when a delegate-only skill does not resolve', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\nsubagents: [reviewer]\n---\n\nBody.\n',
+    );
+    write(
+      join(project, '.agents', 'agents', 'reviewer', 'agent.md'),
+      '---\nname: reviewer\nskills: [ghost]\n---\n\nReview.\n',
+    );
+
+    const result = compose(resolveSet(join(root, 'home'), project), 'engineer');
+
+    expect(result.plan?.loadout.delegateSkills).toEqual([]);
+    expect(result.plan?.warnings).toContain("subagent 'reviewer' loadout skills references unknown skill 'ghost'.");
+  });
+
+  it('keeps the first materializable definition when delegate skill slugs conflict', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\nsubagents: [alpha, beta]\n---\n\nBody.\n',
+    );
+
+    for (const delegate of ['alpha', 'beta']) {
+      write(
+        join(project, '.agents', 'agents', delegate, 'agent.md'),
+        `---\nname: ${delegate}\nskills: [review]\n---\n\nReview.\n`,
+      );
+      write(
+        join(project, '.agents', 'agents', delegate, 'skills', 'review', 'SKILL.md'),
+        `---\nname: review\n---\n\n${delegate}\n`,
+      );
+    }
+
+    const result = compose(resolveSet(join(root, 'home'), project), 'engineer');
+
+    expect(result.plan?.loadout.delegateSkills).toHaveLength(1);
+    expect(result.plan?.loadout.delegateSkills[0]?.winner.ownerAgent).toBe('alpha');
+    expect(result.plan?.warnings).toEqual([expect.stringContaining("delegate skill 'review' resolves")]);
+  });
+
+  it('does not resolve skills from invalid or mislabeled delegates', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\nsubagents: [broken, mislabeled]\n---\n\nBody.\n',
+    );
+    write(join(project, '.agents', 'agents', 'broken', 'agent.md'), 'missing frontmatter');
+    write(
+      join(project, '.agents', 'agents', 'mislabeled', 'agent.md'),
+      '---\nname: other\nskills: [ghost]\n---\n\nReview.\n',
+    );
+
+    const result = compose(resolveSet(join(root, 'home'), project), 'engineer');
+
+    expect(result.errors).toEqual([]);
+    expect(result.plan?.loadout.delegateSkills).toEqual([]);
+    expect(result.plan?.warnings).toEqual([]);
+  });
+
+  it('does not read delegate definitions through an escaping symlink', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    const external = join(createTemporaryRoot(), 'outside-agent.md');
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\nsubagents: [reviewer]\n---\n\nBody.\n',
+    );
+    write(external, '---\nname: reviewer\nskills: [ghost]\n---\n\nOutside.\n');
+    mkdirSync(join(project, '.agents', 'agents', 'reviewer'), { recursive: true });
+    symlinkSync(external, join(project, '.agents', 'agents', 'reviewer', 'agent.md'));
+
+    const result = compose(resolveSet(join(root, 'home'), project), 'engineer');
+
+    expect(result.errors).toEqual([]);
+    expect(result.plan?.loadout.delegateSkills).toEqual([]);
+    expect(result.plan?.warnings).toEqual([]);
   });
 });

--- a/code/cli/tests/unit/project-harness.test.ts
+++ b/code/cli/tests/unit/project-harness.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import type { CompositionPlan } from '../../src/composer/Composition.js';
 import { projectComposition } from '../../src/projection/ProjectHarness.js';
+import type { ResolvedResource } from '../../src/resolver/Resource.js';
 
 const roots: string[] = [];
 const root = (): string => {
@@ -21,7 +22,15 @@ afterEach(() => {
 const planWith = (extensions: readonly string[]): CompositionPlan => ({
   agent: 'agent',
   identity: { agentBody: 'Body.' },
-  loadout: { skills: [], subagents: [], mcp: [], extensions: [...extensions], plugins: [] },
+  loadout: {
+    skills: [],
+    delegateSkills: [],
+    subagents: [],
+    mcp: [],
+    mcpServers: {},
+    extensions: [...extensions],
+    plugins: [],
+  },
   warnings: [],
 });
 
@@ -60,6 +69,228 @@ describe('projectComposition extensions', () => {
     });
     expect(projection.launch.args).not.toContain('--extension');
     expect(projection.unsupported).toContain('extensions');
+  });
+});
+
+const subagentResource = (slug: string, path: string, layerRoot: string): ResolvedResource => ({
+  kind: 'agent',
+  slug,
+  winner: {
+    kind: 'agent',
+    slug,
+    path,
+    layer: { root: layerRoot, origin: 'workspace', label: 'workspace' },
+  },
+  shadowed: [],
+});
+
+const skillResource = (slug: string, path: string, layerRoot: string): ResolvedResource => ({
+  kind: 'skill',
+  slug,
+  winner: {
+    kind: 'skill',
+    slug,
+    path,
+    layer: { root: layerRoot, origin: 'workspace', label: 'workspace' },
+  },
+  shadowed: [],
+});
+
+describe('projectComposition Pi delegates', () => {
+  it('materializes a minimal selected subagent with a usable fallback description', () => {
+    const dir = root();
+    const catalog = root();
+    const path = join(catalog, 'agents', 'reviewer', 'agent.md');
+    mkdirSync(join(catalog, 'agents', 'reviewer'), { recursive: true });
+    writeFileSync(path, '---\nname: reviewer\n---\n\nReview carefully.\n');
+    const plan = planWith([]);
+    const projection = projectComposition(
+      { ...plan, loadout: { ...plan.loadout, subagents: [subagentResource('reviewer', path, catalog)] } },
+      {
+        harness: 'pi',
+        rootDirectory: dir,
+        homeDirectory: dir,
+      },
+    );
+
+    expect(readFileSync(join(dir, 'agents', 'reviewer.md'), 'utf8')).toContain(
+      'description: "Delegated reviewer agent."',
+    );
+    expect(projection.unsupported).not.toContain('subagents');
+  });
+
+  it('serializes selected delegate controls and writes only selected MCP servers', () => {
+    const dir = root();
+    const catalog = root();
+    const path = join(catalog, 'agents', 'reviewer', 'agent.md');
+    mkdirSync(join(catalog, 'agents', 'reviewer'), { recursive: true });
+    writeFileSync(
+      path,
+      [
+        '---',
+        'name: reviewer',
+        'description: Reviews implementation changes.',
+        'skills: [review, style]',
+        'extensions: [npm:review-extension, git:github.com/example/review]',
+        'model: review-model',
+        'thinking: high',
+        'tools:',
+        '  allow: [read, bash, write]',
+        '  deny: [bash]',
+        '---',
+        '',
+        'Review carefully.',
+        '',
+      ].join('\n'),
+    );
+    const reviewSkill = join(catalog, 'skills', 'review', 'SKILL.md');
+    const styleSkill = join(catalog, 'skills', 'style', 'SKILL.md');
+    mkdirSync(join(catalog, 'skills', 'review'), { recursive: true });
+    mkdirSync(join(catalog, 'skills', 'style'), { recursive: true });
+    writeFileSync(reviewSkill, '---\nname: review\n---\n\nReview skill.\n');
+    writeFileSync(styleSkill, '---\nname: style\n---\n\nStyle skill.\n');
+    const plan = planWith([]);
+    const projection = projectComposition(
+      {
+        ...plan,
+        loadout: {
+          ...plan.loadout,
+          delegateSkills: [skillResource('review', reviewSkill, catalog), skillResource('style', styleSkill, catalog)],
+          subagents: [subagentResource('reviewer', path, catalog)],
+          mcp: ['playwright'],
+          mcpServers: { playwright: { command: 'playwright-mcp' } },
+        },
+      },
+      {
+        harness: 'pi',
+        rootDirectory: dir,
+        homeDirectory: dir,
+      },
+    );
+
+    const reviewer = readFileSync(join(dir, 'agents', 'reviewer.md'), 'utf8');
+    expect(reviewer).toContain('description: "Reviews implementation changes."');
+    expect(reviewer).toContain('model: "review-model"');
+    expect(reviewer).toContain('thinking: "high"');
+    expect(reviewer).toContain('tools: "read, write"');
+    expect(reviewer).toContain('skills: "review, style"');
+    expect(reviewer).toContain('extensions: "npm:review-extension, git:github.com/example/review"');
+    expect(reviewer).toContain('Review carefully.');
+    expect(readFileSync(join(dir, 'skills', 'review', 'SKILL.md'), 'utf8')).toContain('Review skill.');
+    expect(readFileSync(join(dir, 'skills', 'style', 'SKILL.md'), 'utf8')).toContain('Style skill.');
+    expect(projection.launch.args).not.toContain('review');
+    expect(projection.launch.args).not.toContain('style');
+    expect(JSON.parse(readFileSync(join(dir, 'mcp.json'), 'utf8'))).toEqual({
+      mcpServers: { playwright: { command: 'playwright-mcp' } },
+    });
+  });
+
+  it('reports a selected subagent whose definition cannot be materialized', () => {
+    const dir = root();
+    const catalog = root();
+    const path = join(catalog, 'agents', 'broken', 'agent.md');
+    mkdirSync(join(catalog, 'agents', 'broken'), { recursive: true });
+    writeFileSync(path, 'missing frontmatter');
+    const plan = planWith([]);
+    const projection = projectComposition(
+      { ...plan, loadout: { ...plan.loadout, subagents: [subagentResource('broken', path, catalog)] } },
+      {
+        harness: 'pi',
+        rootDirectory: dir,
+        homeDirectory: dir,
+      },
+    );
+
+    expect(projection.unsupported).toContain('subagent:broken (invalid definition)');
+  });
+
+  it('reports a selected subagent whose declared name does not match its slug', () => {
+    const dir = root();
+    const catalog = root();
+    const path = join(catalog, 'agents', 'reviewer', 'agent.md');
+    mkdirSync(join(catalog, 'agents', 'reviewer'), { recursive: true });
+    writeFileSync(path, '---\nname: other\n---\n\nReview carefully.\n');
+    const plan = planWith([]);
+    const projection = projectComposition(
+      { ...plan, loadout: { ...plan.loadout, subagents: [subagentResource('reviewer', path, catalog)] } },
+      {
+        harness: 'pi',
+        rootDirectory: dir,
+        homeDirectory: dir,
+      },
+    );
+
+    expect(projection.unsupported).toContain('subagent:reviewer (invalid definition)');
+    expect(() => readFileSync(join(dir, 'agents', 'reviewer.md'), 'utf8')).toThrow();
+  });
+
+  it('accepts a config-only overlay layer for a selected subagent', () => {
+    const dir = root();
+    const catalog = root();
+    const overlay = root();
+    const path = join(catalog, 'agents', 'reviewer', 'agent.md');
+    const configPath = join(overlay, 'agents', 'reviewer', 'config.json');
+    mkdirSync(join(catalog, 'agents', 'reviewer'), { recursive: true });
+    mkdirSync(join(overlay, 'agents', 'reviewer'), { recursive: true });
+    writeFileSync(path, '---\nname: reviewer\n---\n\nReview carefully.\n');
+    writeFileSync(configPath, '{"model":"review-model"}');
+    const plan = planWith([]);
+    const reviewer = {
+      ...subagentResource('reviewer', path, catalog),
+      configPaths: [configPath],
+      configLayerRoots: [overlay],
+    };
+    const projection = projectComposition(
+      { ...plan, loadout: { ...plan.loadout, subagents: [reviewer] } },
+      {
+        harness: 'pi',
+        rootDirectory: dir,
+        homeDirectory: dir,
+      },
+    );
+
+    expect(readFileSync(join(dir, 'agents', 'reviewer.md'), 'utf8')).toContain('model: "review-model"');
+    expect(projection.unsupported).not.toContain('subagents');
+  });
+
+  it('does not materialize a selected subagent through an escaping symlink', () => {
+    const dir = root();
+    const catalog = root();
+    const external = join(root(), 'outside-agent.md');
+    const path = join(catalog, 'agents', 'linked', 'agent.md');
+    writeFileSync(external, '---\nname: linked\n---\n\nOutside.\n');
+    mkdirSync(join(catalog, 'agents', 'linked'), { recursive: true });
+    symlinkSync(external, path);
+    const plan = planWith([]);
+    const linked = subagentResource('linked', path, catalog);
+    const projection = projectComposition(
+      {
+        ...plan,
+        loadout: {
+          ...plan.loadout,
+          subagents: [
+            {
+              ...linked,
+              shadowed: [
+                {
+                  kind: 'agent',
+                  slug: 'linked',
+                  path,
+                  layer: { root: catalog, origin: 'global', label: 'global' },
+                },
+              ],
+            },
+          ],
+        },
+      },
+      {
+        harness: 'pi',
+        rootDirectory: dir,
+        homeDirectory: dir,
+      },
+    );
+
+    expect(projection.unsupported).toContain('subagent:linked (invalid definition)');
   });
 });
 

--- a/code/cli/tests/unit/resolver.test.ts
+++ b/code/cli/tests/unit/resolver.test.ts
@@ -373,7 +373,7 @@ describe('resource resolution', () => {
     ]);
   });
 
-  it('discovers per-agent mcp.json and reserved hooks, warning that they are not yet projected', () => {
+  it('discovers per-agent mcp.json and warns only for the reserved hooks namespace', () => {
     const root = createTemporaryRoot();
     const home = join(root, 'home');
     const project = join(root, 'project');
@@ -394,7 +394,7 @@ describe('resource resolution', () => {
     expect(plain.hookPaths).toEqual([]); // empty hooks/ is not collected
 
     const findings = validateEffectiveSet(set);
-    expect(findings.some((f) => f.resource === 'agent:engineer' && /mcp\.json/.test(f.message))).toBe(true);
+    expect(findings.some((f) => f.resource === 'agent:engineer' && /mcp\.json/.test(f.message))).toBe(false);
     expect(findings.some((f) => f.resource === 'agent:engineer' && /hooks/.test(f.message))).toBe(true);
     // Stubs surface as warnings (fatal only under --strict), never as errors.
     expect(findings.filter((f) => f.severity === 'error')).toHaveLength(0);
@@ -439,6 +439,7 @@ describe('resource resolution', () => {
     const set = setFor(home, project);
     const engineer = findResource(set, 'agent', 'engineer')!;
     expect(engineer.winner.layer.origin).toBe('global');
+    expect(engineer.configLayerRoots).toEqual([join(project, '.agents')]);
     const definition = readAgentDefinition(engineer.winner.path, engineer.configPaths);
     expect(isAgentDefinitionIssue(definition)).toBe(false);
     if (isAgentDefinitionIssue(definition)) return;

--- a/code/cli/tests/unit/run-agent.test.ts
+++ b/code/cli/tests/unit/run-agent.test.ts
@@ -321,25 +321,30 @@ describe('run agent', () => {
     expect(result.launchPlan?.command).toBe('pi');
   });
 
-  it('reports every non-projected loadout element as unsupported', async () => {
+  it('projects Pi subagents and MCP while reporting the remaining unsupported loadout elements', async () => {
     const root = createTemporaryRoot();
+    const home = join(root, 'home');
     const project = join(root, 'project');
+    write(join(home, '.agents', 'mcp.json'), JSON.stringify({ mcpServers: { gh: { command: 'gh-mcp' } } }));
     write(join(project, '.agents', 'agents', 'reviewer', 'agent.md'), '---\nname: reviewer\n---\n\nReview.\n');
     write(
       join(project, '.agents', 'agents', 'lead', 'agent.md'),
       '---\nname: lead\nsubagents: [reviewer]\nmcp: [gh]\nplugins: [p]\nextensions: [e]\nmodel: m\nthinking: high\ntools:\n  allow: [read]\n---\n\nBody.\n',
     );
     const result = await executeRunAgentCommand({
-      homeDirectory: join(root, 'home'),
+      homeDirectory: home,
       projectDirectory: project,
       agent: 'lead',
       harness: 'pi',
       launcher,
     });
     const messages = result.messages.join(' ');
-    for (const element of ['subagents', 'mcp', 'plugins', 'tools']) {
+    for (const element of ['plugins', 'tools']) {
       expect(messages).toContain(`loadout element '${element}'`);
     }
+    expect(messages).not.toContain("loadout element 'subagents'");
+    expect(messages).not.toContain("loadout element 'mcp'");
+    expect(messages).not.toContain('unknown server');
     // pi extensions are now projected, so a non-git/npm specifier is reported as an unsupported
     // source rather than a categorically unsupported loadout element.
     expect(messages).toContain("extension 'e' uses an unsupported source");

--- a/code/cli/tests/unit/sync-command.test.ts
+++ b/code/cli/tests/unit/sync-command.test.ts
@@ -221,7 +221,7 @@ describe('sync command', () => {
     const input = createInvocation();
     const catalog = createRepository({
       'payload/agents/warned/agent.md': agent('warned'),
-      'payload/agents/warned/mcp.json': '{}\n',
+      'payload/agents/warned/hooks/pre.md': 'reserved hook\n',
     });
     writeHomeSettings(
       input.homeDirectory,

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -135,7 +135,7 @@ Rules:
 For a selected agent, the composer builds the run's effective configuration from the effective resource set:
 
 1. **Identity**: the tree's `system-prompt.md` is the base; `agents.md` contributes shared operating context; the selected agent's `agent.md` layers on top. Composition order is explicit and deterministic.
-2. **Subagents**: agents named in the selected agent's `subagents` loadout are marked for projection into the harness's delegation surface.
+2. **Subagents**: agents named in the selected agent's `subagents` loadout are marked for projection into the harness's delegation surface; their own selected skills are resolved and materialized separately from the leader's active skills.
 3. **Skills**: skills named in the loadout are materialized (frontmatter `references`/`scripts`/`assets` resolved from their two-root model, validated for escapes and collisions) into generated skill directories.
 4. **Harness elements**: extensions and plugins named in the loadout are marked for the adapter (first-class for pi).
 5. **Structured configuration**: `models.json`, `mcp.json`, and per-agent `config.json` merge per protocol JSON semantics; the loadout's `model`, `thinking`, and `tools` select and constrain within them.

--- a/docs/documentation/agents.md
+++ b/docs/documentation/agents.md
@@ -79,9 +79,20 @@ agents/founder/
 
 The overlay is file-based. Source layers are applied from lowest to highest precedence, so a workspace `agents/founder/pi/keybindings.json` replaces the same file from a global or remote catalog while unrelated lower-layer files remain present. Outfitter does not follow symlinks from the overlay. The folder is ignored when the selected harness is not Pi.
 
-Outfitter writes generated identity and composed skills after applying the native overlay, and seeds durable Pi credentials immediately before launch. Those runtime-owned resources therefore cannot be replaced accidentally by a profile overlay.
+Outfitter writes generated identity, composed skills, selected delegates, and
+selected MCP servers after applying the native overlay, and seeds durable Pi
+credentials immediately before launch. Those runtime-owned resources therefore
+cannot be replaced accidentally by a profile overlay.
 
-Two per-agent surfaces are **discovered but not yet projected** (adapter parity is tracked in [#183](https://github.com/ai-outfitter/outfitter/issues/183)): `agents/<agent>/mcp.json` (merges by server id over the tree-root `mcp.json`) and the reserved `agents/<agent>/hooks/` namespace (see [Hooks](./hooks.md)). Both surface a validation warning when present so a selection placed there is never silently dropped.
+`agents/<agent>/mcp.json` merges by server id over layered tree-root `mcp.json`
+files. The Pi projection writes only the servers selected by the active
+agent's `mcp` loadout into the runtime `mcp.json`.
+
+The per-agent `agents/<agent>/hooks/` namespace remains reserved and is not yet
+projected (adapter parity is tracked in
+[#183](https://github.com/ai-outfitter/outfitter/issues/183)). Its presence
+surfaces a validation warning so content placed there is never silently
+dropped.
 
 ## config.json
 
@@ -112,3 +123,5 @@ Agents resolve by slug across layers — workspace, global, then remote sources 
 ## Agents as delegates
 
 The same agent definition can also be selected as a [subagent](./subagents.md) in another agent's `subagents` list — a delegate the run can hand focused work to. A leader agent's loadout is where that delegation is declared.
+For Pi runs, Outfitter also resolves and materializes the delegate's selected skills. Those skills
+are available to the delegate without being loaded into the leader's active skill set.


### PR DESCRIPTION
## What changed

- project selected subagents into Pi's runtime `agents/` directory
- merge layered and per-agent MCP configuration, then write only selected servers
- materialize delegate-only skills without activating them for the leader
- retain config-only overlay provenance for safe containment checks
- emit delegate list fields in a format supported by both Pi subagent extensions
- reject invalid delegate identity mismatches

## Why

Outfitter v1.1.1 reported `subagents` and `mcp` as unsupported for Pi, even
when the active profile selected them. This caused real profiles such as
Founder to lose their configured delegates and MCP server at launch.

## Validation

- `npm run check-ci`
- 265 tests across 25 files
- lint and coverage
- documentation lint and production build
- strict Founder-to-Pi projection smoke: `engineer`, `platform`, and
  `researcher` delegates plus only the selected `playwright` MCP server
- generated delegate scalar fields checked against `pi-subagents@0.28.0` and
  `@mjakl/pi-subagent@2.1.0`
