### PR TITLE
feat(agents): restore inheritance and prompt composition

### DIFF
--- a/code/cli/src/cli/commands/DumpCommand.ts
+++ b/code/cli/src/cli/commands/DumpCommand.ts
@@ -49,7 +49,7 @@ export const executeDumpCommand = (input: DumpInput): DumpCommandResult => {
   const syncWarnings = warnings.map((warning) => `warning: ${warning}`);
 
   const agentSlug = resolveAgentSlug(settings, input.agent);
-  const result = dumpAgent(set, agentSlug, input.out);
+  const result = dumpAgent(set, agentSlug, input.out, input.projectDirectory);
   const ok = result.errors.length === 0;
   const messages = ok
     ? [

--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -136,6 +136,12 @@ const resolvePiExtensions = async (
   });
 };
 
+const piConfigurationOverlays = (
+  plan: NonNullable<ReturnType<typeof compose>['plan']>,
+  selectedAgent: NonNullable<ReturnType<typeof findResource>>,
+): readonly string[] =>
+  [...(plan.contributingAgents ?? [selectedAgent])].reverse().flatMap((agent) => agent.piConfigDirectories ?? []);
+
 export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunAgentResult> => {
   // Flush messages to the terminal (before launch); they are also returned so callers can inspect them.
   const emit = (messages: readonly string[]): void => {
@@ -164,10 +170,10 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
   const { set, settings } = resolved;
   const agentSlug = resolveAgentSlug(settings.defaultAgent, input.agent);
   const harness = resolveHarness(settings.defaultHarness, input.harness);
-  const composed = compose(set, agentSlug);
+  const composed = compose(set, agentSlug, { projectDirectory: input.projectDirectory });
 
   if (composed.plan === undefined) {
-    const messages = [...setupMessages, ...composed.errors];
+    const messages = [...setupMessages, ...composed.warnings, ...composed.errors];
     emit(messages);
     return { exitCode: 1, messages };
   }
@@ -175,6 +181,7 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
   // Install/cache the pi extensions into a shared XDG cache and load them at launch (pi only).
   const extensions = await resolvePiExtensions(input, harness, composed.plan.loadout.extensions);
   const selectedAgent = findResource(set, 'agent', agentSlug)!;
+  const configurationOverlays = piConfigurationOverlays(composed.plan, selectedAgent);
 
   const rootDirectory = mkdtempSync(join(tmpdir(), `outfitter-${agentSlug}-${harness}-`));
 
@@ -186,7 +193,7 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
       passThroughArgs: input.passThroughArgs,
       extensionLoadDirs: harness === 'pi' ? extensions.loadDirs : undefined,
       // ProjectHarness only overlays these for the pi harness, so pass them through unconditionally.
-      configurationOverlayDirectories: selectedAgent.piConfigDirectories,
+      configurationOverlayDirectories: configurationOverlays,
     });
 
     // Composition warnings, unsupported harness elements, and extension-install failures are all

--- a/code/cli/src/cli/commands/ValidateCommand.ts
+++ b/code/cli/src/cli/commands/ValidateCommand.ts
@@ -36,7 +36,7 @@ export const executeValidateCommand = (input: ValidateInput): ValidateResult => 
   const findings = [
     ...settingsFindings(settingsIssues.map(formatSettingsIssue)),
     ...warnings.map((message) => ({ severity: 'warning' as const, resource: 'settings', message })),
-    ...validateEffectiveSet(set),
+    ...validateEffectiveSet(set, input.projectDirectory),
   ];
 
   const hasErrors = findings.some((finding) => finding.severity === 'error');

--- a/code/cli/src/composer/Composer.ts
+++ b/code/cli/src/composer/Composer.ts
@@ -4,43 +4,233 @@ import { join } from 'node:path';
 
 import { escapesRoots } from '../dump/Containment.js';
 import { isAgentDefinitionIssue, readAgentDefinition } from '../resolver/AgentDefinition.js';
+import type { AgentDefinition } from '../resolver/AgentDefinition.js';
 import type { EffectiveResourceSet, Loadout, ResolvedResource } from '../resolver/Resource.js';
 import { findLoadoutResource, findResource } from '../resolver/Resource.js';
-import type { ComposedLoadout, CompositionPlan } from './Composition.js';
+import type { ComposedLoadout, ComposedSubagent, ComposedSubagentIdentity, CompositionPlan } from './Composition.js';
+import type { PromptFragment, PromptSourceReference } from './PromptSource.js';
+import { agentBodyFragment, promptSourceKey, resolvePromptSource, rootPromptFragment } from './PromptSource.js';
+
+export interface ComposeOptions {
+  /** Active repository root for `repo_file` prompt references. */
+  readonly projectDirectory?: string;
+}
 
 export interface ComposeResult {
   readonly plan?: CompositionPlan;
   readonly errors: readonly string[];
+  readonly warnings: readonly string[];
+}
+
+interface ChainEntry {
+  readonly resource: ResolvedResource;
+  readonly definition: AgentDefinition;
+}
+
+interface DeclaredSlug {
+  readonly slug: string;
+  readonly owner: string;
+}
+
+interface EffectiveControls {
+  readonly loadout: Loadout;
+  readonly skillSelections: readonly DeclaredSlug[];
+  readonly subagentSelections: readonly DeclaredSlug[];
+  readonly mcpSelections: readonly DeclaredSlug[];
+  readonly appendPromptSelections: readonly {
+    readonly source: PromptSourceReference;
+    readonly owner: string;
+    readonly index: number;
+  }[];
+  readonly systemPrompt?: { readonly source: PromptSourceReference; readonly owner: string };
+  readonly promptTemplate?: { readonly source: PromptSourceReference; readonly owner: string };
+  readonly label?: string;
+  readonly description?: string;
 }
 
 /** Reads the highest-precedence tree-root file (e.g. system-prompt.md) across layers, or undefined. */
-const readRootFile = (set: EffectiveResourceSet, fileName: string): string | undefined => {
+const readRootFile = (set: EffectiveResourceSet, fileName: string): PromptFragment | undefined => {
   for (const layer of set.layers) {
     const candidate = join(layer.root, fileName);
 
     if (existsSync(candidate)) {
-      return readFileSync(candidate, 'utf8');
+      return rootPromptFragment({ fileName, layer, content: readFileSync(candidate, 'utf8') });
     }
   }
 
   return undefined;
 };
 
-const resolveSlugs = (
+const readValidAgent = (agent: ResolvedResource): AgentDefinition | string => {
+  const definition = readAgentDefinition(agent.winner.path, agent.configPaths);
+  if (isAgentDefinitionIssue(definition)) return definition.message;
+  if (definition.name !== agent.slug) return `agent.md name '${definition.name}' must match its directory.`;
+  return definition;
+};
+
+const resolveInheritanceChain = (
   set: EffectiveResourceSet,
   agentSlug: string,
+): { entries?: readonly ChainEntry[]; errors: readonly string[] } => {
+  const entries: ChainEntry[] = [];
+  const composed = new Set<string>();
+  const visiting: string[] = [];
+  const errors: string[] = [];
+
+  const visit = (slug: string): void => {
+    if (composed.has(slug)) return;
+    const cycleIndex = visiting.indexOf(slug);
+    if (cycleIndex !== -1) {
+      errors.push(`Agent inheritance cycle detected: ${[...visiting.slice(cycleIndex), slug].join(' -> ')}.`);
+      return;
+    }
+
+    const resource = findResource(set, 'agent', slug);
+    if (resource === undefined) {
+      errors.push(
+        `Agent inheritance references unknown parent '${slug}' in chain ${[...visiting, slug].join(' -> ')}.`,
+      );
+      return;
+    }
+
+    const definition = readValidAgent(resource);
+    if (typeof definition === 'string') {
+      errors.push(`Agent '${slug}' is invalid: ${definition}`);
+      return;
+    }
+
+    visiting.push(slug);
+    for (const parent of definition.inherits) visit(parent);
+    visiting.pop();
+
+    if (!composed.has(slug)) {
+      composed.add(slug);
+      entries.push({ resource, definition });
+    }
+  };
+
+  visit(agentSlug);
+  return errors.length > 0 ? { errors } : { entries, errors: [] };
+};
+
+const stablePush = <T>(items: T[], keySet: Set<string>, key: string, value: T): void => {
+  if (!keySet.has(key)) {
+    keySet.add(key);
+    items.push(value);
+  }
+};
+
+const union = (values: readonly string[] = [], next: readonly string[] = []): readonly string[] | undefined => {
+  const merged: string[] = [];
+  const seen = new Set<string>();
+  for (const value of [...values, ...next]) stablePush(merged, seen, value, value);
+  return merged.length > 0 ? merged : undefined;
+};
+
+const uniqueStrings = (values: readonly string[]): readonly string[] => [...new Set(values)];
+
+const declaredSelections = (
+  chain: readonly ChainEntry[],
+  select: (definition: AgentDefinition) => readonly string[],
+): readonly DeclaredSlug[] => {
+  const selections: DeclaredSlug[] = [];
+  const seen = new Set<string>();
+  for (const entry of chain) {
+    for (const slug of select(entry.definition)) {
+      stablePush(selections, seen, slug, { slug, owner: entry.resource.slug });
+    }
+  }
+  return selections;
+};
+
+const appendPromptSelections = (chain: readonly ChainEntry[]): EffectiveControls['appendPromptSelections'] => {
+  const selections: { readonly source: PromptSourceReference; readonly owner: string; readonly index: number }[] = [];
+  const seen = new Set<string>();
+  for (const entry of chain) {
+    entry.definition.promptControls.appendSystemPrompt.forEach((source, index) => {
+      stablePush(selections, seen, promptSourceKey(source), { source, owner: entry.resource.slug, index });
+    });
+  }
+  return selections;
+};
+
+const nearest = <T>(
+  chain: readonly ChainEntry[],
+  select: (definition: AgentDefinition) => T | undefined,
+): T | undefined => {
+  for (const entry of [...chain].reverse()) {
+    const value = select(entry.definition);
+    if (value !== undefined) return value;
+  }
+  return undefined;
+};
+
+const composeTools = (chain: readonly ChainEntry[]): Loadout['tools'] => {
+  const allow = union(
+    [],
+    chain.flatMap((entry) => entry.definition.loadout.tools?.allow ?? []),
+  );
+  const deny = union(
+    [],
+    chain.flatMap((entry) => entry.definition.loadout.tools?.deny ?? []),
+  );
+  return allow === undefined && deny === undefined ? undefined : { allow, deny };
+};
+
+const nearestPrompt = (
+  chain: readonly ChainEntry[],
+  select: (definition: AgentDefinition) => PromptSourceReference | undefined,
+): EffectiveControls['systemPrompt'] => {
+  for (const entry of [...chain].reverse()) {
+    const source = select(entry.definition);
+    if (source !== undefined) return { source, owner: entry.resource.slug };
+  }
+  return undefined;
+};
+
+const composeEffectiveControls = (chain: readonly ChainEntry[]): EffectiveControls => {
+  const skills = declaredSelections(chain, (definition) => definition.loadout.skills);
+  const subagents = declaredSelections(chain, (definition) => definition.loadout.subagents);
+  const mcp = declaredSelections(chain, (definition) => definition.loadout.mcp);
+  const model = nearest(chain, (definition) => definition.loadout.model);
+  const thinking = nearest(chain, (definition) => definition.loadout.thinking);
+
+  return {
+    skillSelections: skills,
+    subagentSelections: subagents,
+    mcpSelections: mcp,
+    appendPromptSelections: appendPromptSelections(chain),
+    systemPrompt: nearestPrompt(chain, (definition) => definition.promptControls.systemPrompt),
+    promptTemplate: nearestPrompt(chain, (definition) => definition.promptControls.promptTemplate),
+    label: nearest(chain, (definition) => definition.label),
+    description: nearest(chain, (definition) => definition.description),
+    loadout: {
+      skills: skills.map((selection) => selection.slug),
+      subagents: subagents.map((selection) => selection.slug),
+      mcp: mcp.map((selection) => selection.slug),
+      extensions: uniqueStrings(chain.flatMap((entry) => entry.definition.loadout.extensions)),
+      plugins: uniqueStrings(chain.flatMap((entry) => entry.definition.loadout.plugins)),
+      model,
+      thinking,
+      tools: composeTools(chain),
+    },
+  };
+};
+
+const resolveDeclaredSlugs = (
+  set: EffectiveResourceSet,
   kind: 'skill' | 'agent',
   reference: string,
-  slugs: readonly string[],
+  selections: readonly DeclaredSlug[],
   warnings: string[],
 ): readonly ResolvedResource[] => {
   const resolved: ResolvedResource[] = [];
 
-  for (const slug of slugs) {
-    const resource = findLoadoutResource(set, agentSlug, kind, slug);
+  for (const selection of selections) {
+    const resource = findLoadoutResource(set, selection.owner, kind, selection.slug);
 
     if (resource === undefined) {
-      warnings.push(`${reference} references unknown ${kind} '${slug}'.`);
+      warnings.push(`${reference} references unknown ${kind} '${selection.slug}'.`);
     } else {
       resolved.push(resource);
     }
@@ -75,38 +265,48 @@ const readMcpServers = (path: string, warnings: string[]): Readonly<Record<strin
 
 const composeMcpServers = (
   set: EffectiveResourceSet,
-  agent: ResolvedResource,
-  selectedIds: readonly string[],
+  selections: readonly DeclaredSlug[],
   warnings: string[],
 ): Readonly<Record<string, unknown>> => {
-  if (selectedIds.length === 0) {
-    return {};
-  }
+  if (selections.length === 0) return {};
 
   const rootPaths = set.layers.map((layer) => join(layer.root, 'mcp.json')).filter((path) => existsSync(path));
-  const pathsByPrecedence = [
-    ...rootPaths.reverse(),
-    // Resolver annotates every agent resource with mcpPaths, including an empty array.
-    ...[...agent.mcpPaths!].reverse(),
-  ];
-  const available: Record<string, unknown> = {};
   const roots = set.layers.map((layer) => layer.root);
-
-  for (const path of pathsByPrecedence) {
+  const cache = new Map<string, Readonly<Record<string, unknown>>>();
+  const serversAt = (path: string): Readonly<Record<string, unknown>> => {
+    const cached = cache.get(path);
+    if (cached !== undefined) return cached;
+    let servers: Readonly<Record<string, unknown>>;
     if (escapesRoots(path, roots)) {
       warnings.push(`MCP configuration '${path}' resolves outside the resource layers and was skipped.`);
-      continue;
+      servers = {};
+    } else {
+      servers = readMcpServers(path, warnings);
     }
-    Object.assign(available, readMcpServers(path, warnings));
-  }
+    cache.set(path, servers);
+    return servers;
+  };
 
   const selected: Record<string, unknown> = {};
-  for (const id of selectedIds) {
-    if (Object.hasOwn(available, id)) {
-      selected[id] = available[id];
-    } else {
-      warnings.push(`loadout mcp references unknown server '${id}'.`);
+  for (const selection of selections) {
+    // MCP selections are created only from entries in the resolved inheritance chain.
+    const owner = findResource(set, 'agent', selection.owner)!;
+    // Root definitions are shared; only the declaring agent's overlays may override its selection.
+    const ownerPaths = [...owner.mcpPaths!].reverse();
+    const pathsByPrecedence = [...rootPaths].reverse().concat(ownerPaths);
+    let definition: unknown;
+    let found = false;
+
+    for (const path of pathsByPrecedence) {
+      const servers = serversAt(path);
+      if (Object.hasOwn(servers, selection.slug)) {
+        definition = servers[selection.slug];
+        found = true;
+      }
     }
+
+    if (found) selected[selection.slug] = definition;
+    else warnings.push(`loadout mcp references unknown server '${selection.slug}'.`);
   }
 
   return selected;
@@ -123,21 +323,19 @@ const resolveDelegateSkills = (
   const roots = set.layers.map((layer) => layer.root);
 
   for (const subagent of subagents) {
-    const definitionPaths = [subagent.winner.path, ...(subagent.configPaths ?? [])];
+    // Resolver annotates every agent resource with configPaths, including an empty array.
+    const definitionPaths = [subagent.winner.path, ...subagent.configPaths!];
     if (definitionPaths.some((path) => escapesRoots(path, roots))) continue;
 
-    const definition = readAgentDefinition(subagent.winner.path, subagent.configPaths);
+    const chain = resolveInheritanceChain(set, subagent.slug);
+    if (chain.entries === undefined) continue;
+    const controls = composeEffectiveControls(chain.entries);
 
-    if (isAgentDefinitionIssue(definition) || definition.name !== subagent.slug) {
-      continue;
-    }
-
-    for (const skill of resolveSlugs(
+    for (const skill of resolveDeclaredSlugs(
       set,
-      subagent.slug,
       'skill',
       `subagent '${subagent.slug}' loadout skills`,
-      definition.loadout.skills,
+      controls.skillSelections,
       warnings,
     )) {
       const selected = skills.get(skill.slug);
@@ -158,64 +356,199 @@ const resolveDelegateSkills = (
 
 const composeLoadout = (
   set: EffectiveResourceSet,
-  agent: ResolvedResource,
-  loadout: Loadout,
+  controls: EffectiveControls,
   warnings: string[],
 ): ComposedLoadout => {
-  const subagents = resolveSlugs(set, agent.slug, 'agent', 'loadout subagents', loadout.subagents, warnings);
-  const skills = resolveSlugs(set, agent.slug, 'skill', 'loadout skills', loadout.skills, warnings);
+  const subagents = resolveDeclaredSlugs(set, 'agent', 'loadout subagents', controls.subagentSelections, warnings);
+  const skills = resolveDeclaredSlugs(set, 'skill', 'loadout skills', controls.skillSelections, warnings);
 
   return {
     skills,
     delegateSkills: resolveDelegateSkills(set, subagents, skills, warnings),
     subagents,
-    mcp: loadout.mcp,
-    mcpServers: composeMcpServers(set, agent, loadout.mcp, warnings),
-    extensions: loadout.extensions,
-    plugins: loadout.plugins,
-    model: loadout.model,
-    thinking: loadout.thinking,
-    tools: loadout.tools,
+    mcp: controls.loadout.mcp,
+    mcpServers: composeMcpServers(set, controls.mcpSelections, warnings),
+    extensions: controls.loadout.extensions,
+    plugins: controls.loadout.plugins,
+    model: controls.loadout.model,
+    thinking: controls.loadout.thinking,
+    tools: controls.loadout.tools,
   };
 };
 
-/**
- * Composes the selected agent into a CompositionPlan. Returns an error when the agent slug does not
- * resolve or its definition is invalid; loadout slugs that do not resolve are non-fatal warnings.
- */
-export const compose = (set: EffectiveResourceSet, agentSlug: string): ComposeResult => {
-  const agent = findResource(set, 'agent', agentSlug);
+const resolvePromptSelection = (
+  set: EffectiveResourceSet,
+  selection: { readonly source: PromptSourceReference; readonly owner: string },
+  options: ComposeOptions,
+  label: string,
+  warnings: string[],
+  errors: string[],
+): PromptFragment | undefined => {
+  // Prompt selections are created only from entries in the resolved inheritance chain.
+  const owner = findResource(set, 'agent', selection.owner)!;
+  const resolved = resolvePromptSource({
+    source: selection.source,
+    declaringAgent: selection.owner,
+    layer: owner.winner.layer,
+    projectDirectory: options.projectDirectory,
+    optionalRepoFile: true,
+    label,
+  });
+  if (resolved.warning !== undefined) warnings.push(resolved.warning);
+  if (resolved.error !== undefined) errors.push(resolved.error);
+  return resolved.fragment;
+};
 
-  if (agent === undefined) {
-    return { errors: [`Unknown agent '${agentSlug}'. Run 'outfitter list agents' to see resolvable agents.`] };
+const resolveOptionalPrompt = (
+  set: EffectiveResourceSet,
+  selection: EffectiveControls['systemPrompt'],
+  options: ComposeOptions,
+  label: string,
+  warnings: string[],
+  errors: string[],
+): PromptFragment | undefined =>
+  selection === undefined ? undefined : resolvePromptSelection(set, selection, options, label, warnings, errors);
+
+const composeIdentity = (
+  set: EffectiveResourceSet,
+  chain: readonly ChainEntry[],
+  controls: EffectiveControls,
+  options: ComposeOptions,
+  warnings: string[],
+  errors: string[],
+): ComposedSubagentIdentity => {
+  const declaredSystemPrompt = resolveOptionalPrompt(
+    set,
+    controls.systemPrompt,
+    options,
+    'system-prompt',
+    warnings,
+    errors,
+  );
+  if (declaredSystemPrompt?.kind === 'repo_file') {
+    warnings.push(
+      `agent '${controls.systemPrompt!.owner}' uses untrusted repo_file '${declaredSystemPrompt.reference}' as system_prompt.`,
+    );
+  }
+  const systemPrompt = declaredSystemPrompt ?? readRootFile(set, 'system-prompt.md');
+  const sharedContext = readRootFile(set, 'agents.md');
+  const appendSystemPrompts = controls.appendPromptSelections
+    .map((selection) =>
+      resolvePromptSelection(
+        set,
+        selection,
+        options,
+        `append-${selection.owner}-${selection.index + 1}`,
+        warnings,
+        errors,
+      ),
+    )
+    .filter((fragment): fragment is PromptFragment => fragment !== undefined);
+  const promptTemplate = resolveOptionalPrompt(
+    set,
+    controls.promptTemplate,
+    options,
+    'prompt-template',
+    warnings,
+    errors,
+  );
+  const agentBodies = chain.map((entry) =>
+    agentBodyFragment({
+      agent: entry.resource.slug,
+      layer: entry.resource.winner.layer,
+      path: entry.resource.winner.path,
+      content: entry.definition.body,
+    }),
+  );
+
+  return {
+    systemPrompt: systemPrompt?.content,
+    systemPromptFragment: systemPrompt,
+    sharedContext: sharedContext?.content,
+    sharedContextFragment: sharedContext,
+    appendSystemPrompts,
+    agentBodies,
+    promptTemplate,
+    agentBody: agentBodies.map((fragment) => fragment.content).join('\n'),
+    label: controls.label,
+    description: controls.description,
+  };
+};
+
+const composeSubagents = (
+  set: EffectiveResourceSet,
+  subagents: readonly ResolvedResource[],
+  options: ComposeOptions,
+  warnings: string[],
+  errors: string[],
+): readonly ComposedSubagent[] => {
+  const composed: ComposedSubagent[] = [];
+
+  const roots = set.layers.map((layer) => layer.root);
+  for (const resource of subagents) {
+    const definitionPaths = [resource.winner.path, ...resource.configPaths!];
+    if (definitionPaths.some((path) => escapesRoots(path, roots))) continue;
+
+    const chainResult = resolveInheritanceChain(set, resource.slug);
+    if (chainResult.entries === undefined) {
+      errors.push(...chainResult.errors.map((error) => `Subagent '${resource.slug}' is invalid: ${error}`));
+      continue;
+    }
+
+    const controls = composeEffectiveControls(chainResult.entries);
+    const identity = composeIdentity(set, chainResult.entries, controls, options, warnings, errors);
+    const skills = resolveDeclaredSlugs(
+      set,
+      'skill',
+      `subagent '${resource.slug}' loadout skills`,
+      controls.skillSelections,
+      warnings,
+    );
+    composed.push({
+      resource,
+      identity,
+      skills,
+      extensions: controls.loadout.extensions,
+      model: controls.loadout.model,
+      thinking: controls.loadout.thinking,
+      tools: controls.loadout.tools,
+    });
   }
 
-  const definition = readAgentDefinition(agent.winner.path, agent.configPaths);
+  return composed;
+};
 
-  if (isAgentDefinitionIssue(definition)) {
-    return { errors: [`Agent '${agentSlug}' is invalid: ${definition.message}`] };
-  }
-
-  // A name/directory mismatch is an invalid agent (OFTR-003.2) and must fail composition.
-  if (definition.name !== agentSlug) {
+/** Composes one selected agent from the shared effective resource set. */
+export const compose = (set: EffectiveResourceSet, agentSlug: string, options: ComposeOptions = {}): ComposeResult => {
+  if (findResource(set, 'agent', agentSlug) === undefined) {
     return {
-      errors: [`Agent '${agentSlug}' is invalid: agent.md name '${definition.name}' must match its directory.`],
+      errors: [`Unknown agent '${agentSlug}'. Run 'outfitter list agents' to see resolvable agents.`],
+      warnings: [],
     };
   }
 
+  const chainResult = resolveInheritanceChain(set, agentSlug);
+  if (chainResult.entries === undefined) return { errors: chainResult.errors, warnings: [] };
+  const chain = chainResult.entries;
   const warnings: string[] = [];
-  const plan: CompositionPlan = {
-    agent: agentSlug,
-    identity: {
-      systemPrompt: readRootFile(set, 'system-prompt.md'),
-      sharedContext: readRootFile(set, 'agents.md'),
-      agentBody: definition.body,
-      label: definition.label,
-      description: definition.description,
-    },
-    loadout: composeLoadout(set, agent, definition.loadout, warnings),
-    warnings,
-  };
+  const errors: string[] = [];
+  const controls = composeEffectiveControls(chain);
+  const identity = composeIdentity(set, chain, controls, options, warnings, errors);
+  const loadout = composeLoadout(set, controls, warnings);
+  const composedSubagents = composeSubagents(set, loadout.subagents, options, warnings, errors);
+  const uniqueWarnings = uniqueStrings(warnings);
+  if (errors.length > 0) return { errors, warnings: uniqueWarnings };
 
-  return { plan, errors: [] };
+  return {
+    plan: {
+      agent: agentSlug,
+      identity,
+      loadout: { ...loadout, composedSubagents },
+      contributingAgents: chain.map((entry) => entry.resource),
+      inheritanceChain: chain.map((entry) => entry.resource.slug),
+      warnings: uniqueWarnings,
+    },
+    errors: [],
+    warnings: uniqueWarnings,
+  };
 };

--- a/code/cli/src/composer/Composition.ts
+++ b/code/cli/src/composer/Composition.ts
@@ -1,17 +1,44 @@
 // Harness-neutral composition types produced from the effective resource set for a selected agent.
 import type { Loadout, ResolvedResource } from '../resolver/Resource.js';
+import type { PromptFragment } from './PromptSource.js';
 
-/** The composed identity: base prompt, shared context, and the selected agent's body. */
+/** The composed identity: base prompt, shared context, prompt fragments, and agent bodies. */
 export interface ComposedIdentity {
-  /** Content of the winning `system-prompt.md`, if any. */
+  /** Content of the effective system prompt, if any. Kept for compatibility with existing callers. */
   readonly systemPrompt?: string;
+  /** Provenance-rich effective system prompt fragment. */
+  readonly systemPromptFragment?: PromptFragment;
   /** Content of the winning `agents.md` shared operating context, if any. */
   readonly sharedContext?: string;
-  /** The selected agent's `agent.md` markdown body. */
+  readonly sharedContextFragment?: PromptFragment;
+  /** Effective appended prompt fragments, inherited parent-first and de-duplicated. */
+  readonly appendSystemPrompts?: readonly PromptFragment[];
+  /** Effective agent body fragments, inherited parent-first and selected child last. */
+  readonly agentBodies?: readonly PromptFragment[];
+  /** Effective prompt template fragment, when declared. */
+  readonly promptTemplate?: PromptFragment;
+  /** The composed `agent.md` markdown body. Kept for compatibility with existing callers. */
   readonly agentBody: string;
   /** Human-readable profile name for interactive harness UI. */
   readonly label?: string;
   readonly description?: string;
+}
+
+/** Identity fields guaranteed for a delegate composed from the effective resource set. */
+export interface ComposedSubagentIdentity extends ComposedIdentity {
+  readonly appendSystemPrompts: readonly PromptFragment[];
+  readonly agentBodies: readonly PromptFragment[];
+}
+
+/** Effective delegated-agent controls projected into a native subagent definition. */
+export interface ComposedSubagent {
+  readonly resource: ResolvedResource;
+  readonly identity: ComposedSubagentIdentity;
+  readonly skills: readonly ResolvedResource[];
+  readonly extensions: readonly string[];
+  readonly model?: string;
+  readonly thinking?: string;
+  readonly tools?: Loadout['tools'];
 }
 
 /** A loadout with its slug references resolved against the effective set. */
@@ -20,6 +47,8 @@ export interface ComposedLoadout {
   /** Skills selected by delegates, materialized for them without loading them into the leader. */
   readonly delegateSkills: readonly ResolvedResource[];
   readonly subagents: readonly ResolvedResource[];
+  /** Inheritance-aware definitions for each selected delegate. */
+  readonly composedSubagents?: readonly ComposedSubagent[];
   readonly mcp: readonly string[];
   /** Selected MCP server definitions after layer and per-agent precedence are applied. */
   readonly mcpServers: Readonly<Record<string, unknown>>;
@@ -38,6 +67,10 @@ export interface CompositionPlan {
   readonly agent: string;
   readonly identity: ComposedIdentity;
   readonly loadout: ComposedLoadout;
+  /** Parent-first agent resources that contributed identity, loadout, or native overlays. */
+  readonly contributingAgents?: readonly ResolvedResource[];
+  /** Parent-first chain of agent slugs that contributed to this composition, selected child last. */
+  readonly inheritanceChain?: readonly string[];
   /** Non-fatal issues (e.g. unknown loadout slugs) surfaced during composition. */
   readonly warnings: readonly string[];
 }

--- a/code/cli/src/composer/PromptSource.ts
+++ b/code/cli/src/composer/PromptSource.ts
@@ -1,0 +1,168 @@
+// Resolves prompt source references declared in agent frontmatter with containment provenance.
+import { existsSync, realpathSync, statSync, readFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+
+import { escapesRoots } from '../dump/Containment.js';
+import type { Layer } from '../resolver/Resource.js';
+
+export type PromptSourceKind = 'root' | 'file' | 'repo_file' | 'agent_body';
+
+export interface PromptSourceReference {
+  readonly file?: string;
+  readonly repo_file?: string;
+}
+
+export interface PromptFragment {
+  readonly kind: PromptSourceKind;
+  readonly content: string;
+  readonly path?: string;
+  readonly reference?: string;
+  readonly declaringAgent?: string;
+  readonly layer?: Layer;
+  /** Human-readable label used for deterministic generated filenames and dump metadata. */
+  readonly label: string;
+  /** Repository prompt content is untrusted active-project content, not catalog policy. */
+  readonly trust: 'catalog' | 'repository' | 'generated';
+}
+
+export interface PromptResolution {
+  readonly fragment?: PromptFragment;
+  readonly warning?: string;
+  readonly error?: string;
+}
+
+export const isPromptSourceReference = (value: unknown): value is PromptSourceReference =>
+  value !== null &&
+  typeof value === 'object' &&
+  !Array.isArray(value) &&
+  ((typeof (value as { file?: unknown }).file === 'string' &&
+    (value as { repo_file?: unknown }).repo_file === undefined) ||
+    (typeof (value as { repo_file?: unknown }).repo_file === 'string' &&
+      (value as { file?: unknown }).file === undefined));
+
+const safeRelative = (value: string): boolean =>
+  value.length > 0 && !value.startsWith('/') && !value.split(/[\\/]+/).includes('..');
+
+const containedFile = (path: string, root: string): true | string => {
+  if (!existsSync(path)) return `missing file '${path}'.`;
+
+  let real: string;
+  try {
+    real = realpathSync(path);
+    /* v8 ignore next 2 -- existsSync succeeded; this only covers a concurrent filesystem race. */
+  } catch (error) {
+    return `cannot resolve '${path}': ${String(error)}`;
+  }
+
+  if (escapesRoots(real, [root])) return `'${path}' resolves outside '${root}'.`;
+
+  try {
+    if (!statSync(real).isFile()) return `'${path}' is not a file.`;
+    /* v8 ignore next 2 -- realpathSync succeeded; this only covers a concurrent filesystem race. */
+  } catch (error) {
+    return `cannot stat '${path}': ${String(error)}`;
+  }
+
+  return true;
+};
+
+export const promptSourceKey = (source: PromptSourceReference): string =>
+  source.file !== undefined ? `file:${source.file}` : `repo_file:${source.repo_file!}`;
+
+export const resolvePromptSource = (input: {
+  readonly source: PromptSourceReference;
+  readonly declaringAgent: string;
+  readonly layer: Layer;
+  readonly projectDirectory?: string;
+  readonly optionalRepoFile?: boolean;
+  readonly label: string;
+}): PromptResolution => {
+  const { source, declaringAgent, layer, label } = input;
+
+  if (source.file !== undefined) {
+    if (!safeRelative(source.file)) {
+      return {
+        error: `agent '${declaringAgent}' prompt source file '${source.file}' must be a contained relative path.`,
+      };
+    }
+    const path = join(layer.root, source.file);
+    const contained = containedFile(path, layer.root);
+    if (contained !== true) return { error: `agent '${declaringAgent}' prompt source file ${contained}` };
+    return {
+      fragment: {
+        kind: 'file',
+        content: readFileSync(path, 'utf8'),
+        path,
+        reference: source.file,
+        declaringAgent,
+        layer,
+        label,
+        trust: 'catalog',
+      },
+    };
+  }
+
+  const repoFile = source.repo_file!;
+  if (!safeRelative(repoFile)) {
+    return {
+      error: `agent '${declaringAgent}' repo_file prompt source '${repoFile}' must be a contained relative path.`,
+    };
+  }
+
+  const projectDirectory = input.projectDirectory;
+  if (projectDirectory === undefined) {
+    return {
+      warning: `agent '${declaringAgent}' repo_file prompt source '${repoFile}' cannot be resolved without a project root.`,
+    };
+  }
+
+  const path = join(projectDirectory, repoFile);
+  if (!existsSync(path) && input.optionalRepoFile === true) {
+    return { warning: `agent '${declaringAgent}' optional repo_file prompt source '${repoFile}' was not found.` };
+  }
+  const contained = containedFile(path, projectDirectory);
+  if (contained !== true) return { error: `agent '${declaringAgent}' repo_file prompt source ${contained}` };
+
+  return {
+    fragment: {
+      kind: 'repo_file',
+      content: readFileSync(path, 'utf8'),
+      path,
+      reference: repoFile,
+      declaringAgent,
+      layer,
+      label,
+      trust: 'repository',
+    },
+  };
+};
+
+export const rootPromptFragment = (input: {
+  readonly fileName: string;
+  readonly layer: Layer;
+  readonly content: string;
+}): PromptFragment => ({
+  kind: 'root',
+  content: input.content,
+  path: join(input.layer.root, input.fileName),
+  reference: input.fileName,
+  layer: input.layer,
+  label: input.fileName.replace(/\.md$/, ''),
+  trust: 'catalog',
+});
+
+export const agentBodyFragment = (input: {
+  readonly agent: string;
+  readonly layer: Layer;
+  readonly path: string;
+  readonly content: string;
+}): PromptFragment => ({
+  kind: 'agent_body',
+  content: input.content,
+  path: input.path,
+  reference: relative(dirname(input.path), input.path),
+  declaringAgent: input.agent,
+  layer: input.layer,
+  label: `agent-${input.agent}`,
+  trust: 'catalog',
+});

--- a/code/cli/src/dump/Dump.ts
+++ b/code/cli/src/dump/Dump.ts
@@ -11,6 +11,8 @@ import {
 } from 'node:fs';
 import { dirname, join } from 'node:path';
 
+import type { CompositionPlan } from '../composer/Composition.js';
+import type { PromptFragment } from '../composer/PromptSource.js';
 import { compose } from '../composer/Composer.js';
 import { removeTargetTypeConflict } from '../fs/TypeConflict.js';
 import { pickLoadoutKeys } from '../resolver/AgentDefinition.js';
@@ -99,23 +101,124 @@ const writeRootFiles = (set: EffectiveResourceSet, outRoot: string, written: str
   return errors;
 };
 
+interface PromptProvenance {
+  readonly order: number;
+  readonly role: 'system_prompt' | 'shared_context' | 'append_system_prompt' | 'agent_body';
+  readonly kind: PromptFragment['kind'];
+  readonly reference?: string;
+  readonly declaringAgent?: string;
+  readonly layer?: string;
+  readonly trust: PromptFragment['trust'];
+}
+
+interface CompositionProvenance {
+  readonly agent: string;
+  readonly inheritanceChain: readonly string[];
+  readonly prompts: readonly PromptProvenance[];
+  readonly promptTemplate?: Omit<PromptProvenance, 'order' | 'role'>;
+}
+
 interface ClosureCompose {
   readonly agents: readonly ResolvedResource[];
   readonly skills: readonly ResolvedResource[];
+  readonly promptFiles: readonly { readonly reference: string; readonly content: string }[];
+  readonly provenance: readonly CompositionProvenance[];
   readonly warnings: readonly string[];
   readonly errors: readonly string[];
 }
 
-/**
- * BFS over the selected agent and its subagents, composing each closure member exactly once to
- * collect the transitive agent list, its skills, warnings, and any composition errors.
- */
-const composeClosure = (set: EffectiveResourceSet, rootSlug: string): ClosureCompose => {
+const collectContributingAgents = (
+  set: EffectiveResourceSet,
+  slugs: readonly string[],
+  agents: ResolvedResource[],
+): void => {
+  const existing = new Set(agents.map((agent) => agent.slug));
+  for (const slug of slugs) {
+    const agent = findResource(set, 'agent', slug);
+    if (agent !== undefined && !existing.has(slug)) {
+      agents.push(agent);
+      existing.add(slug);
+    }
+  }
+};
+
+const fragmentProvenance = (fragment: PromptFragment): Omit<PromptProvenance, 'order' | 'role'> => ({
+  kind: fragment.kind,
+  reference: fragment.reference,
+  declaringAgent: fragment.declaringAgent,
+  layer: fragment.layer?.label,
+  trust: fragment.trust,
+});
+
+const compositionProvenance = (plan: CompositionPlan): CompositionProvenance => {
+  const ordered: readonly { readonly role: PromptProvenance['role']; readonly fragment?: PromptFragment }[] = [
+    { role: 'system_prompt', fragment: plan.identity.systemPromptFragment },
+    { role: 'shared_context', fragment: plan.identity.sharedContextFragment },
+    ...plan.identity.appendSystemPrompts!.map((fragment) => ({
+      role: 'append_system_prompt' as const,
+      fragment,
+    })),
+    ...plan.identity.agentBodies!.map((fragment) => ({ role: 'agent_body' as const, fragment })),
+  ];
+
+  return {
+    agent: plan.agent,
+    inheritanceChain: plan.inheritanceChain!,
+    prompts: ordered
+      .filter(
+        (entry): entry is { readonly role: PromptProvenance['role']; readonly fragment: PromptFragment } =>
+          entry.fragment !== undefined,
+      )
+      .map((entry, order) => ({ order, role: entry.role, ...fragmentProvenance(entry.fragment) })),
+    promptTemplate:
+      plan.identity.promptTemplate === undefined ? undefined : fragmentProvenance(plan.identity.promptTemplate),
+  };
+};
+
+const collectPromptFiles = (plan: CompositionPlan, promptFiles: Map<string, string>, errors: string[]): void => {
+  const fragments = [
+    plan.identity.systemPromptFragment,
+    plan.identity.promptTemplate,
+    ...plan.identity.appendSystemPrompts!,
+  ];
+  for (const fragment of fragments) {
+    if (fragment?.kind === 'file' && fragment.reference !== undefined) {
+      const existing = promptFiles.get(fragment.reference);
+      if (existing !== undefined && existing !== fragment.content) {
+        errors.push(
+          `dump closure resolves conflicting contents for prompt file '${fragment.reference}' and cannot flatten both.`,
+        );
+      } else {
+        promptFiles.set(fragment.reference, fragment.content);
+      }
+    }
+  }
+};
+
+const collectSkills = (
+  selected: readonly ResolvedResource[],
+  skills: Map<string, ResolvedResource>,
+  errors: string[],
+): void => {
+  for (const skill of selected) {
+    const existing = skills.get(skill.slug);
+    if (existing !== undefined && existing.winner.path !== skill.winner.path) {
+      errors.push(`dump closure resolves conflicting definitions for skill '${skill.slug}' and cannot flatten both.`);
+    } else {
+      skills.set(skill.slug, skill);
+    }
+  }
+};
+
+/** BFS over the selected agent and its delegated-agent closure. */
+const composeClosure = (set: EffectiveResourceSet, rootSlug: string, projectDirectory?: string): ClosureCompose => {
   const seen = new Set<string>();
   const agents: ResolvedResource[] = [];
   const skills = new Map<string, ResolvedResource>();
   const warnings: string[] = [];
   const errors: string[] = [];
+  const promptFiles = new Map<string, string>();
+  const provenance: CompositionProvenance[] = [];
   const queue = [rootSlug];
 
   while (queue.length > 0) {
@@ -128,29 +231,29 @@ const composeClosure = (set: EffectiveResourceSet, rootSlug: string): ClosureCom
 
     // compose surfaces an unknown/invalid root agent as an error; every queued subagent is already
     // resolved by the composer, so a plan implies findResource returns the agent.
-    const composed = compose(set, slug);
+    const composed = compose(set, slug, { projectDirectory });
 
     if (composed.plan === undefined) {
       errors.push(...composed.errors);
+      warnings.push(...composed.warnings);
       continue;
     }
 
-    agents.push(findResource(set, 'agent', slug)!);
+    collectContributingAgents(set, composed.plan.inheritanceChain!, agents);
+    provenance.push(compositionProvenance(composed.plan));
     warnings.push(...composed.plan.warnings);
-    for (const skill of composed.plan.loadout.skills) {
-      const existing = skills.get(skill.slug);
-      if (existing !== undefined && existing.winner.path !== skill.winner.path) {
-        errors.push(`dump closure resolves conflicting definitions for skill '${skill.slug}' and cannot flatten both.`);
-      } else {
-        skills.set(skill.slug, skill);
-      }
-    }
+    collectPromptFiles(composed.plan, promptFiles, errors);
+    collectSkills(composed.plan.loadout.skills, skills, errors);
     queue.push(...composed.plan.loadout.subagents.map((subagent) => subagent.slug).sort(compareSlugs));
   }
 
   return {
     agents,
     skills: [...skills.values()].sort((left, right) => compareSlugs(left.slug, right.slug)),
+    promptFiles: [...promptFiles.entries()]
+      .map(([reference, content]) => ({ reference, content }))
+      .sort((left, right) => compareSlugs(left.reference, right.reference)),
+    provenance,
     warnings,
     errors,
   };
@@ -183,7 +286,7 @@ const overlapError = (outRoot: string, layers: readonly Layer[]): string | undef
 };
 
 const writeMergedConfig = (agent: ResolvedResource, agentTarget: string, written: string[]): void => {
-  const mergedConfig = mergeEffectiveConfig(agent.configPaths ?? []);
+  const mergedConfig = mergeEffectiveConfig(agent.configPaths!);
 
   if (Object.keys(mergedConfig).length > 0) {
     const configTarget = join(agentTarget, 'config.json');
@@ -199,10 +302,31 @@ const failure = (errors: readonly string[], warnings: readonly string[] = []): D
   errors,
 });
 
+const promptTargetCollisions = (outRoot: string, prompts: ClosureCompose['promptFiles']): readonly string[] => {
+  const errors: string[] = [];
+
+  for (const prompt of prompts) {
+    const target = join(outRoot, prompt.reference);
+    if (!existsSync(target)) continue;
+
+    const matches = lstatSync(target).isFile() && readFileSync(target, 'utf8') === prompt.content;
+    if (!matches) {
+      errors.push(`dump prompt file '${prompt.reference}' conflicts with another flattened file.`);
+    }
+  }
+
+  return errors;
+};
+
 /** Writes the composed closure of `agentSlug` into a freshly cleaned `<outDirectory>/.agents/`. */
-export const dumpAgent = (set: EffectiveResourceSet, agentSlug: string, outDirectory: string): DumpResult => {
+export const dumpAgent = (
+  set: EffectiveResourceSet,
+  agentSlug: string,
+  outDirectory: string,
+  projectDirectory?: string,
+): DumpResult => {
   // composeClosure composes the root once and surfaces an unknown/invalid root agent as an error.
-  const closure = composeClosure(set, agentSlug);
+  const closure = composeClosure(set, agentSlug, projectDirectory);
 
   if (closure.errors.length > 0) {
     return failure(closure.errors, closure.warnings);
@@ -231,19 +355,37 @@ export const dumpAgent = (set: EffectiveResourceSet, agentSlug: string, outDirec
     return failure(rootErrors, closure.warnings);
   }
 
+  const provenanceTarget = join(outRoot, '.outfitter', 'composition.json');
+  mkdirSync(dirname(provenanceTarget), { recursive: true });
+  writeFileSync(provenanceTarget, `${JSON.stringify({ version: 1, compositions: closure.provenance }, null, 2)}\n`);
+  written.push(provenanceTarget);
+
   for (const agent of closure.agents) {
     const agentTarget = join(outRoot, 'agents', agent.slug);
     // Local resources are flattened below so the dumped tree is directly consumable by harnesses.
     copyResourceDirectory(dirname(agent.winner.path), agentTarget, written, ['config.json', 'skills', 'pi']);
     writeMergedConfig(agent, agentTarget, written);
     // Overlay each layer's pi config into a single `pi/` dir, highest precedence last so it wins.
-    for (const piConfigDirectory of [...(agent.piConfigDirectories ?? [])].reverse()) {
+    for (const piConfigDirectory of [...agent.piConfigDirectories!].reverse()) {
       copyResourceDirectory(piConfigDirectory, join(agentTarget, 'pi'), written);
     }
   }
 
   for (const skill of closure.skills) {
     copyResourceDirectory(dirname(skill.winner.path), join(outRoot, 'skills', skill.slug), written);
+  }
+
+  const promptCollisions = promptTargetCollisions(outRoot, closure.promptFiles);
+  if (promptCollisions.length > 0) {
+    rmSync(outRoot, { recursive: true, force: true });
+    return failure(promptCollisions, closure.warnings);
+  }
+
+  for (const prompt of closure.promptFiles) {
+    const target = join(outRoot, prompt.reference);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, prompt.content);
+    written.push(target);
   }
 
   return { writtenPaths: [...new Set(written)].sort(compareSlugs), warnings: closure.warnings, errors: [] };

--- a/code/cli/src/projection/Materialize.ts
+++ b/code/cli/src/projection/Materialize.ts
@@ -2,7 +2,7 @@
 import { copyFileSync, lstatSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
-import type { CompositionPlan } from '../composer/Composition.js';
+import type { ComposedSubagent, CompositionPlan } from '../composer/Composition.js';
 import { escapesRoots } from '../dump/Containment.js';
 import { removeTargetTypeConflict } from '../fs/TypeConflict.js';
 import type { AgentDefinition } from '../resolver/AgentDefinition.js';
@@ -49,6 +49,8 @@ const writeGeneratedFile = (path: string, content: string): void => {
   removeTargetTypeConflict(path, 'file');
   writeFileSync(path, content);
 };
+
+const safeName = (value: string): string => value.replace(/[^a-zA-Z0-9._-]+/g, '-');
 
 /**
  * Overlays native harness configuration into the runtime root. Inputs arrive highest precedence
@@ -123,7 +125,41 @@ const serializeSubagent = (subagent: ResolvedResource): string | undefined => {
   return `---\n${frontmatter.join('\n')}\n---\n\n${definition.body}`;
 };
 
-const materializeSubagents = (subagents: readonly ResolvedResource[], rootDirectory: string): readonly string[] => {
+const composedSubagentBody = (subagent: ComposedSubagent): string =>
+  [
+    subagent.identity.systemPrompt,
+    subagent.identity.sharedContext,
+    ...subagent.identity.appendSystemPrompts.map((fragment) => fragment.content),
+    ...subagent.identity.agentBodies.map((fragment) => fragment.content),
+  ]
+    .filter((fragment): fragment is string => fragment !== undefined && fragment.length > 0)
+    .join('\n\n');
+
+const serializeComposedSubagent = (subagent: ComposedSubagent): string => {
+  const denied = new Set(subagent.tools?.deny ?? []);
+  const tools = subagent.tools?.allow?.filter((tool) => !denied.has(tool));
+  const description = subagent.identity.description ?? subagent.identity.label;
+  const frontmatter = [
+    `name: ${JSON.stringify(subagent.resource.slug)}`,
+    `description: ${JSON.stringify(description ?? `Delegated ${subagent.resource.slug} agent.`)}`,
+    ...optionalScalar('model', subagent.model),
+    ...optionalScalar('thinking', subagent.thinking),
+    ...optionalList('tools', tools ?? []),
+    ...optionalList(
+      'skills',
+      subagent.skills.map((skill) => skill.slug),
+    ),
+    ...optionalList('extensions', subagent.extensions),
+  ];
+
+  return `---\n${frontmatter.join('\n')}\n---\n\n${composedSubagentBody(subagent)}`;
+};
+
+const materializeSubagents = (
+  subagents: readonly ResolvedResource[],
+  composedSubagents: readonly ComposedSubagent[] | undefined,
+  rootDirectory: string,
+): readonly string[] => {
   if (subagents.length === 0) {
     return [];
   }
@@ -132,9 +168,13 @@ const materializeSubagents = (subagents: readonly ResolvedResource[], rootDirect
   rmSync(agentsDirectory, { recursive: true, force: true });
   mkdirSync(agentsDirectory, { recursive: true });
   const skipped: string[] = [];
+  const composedBySlug = new Map<string, ComposedSubagent>(
+    (composedSubagents ?? []).map((subagent) => [subagent.resource.slug, subagent]),
+  );
 
   for (const subagent of subagents) {
-    const content = serializeSubagent(subagent);
+    const composed = composedBySlug.get(subagent.slug);
+    const content = composed === undefined ? serializeSubagent(subagent) : serializeComposedSubagent(composed);
     if (content === undefined) {
       skipped.push(subagent.slug);
     } else {
@@ -145,20 +185,12 @@ const materializeSubagents = (subagents: readonly ResolvedResource[], rootDirect
   return skipped;
 };
 
-/**
- * Writes the composed identity, skills, subagents, and selected MCP servers into
- * `rootDirectory`. The base `system-prompt.md` becomes the system prompt; shared `agents.md`
- * context and the agent body are appended in order.
- */
-export const materializeComposition = (
+const materializeIdentity = (
   composition: CompositionPlan,
   rootDirectory: string,
-): MaterializedComposition => {
-  mkdirSync(rootDirectory, { recursive: true });
-
+): { readonly systemPromptPath: string; readonly appendPromptPaths: readonly string[] } => {
   const systemPromptPath = join(rootDirectory, 'system-prompt.md');
   writeGeneratedFile(systemPromptPath, composition.identity.systemPrompt ?? '');
-
   const appendPromptPaths: string[] = [];
 
   if (composition.identity.sharedContext !== undefined) {
@@ -166,11 +198,38 @@ export const materializeComposition = (
     writeGeneratedFile(contextPath, composition.identity.sharedContext);
     appendPromptPaths.push(contextPath);
   }
+  (composition.identity.appendSystemPrompts ?? []).forEach((fragment, index) => {
+    const name = `append-${String(index + 1).padStart(2, '0')}-${safeName(fragment.label)}.md`;
+    writeGeneratedFile(join(rootDirectory, name), fragment.content);
+    appendPromptPaths.push(join(rootDirectory, name));
+  });
 
-  const agentBodyPath = join(rootDirectory, 'agent.md');
-  writeGeneratedFile(agentBodyPath, composition.identity.agentBody);
-  appendPromptPaths.push(agentBodyPath);
+  const bodies = composition.identity.agentBodies ?? [];
+  if (bodies.length <= 1) {
+    const path = join(rootDirectory, 'agent.md');
+    writeGeneratedFile(path, bodies[0]?.content ?? composition.identity.agentBody);
+    appendPromptPaths.push(path);
+  } else {
+    bodies.forEach((fragment, index) => {
+      const name = `${String(index + 1).padStart(2, '0')}-${safeName(fragment.label)}.md`;
+      writeGeneratedFile(join(rootDirectory, name), fragment.content);
+      appendPromptPaths.push(join(rootDirectory, name));
+    });
+  }
 
+  if (composition.identity.promptTemplate !== undefined) {
+    writeGeneratedFile(join(rootDirectory, 'prompt-template.md'), composition.identity.promptTemplate.content);
+  }
+  return { systemPromptPath, appendPromptPaths };
+};
+
+/** Writes composed identity, skills, subagents, and selected MCP servers into the runtime root. */
+export const materializeComposition = (
+  composition: CompositionPlan,
+  rootDirectory: string,
+): MaterializedComposition => {
+  mkdirSync(rootDirectory, { recursive: true });
+  const { systemPromptPath, appendPromptPaths } = materializeIdentity(composition, rootDirectory);
   const skillDirectories: string[] = [];
   const skippedSkills: string[] = [];
 
@@ -183,7 +242,11 @@ export const materializeComposition = (
     }
   }
 
-  const skippedSubagents = materializeSubagents(composition.loadout.subagents, rootDirectory);
+  const skippedSubagents = materializeSubagents(
+    composition.loadout.subagents,
+    composition.loadout.composedSubagents,
+    rootDirectory,
+  );
 
   if (composition.loadout.mcp.length > 0) {
     writeGeneratedFile(

--- a/code/cli/src/projection/ProjectHarness.ts
+++ b/code/cli/src/projection/ProjectHarness.ts
@@ -13,7 +13,7 @@ import type { AgentLaunchPlan, AgentProjectionPlan, ProjectionInput } from './Pr
 const supportedElements = (input: ProjectionInput): readonly string[] => {
   const baseline = ['skills', 'model', 'thinking'];
   if (input.harness !== 'pi') return baseline;
-  const pi = [...baseline, 'subagents', 'mcp'];
+  const pi = [...baseline, 'subagents', 'mcp', 'prompt_template'];
   return input.extensionLoadDirs === undefined ? pi : [...pi, 'extensions'];
 };
 
@@ -29,6 +29,7 @@ const loadoutElementsInUse = (composition: CompositionPlan): readonly string[] =
   if (loadout.model !== undefined) present.push('model');
   if (loadout.thinking !== undefined) present.push('thinking');
   if (loadout.tools !== undefined) present.push('tools');
+  if (composition.identity.promptTemplate !== undefined) present.push('prompt_template');
 
   return present;
 };
@@ -36,10 +37,18 @@ const loadoutElementsInUse = (composition: CompositionPlan): readonly string[] =
 export const unsupportedElements = (composition: CompositionPlan, input: ProjectionInput): readonly string[] =>
   loadoutElementsInUse(composition).filter((element) => !supportedElements(input).includes(element));
 
-const promptArgs = (systemPromptPath: string, appendPromptPaths: readonly string[]): readonly string[] => [
+const promptArgs = (
+  composition: CompositionPlan,
+  input: ProjectionInput,
+  systemPromptPath: string,
+  appendPromptPaths: readonly string[],
+): readonly string[] => [
   '--system-prompt',
   systemPromptPath,
   ...appendPromptPaths.flatMap((path) => ['--append-system-prompt', path]),
+  ...(input.harness === 'pi' && composition.identity.promptTemplate !== undefined
+    ? ['--prompt-template', `${input.rootDirectory}/prompt-template.md`]
+    : []),
 ];
 
 const modelArgs = (composition: CompositionPlan, harness: Harness): readonly string[] => {
@@ -69,7 +78,7 @@ const buildLaunchPlan = (
   return {
     command: isPi ? 'pi' : 'claude',
     args: [
-      ...promptArgs(systemPromptPath, appendPromptPaths),
+      ...promptArgs(composition, input, systemPromptPath, appendPromptPaths),
       ...skillArgs,
       ...extensionArgs,
       ...modelArgs(composition, input.harness),

--- a/code/cli/src/resolver/AgentDefinition.ts
+++ b/code/cli/src/resolver/AgentDefinition.ts
@@ -3,6 +3,8 @@ import { readFileSync } from 'node:fs';
 
 import { validateSchema } from '../validation/SchemaValidator.js';
 import { parseYamlDocument } from '../validation/YamlDocument.js';
+import type { PromptSourceReference } from '../composer/PromptSource.js';
+import { isPromptSourceReference } from '../composer/PromptSource.js';
 import type { Loadout } from './Resource.js';
 import { emptyLoadout } from './Resource.js';
 
@@ -14,6 +16,15 @@ export interface AgentDefinition {
   /** Markdown body after the frontmatter — the agent's identity prose. */
   readonly body: string;
   readonly loadout: Loadout;
+  /** Ordered parent agent slugs declared by `inherits`. */
+  readonly inherits: readonly string[];
+  readonly promptControls: PromptControls;
+}
+
+export interface PromptControls {
+  readonly systemPrompt?: PromptSourceReference;
+  readonly appendSystemPrompt: readonly PromptSourceReference[];
+  readonly promptTemplate?: PromptSourceReference;
 }
 
 export interface AgentDefinitionIssue {
@@ -73,6 +84,21 @@ const asStringArray = (value: unknown): readonly string[] =>
   Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : [];
 
 const asString = (value: unknown): string | undefined => (typeof value === 'string' ? value : undefined);
+
+const asSlugListOrScalar = (value: unknown): readonly string[] => {
+  if (typeof value === 'string') return [value];
+  return asStringArray(value);
+};
+
+const promptControlsFromRecord = (record: Readonly<Record<string, unknown>>): PromptControls => ({
+  systemPrompt: isPromptSourceReference(record.system_prompt) ? record.system_prompt : undefined,
+  appendSystemPrompt: Array.isArray(record.append_system_prompt)
+    ? record.append_system_prompt.filter(isPromptSourceReference)
+    : isPromptSourceReference(record.append_system_prompt)
+      ? [record.append_system_prompt]
+      : [],
+  promptTemplate: isPromptSourceReference(record.prompt_template) ? record.prompt_template : undefined,
+});
 
 const readMarkdownHeading = (body: string): string | undefined => /^#\s+(.+)$/mu.exec(body)?.[1]?.trim();
 
@@ -174,6 +200,8 @@ export const parseAgentDefinition = (
     description: asString(frontmatter.record.description),
     body: frontmatter.body,
     loadout: loadoutFromRecord(merged),
+    inherits: asSlugListOrScalar(frontmatter.record.inherits),
+    promptControls: promptControlsFromRecord(frontmatter.record),
   };
 };
 

--- a/code/cli/src/resolver/ResolverValidation.ts
+++ b/code/cli/src/resolver/ResolverValidation.ts
@@ -1,8 +1,9 @@
 // Validates an effective resource set: agent + skill definitions, unresolved loadout slugs, shadowing.
+import { compose } from '../composer/Composer.js';
 import { isSkillDocumentIssue, readSkillDocument } from '../skills/SkillDocument.js';
 import { isAgentDefinitionIssue, readAgentDefinition } from './AgentDefinition.js';
 import type { EffectiveResourceSet, ResolvedResource } from './Resource.js';
-import { agentLocalKinds, findLoadoutResource, findResource, listAgentResources, listResources } from './Resource.js';
+import { agentLocalKinds, findResource, listAgentResources, listResources } from './Resource.js';
 
 export interface ValidationFinding {
   readonly severity: 'error' | 'warning';
@@ -10,22 +11,14 @@ export interface ValidationFinding {
   readonly message: string;
 }
 
-const loadoutSlugReference = (
-  set: EffectiveResourceSet,
-  agentSlug: string,
-  kind: 'agent' | 'skill',
-  field: string,
-  slugs: readonly string[],
-): readonly ValidationFinding[] =>
-  slugs
-    .filter((slug) => findLoadoutResource(set, agentSlug, kind, slug) === undefined)
-    .map((slug) => ({
-      severity: 'error' as const,
-      resource: `agent:${agentSlug}`,
-      message: `loadout ${field} references unknown ${kind} '${slug}'.`,
-    }));
+const compositionWarningSeverity = (message: string): ValidationFinding['severity'] =>
+  /^loadout (?:skills|subagents) references unknown (?:skill|agent) '/.test(message) ? 'error' : 'warning';
 
-const validateAgent = (set: EffectiveResourceSet, agent: ResolvedResource): readonly ValidationFinding[] => {
+const validateAgent = (
+  set: EffectiveResourceSet,
+  agent: ResolvedResource,
+  projectDirectory?: string,
+): readonly ValidationFinding[] => {
   const definition = readAgentDefinition(agent.winner.path, agent.configPaths);
 
   if (isAgentDefinitionIssue(definition)) {
@@ -42,10 +35,17 @@ const validateAgent = (set: EffectiveResourceSet, agent: ResolvedResource): read
     ];
   }
 
-  return [
-    ...loadoutSlugReference(set, agent.slug, 'skill', 'skills', definition.loadout.skills),
-    ...loadoutSlugReference(set, agent.slug, 'agent', 'subagents', definition.loadout.subagents),
+  const composed = compose(set, agent.slug, { projectDirectory });
+  const compositionFindings: ValidationFinding[] = [
+    ...composed.errors.map((message) => ({ severity: 'error' as const, resource: `agent:${agent.slug}`, message })),
+    ...composed.warnings.map((message) => ({
+      severity: compositionWarningSeverity(message),
+      resource: `agent:${agent.slug}`,
+      message,
+    })),
   ];
+
+  return compositionFindings;
 };
 
 const resourceLabel = (resource: ResolvedResource): string =>
@@ -97,15 +97,27 @@ const reservedNamespaceFindings = (agent: ResolvedResource): readonly Validation
   return findings;
 };
 
+const deduplicateFindings = (findings: readonly ValidationFinding[]): readonly ValidationFinding[] => {
+  const deduplicated = new Map<string, ValidationFinding>();
+  for (const finding of findings) {
+    const key = `${finding.resource}\u0000${finding.message}`;
+    if (!deduplicated.has(key)) deduplicated.set(key, finding);
+  }
+  return [...deduplicated.values()];
+};
+
 /**
  * Collects validation findings across the effective set. `error` findings always fail validation;
  * `warning` findings (such as shadowed definitions) fail only under `--strict`.
  */
-export const validateEffectiveSet = (set: EffectiveResourceSet): readonly ValidationFinding[] => {
+export const validateEffectiveSet = (
+  set: EffectiveResourceSet,
+  projectDirectory?: string,
+): readonly ValidationFinding[] => {
   const findings: ValidationFinding[] = [];
 
   for (const agent of listResources(set, 'agent')) {
-    findings.push(...validateAgent(set, agent), ...reservedNamespaceFindings(agent));
+    findings.push(...validateAgent(set, agent, projectDirectory), ...reservedNamespaceFindings(agent));
   }
 
   for (const skill of listResources(set, 'skill')) {
@@ -136,5 +148,5 @@ export const validateEffectiveSet = (set: EffectiveResourceSet): readonly Valida
     }
   }
 
-  return findings;
+  return deduplicateFindings(findings);
 };

--- a/code/cli/src/schemas/agent.schema.json
+++ b/code/cli/src/schemas/agent.schema.json
@@ -8,6 +8,29 @@
     "name": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$", "maxLength": 64 },
     "label": { "type": "string", "minLength": 1 },
     "description": { "type": "string" },
+    "inherits": {
+      "oneOf": [
+        { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$", "maxLength": 64 },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$", "maxLength": 64 }
+        }
+      ],
+      "description": "Parent agent slug or ordered parent slug list composed parent-first before this agent."
+    },
+    "system_prompt": {
+      "$ref": "#/$defs/promptSource",
+      "description": "Prompt fragment that replaces the winning root system-prompt.md; file is trusted catalog content and repo_file is untrusted repository content."
+    },
+    "append_system_prompt": {
+      "oneOf": [{ "$ref": "#/$defs/promptSource" }, { "type": "array", "items": { "$ref": "#/$defs/promptSource" } }],
+      "description": "Prompt fragments appended after root agents.md and before inherited agent bodies."
+    },
+    "prompt_template": {
+      "$ref": "#/$defs/promptSource",
+      "description": "Harness prompt-template source projected only by harnesses that support templates."
+    },
     "skills": {
       "$ref": "#/$defs/slugList",
       "description": "Skill slugs resolved from agents/<name>/skills first, then catalog-wide skills."
@@ -44,6 +67,15 @@
     "slugList": {
       "type": "array",
       "items": { "type": "string", "minLength": 1 }
+    },
+    "promptSource": {
+      "type": "object",
+      "oneOf": [{ "required": ["file"] }, { "required": ["repo_file"] }],
+      "properties": {
+        "file": { "type": "string", "minLength": 1 },
+        "repo_file": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
     }
   }
 }

--- a/code/cli/tests/unit/composer.test.ts
+++ b/code/cli/tests/unit/composer.test.ts
@@ -117,6 +117,39 @@ describe('composer', () => {
     expect(result.plan?.warnings).toEqual([]);
   });
 
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.10).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it("resolves each inherited MCP selection against only its declaring agent's overlay", () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    write(join(project, '.agents', 'agents', 'alpha', 'agent.md'), '---\nname: alpha\nmcp: [github]\n---\n\nAlpha.\n');
+    write(
+      join(project, '.agents', 'agents', 'alpha', 'mcp.json'),
+      JSON.stringify({ mcpServers: { github: { command: 'alpha-github' } } }),
+    );
+    write(join(project, '.agents', 'agents', 'beta', 'agent.md'), '---\nname: beta\nmcp: [slack]\n---\n\nBeta.\n');
+    write(
+      join(project, '.agents', 'agents', 'beta', 'mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          github: { command: 'unselected-beta-github' },
+          slack: { command: 'beta-slack' },
+        },
+      }),
+    );
+    write(
+      join(project, '.agents', 'agents', 'lead', 'agent.md'),
+      '---\nname: lead\ninherits: [alpha, beta]\n---\n\nLead.\n',
+    );
+
+    const result = compose(resolveSet(join(root, 'home'), project), 'lead');
+
+    expect(result.plan?.loadout.mcpServers).toEqual({
+      github: { command: 'alpha-github' },
+      slack: { command: 'beta-slack' },
+    });
+  });
+
   it('warns when selected MCP configuration is invalid or does not contain the selected server', () => {
     const { home, project } = buildTree();
     write(join(home, '.agents', 'mcp.json'), 'not json');
@@ -172,6 +205,155 @@ describe('composer', () => {
 
     expect(result.plan?.loadout.skills[0]?.winner.ownerAgent).toBe('actions');
     expect(result.plan?.warnings).toEqual([]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.9, OFTR-005.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('composes inheritance parent-first with stable de-duplication and child scalar overrides', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    write(join(project, '.agents', 'skills', 'base-skill', 'SKILL.md'), '---\nname: base-skill\n---\n');
+    write(join(project, '.agents', 'skills', 'child-skill', 'SKILL.md'), '---\nname: child-skill\n---\n');
+    write(join(project, '.agents', 'prompts', 'base.md'), 'BASE SYSTEM');
+    write(join(project, '.agents', 'prompts', 'append.md'), 'APPEND');
+    write(
+      join(project, '.agents', 'agents', 'base', 'agent.md'),
+      '---\nname: base\nskills: [base-skill]\nextensions: [base-extension]\nplugins: [shared-plugin]\nmodel: base-model\ntools:\n  allow: [read, bash]\n  deny: [write]\nsystem_prompt:\n  file: prompts/base.md\nappend_system_prompt:\n  - file: prompts/append.md\n---\n\nBase body.\n',
+    );
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\ninherits: base\nskills: [base-skill, child-skill]\nextensions: [base-extension, child-extension]\nplugins: [shared-plugin, child-plugin]\nmodel: child-model\ntools:\n  allow: [write]\n  deny: [bash]\nappend_system_prompt:\n  - file: prompts/append.md\n---\n\nChild body.\n',
+    );
+
+    const result = compose(resolveSet(join(root, 'home'), project), 'engineer', { projectDirectory: project });
+
+    expect(result.errors).toEqual([]);
+    const plan = result.plan!;
+    expect(plan.inheritanceChain).toEqual(['base', 'engineer']);
+    expect(plan.identity.systemPrompt).toBe('BASE SYSTEM');
+    expect(plan.identity.appendSystemPrompts!.map((fragment) => fragment.content)).toEqual(['APPEND']);
+    expect(plan.identity.agentBodies!.map((fragment) => fragment.declaringAgent)).toEqual(['base', 'engineer']);
+    expect(plan.identity.agentBody).toContain('Base body.');
+    expect(plan.identity.agentBody).toContain('Child body.');
+    expect(plan.loadout.skills.map((skill) => skill.slug)).toEqual(['base-skill', 'child-skill']);
+    expect(plan.loadout.extensions).toEqual(['base-extension', 'child-extension']);
+    expect(plan.loadout.plugins).toEqual(['shared-plugin', 'child-plugin']);
+    expect(plan.loadout.tools).toEqual({ allow: ['read', 'bash', 'write'], deny: ['write', 'bash'] });
+    expect(plan.loadout.model).toBe('child-model');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.9).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('composes diamond inheritance once in deterministic first-encounter order', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    for (const [slug, frontmatter] of [
+      ['common', 'name: common'],
+      ['left', 'name: left\ninherits: common'],
+      ['right', 'name: right\ninherits: common'],
+      ['child', 'name: child\ninherits: [left, right]'],
+    ]) {
+      write(join(project, '.agents', 'agents', slug, 'agent.md'), `---\n${frontmatter}\n---\n\n${slug}\n`);
+    }
+
+    const result = compose(resolveSet(join(root, 'home'), project), 'child');
+
+    expect(result.errors).toEqual([]);
+    expect(result.plan?.inheritanceChain).toEqual(['common', 'left', 'right', 'child']);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.9).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('fails inherited missing parents and cycles with the relevant chain', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    write(
+      join(project, '.agents', 'agents', 'missing-child', 'agent.md'),
+      '---\nname: missing-child\ninherits: ghost\n---\n',
+    );
+    write(join(project, '.agents', 'agents', 'self', 'agent.md'), '---\nname: self\ninherits: self\n---\n');
+    write(join(project, '.agents', 'agents', 'a', 'agent.md'), '---\nname: a\ninherits: b\n---\n');
+    write(join(project, '.agents', 'agents', 'b', 'agent.md'), '---\nname: b\ninherits: a\n---\n');
+    const set = resolveSet(join(root, 'home'), project);
+
+    expect(compose(set, 'missing-child').errors[0]).toContain('missing-child -> ghost');
+    expect(compose(set, 'self').errors[0]).toContain('self -> self');
+    expect(compose(set, 'a').errors[0]).toContain('a -> b -> a');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.10, OFTR-005.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('resolves inherited agent-local skills from the declaring parent owner', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    write(join(project, '.agents', 'skills', 'private', 'SKILL.md'), '---\nname: private\n---\n\nglobal\n');
+    write(join(project, '.agents', 'agents', 'base', 'agent.md'), '---\nname: base\nskills: [private]\n---\n');
+    write(
+      join(project, '.agents', 'agents', 'base', 'skills', 'private', 'SKILL.md'),
+      '---\nname: private\n---\n\nbase\n',
+    );
+    write(join(project, '.agents', 'agents', 'child', 'agent.md'), '---\nname: child\ninherits: base\n---\n');
+
+    const result = compose(resolveSet(join(root, 'home'), project), 'child');
+
+    expect(result.plan?.loadout.skills[0]?.winner.ownerAgent).toBe('base');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.11).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('resolves repo_file prompt fragments from the active project with repository trust provenance', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    write(join(project, 'docs', 'context.md'), 'repo context');
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\nappend_system_prompt:\n  - repo_file: docs/context.md\n---\n\nBody.\n',
+    );
+
+    const result = compose(resolveSet(join(root, 'home'), project), 'engineer', { projectDirectory: project });
+
+    expect(result.errors).toEqual([]);
+    expect(result.plan?.identity.appendSystemPrompts?.[0]?.content).toBe('repo context');
+    expect(result.plan?.identity.appendSystemPrompts?.[0]?.trust).toBe('repository');
+
+    rmSync(join(project, 'docs', 'context.md'));
+    const missing = compose(resolveSet(join(root, 'home'), project), 'engineer', { projectDirectory: project });
+    expect(missing.plan?.warnings).toContain(
+      "agent 'engineer' optional repo_file prompt source 'docs/context.md' was not found.",
+    );
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.11).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('allows repo_file system prompts with a strong trust warning', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    write(join(project, 'policy.md'), 'repository policy');
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\nsystem_prompt:\n  repo_file: policy.md\n---\n',
+    );
+
+    const result = compose(resolveSet(join(root, 'home'), project), 'engineer', { projectDirectory: project });
+
+    expect(result.plan?.identity.systemPrompt).toBe('repository policy');
+    expect(result.plan?.warnings).toContain("agent 'engineer' uses untrusted repo_file 'policy.md' as system_prompt.");
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.11).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('rejects escaping catalog prompt sources', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\nsystem_prompt:\n  file: ../secret.md\n---\n',
+    );
+
+    const result = compose(resolveSet(join(root, 'home'), project), 'engineer', { projectDirectory: project });
+
+    expect(result.plan).toBeUndefined();
+    expect(result.errors[0]).toContain('must be a contained relative path');
   });
 
   it('is deterministic — identical inputs compose to an identical plan', () => {
@@ -263,7 +445,7 @@ describe('composer', () => {
     expect(result.plan?.warnings).toEqual([expect.stringContaining("delegate skill 'review' resolves")]);
   });
 
-  it('does not resolve skills from invalid or mislabeled delegates', () => {
+  it('fails composition for invalid or mislabeled delegates', () => {
     const root = createTemporaryRoot();
     const project = join(root, 'project');
     write(
@@ -278,9 +460,40 @@ describe('composer', () => {
 
     const result = compose(resolveSet(join(root, 'home'), project), 'engineer');
 
-    expect(result.errors).toEqual([]);
-    expect(result.plan?.loadout.delegateSkills).toEqual([]);
-    expect(result.plan?.warnings).toEqual([]);
+    expect(result.plan).toBeUndefined();
+    expect(result.errors).toEqual([
+      expect.stringContaining("Subagent 'broken' is invalid"),
+      expect.stringContaining("Subagent 'mislabeled' is invalid"),
+    ]);
+  });
+
+  it('fails composition when a delegate has a missing parent or inheritance cycle', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\nsubagents: [missing-parent, cycle-a]\n---\n\nBody.\n',
+    );
+    write(
+      join(project, '.agents', 'agents', 'missing-parent', 'agent.md'),
+      '---\nname: missing-parent\ninherits: ghost\n---\n\nReview.\n',
+    );
+    write(
+      join(project, '.agents', 'agents', 'cycle-a', 'agent.md'),
+      '---\nname: cycle-a\ninherits: cycle-b\n---\n\nReview.\n',
+    );
+    write(
+      join(project, '.agents', 'agents', 'cycle-b', 'agent.md'),
+      '---\nname: cycle-b\ninherits: cycle-a\n---\n\nReview.\n',
+    );
+
+    const result = compose(resolveSet(join(root, 'home'), project), 'engineer');
+
+    expect(result.plan).toBeUndefined();
+    expect(result.errors).toEqual([
+      expect.stringContaining('missing-parent -> ghost'),
+      expect.stringContaining('cycle-a -> cycle-b -> cycle-a'),
+    ]);
   });
 
   it('does not read delegate definitions through an escaping symlink', () => {

--- a/code/cli/tests/unit/dump.test.ts
+++ b/code/cli/tests/unit/dump.test.ts
@@ -66,6 +66,7 @@ describe('dump command', () => {
 
     expect(result.ok).toBe(true);
     expect(relativeTree(join(out, '.agents'))).toEqual([
+      '.outfitter/composition.json',
       'agents/engineer/agent.md',
       'agents/reviewer/agent.md',
       'skills/wiki/SKILL.md',
@@ -160,6 +161,93 @@ describe('dump command', () => {
 
     expect(result.ok).toBe(false);
     expect(result.messages.join(' ')).toContain("conflicting definitions for skill 'private'");
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.9, OFTR-003.11, OFTR-005.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('dumps inherited parent agents, inherited skills, and catalog prompt files', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    write(join(project, '.agents', 'prompts', 'base.md'), 'BASE');
+    write(join(project, '.agents', 'skills', 'base-skill', 'SKILL.md'), '---\nname: base-skill\n---\n');
+    write(
+      join(project, '.agents', 'agents', 'base', 'agent.md'),
+      '---\nname: base\nskills: [base-skill]\nsystem_prompt:\n  file: prompts/base.md\n---\n\nBase.\n',
+    );
+    write(join(project, '.agents', 'agents', 'child', 'agent.md'), '---\nname: child\ninherits: base\n---\n\nChild.\n');
+    const out = join(root, 'dump');
+
+    const result = executeDumpCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+      agent: 'child',
+      out,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(relativeTree(join(out, '.agents'))).toEqual([
+      '.outfitter/composition.json',
+      'agents/base/agent.md',
+      'agents/child/agent.md',
+      'prompts/base.md',
+      'skills/base-skill/SKILL.md',
+    ]);
+  });
+
+  it('rejects conflicting prompt contents at one flattened path across layers', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    const source = join(root, 'source');
+    write(join(project, '.agents', 'prompts', 'shared.md'), 'PROJECT PROMPT');
+    write(
+      join(project, '.agents', 'agents', 'lead', 'agent.md'),
+      '---\nname: lead\nappend_system_prompt:\n  file: prompts/shared.md\nsubagents: [reviewer]\n---\n\nLead.\n',
+    );
+    write(join(source, 'prompts', 'shared.md'), 'SOURCE PROMPT');
+    write(
+      join(source, 'agents', 'reviewer', 'agent.md'),
+      '---\nname: reviewer\nappend_system_prompt:\n  file: prompts/shared.md\n---\n\nReview.\n',
+    );
+    write(join(project, '.agents', 'settings.yml'), `sources:\n  - path: ${JSON.stringify(source)}\n`);
+
+    const result = executeDumpCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+      agent: 'lead',
+      out: join(root, 'dump'),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.messages.join(' ')).toContain("conflicting contents for prompt file 'prompts/shared.md'");
+  });
+
+  it('rejects a prompt path that conflicts with another flattened file', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    const source = join(root, 'source');
+    write(join(project, '.agents', 'system-prompt.md'), 'PROJECT ROOT');
+    write(
+      join(project, '.agents', 'agents', 'lead', 'agent.md'),
+      '---\nname: lead\nsubagents: [reviewer]\n---\n\nLead.\n',
+    );
+    write(join(source, 'system-prompt.md'), 'SOURCE PROMPT');
+    write(
+      join(source, 'agents', 'reviewer', 'agent.md'),
+      '---\nname: reviewer\nsystem_prompt:\n  file: system-prompt.md\n---\n\nReview.\n',
+    );
+    write(join(project, '.agents', 'settings.yml'), `sources:\n  - path: ${JSON.stringify(source)}\n`);
+    const out = join(root, 'dump');
+
+    const result = executeDumpCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+      agent: 'lead',
+      out,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.messages.join(' ')).toContain("prompt file 'system-prompt.md' conflicts");
+    expect(() => readFileSync(join(out, '.agents', 'system-prompt.md'), 'utf8')).toThrow();
   });
 
   it('is deterministic — two dumps produce identical trees and contents', () => {
@@ -392,6 +480,55 @@ describe('dump command', () => {
     expect(result.messages.join(' ')).toContain('must match its directory');
     // warnings from closure members are surfaced even on a fatal failure
     expect(result.messages.join(' ')).toContain("unknown skill 'ghost'");
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('writes deterministic inheritance and prompt provenance without prompt contents or absolute paths', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    write(join(project, '.agents', 'system-prompt.md'), 'SECRET SYSTEM CONTENT');
+    write(join(project, '.agents', 'prompts', 'base.md'), 'SECRET APPEND CONTENT');
+    write(join(project, '.agents', 'prompts', 'template.md'), 'SECRET TEMPLATE CONTENT');
+    write(
+      join(project, '.agents', 'agents', 'base', 'agent.md'),
+      '---\nname: base\nappend_system_prompt:\n  file: prompts/base.md\n---\n\nBase.\n',
+    );
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\ninherits: base\nprompt_template:\n  file: prompts/template.md\n---\n\nEngineer.\n',
+    );
+    const out = join(createTemporaryRoot(), 'provenance');
+
+    const result = executeDumpCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+      agent: 'engineer',
+      out,
+    });
+    const metadata = readFileSync(join(out, '.agents', '.outfitter', 'composition.json'), 'utf8');
+    const parsed = JSON.parse(metadata) as {
+      readonly compositions: readonly {
+        readonly inheritanceChain: readonly string[];
+        readonly prompts: readonly { readonly order: number; readonly declaringAgent?: string }[];
+        readonly promptTemplate?: { readonly reference?: string; readonly declaringAgent?: string };
+      }[];
+    };
+
+    expect(result.ok).toBe(true);
+    expect(parsed.compositions[0]?.inheritanceChain).toEqual(['base', 'engineer']);
+    expect(parsed.compositions[0]?.prompts.map((prompt) => prompt.order)).toEqual([0, 1, 2, 3]);
+    expect(parsed.compositions[0]?.prompts.map((prompt) => prompt.declaringAgent)).toEqual([
+      undefined,
+      'base',
+      'base',
+      'engineer',
+    ]);
+    expect(parsed.compositions[0]?.promptTemplate).toEqual(
+      expect.objectContaining({ reference: 'prompts/template.md', declaringAgent: 'engineer' }),
+    );
+    expect(metadata).not.toContain('SECRET');
+    expect(metadata).not.toContain(project);
   });
 
   it('propagates non-fatal loadout warnings from closure members', () => {

--- a/code/cli/tests/unit/project-harness.test.ts
+++ b/code/cli/tests/unit/project-harness.test.ts
@@ -34,6 +34,40 @@ const planWith = (extensions: readonly string[]): CompositionPlan => ({
   warnings: [],
 });
 
+describe('projectComposition prompt templates', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('projects prompt_template for pi and reports it unsupported for claude', () => {
+    const piDir = root();
+    const claudeDir = root();
+    const templatePlan: CompositionPlan = {
+      ...planWith([]),
+      identity: {
+        agentBody: 'Body.',
+        promptTemplate: {
+          kind: 'file',
+          content: 'Template {{input}}',
+          label: 'template',
+          trust: 'catalog',
+        },
+      },
+    };
+
+    const pi = projectComposition(templatePlan, { harness: 'pi', rootDirectory: piDir, homeDirectory: piDir });
+    const claude = projectComposition(templatePlan, {
+      harness: 'claude',
+      rootDirectory: claudeDir,
+      homeDirectory: claudeDir,
+    });
+
+    expect(pi.launch.args).toContain('--prompt-template');
+    expect(readFileSync(join(piDir, 'prompt-template.md'), 'utf8')).toBe('Template {{input}}');
+    expect(pi.unsupported).not.toContain('prompt_template');
+    expect(claude.launch.args).not.toContain('--prompt-template');
+    expect(claude.unsupported).toContain('prompt_template');
+  });
+});
+
 describe('projectComposition extensions', () => {
   it('loads pi extension dirs with --extension and drops extensions from unsupported', () => {
     const dir = root();
@@ -322,6 +356,8 @@ describe('projectComposition native configuration overlays', () => {
     expect(readFileSync(join(dir, 'themes', 'shared.json'), 'utf8')).toContain('high');
   });
 
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.3, OFTR-006.3.17).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('keeps generated composition files authoritative over native overlay collisions', () => {
     const dir = root();
     const overlay = root();

--- a/code/cli/tests/unit/prompt-source.test.ts
+++ b/code/cli/tests/unit/prompt-source.test.ts
@@ -1,0 +1,90 @@
+// Tests prompt source parsing, containment, optional repository behavior, and provenance.
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { isPromptSourceReference, promptSourceKey, resolvePromptSource } from '../../src/composer/PromptSource.js';
+import type { Layer } from '../../src/resolver/Resource.js';
+
+const roots: string[] = [];
+const temporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-prompt-source-'));
+  roots.push(root);
+  return root;
+};
+const write = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+const layer = (root: string): Layer => ({ root, origin: 'source', label: 'catalog' });
+const resolve = (root: string, source: { readonly file?: string; readonly repo_file?: string }, project?: string) =>
+  resolvePromptSource({
+    source,
+    declaringAgent: 'engineer',
+    layer: layer(root),
+    projectDirectory: project,
+    optionalRepoFile: true,
+    label: 'test',
+  });
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('prompt sources', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.11).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('accepts exactly one supported source key and creates stable keys', () => {
+    expect(isPromptSourceReference({ file: 'prompt.md' })).toBe(true);
+    expect(isPromptSourceReference({ repo_file: 'README.md' })).toBe(true);
+    expect(isPromptSourceReference({ file: 'a', repo_file: 'b' })).toBe(false);
+    expect(isPromptSourceReference({ file: 1 })).toBe(false);
+    expect(isPromptSourceReference(null)).toBe(false);
+    expect(isPromptSourceReference([])).toBe(false);
+    expect(promptSourceKey({ file: 'prompt.md' })).toBe('file:prompt.md');
+    expect(promptSourceKey({ repo_file: 'README.md' })).toBe('repo_file:README.md');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.11).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('rejects missing files, directories, absolute paths, traversal, and symlink escapes', () => {
+    const catalog = temporaryRoot();
+    const outside = temporaryRoot();
+    write(join(outside, 'secret.md'), 'secret');
+    mkdirSync(join(catalog, 'directory'), { recursive: true });
+    symlinkSync(join(outside, 'secret.md'), join(catalog, 'linked.md'));
+
+    expect(resolve(catalog, { file: 'missing.md' }).error).toContain('missing file');
+    expect(resolve(catalog, { file: 'directory' }).error).toContain('is not a file');
+    expect(resolve(catalog, { file: '/absolute.md' }).error).toContain('contained relative path');
+    expect(resolve(catalog, { file: '../secret.md' }).error).toContain('contained relative path');
+    expect(resolve(catalog, { file: 'linked.md' }).error).toContain('resolves outside');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.11).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('warns for optional repository sources that lack a project root or file', () => {
+    const catalog = temporaryRoot();
+    const project = temporaryRoot();
+
+    expect(resolve(catalog, { repo_file: 'README.md' }).warning).toContain('without a project root');
+    expect(resolve(catalog, { repo_file: 'README.md' }, project).warning).toContain('was not found');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.11).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('rejects unsafe repository paths, directories, and symlink escapes', () => {
+    const catalog = temporaryRoot();
+    const project = temporaryRoot();
+    const outside = temporaryRoot();
+    write(join(outside, 'secret.md'), 'secret');
+    mkdirSync(join(project, 'directory'), { recursive: true });
+    symlinkSync(join(outside, 'secret.md'), join(project, 'linked.md'));
+
+    expect(resolve(catalog, { repo_file: '../secret.md' }, project).error).toContain('contained relative path');
+    expect(resolve(catalog, { repo_file: 'directory' }, project).error).toContain('is not a file');
+    expect(resolve(catalog, { repo_file: 'linked.md' }, project).error).toContain('resolves outside');
+  });
+});

--- a/code/cli/tests/unit/resolver-inheritance-validation.test.ts
+++ b/code/cli/tests/unit/resolver-inheritance-validation.test.ts
@@ -1,0 +1,72 @@
+// Tests validation against the provenance-aware effective inheritance composition.
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { discoverLayers } from '../../src/resolver/Layer.js';
+import { resolveResources } from '../../src/resolver/Resolver.js';
+import { validateEffectiveSet } from '../../src/resolver/ResolverValidation.js';
+
+const roots: string[] = [];
+
+const temporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-inheritance-validation-'));
+  roots.push(root);
+  return root;
+};
+
+const write = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('inheritance validation', () => {
+  it('validates inherited skills after parent-first de-duplication', () => {
+    const root = temporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    write(join(project, '.agents', 'agents', 'base', 'agent.md'), '---\nname: base\nskills: [private]\n---\n');
+    write(join(project, '.agents', 'agents', 'base', 'skills', 'private', 'SKILL.md'), '---\nname: private\n---\n');
+    write(
+      join(project, '.agents', 'agents', 'child', 'agent.md'),
+      '---\nname: child\ninherits: base\nskills: [private]\n---\n',
+    );
+    const set = resolveResources(
+      discoverLayers({ homeDirectory: home, projectDirectory: project, settings: {} }).layers,
+    );
+
+    const findings = validateEffectiveSet(set);
+
+    expect(
+      findings.some(
+        (finding) => finding.resource === 'agent:child' && finding.message.includes("unknown skill 'private'"),
+      ),
+    ).toBe(false);
+  });
+
+  it('keeps non-resource composition diagnostics as warnings', () => {
+    const root = temporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    write(join(project, '.agents', 'agents', 'engineer', 'agent.md'), '---\nname: engineer\nmcp: [missing]\n---\n');
+    const set = resolveResources(
+      discoverLayers({ homeDirectory: home, projectDirectory: project, settings: {} }).layers,
+    );
+
+    const findings = validateEffectiveSet(set);
+
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        severity: 'warning',
+        resource: 'agent:engineer',
+        message: "loadout mcp references unknown server 'missing'.",
+      }),
+    );
+  });
+});

--- a/code/cli/tests/unit/resolver.test.ts
+++ b/code/cli/tests/unit/resolver.test.ts
@@ -77,6 +77,28 @@ describe('agent definition parsing', () => {
     expect(parsed.body).toContain('# engineer');
   });
 
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.9, OFTR-003.11).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('parses ordered inheritance and explicit prompt source controls', () => {
+    const parsed = parseAgentDefinition(
+      agentMd(
+        'engineer',
+        'inherits: [base, platform]\nsystem_prompt:\n  file: prompts/system.md\nappend_system_prompt:\n  - repo_file: docs/context.md\nprompt_template:\n  file: prompts/template.md\n',
+      ),
+      [],
+      '/nowhere/agent.md',
+    );
+
+    expect(isAgentDefinitionIssue(parsed)).toBe(false);
+    if (isAgentDefinitionIssue(parsed)) return;
+    expect(parsed.inherits).toEqual(['base', 'platform']);
+    expect(parsed.promptControls).toEqual({
+      systemPrompt: { file: 'prompts/system.md' },
+      appendSystemPrompt: [{ repo_file: 'docs/context.md' }],
+      promptTemplate: { file: 'prompts/template.md' },
+    });
+  });
+
   it('derives the profile display label from frontmatter, then the first H1', () => {
     const explicit = parseAgentDefinition(
       '---\nname: engineer\nlabel: Engineering Lead\n---\n\n# Engineer\n',
@@ -240,6 +262,28 @@ describe('layer discovery', () => {
 
     expect(discovered.unsynchronized).toHaveLength(1);
     expect(findResource(resolveResources(discovered.layers), 'agent', 'ok')).toBeDefined();
+  });
+});
+
+describe('inheritance and prompt validation', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.9, OFTR-003.11, OFTR-005.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('reports graph and prompt containment failures without launching a harness', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    write(join(project, '.agents', 'agents', 'cycle-a', 'agent.md'), agentMd('cycle-a', 'inherits: cycle-b\n'));
+    write(join(project, '.agents', 'agents', 'cycle-b', 'agent.md'), agentMd('cycle-b', 'inherits: cycle-a\n'));
+    write(
+      join(project, '.agents', 'agents', 'escaping', 'agent.md'),
+      agentMd('escaping', 'system_prompt:\n  file: ../outside.md\n'),
+    );
+
+    const result = executeValidateCommand({ homeDirectory: join(root, 'home'), projectDirectory: project });
+    const messages = result.findings.map((finding) => finding.message).join('\n');
+
+    expect(result.ok).toBe(false);
+    expect(messages).toContain('cycle-a -> cycle-b -> cycle-a');
+    expect(messages).toContain('contained relative path');
   });
 });
 
@@ -491,6 +535,11 @@ describe('resource resolution', () => {
       findings.some((finding) => finding.resource === resource && finding.message.includes(substring));
 
     expect(hasFinding('agent:engineer', "unknown skill 'missing'")).toBe(true);
+    expect(
+      findings.filter(
+        (finding) => finding.resource === 'agent:engineer' && finding.message.includes("unknown skill 'missing'"),
+      ),
+    ).toEqual([expect.objectContaining({ severity: 'error' })]);
     expect(hasFinding('agent:mislabeled', 'must match its directory')).toBe(true);
     expect(hasFinding('skill:wrong', 'must match its directory')).toBe(true);
   });

--- a/code/cli/tests/unit/run-agent-inheritance.test.ts
+++ b/code/cli/tests/unit/run-agent-inheritance.test.ts
@@ -1,0 +1,258 @@
+// Tests inherited prompt ordering and native Pi configuration projection through the run boundary.
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { Command } from 'commander';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createRunAgentCommand, executeRunAgentCommand } from '../../src/cli/commands/RunAgentCommand.js';
+
+const roots: string[] = [];
+
+const temporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-run-inheritance-'));
+  roots.push(root);
+  return root;
+};
+
+const write = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+
+const tree = (): { readonly home: string; readonly project: string } => {
+  const root = temporaryRoot();
+  const project = join(root, 'project');
+  write(join(project, '.agents', 'system-prompt.md'), 'SYSTEM');
+  write(join(project, '.agents', 'agents.md'), 'SHARED');
+  return { home: join(root, 'home'), project };
+};
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('run inherited agent', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.3, OFTR-006.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('launches prompt fragments in exact inherited composition order with passthrough last', async () => {
+    const { home, project } = tree();
+    write(join(project, '.agents', 'prompts', 'base.md'), 'BASE APPEND');
+    write(join(project, '.agents', 'prompts', 'child.md'), 'CHILD APPEND');
+    write(
+      join(project, '.agents', 'agents', 'base', 'agent.md'),
+      '---\nname: base\nappend_system_prompt:\n  - file: prompts/base.md\n---\n\nBASE BODY\n',
+    );
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\ninherits: base\nappend_system_prompt:\n  - file: prompts/child.md\n---\n\nCHILD BODY\n',
+    );
+
+    const result = await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      agent: 'engineer',
+      harness: 'pi',
+      passThroughArgs: ['--print'],
+      launcher: (plan) => {
+        const appendPaths = plan.args
+          .map((arg, index) => (arg === '--append-system-prompt' ? plan.args[index + 1] : undefined))
+          .filter((path): path is string => path !== undefined);
+        expect(appendPaths.map((path) => readFileSync(path, 'utf8'))).toEqual([
+          'SHARED',
+          'BASE APPEND',
+          'CHILD APPEND',
+          'BASE BODY\n',
+          'CHILD BODY\n',
+        ]);
+        expect(plan.args.at(-1)).toBe('--print');
+        return Promise.resolve(0);
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.3, OFTR-006.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('projects exact inherited prompt order through the Claude adapter', async () => {
+    const { home, project } = tree();
+    write(join(project, '.agents', 'prompts', 'base.md'), 'BASE APPEND');
+    write(
+      join(project, '.agents', 'agents', 'base', 'agent.md'),
+      '---\nname: base\nappend_system_prompt:\n  file: prompts/base.md\n---\n\nBASE BODY\n',
+    );
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\ninherits: base\n---\n\nCHILD BODY\n',
+    );
+
+    await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      agent: 'engineer',
+      harness: 'claude',
+      launcher: (plan) => {
+        const appendPaths = plan.args
+          .map((arg, index) => (arg === '--append-system-prompt' ? plan.args[index + 1] : undefined))
+          .filter((path): path is string => path !== undefined);
+        expect(appendPaths.map((path) => readFileSync(path, 'utf8'))).toEqual([
+          'SHARED',
+          'BASE APPEND',
+          'BASE BODY\n',
+          'CHILD BODY\n',
+        ]);
+        return Promise.resolve(0);
+      },
+    });
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.9, OFTR-006.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('materializes inherited delegate identity and loadout controls', async () => {
+    const { home, project } = tree();
+    write(join(project, '.agents', 'skills', 'wiki', 'SKILL.md'), '---\nname: wiki\n---\n\nWiki.\n');
+    write(
+      join(project, '.agents', 'agents', 'base-reviewer', 'agent.md'),
+      '---\nname: base-reviewer\nmodel: inherited-model\nskills: [wiki]\nextensions: [review-ext]\ntools:\n  allow: [read, bash]\n  deny: [bash]\n---\n\nBASE REVIEW BODY\n',
+    );
+    write(
+      join(project, '.agents', 'agents', 'reviewer', 'agent.md'),
+      '---\nname: reviewer\ninherits: base-reviewer\nthinking: high\n---\n\nCHILD REVIEW BODY\n',
+    );
+    write(
+      join(project, '.agents', 'agents', 'lead', 'agent.md'),
+      '---\nname: lead\nsubagents: [reviewer]\n---\n\nLead.\n',
+    );
+
+    await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      agent: 'lead',
+      harness: 'pi',
+      launcher: (plan) => {
+        const delegate = readFileSync(join(plan.env.PI_CODING_AGENT_DIR, 'agents', 'reviewer.md'), 'utf8');
+        expect(delegate).toContain('model: "inherited-model"');
+        expect(delegate).toContain('thinking: "high"');
+        expect(delegate).toContain('tools: "read"');
+        expect(delegate).toContain('skills: "wiki"');
+        expect(delegate).toContain('extensions: "review-ext"');
+        expect(delegate).toContain('BASE REVIEW BODY');
+        expect(delegate).toContain('CHILD REVIEW BODY');
+        return Promise.resolve(0);
+      },
+    });
+  });
+
+  it('fails before launch when a delegate inheritance graph is invalid', async () => {
+    const { home, project } = tree();
+    write(
+      join(project, '.agents', 'agents', 'reviewer', 'agent.md'),
+      '---\nname: reviewer\ninherits: missing-base\n---\n\nReview.\n',
+    );
+    write(
+      join(project, '.agents', 'agents', 'lead', 'agent.md'),
+      '---\nname: lead\nsubagents: [reviewer]\n---\n\nLead.\n',
+    );
+    let launched = false;
+
+    const result = await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      agent: 'lead',
+      harness: 'pi',
+      strict: true,
+      launcher: () => {
+        launched = true;
+        return Promise.resolve(0);
+      },
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(launched).toBe(false);
+    expect(result.messages.join(' ')).toContain("Subagent 'reviewer' is invalid");
+    expect(result.messages.join(' ')).toContain('reviewer -> missing-base');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.3, OFTR-006.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('enters inherited composition through the public Commander run path', async () => {
+    const { home, project } = tree();
+    write(join(project, '.agents', 'agents', 'base', 'agent.md'), '---\nname: base\n---\n\nBASE BODY\n');
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\ninherits: base\n---\n\nCHILD BODY\n',
+    );
+    const program = new Command();
+    let inheritedBodies: readonly string[] = [];
+    createRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      writeLine: () => undefined,
+      launcher: (plan) => {
+        inheritedBodies = plan.args
+          .map((arg, index) => (arg === '--append-system-prompt' ? plan.args[index + 1] : undefined))
+          .filter((path): path is string => path !== undefined)
+          .map((path) => readFileSync(path, 'utf8'));
+        return Promise.resolve(0);
+      },
+    }).register(program);
+
+    await program.parseAsync(['node', 'outfitter', 'run', 'engineer', '--harness', 'pi']);
+
+    expect(inheritedBodies).toEqual(['SHARED', 'BASE BODY\n', 'CHILD BODY\n']);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('fails before Claude launch when prompt_template is selected under --strict', async () => {
+    const { home, project } = tree();
+    write(join(project, '.agents', 'prompts', 'template.md'), 'Template {{input}}');
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\nprompt_template:\n  file: prompts/template.md\n---\n\nBody.\n',
+    );
+    let launched = false;
+
+    const result = await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      agent: 'engineer',
+      harness: 'claude',
+      strict: true,
+      launcher: () => {
+        launched = true;
+        return Promise.resolve(0);
+      },
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(launched).toBe(false);
+    expect(result.messages.join(' ')).toContain("cannot project loadout element 'prompt_template'");
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.10, OFTR-006.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('overlays inherited Pi configuration parent-first with the child authoritative', async () => {
+    const { home, project } = tree();
+    write(join(project, '.agents', 'agents', 'base', 'agent.md'), '---\nname: base\n---\n\nBase.\n');
+    write(join(project, '.agents', 'agents', 'base', 'pi', 'settings.json'), '{"owner":"base"}');
+    write(
+      join(project, '.agents', 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\ninherits: base\n---\n\nChild.\n',
+    );
+    write(join(project, '.agents', 'agents', 'engineer', 'pi', 'settings.json'), '{"owner":"child"}');
+
+    await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      agent: 'engineer',
+      harness: 'pi',
+      launcher: (plan) => {
+        expect(readFileSync(join(plan.env.PI_CODING_AGENT_DIR, 'settings.json'), 'utf8')).toBe('{"owner":"child"}');
+        return Promise.resolve(0);
+      },
+    });
+  });
+});

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -2,21 +2,30 @@
 
 ## Purpose
 
-Outfitter is a TypeScript CLI that resolves, composes, bakes, and launches agent configuration stored in the [Dotagents `.agents` protocol](https://dotagentsprotocol.com/) (pinned at revision `502a9d5`). It is generic enough for organizations to define resources once and run them across multiple agent CLIs, while supporting `pi` first and most deeply, plus Claude Code as an additional supported adapter.
+Outfitter is a TypeScript CLI that resolves, composes, bakes, and launches agent configuration stored in the [Dotagents `.agents` protocol](https://dotagentsprotocol.com/) (pinned at revision `502a9d5`).
+It is generic enough for organizations to define resources once and run them across multiple agent CLIs, while supporting `pi` first and most deeply, plus Claude Code as an additional supported adapter.
 
-Outfitter's differentiated value is source resolution, selective composition, task baking, validation, provenance, and harness projection — not ownership of a configuration format. The protocol tree is the source of truth and remains useful without Outfitter.
+Outfitter's differentiated value is source resolution, selective composition, task baking, validation, provenance, and harness projection — not ownership of a configuration format.
+The protocol tree is the source of truth and remains useful without Outfitter.
 
 Formal implementation requirements live in [`../requirements/`](../requirements/); note the [transition status](../requirements/README.md) — this document describes the RFC [#165](https://github.com/ai-outfitter/outfitter/issues/165) target architecture.
 
 ## Architectural Principles
 
 1. **TypeScript first**: production code, tests, schemas, and tooling are centered on TypeScript.
-2. **Protocol-native storage**: all authored configuration is a protocol `.agents` payload. Outfitter-specific metadata (settings, provenance) is optional, namespaced, and removable without losing the underlying resources. No parallel manifest, persona, or task YAML formats.
-3. **Pin the protocol**: the implementation and its conformance fixtures target one pinned protocol revision. Protocol upgrades are deliberate, reviewed changes — never silent tracking of upstream `main`.
-4. **One resolver**: listing, validation, task baking, running, and dumping share a single effective-resolution path. There is no code path that composes resources differently from another.
+2. **Protocol-native storage**: all authored configuration is a protocol `.agents` payload.
+   Outfitter-specific metadata (settings, provenance) is optional, namespaced, and removable without losing the underlying resources.
+   No parallel manifest, persona, or task YAML formats.
+3. **Pin the protocol**: the implementation and its conformance fixtures target one pinned protocol revision.
+   Protocol upgrades are deliberate, reviewed changes — never silent tracking of upstream `main`.
+4. **One resolver**: listing, validation, task baking, running, and dumping share a single effective-resolution path.
+   There is no code path that composes resources differently from another.
 5. **Deterministic composition**: identical sources, refs, selections, and inputs produce identical results — the same effective identity for a run, and byte-identical output for a dump.
-6. **Generic composition, adapter projection**: compositions are harness-neutral; adapters project them to agent-specific files, flags, and environment variables. If a composition asks for something an adapter cannot project, Outfitter warns to stderr; `--strict` makes it fatal.
-7. **Pi-native by design**: pi is not merely the first adapter — targeting pi natively and completely is a deliberate design choice. Pi's configuration surface (extensions, plugins, subagents, keybindings, bootstrap) is treated as first-class, and the composition model is validated against it before being generalized to other harnesses. Claude Code is a supported additional adapter with documented gaps, not a co-equal design target.
+6. **Generic composition, adapter projection**: compositions are harness-neutral; adapters project them to agent-specific files, flags, and environment variables.
+   If a composition asks for something an adapter cannot project, Outfitter warns to stderr; `--strict` makes it fatal.
+7. **Pi-native by design**: pi is not merely the first adapter — targeting pi natively and completely is a deliberate design choice.
+   Pi's configuration surface (extensions, plugins, subagents, keybindings, bootstrap) is treated as first-class, and the composition model is validated against it before being generalized to other harnesses.
+   Claude Code is a supported additional adapter with documented gaps, not a co-equal design target.
 8. **Command objects for complexity**: non-trivial CLI commands are implemented as command objects with explicit dependencies and typed inputs/outputs.
 9. **Schema validation at boundaries**: every persisted file format read by Outfitter is validated at the read boundary (JSON Schema for JSON and YAML files, frontmatter schemas for markdown resources).
 10. **Complete test coverage early**: the project maintains a test framework with a 100% global coverage requirement.
@@ -25,14 +34,18 @@ Formal implementation requirements live in [`../requirements/`](../requirements/
 ## Runtime and Tooling Baseline
 
 - Runtime: Node.js `>=24.18.0 <25`, tested with the exact version pinned in `.node-version`.
-- Language: TypeScript. Package manager: npm.
+- Language: TypeScript.
+  Package manager: npm.
 - CLI framework: Commander `^14` (default commands, aliases, `allowUnknownOption`, pass-through argument collection, testable parser construction).
 - Test framework: Vitest `^4` with `@vitest/coverage-v8`; 100% global coverage thresholds.
 - Linting: ESLint `^10`, `@eslint/js`, `typescript-eslint`, `complexity: ["error", 10]`.
 - Schema and validation: TypeBox for schema authoring, JSON Schema artifacts for persisted contracts, AJV for runtime validation.
 - YAML (`yaml`) for Outfitter settings; JSON for protocol files (`mcp.json`, `models.json`, `config.json`) per the protocol.
 - Merge behavior: `defu` for settings; protocol merge-by-ID and JSON merge semantics implemented per the pinned revision with conformance fixtures.
-- Process launch: `cross-spawn`. Discovery and URI parsing: `glob`, `hosted-git-info`. Diagnostics: `chalk`. Templating of generated harness files: `liquidjs` with Outfitter-specific delimiters.
+- Process launch: `cross-spawn`.
+  Discovery and URI parsing: `glob`, `hosted-git-info`.
+  Diagnostics: `chalk`.
+  Templating of generated harness files: `liquidjs` with Outfitter-specific delimiters.
 
 The CLI workspace includes `code/cli/tsconfig.json` for strict typechecking and `code/cli/tsconfig.build.json` for production emission from `code/cli/src/` to `code/cli/dist/`.
 
@@ -68,19 +81,27 @@ Outfitter resolves protocol resources from layered `.agents` trees:
   settings.local.yml
 ```
 
-Remote sources (catalog repositories) supply additional layers below the local ones, in configured order. A standalone catalog repository's root _is_ the payload; a colocated source nests it under `.agents/` (selected with the source's `path:`).
+Remote sources (catalog repositories) supply additional layers below the local ones, in configured order.
+A standalone catalog repository's root _is_ the payload; a colocated source nests it under `.agents/` (selected with the source's `path:`).
 
 ### Resolution semantics
 
-- Resources merge **by ID** across layers: workspace over global over remote sources in configured order. The winning definition replaces lower ones; there is no partial merge of markdown resources.
+- Resources merge **by ID** across layers: workspace over global over remote sources in configured order.
+  The winning definition replaces lower ones; there is no partial merge of markdown resources.
+- After layer resolution, an agent's `inherits` graph resolves through that same effective set.
+  Traversal is recursive parent-first, multiple parents retain authored order, diamond ancestors contribute once, and cycles or missing parents fail with their chain.
+- Inherited selections retain the declaring agent and winning layer.
+  This provenance is required for parent-local skills, per-agent configuration, and catalog prompt files to resolve against their owner rather than the selected child.
 - JSON files (`mcp.json`, `models.json`, per-agent `config.json`) follow the protocol's JSON merge behavior across layers.
 - The resolver produces one immutable **effective resource set** per invocation: every slug mapped to its winning source, with shadowed definitions retained for diagnostics.
-- `list`, `validate`, `run`, and `dump` all consume the same effective resource set. This is a hard invariant, enforced by sharing one `Resolver` component.
+- `list`, `validate`, `run`, and `dump` all consume the same effective resource set.
+  This is a hard invariant, enforced by sharing one `Resolver` component.
 - Conformance fixtures (layer trees + expected effective output) pin the merge semantics to the protocol revision; a protocol upgrade updates fixtures in the same change.
 
 ## Settings
 
-Outfitter settings are the only Outfitter-specific files in a tree: `settings.yml` plus a flat sibling `settings.local.yml` at both scopes. There is no nested local settings directory.
+Outfitter settings are the only Outfitter-specific files in a tree: `settings.yml` plus a flat sibling `settings.local.yml` at both scopes.
+There is no nested local settings directory.
 
 ### Precedence
 
@@ -93,7 +114,8 @@ Highest to lowest:
 5. Cached remote settings referenced by `remote_settings`
 6. Built-in defaults
 
-The internal `Settings` object is the single conceptual result of reading all settings sources and applying precedence. Every settings file MUST validate against `settings.schema.json`.
+The internal `Settings` object is the single conceptual result of reading all settings sources and applying precedence.
+Every settings file MUST validate against `settings.schema.json`.
 
 ### Schema
 
@@ -123,38 +145,53 @@ custom_settings: {}
 
 Rules:
 
-- Settings do not carry resource selections. An agent's loadout — skills, subagents, mcp, extensions, plugins, model, thinking, tools — is declared on the agent (`agents/<id>/agent.md` frontmatter or `config.json`), not in settings. There is no `profiles` map and no `default_profile`.
+- Settings do not carry resource selections.
+  An agent's loadout — skills, subagents, mcp, extensions, plugins, model, thinking, tools — is declared on the agent (`agents/<id>/agent.md` frontmatter or `config.json`), not in settings.
+  There is no `profiles` map and no `default_profile`.
 - `default_agent` names the agent plain `outfitter` runs; `default_harness` selects the harness (`pi` or `claude`).
-- `sources` entries MUST specify a local `path`, a remote `uri`, or a `github` shorthand; remote entries accept `ref` and payload-subdirectory `path`. Relative `path` values resolve relative to the settings file containing them.
+- `sources` entries MUST specify a local `path`, a remote `uri`, or a `github` shorthand; remote entries accept `ref` and payload-subdirectory `path`.
+  Relative `path` values resolve relative to the settings file containing them.
 - `remote_settings` entries point at settings-style YAML files inside synced remote repositories; fetched by `outfitter sync` and loaded at lower precedence.
-- `cache_directory` selects the repository cache root for sync, remote-settings loading, remote layer discovery, and default-catalog bootstrap. Its default is `~/.agents/cache`.
+- `cache_directory` selects the repository cache root for sync, remote-settings loading, remote layer discovery, and default-catalog bootstrap.
+  Its default is `~/.agents/cache`.
 - `custom_settings` may contain arbitrary YAML-compatible nested data, deep-merged by precedence.
 
 ## Composition
 
 For a selected agent, the composer builds the run's effective configuration from the effective resource set:
 
-1. **Identity**: the tree's `system-prompt.md` is the base; `agents.md` contributes shared operating context; the selected agent's `agent.md` layers on top. Composition order is explicit and deterministic.
-2. **Subagents**: agents named in the selected agent's `subagents` loadout are marked for projection into the harness's delegation surface; their own selected skills are resolved and materialized separately from the leader's active skills.
-3. **Skills**: skills named in the loadout are materialized (frontmatter `references`/`scripts`/`assets` resolved from their two-root model, validated for escapes and collisions) into generated skill directories.
-4. **Harness elements**: extensions and plugins named in the loadout are marked for the adapter (first-class for pi).
-5. **Structured configuration**: `models.json`, `mcp.json`, and per-agent `config.json` merge per protocol JSON semantics; the loadout's `model`, `thinking`, and `tools` select and constrain within them.
+1. **Identity**: the nearest inherited `system_prompt` declaration (or tree root `system-prompt.md`) is the base; root `agents.md` follows; inherited/child `append_system_prompt` fragments and inherited/child agent bodies append parent-first.
+   Each fragment carries source, owner, layer, and trust provenance.
+2. **Prompt trust**: `{ file }` reads required trusted catalog content inside the declaring agent's winning layer.
+   `{ repo_file }` reads optional untrusted active-repository content inside the project root.
+   Both are checked after symlink resolution; named prompt slugs are not part of this contract.
+3. **Subagents**: agents named in the selected agent's `subagents` loadout are marked for projection into the harness's delegation surface; their own selected skills are resolved and materialized separately from the leader's active skills.
+4. **Skills**: skills named in the loadout are materialized (frontmatter `references`/`scripts`/`assets` resolved from their two-root model, validated for escapes and collisions) into generated skill directories.
+5. **Harness elements**: extensions and plugins named in the loadout are marked for the adapter (first-class for pi).
+6. **Structured configuration**: `models.json`, `mcp.json`, and per-agent `config.json` merge per protocol JSON semantics; the loadout's `model`, `thinking`, and `tools` select and constrain within them.
 
 The composed result is a harness-neutral **composition plan** — the input to dump and adapter projection.
 
-> **Tasks and bake** — freezing a named work contract and its typed inputs into an immutable execution artifact — are the subject of a [separate upcoming RFC](../documentation/tasks.md) and are not part of this architecture yet. The `ai-outfitter/actions` Action currently launches a composed agent headlessly with structured inputs through the same resolver.
+> **Tasks and bake** — freezing a named work contract and its typed inputs into an immutable execution artifact — are the subject of a [separate upcoming RFC](../documentation/tasks.md) and are not part of this architecture yet.
+> The `ai-outfitter/actions` Action currently launches a composed agent headlessly with structured inputs through the same resolver.
 
 ## Dump
 
 `outfitter dump` writes the effective resource set (or one selection's transitive closure) as a plain `.agents/` directory.
+The removable `.agents/.outfitter/composition.json` audit record lists each composed agent's resolved inheritance chain and ordered prompt provenance without prompt contents or absolute paths.
 
 - Deterministic: byte-identical for identical inputs.
-- Safe: never contains credentials, auth state, sessions, transcripts, caches, backups, mutable harness state, or symlinks resolving outside the tree. Dump shares the state-path knowledge of the adapters to guarantee exclusion.
+- Safe: never contains credentials, auth state, sessions, transcripts, caches, backups, mutable harness state, or symlinks resolving outside the tree.
+  Dump shares the state-path knowledge of the adapters to guarantee exclusion.
 - Protocol-shaped: valid payload for any protocol consumer; Outfitter provenance metadata is optional and removable.
 
 ## Generated-File Templating
 
-Generated harness files may use LiquidJS templating with Outfitter-specific delimiters (`[[= expression ]]`, `[[% tag %]]`) so templates do not collide with agent prompt, skill, Handlebars, Mustache, Jinja, or Claude Code syntaxes. Plain `[[ -f file ]]` shell text passes through unchanged. The template context exposes resolved `custom_settings`, settings, the composition, the agent id, and the project root. Undefined output variables and unknown filters are template errors; undefined variables in conditions evaluate falsy. Source files are never rewritten; templating applies only to generated composition files.
+Generated harness files may use LiquidJS templating with Outfitter-specific delimiters (`[[= expression ]]`, `[[% tag %]]`) so templates do not collide with agent prompt, skill, Handlebars, Mustache, Jinja, or Claude Code syntaxes.
+Plain `[[ -f file ]]` shell text passes through unchanged.
+The template context exposes resolved `custom_settings`, settings, the composition, the agent id, and the project root.
+Undefined output variables and unknown filters are template errors; undefined variables in conditions evaluate falsy.
+Source files are never rewritten; templating applies only to generated composition files.
 
 ## Runtime Model and State
 
@@ -164,9 +201,12 @@ A launch materializes the composed agent under the system temp directory:
 $TMPDIR/outfitter-<agent>-<harness>-<random>/
 ```
 
-Adapter-declared state paths symlink to durable native CLI locations (`~/.pi/agent/...`, `~/.claude/...`) per the functional state model — see [`./state_writeback_strategy.md`](./state_writeback_strategy.md). State handling strategies are `symlink`, `discard`, `warn`, `error`, and `prompt`; unknown writes are never silently persisted. `state_persistence` policy lives in settings.
+Adapter-declared state paths symlink to durable native CLI locations (`~/.pi/agent/...`, `~/.claude/...`) per the functional state model — see [`./state_writeback_strategy.md`](./state_writeback_strategy.md).
+State handling strategies are `symlink`, `discard`, `warn`, `error`, and `prompt`; unknown writes are never silently persisted.
+`state_persistence` policy lives in settings.
 
-The Pi adapter reconciles generated runtime `settings.json` and `keybindings.json` (reserving `Shift+Tab` for Outfitter mode switching) as non-durable generated files. Interactive Pi launches inject the Outfitter bootstrap extension for build/plan mode switching; non-interactive launches skip it.
+The Pi adapter reconciles generated runtime `settings.json` and `keybindings.json` (reserving `Shift+Tab` for Outfitter mode switching) as non-durable generated files.
+Interactive Pi launches inject the Outfitter bootstrap extension for build/plan mode switching; non-interactive launches skip it.
 
 During `outfitter run`, the Outfitter process remains alive while the child agent CLI runs and owns the temporary composition lifecycle.
 
@@ -198,17 +238,26 @@ The adapter owns CLI-specific details: env vars, flags, state path declarations,
 
 ### Pi
 
-Pi is the default adapter. Outfitter prefers native pi mechanisms: `PI_CODING_AGENT_DIR`, `PI_CODING_AGENT_SESSION_DIR`/`--session-dir`, `--extension`, `--skill`, `--prompt-template`, `--system-prompt`/`--append-system-prompt`, model/provider/thinking flags, and generated settings reconciliation where flags are not the right mechanism. Startup-order-impossible requests surface as adapter warnings (`--strict` makes them fatal). If generic naming conflicts with pi behavior, prefer pi's terminology.
+Pi is the default adapter.
+Outfitter prefers native pi mechanisms: `PI_CODING_AGENT_DIR`, `PI_CODING_AGENT_SESSION_DIR`/`--session-dir`, `--extension`, `--skill`, `--prompt-template`, `--system-prompt`/`--append-system-prompt`, model/provider/thinking flags, and generated settings reconciliation where flags are not the right mechanism.
+Startup-order-impossible requests surface as adapter warnings (`--strict` makes them fatal).
+If generic naming conflicts with pi behavior, prefer pi's terminology.
 
 ### Claude Code
 
-Outfitter launches `claude` with `CLAUDE_CONFIG_DIR` pointing at the projection root and maps the elements supported by the current baseline adapter to native files and flags. Persistent state projection and managed harness symlinks are deferred to [#187](https://github.com/ai-outfitter/outfitter/issues/187); setup does not create them.
+Outfitter launches `claude` with `CLAUDE_CONFIG_DIR` pointing at the projection root and maps the elements supported by the current baseline adapter to native files and flags.
+Persistent state projection and managed harness symlinks are deferred to [#187](https://github.com/ai-outfitter/outfitter/issues/187); setup does not create them.
 
 ## CLI Commands
 
-- **`outfitter run [agent]`** (default command): resolve → compose → project → launch. A positional agent slug selects what to run (default from settings `default_agent`); `--harness <pi|claude>` selects the harness (default from settings `default_harness`, then `pi`); unknown args pass through to the child CLI; `--strict` makes warnings fatal. Interactive clean-home launches start Pi-native onboarding; non-interactive clean-home launches require `outfitter setup` first.
+- **`outfitter run [agent]`** (default command): resolve → compose → project → launch.
+  A positional agent slug selects what to run (default from settings `default_agent`); `--harness <pi|claude>` selects the harness (default from settings `default_harness`, then `pi`); unknown args pass through to the child CLI; `--strict` makes warnings fatal.
+  Interactive clean-home launches start Pi-native onboarding; non-interactive clean-home launches require `outfitter setup` first.
 - **`outfitter setup [source]`**: launch the bundled, model-free Pi walkthrough with the original three setup modes (default catalog, create a profile, or another catalog), original profile/target wording, and optional direct-source path; append only the default CLI-agent choice (Pi/Outfitter preselected); then atomically apply the result through the CLI state machine.
-- **`outfitter sync`**: validate local settings; atomically fetch configured remote settings; reload the merged settings; then atomically fetch every resulting remote source into `<cache_directory>/repos/<encoded-uri-and-ref>/`. Validate before swapping, preserve the last good checkout on failure, report per-source status, and redact embedded credentials from all output. Required-source failures exit nonzero. Network synchronization never runs implicitly during `outfitter run`.
+- **`outfitter sync`**: validate local settings; atomically fetch configured remote settings; reload the merged settings; then atomically fetch every resulting remote source into `<cache_directory>/repos/<encoded-uri-and-ref>/`.
+  Validate before swapping, preserve the last good checkout on failure, report per-source status, and redact embedded credentials from all output.
+  Required-source failures exit nonzero.
+  Network synchronization never runs implicitly during `outfitter run`.
 - **`outfitter list [kind]`**: report the effective resource set — slugs, winning sources, shadowed definitions — deterministically.
 - **`outfitter validate [--strict] [--json]`**: protocol layout, frontmatter and JSON schemas, unresolved loadout slugs, skill reference escapes/collisions, settings schema.
 - **`outfitter dump [--agent <id>] [--out]`**: write the deterministic tree, optionally restricted to one agent's transitive closure.
@@ -217,11 +266,13 @@ Outfitter launches `claude` with `CLAUDE_CONFIG_DIR` pointing at the projection 
 
 ## Command Object Pattern
 
-Each non-trivial command is a command object with explicit dependencies (`SettingsLoader`, `Resolver`, `Composer`, `Baker`, `ProcessRunner`) and typed inputs/outputs — no direct `process.argv` access inside command logic. Benefits: unit testability, low parser coupling, explicit dependencies, natural complexity limits.
+Each non-trivial command is a command object with explicit dependencies (`SettingsLoader`, `Resolver`, `Composer`, `Baker`, `ProcessRunner`) and typed inputs/outputs — no direct `process.argv` access inside command logic.
+Benefits: unit testability, low parser coupling, explicit dependencies, natural complexity limits.
 
 ## Validation Strategy
 
-Validation happens at every file boundary: settings (`settings.schema.json`), protocol JSON files (schemas per the pinned revision), resource frontmatter, task input contracts, command inputs, and cache metadata. Diagnostics point to the file and key that failed where practical.
+Validation happens at every file boundary: settings (`settings.schema.json`), protocol JSON files (schemas per the pinned revision), resource frontmatter, task input contracts, command inputs, and cache metadata.
+Diagnostics point to the file and key that failed where practical.
 
 ## Test Strategy
 
@@ -235,6 +286,7 @@ Validation happens at every file boundary: settings (`settings.schema.json`), pr
 1. npm with committed `package-lock.json`; Commander; Vitest with V8 coverage.
 2. Resource IDs are filesystem-safe slugs; display names live in frontmatter.
 3. The protocol revision is pinned; upgrades are explicit, fixture-backed changes.
-4. There is no legacy profile compatibility layer: no readers, writers, aliases, detection, or migration commands. The only old-version material is the manual migration reference routed from the bundled Outfitter skill.
+4. There is no legacy profile compatibility layer: no readers, writers, aliases, detection, or migration commands.
+   The only old-version material is the manual migration reference routed from the bundled Outfitter skill.
 5. A remote repository named `.outfitter` is supported only as a distribution convention for the new protocol payload.
 6. Claude Code is supported as an additional adapter; pi remains the default.

--- a/docs/architecture/controllable-elements.md
+++ b/docs/architecture/controllable-elements.md
@@ -1,6 +1,8 @@
 # Controllable Elements
 
-This document defines the cross-agent-CLI concepts an Outfitter composition may control — the harness-neutral vocabulary adapters project into native mechanisms. Pi is the first supported CLI, and Claude Code is supported as an additional adapter. Other CLIs may be added later while keeping the composition model generic.
+This document defines the cross-agent-CLI concepts an Outfitter composition may control — the harness-neutral vocabulary adapters project into native mechanisms.
+Pi is the first supported CLI, and Claude Code is supported as an additional adapter.
+Other CLIs may be added later while keeping the composition model generic.
 
 Status values:
 
@@ -12,9 +14,11 @@ Status values:
 
 ## How to Read This Matrix
 
-A `Supported` entry means Outfitter can project that concept for the agent CLI through at least one native mechanism: a config-directory boundary, state-path placement, generated files, environment variables, command-line flags, or pass-through arguments. It does not always mean there is a one-to-one native CLI flag.
+A `Supported` entry means Outfitter can project that concept for the agent CLI through at least one native mechanism: a config-directory boundary, state-path placement, generated files, environment variables, command-line flags, or pass-through arguments.
+It does not always mean there is a one-to-one native CLI flag.
 
-For example, Claude Code session/project state lives under Claude's config home rather than a standalone `--session-dir` flag. Outfitter supports the session-directory concept for Claude by setting `CLAUDE_CONFIG_DIR` to the projection root and declaring Claude `projects/` state for persistence.
+For example, Claude Code session/project state lives under Claude's config home rather than a standalone `--session-dir` flag.
+Outfitter supports the session-directory concept for Claude by setting `CLAUDE_CONFIG_DIR` to the projection root and declaring Claude `projects/` state for persistence.
 
 ## Defined Terms
 
@@ -34,7 +38,9 @@ The directory where conversation sessions, transcripts, or run state are stored.
 
 ### Personas
 
-Not a composed key. A persona is a convention: a shared review [agent](../documentation/agents.md) plus one portable persona document appended at launch (see [Personas](../documentation/personas.md)). The controllable element underneath it is harness argument passthrough — `--append-system-prompt <file>` on the launch command — not a `personas` list.
+Not a composed key.
+A persona is a convention: a shared review [agent](../documentation/agents.md) plus one portable persona document appended at launch (see [Personas](../documentation/personas.md)).
+The controllable element underneath it is harness argument passthrough — `--append-system-prompt <file>` on the launch command — not a `personas` list.
 
 - Pi name: `--system-prompt` / `--append-system-prompt` composition
 - Claude name: `--system-prompt` / `--append-system-prompt` composition
@@ -55,10 +61,11 @@ Protocol `skills/<id>/` packages exposed to the agent.
 
 ### Commands / Prompt Templates
 
-Named reusable prompts or slash commands available to the agent runtime, from the tree's `commands/`.
+Named reusable prompts or slash commands may live in the tree's `commands/`.
+Separately, an agent may select one eager `prompt_template` source with an explicit `{ file }` or `{ repo_file }` reference; Outfitter does not treat command slugs as prompt-source shorthand.
 
-- Pi name: prompt templates, `--prompt-template`
-- Claude name: commands under the Claude config directory
+- Pi name: prompt templates, agent `prompt_template`, `--prompt-template`
+- Claude name: commands under the Claude config directory; agent `prompt_template` projection is currently unsupported and follows warning/`--strict` policy
 
 ### Knowledge
 
@@ -82,28 +89,33 @@ Model Context Protocol server configuration from the tree's `mcp.json`.
 
 ### Extensions
 
-Pi extensions selected by an agent's loadout (`extensions:`) and loaded into the run. A first-class, pi-native configuration element in its own right — distinct from the single bootstrap extension Outfitter injects for mode switching. An agent can select any number of extensions; the adapter registers them alongside the bootstrap extension.
+Pi extensions selected by an agent's loadout (`extensions:`) and loaded into the run.
+A first-class, pi-native configuration element in its own right — distinct from the single bootstrap extension Outfitter injects for mode switching.
+An agent can select any number of extensions; the adapter registers them alongside the bootstrap extension.
 
 - Pi name: extensions loaded via `--extension` / `-e`
 - Claude name: no direct equivalent; roadmap adapter mapping
 
 ### Plugins
 
-Pi plugins selected by an agent's loadout (`plugins:`). Also first-class and pi-native, tracked separately from extensions because Pi treats them as a distinct mechanism.
+Pi plugins selected by an agent's loadout (`plugins:`).
+Also first-class and pi-native, tracked separately from extensions because Pi treats them as a distinct mechanism.
 
 - Pi name: plugin loading
 - Claude name: plugin/marketplace mechanism, not mapped by Outfitter yet
 
 ### Credentials and Environment
 
-Environment variables, API keys, auth files, and related secret material needed by providers or tools. Never stored in the tree; supplied at runtime.
+Environment variables, API keys, auth files, and related secret material needed by providers or tools.
+Never stored in the tree; supplied at runtime.
 
 - Pi name: provider env vars, `auth.json`, `--api-key`
 - Claude name: environment variables and config files under `CLAUDE_CONFIG_DIR`
 
 ### Tasks
 
-Named work contracts baked into immutable artifacts for headless execution. The task/bake surface is deferred to a [separate upcoming RFC](../documentation/tasks.md); today headless runs launch an agent in print mode with structured inputs.
+Named work contracts baked into immutable artifacts for headless execution.
+The task/bake surface is deferred to a [separate upcoming RFC](../documentation/tasks.md); today headless runs launch an agent in print mode with structured inputs.
 
 - Pi name: headless print mode (`-p`) with the composed projection
 - Claude name: print mode with the composed projection
@@ -117,7 +129,8 @@ Reusable multi-step procedures selected by an agent's loadout.
 
 ### Hooks
 
-Deterministic code at fixed session points. No protocol resource exists yet; see [Hooks](../documentation/hooks.md) for the roadmap TODO on an Outfitter hooks extension.
+Deterministic code at fixed session points.
+No protocol resource exists yet; see [Hooks](../documentation/hooks.md) for the roadmap TODO on an Outfitter hooks extension.
 
 - Pi name: bootstrap extension via `--extension` / `-e`; per-event hooks are extension territory
 - Claude name: `hooks` in the generated `settings.json`
@@ -182,4 +195,5 @@ An early-startup customization used to register providers, tools, hooks, or addi
 | Pass-through Arguments      | Supported | Supported |
 | Bootstrap Hook              | Supported | Roadmap   |
 
-The user-facing view of this matrix, with per-gap notes, lives in the [adapter support matrix](../documentation/support-matrix.md). Unsupported elements warn at runtime; `--strict` makes those warnings fatal.
+The user-facing view of this matrix, with per-gap notes, lives in the [adapter support matrix](../documentation/support-matrix.md).
+Unsupported elements warn at runtime; `--strict` makes those warnings fatal.

--- a/docs/architecture/file_structure.md
+++ b/docs/architecture/file_structure.md
@@ -3,7 +3,8 @@
 This document records the key repository file and directory structure used by Outfitter.
 See [`./README.md`](./README.md) for runtime file conventions such as `.agents` layers, settings files, and generated composition directories.
 
-> **RFC [#165](https://github.com/ai-outfitter/outfitter/issues/165) status:** the profile-era `profiles/` and `compositeProfile/` modules have been removed; `code/cli/src` now uses the dotagents pipeline (`resolver/`, `composer/`, `projection/`, `dump/`, `sources/`). Interactive `.agents` onboarding and explicit remote synchronization are implemented as `outfitter setup` and `outfitter sync`.
+> **RFC [#165](https://github.com/ai-outfitter/outfitter/issues/165) status:** the profile-era `profiles/` and `compositeProfile/` modules have been removed; `code/cli/src` now uses the dotagents pipeline (`resolver/`, `composer/`, `projection/`, `dump/`, `sources/`).
+> Interactive `.agents` onboarding and explicit remote synchronization are implemented as `outfitter setup` and `outfitter sync`.
 
 ## Repository Layout
 
@@ -67,7 +68,8 @@ Outfitter is organized around a private npm workspace root, clear TypeScript pac
 └── package.json                       # private npm workspace root and delegating scripts
 ```
 
-The exact layout may evolve, but these boundaries should stay recognizable. Root scripts delegate to the `@ai-outfitter/outfitter` workspace so commands such as `npm run check-ci` continue to work from the repository root.
+The exact layout may evolve, but these boundaries should stay recognizable.
+Root scripts delegate to the `@ai-outfitter/outfitter` workspace so commands such as `npm run check-ci` continue to work from the repository root.
 
 Within a resolved `.agents` layer, an agent may include a harness-native Pi configuration overlay:
 
@@ -81,11 +83,16 @@ agents/<agent>/
     └── ...                 # other native Pi configuration files/directories
 ```
 
-The resolver retains every contributing `pi/` directory in layer-precedence order. The Pi projection materializes them from lowest to highest precedence and skips symlinks; other harness projections do not consume them.
+The resolver retains every contributing `pi/` directory in layer-precedence order.
+The Pi projection materializes them from lowest to highest precedence and skips symlinks; other harness projections do not consume them.
+
+A generated dump MAY include `.agents/.outfitter/composition.json`.
+This deterministic, removable audit record contains resolved inheritance and prompt provenance but no prompt contents, absolute paths, credentials, or runtime state; protocol consumers may ignore the `.outfitter/` metadata directory.
 
 ## Published Package Assets
 
-The CLI package root is `code/cli`, but the npm package must still include repository-level notices. The CLI package `prepack` script runs `code/cli/scripts/sync-package-assets.mjs`, which stages `README.md`, `LICENSE.md`, `code/enterprise/LICENSE`, and `code/enterprise/README.md` inside `code/cli` before `npm pack` or `npm publish`.
+The CLI package root is `code/cli`, but the npm package must still include repository-level notices.
+The CLI package `prepack` script runs `code/cli/scripts/sync-package-assets.mjs`, which stages `README.md`, `LICENSE.md`, `code/enterprise/LICENSE`, and `code/enterprise/README.md` inside `code/cli` before `npm pack` or `npm publish`.
 
 ## Test Fixtures
 
@@ -103,4 +110,5 @@ code/cli/tests/fixtures/scenarios/
   profile-precedence/
 ```
 
-The `profile-*` scenarios above are the current profile-era fixtures; per the transition note, the implementation PRs that add the resolver and composition modules replace them with target-state scenarios whose fixtures include realistic `.agents` trees and expected resolution output. Protocol conformance fixtures (layered trees plus expected effective output, pinned to the protocol revision) follow the same convention.
+The `profile-*` scenarios above are the current profile-era fixtures; per the transition note, the implementation PRs that add the resolver and composition modules replace them with target-state scenarios whose fixtures include realistic `.agents` trees and expected resolution output.
+Protocol conformance fixtures (layered trees plus expected effective output, pinned to the protocol revision) follow the same convention.

--- a/docs/documentation/agents.md
+++ b/docs/documentation/agents.md
@@ -1,6 +1,11 @@
 # Agents
 
-An agent is the protocol's identity resource — and, in Outfitter, the thing you run. A directory under `agents/<id>/` holds an `agent.md` definition and an optional `config.json`. Together they carry both _who the agent is_ and _what it runs with_: its skills, MCP servers, subagents, extensions, plugins, model, thinking level, and tool policy. That whole bundle — identity plus loadout — is what earlier drafts called a "profile." There is no separate profile resource; **an agent is the profile**. See [Profiles](./profiles.md).
+An agent is the protocol's identity resource — and, in Outfitter, the thing you run.
+A directory under `agents/<id>/` holds an `agent.md` definition and an optional `config.json`.
+Together they carry both _who the agent is_ and _what it runs with_: its skills, MCP servers, subagents, extensions, plugins, model, thinking level, and tool policy.
+That whole bundle — identity plus loadout — is what earlier drafts called a "profile."
+There is no separate profile resource; **an agent is the profile**.
+See [Profiles](./profiles.md).
 
 ```text
 .agents/
@@ -33,6 +38,8 @@ model: gpt-5.2
 thinking: high
 tools:
   allow: [read, edit, bash]
+append_system_prompt:
+  - repo_file: docs/architecture.md
 ---
 
 # Engineer
@@ -40,11 +47,12 @@ tools:
 You implement changes directly, keep diffs small, and verify before claiming done...
 ```
 
-`name` is the stable slug used for resolution. The optional `label` is the human-readable profile
-name shown during setup and in interactive harness UI. When `label` is omitted, Outfitter uses the
-first level-one Markdown heading, then falls back to the slug.
+`name` is the stable slug used for resolution.
+The optional `label` is the human-readable profile name shown during setup and in interactive harness UI.
+When `label` is omitted, Outfitter uses the first level-one Markdown heading, then falls back to the slug.
 
-Keep the prose focused on durable identity and behavior. Per-capability procedures belong in [skills](./skills.md); the frontmatter only _selects_ resources by slug — it never copies their content.
+Keep the prose focused on durable identity and behavior.
+Per-capability procedures belong in [skills](./skills.md); the frontmatter only _selects_ resources by slug — it never copies their content.
 
 ### Loadout fields
 
@@ -59,13 +67,59 @@ Keep the prose focused on durable identity and behavior. Per-capability procedur
 | `thinking`   | Thinking/effort level.                                                       |
 | `tools`      | Allowed/denied tool policy for the run.                                      |
 
-Every value is a slug resolved across layers. Skills first check `agents/<agent>/skills/<slug>/` across layer precedence, then fall back to catalog-wide `skills/<slug>/`. This lets an agent own private implementation capabilities without exposing them to every agent in the catalog. See [Skills](./skills.md#agent-local-skills).
+Every value is a slug resolved across layers.
+Skills first check `agents/<agent>/skills/<slug>/` across layer precedence, then fall back to catalog-wide `skills/<slug>/`.
+This lets an agent own private implementation capabilities without exposing them to every agent in the catalog.
+See [Skills](./skills.md#agent-local-skills).
 
-`knowledge` and `commands` resolve the same way — an agent may keep private files under `agents/<agent>/knowledge/` and `agents/<agent>/commands/`, local-first over the catalog-wide trees. `subagents` are always catalog-wide (a delegate is a shared agent). `extensions`/`plugins` are harness-native passthroughs with no on-disk namespace, and `model`/`thinking`/`tools` are per-agent already via `config.json` merge.
+`knowledge` and `commands` resolve the same way — an agent may keep private files under `agents/<agent>/knowledge/` and `agents/<agent>/commands/`, local-first over the catalog-wide trees.
+`subagents` are always catalog-wide (a delegate is a shared agent).
+`extensions`/`plugins` are harness-native passthroughs with no on-disk namespace, and `model`/`thinking`/`tools` are per-agent already via `config.json` merge.
+
+## Inheritance and prompt fragments
+
+An agent may specialize one or more base agents with `inherits`.
+Parents compose recursively, parent-first, and multiple parents keep the order written in the child.
+Diamond graphs include each ancestor once.
+Outfitter fails validation and composition for missing parents, self-inheritance, or indirect cycles.
+
+```markdown
+---
+name: platform-engineer
+inherits: engineer
+skills: [nix, kubernetes]
+system_prompt:
+  file: prompts/platform-system.md
+append_system_prompt:
+  - file: prompts/platform-review.md
+  - repo_file: docs/architecture.md
+prompt_template:
+  file: prompt-templates/implementation.md
+---
+
+# Platform Engineer
+
+You specialize the base engineer for NixOS and Kubernetes work.
+```
+
+Merge policy is deterministic: Markdown bodies append ancestor-first and child-last; list fields (`skills`, `subagents`, `mcp`, `extensions`, `plugins`, `append_system_prompt`) de-duplicate parent-first; scalar controls (`system_prompt`, `prompt_template`, `model`, `thinking`, `label`, `description`) use the nearest child declaration.
+Parent-declared skills resolve against that parent's local skill namespace before catalog fallback, so a child cannot accidentally capture a parent's private loadout.
+
+Prompt sources are explicit objects.
+`file` reads trusted catalog content relative to the `.agents` layer that owns the declaring agent and must stay inside that layer.
+`repo_file` reads active-repository content relative to the project root, remains contained after symlink resolution, and is treated as untrusted repository context; missing optional repository files warn so reusable catalog agents do not become brittle across projects.
+Named prompt slugs are intentionally not accepted yet.
+
+Effective prompt order is: selected `system_prompt` or root `system-prompt.md`; root `agents.md`; inherited then child `append_system_prompt`; inherited then child agent bodies; any runtime passthrough append prompts.
+
+Inheritance is not delegation.
+Inheritance composes one selected agent's identity and loadout before launch.
+`subagents` expose other agents as delegates the selected agent may call at runtime.
 
 ## Pi configuration overlay
 
-An agent may own native Pi configuration under `agents/<agent>/pi/`. Outfitter overlays that folder into the temporary `PI_CODING_AGENT_DIR` before launching Pi, so native files keep their standard names and formats:
+An agent may own native Pi configuration under `agents/<agent>/pi/`.
+Outfitter overlays that folder into the temporary `PI_CODING_AGENT_DIR` before launching Pi, so native files keep their standard names and formats:
 
 ```text
 agents/founder/
@@ -77,26 +131,24 @@ agents/founder/
     └── themes/
 ```
 
-The overlay is file-based. Source layers are applied from lowest to highest precedence, so a workspace `agents/founder/pi/keybindings.json` replaces the same file from a global or remote catalog while unrelated lower-layer files remain present. Outfitter does not follow symlinks from the overlay. The folder is ignored when the selected harness is not Pi.
+The overlay is file-based.
+Source layers are applied from lowest to highest precedence, so a workspace `agents/founder/pi/keybindings.json` replaces the same file from a global or remote catalog while unrelated lower-layer files remain present.
+Outfitter does not follow symlinks from the overlay.
+The folder is ignored when the selected harness is not Pi.
 
-Outfitter writes generated identity, composed skills, selected delegates, and
-selected MCP servers after applying the native overlay, and seeds durable Pi
-credentials immediately before launch. Those runtime-owned resources therefore
-cannot be replaced accidentally by a profile overlay.
+Outfitter writes generated identity, composed skills, selected delegates, and selected MCP servers after applying the native overlay, and seeds durable Pi credentials immediately before launch.
+Those runtime-owned resources therefore cannot be replaced accidentally by a profile overlay.
 
-`agents/<agent>/mcp.json` merges by server id over layered tree-root `mcp.json`
-files. The Pi projection writes only the servers selected by the active
-agent's `mcp` loadout into the runtime `mcp.json`.
+`agents/<agent>/mcp.json` merges by server id over layered tree-root `mcp.json` files.
+The Pi projection writes only the servers selected by the active agent's `mcp` loadout into the runtime `mcp.json`.
 
-The per-agent `agents/<agent>/hooks/` namespace remains reserved and is not yet
-projected (adapter parity is tracked in
-[#183](https://github.com/ai-outfitter/outfitter/issues/183)). Its presence
-surfaces a validation warning so content placed there is never silently
-dropped.
+The per-agent `agents/<agent>/hooks/` namespace remains reserved and is not yet projected (adapter parity is tracked in [#183](https://github.com/ai-outfitter/outfitter/issues/183)).
+Its presence surfaces a validation warning so content placed there is never silently dropped.
 
 ## config.json
 
-The optional `config.json` carries structured or harness-specific configuration that is awkward in frontmatter, following the protocol's schema for the pinned revision. JSON files merge across layers per the protocol's JSON merge behavior, so a workspace layer can adjust one field of a globally defined agent — swap the model, add an extension — without copying the whole definition.
+The optional `config.json` carries structured or harness-specific configuration that is awkward in frontmatter, following the protocol's schema for the pinned revision.
+JSON files merge across layers per the protocol's JSON merge behavior, so a workspace layer can adjust one field of a globally defined agent — swap the model, add an extension — without copying the whole definition.
 
 ## Tree-level context
 
@@ -118,10 +170,13 @@ outfitter run engineer --harness claude
 
 ## Resolution
 
-Agents resolve by slug across layers — workspace, global, then remote sources — with merge-by-ID semantics: a workspace `agents/engineer/` overrides a global or remote one. Agent-local skills merge by their owner and slug using the same layer order. `outfitter list agents` shows every resolvable agent and its winning source; `outfitter list skills --agent engineer` shows its effective skill namespace; `outfitter validate` reports broken loadout slugs and shadowed definitions.
+Agents resolve by slug across layers — workspace, global, then remote sources — with merge-by-ID semantics: a workspace `agents/engineer/` overrides a global or remote one.
+Agent-local skills merge by their owner and slug using the same layer order.
+`outfitter list agents` shows every resolvable agent and its winning source; `outfitter list skills --agent engineer` shows its effective skill namespace; `outfitter validate` reports broken loadout slugs and shadowed definitions.
 
 ## Agents as delegates
 
-The same agent definition can also be selected as a [subagent](./subagents.md) in another agent's `subagents` list — a delegate the run can hand focused work to. A leader agent's loadout is where that delegation is declared.
-For Pi runs, Outfitter also resolves and materializes the delegate's selected skills. Those skills
-are available to the delegate without being loaded into the leader's active skill set.
+The same agent definition can also be selected as a [subagent](./subagents.md) in another agent's `subagents` list — a delegate the run can hand focused work to.
+A leader agent's loadout is where that delegation is declared.
+For Pi runs, Outfitter also resolves and materializes the delegate's selected skills.
+Those skills are available to the delegate without being loaded into the leader's active skill set.

--- a/docs/documentation/migration.md
+++ b/docs/documentation/migration.md
@@ -1,18 +1,21 @@
 # Migration from legacy profiles
 
-Earlier Outfitter versions used an authored profile system: `.outfitter/` directories, `profile.yml` files, profile inheritance, and `--profile` pointing at profile definitions. [RFC #165](https://github.com/ai-outfitter/outfitter/issues/165) replaces that system with the Dotagents `.agents` protocol as a hard cut: the end-state runtime has **no knowledge of the old format** — no compatibility reader, no migration command, no deprecated aliases. (These docs describe that target; the released CLI still runs the legacy profile format during the transition.) This page is the manual migration reference, and the bundled Outfitter skill can walk an agent session through it interactively.
+Earlier Outfitter versions used an authored profile system: `.outfitter/` directories, `profile.yml` files, profile inheritance, and `--profile` pointing at profile definitions.
+[RFC #165](https://github.com/ai-outfitter/outfitter/issues/165) replaces that system with the Dotagents `.agents` protocol as a hard cut: the end-state runtime has **no knowledge of the old format** — no compatibility reader, no migration command, no deprecated aliases.
+(These docs describe that target; the released CLI still runs the legacy profile format during the transition.)
+This page is the manual migration reference, and the bundled Outfitter skill can walk an agent session through it interactively.
 
 ## Mapping
 
 | Legacy                                                  | End state                                                                                                                                                                                        |
 | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `.outfitter/profiles/<id>/profile.yml` (or `<id>.yml`)  | Split into resources: identity → `agents/<id>/agent.md`, procedures → `skills/`; the loadout lives in that [agent](./profiles.md)'s frontmatter / `config.json` — there is no separate selection |
-| `controls.system_prompt` / `append_system_prompt`       | `system-prompt.md`, `agents.md`, and the agent's `agent.md` body                                                                                                                                 |
+| `controls.system_prompt` / `append_system_prompt`       | Agent frontmatter `system_prompt` / `append_system_prompt` with explicit `{ file }` or `{ repo_file }` sources; use root `system-prompt.md` / `agents.md` for tree-wide context                  |
 | `controls.model`, `provider`, `thinking`                | `models.json` (and per-agent `config.json`)                                                                                                                                                      |
 | `controls.skills`                                       | The agent's `skills:` loadout; skills live at `skills/<id>/`                                                                                                                                     |
 | `controls.extensions`, `args`, `environment`            | Harness configuration projected by adapters; MCP servers → `mcp.json`                                                                                                                            |
-| Profile inheritance (`inherits:`)                       | Layer merge-by-ID, plus shared context in `system-prompt.md` / `agents.md`                                                                                                                       |
-| `template: true` base profiles                          | A base agent whose shared context lives in `system-prompt.md` / `agents.md` (or a base agent selected as a delegate)                                                                             |
+| Profile inheritance (`inherits:`)                       | Agent frontmatter `inherits:` naming one parent slug or an ordered parent list; manually translate the old profile into an agent first                                                           |
+| `template: true` base profiles                          | A base agent referenced with agent `inherits`; there is no separate template flag                                                                                                                |
 | `~/.outfitter/settings.yml`                             | `~/.agents/settings.yml`                                                                                                                                                                         |
 | `<project>/.outfitter/settings.yml`                     | `<project>/.agents/settings.yml`                                                                                                                                                                 |
 | `<project>/.outfitter/local/settings.yml` (nested dir)  | `<project>/.agents/settings.local.yml` (flat, gitignored)                                                                                                                                        |
@@ -25,14 +28,20 @@ Earlier Outfitter versions used an authored profile system: `.outfitter/` direct
 
 ## Procedure
 
-1. **Inventory** your `.outfitter/profiles`. For each profile, separate what it contains: identity/policy prose, capability procedures, model/provider config, tool wiring.
-2. **Create resources**: one `agents/<id>/agent.md` per durable identity; one `skills/<id>/` per capability (most `append_system_prompt` procedure text belongs in skills); shared context into `agents.md`; model config into `models.json`; MCP into `mcp.json`.
-3. **Rebuild as agents**: for each profile people actually ran, create an `agents/<id>/agent.md` whose frontmatter (or `config.json`) loadout selects the new resources by slug. Set `default_agent` to the one you run most. Inheritance chains become shared context in `system-prompt.md` / `agents.md` (or a base agent selected as a delegate), not an ordered selection.
-4. **Move settings**: relocate `~/.outfitter/settings.yml` content into `~/.agents/settings.yml`, project settings into `<project>/.agents/settings.yml`, and anything under `.outfitter/local/` into a flat `.agents/settings.local.yml` (gitignore it). Rename `profile_sources` to `sources`; sources must now publish `.agents` payloads.
+1. **Inventory** your `.outfitter/profiles`.
+   For each profile, separate what it contains: identity/policy prose, capability procedures, model/provider config, tool wiring.
+2. **Create resources**: one `agents/<id>/agent.md` per durable identity; one `skills/<id>/` per capability; shared context into `agents.md`; model config into `models.json`; MCP into `mcp.json`.
+   Move prompt fragments that must load eagerly into catalog-contained `file` sources or project-contained `repo_file` sources.
+3. **Rebuild as agents**: for each profile people actually ran, create an `agents/<id>/agent.md` whose frontmatter (or `config.json`) loadout selects the new resources by slug.
+   Translate reusable base profiles into base agents and preserve intentional inheritance order with agent `inherits`.
+   Set `default_agent` to the one you run most.
+4. **Move settings**: relocate `~/.outfitter/settings.yml` content into `~/.agents/settings.yml`, project settings into `<project>/.agents/settings.yml`, and anything under `.outfitter/local/` into a flat `.agents/settings.local.yml` (gitignore it).
+   Rename `profile_sources` to `sources`; sources must now publish `.agents` payloads.
 5. **Validate**: `outfitter validate --strict`, then `outfitter dump` and review the tree.
 6. **Delete** the `.outfitter/` directory once the dump matches expectations.
 
-A remote repository _named_ `.outfitter` remains a supported convention for organization control repos — but only when it publishes the new protocol payload. The name is supported; the previous profile layout inside it is not.
+A remote repository _named_ `.outfitter` remains a supported convention for organization control repos — but only when it publishes the new protocol payload.
+The name is supported; the previous profile layout inside it is not.
 
 ## Claude Code users
 

--- a/docs/documentation/profiles.md
+++ b/docs/documentation/profiles.md
@@ -1,30 +1,47 @@
 # Agent profiles
 
-"Profile" is a description, not a resource or a settings key. There is no `profile.yml`, no `profiles:` map, and no profile file format. What earlier drafts modeled as a standalone profile — a named selection of skills, subagents, model, and so on — is now just an [agent](./agents.md) and its loadout.
+"Profile" is a description, not a resource or a settings key.
+There is no `profile.yml`, no `profiles:` map, and no profile file format.
+What earlier drafts modeled as a standalone profile — a named selection of skills, subagents, model, and so on — is now just an [agent](./agents.md) and its loadout.
 
 ## Profiles are agents
 
-An **agent profile** is the whole bundle an agent carries: its identity (`agent.md`) plus the loadout declared in that agent's frontmatter or `config.json` — skills, MCP servers, subagents, extensions, plugins, model, thinking level, and tool policy. When someone says "the engineer profile," they mean the `engineer` agent with everything it composes.
+An **agent profile** is the whole bundle an agent carries: its identity (`agent.md`) plus the loadout declared in that agent's frontmatter or `config.json` — skills, MCP servers, subagents, extensions, plugins, model, thinking level, and tool policy.
+When someone says "the engineer profile," they mean the `engineer` agent with everything it composes.
 
-Folding profiles into agents removes a layer of indirection. Instead of a settings map that points at resources that point at an identity, one agent directory holds identity and loadout together, resolves by slug like any other resource, and is what you run:
+Folding profiles into agents removes a layer of indirection.
+Instead of a settings map that points at resources that point at an identity, one agent directory holds identity and loadout together, resolves by slug like any other resource, and is what you run:
 
 ```bash
 outfitter run engineer
 outfitter run engineer --harness claude
 ```
 
-`outfitter list agents` shows every resolvable agent and where each resolves from, including shadowed IDs. Set `default_agent` in [settings](./settings.md) to choose what plain `outfitter` runs.
+`outfitter list agents` shows every resolvable agent and where each resolves from, including shadowed IDs.
+Set `default_agent` in [settings](./settings.md) to choose what plain `outfitter` runs.
 
 ## Where the loadout lives
 
-The loadout lives on the agent, not in settings. Add or change what an agent composes by editing that agent's `agents/<id>/agent.md` frontmatter or `config.json` — see [Agents](./agents.md#loadout-fields) for the field list. To override just one field from a higher layer (swap the model, add an extension) without redefining the agent, put it in the agent's `config.json`: JSON files shallow-merge by key across layers. An `agent.md` resolves whole-resource by ID — the winning layer's `agent.md` replaces lower ones rather than field-merging — so a partial `agent.md` would discard the base identity.
+The loadout lives on the agent, not in settings.
+Add or change what an agent composes by editing that agent's `agents/<id>/agent.md` frontmatter or `config.json` — see [Agents](./agents.md#loadout-fields) for the field list.
+To override just one field from a higher layer (swap the model, add an extension) without redefining the agent, put it in the agent's `config.json`: JSON files shallow-merge by key across layers.
+An `agent.md` resolves whole-resource by ID — the winning layer's `agent.md` replaces lower ones rather than field-merging — so a partial `agent.md` would discard the base identity.
 
 Settings ([settings.md](./settings.md)) is left with just resolution and launch concerns — `default_agent`, `default_harness`, `sources`, and state policy — not resource selection.
 
 ## Composing from a base
 
-To share behavior across several agents, keep shared operating context in the tree's `system-prompt.md` and `agents.md` — every agent in the tree inherits those — and put shared procedures in [skills](./skills.md) each agent selects. Selecting an agent as a subagent does _not_ share its policy; it only makes that agent available as a delegation target. The [persona](./personas.md) convention builds on the shared-context idea: one shared review agent, many single-file persona documents appended at launch.
+Use `inherits` when one agent is a specialization of another.
+The base agent's body and additive loadout compose first; child bodies append, child scalar controls override, and inherited parent-local resources retain their parent ownership.
+For example, `platform-engineer` can `inherits: engineer` and add `skills: [nix, kubernetes]`.
+Multiple parents are ordered left-to-right, recursively, with diamond ancestors included once.
+
+Use tree-level `system-prompt.md` and `agents.md` for context shared by every agent, and [skills](./skills.md) for reusable procedures.
+Selecting an agent as a `subagent` is different from inheritance: it exposes a runtime delegation target and does not merge that delegate's identity into the leader.
+See [Agents](./agents.md#inheritance-and-prompt-fragments) for the exact merge and prompt-source rules.
 
 ## Migrating from authored profiles
 
-Earlier Outfitter versions defined profiles as authored YAML files (`.outfitter/profiles/`, `profile.yml`, inheritance, `controls`). That system is removed with no compatibility mode. See the [migration reference](./migration.md) for the manual mapping from the legacy format to agents and their loadouts.
+Earlier Outfitter versions defined profiles as authored YAML files (`.outfitter/profiles/`, `profile.yml`, inheritance, `controls`).
+That system is removed with no compatibility mode.
+See the [migration reference](./migration.md) for the manual mapping from the legacy format to agents and their loadouts.

--- a/docs/requirements/OFTR-003-profiles.md
+++ b/docs/requirements/OFTR-003-profiles.md
@@ -1,17 +1,15 @@
 # OFTR-003: Agents and Resolution
 
-> **Amendment (2026-07-17, RFC [#165](https://github.com/ai-outfitter/outfitter/issues/165)):**
-> profiles fold into agents. Authored `profile.yml` files, `inherits` inheritance, `template`
-> profiles, and `profile_export` are removed; an agent is `agents/<id>/agent.md` frontmatter plus an
-> optional `config.json`, resolved by slug across `.agents` layers with merge-by-ID. Section IDs are
-> preserved for pinned-test traceability. Target design: [docs/documentation/agents.md](../documentation/agents.md)
-> and [docs/architecture/README.md](../architecture/README.md).
+> **Amendment (2026-07-17, RFC [#165](https://github.com/ai-outfitter/outfitter/issues/165)):** Profiles fold into agents.
+> Authored `profile.yml` files, profile-era inheritance, `template` profiles, and `profile_export` are removed; agent inheritance is declared by `inherits` in `agents/<id>/agent.md` frontmatter.
+> An agent may also have an optional `config.json` and resolves by slug across `.agents` layers with merge-by-ID.
+> Section IDs are preserved for pinned-test traceability.
+> Target design: [docs/documentation/agents.md](../documentation/agents.md) and [docs/architecture/README.md](../architecture/README.md).
 
 ## Overview
 
-An agent is the protocol's identity resource and the thing Outfitter runs. Outfitter resolves agents
-and other resources from layered `.agents` trees into one immutable effective resource set that every
-command shares.
+An agent is the protocol's identity resource and the thing Outfitter runs.
+Outfitter resolves agents and other resources from layered `.agents` trees into one immutable effective resource set that every command shares.
 
 ## Requirements
 
@@ -38,9 +36,10 @@ command shares.
 
 ### OFTR-003.4: Merge by ID
 
-1. Resources MUST merge by ID across layers: the highest-precedence definition of a slug wins and replaces lower ones. Markdown resources are not partially merged.
+1. Resources MUST merge by ID across layers: the highest-precedence definition of a slug wins and replaces lower ones.
+   Markdown resources are not partially merged.
 2. Per-agent `config.json` MUST shallow-merge by key over the `agent.md` frontmatter loadout for the same agent directory.
-3. There is no profile inheritance; shared context lives in tree-level `system-prompt.md`/`agents.md`.
+3. Legacy profile inheritance MUST NOT be restored; agent inheritance follows OFTR-003.9 and shared context lives in tree-level `system-prompt.md`/`agents.md`.
 4. Agent-local resources MUST merge by owner and ID across layers before catalog-wide fallback is considered.
 5. An agent-local skill MAY shadow a catalog-wide skill for its owner without being reported as a catalog collision.
 
@@ -71,3 +70,30 @@ command shares.
 2. `outfitter list <kind>` MUST restrict output to one kind of `agents`, `skills`, `knowledge`, or `commands` and MUST reject unknown kinds.
 3. Listed resources MUST report the winning layer for each slug deterministically.
 4. `outfitter list skills --agent <id>` MUST show the agent's local-first effective skill view and distinguish agent-local winners.
+
+### OFTR-003.9: Agent Inheritance Graph
+
+1. `agent.md` frontmatter MAY declare `inherits` as one parent slug or an ordered non-empty list of parent slugs.
+2. Outfitter MUST resolve every inherited parent through the same effective layered resource set used for the selected child.
+3. Inheritance traversal MUST be recursive, parent-first, and left-to-right for multiple parents.
+4. A diamond inheritance graph MUST compose each ancestor once in deterministic first-encounter order.
+5. Missing parents, self-inheritance, and direct or indirect cycles MUST fail validation and composition with the relevant chain.
+6. Inheritance MUST extend the `.agents` agent model and MUST NOT reintroduce `.outfitter/profiles`, `profile.yml`, profile templates, or legacy profile readers.
+
+### OFTR-003.10: Inherited Merge Policy
+
+1. Agent Markdown bodies MUST compose ancestor-first and selected-child-last.
+2. `skills`, `subagents`, `mcp`, `extensions`, `plugins`, and `append_system_prompt` MUST use stable parent-first de-duplication.
+3. `system_prompt`, `prompt_template`, `model`, `thinking`, `label`, and `description` MUST use the nearest child declaration.
+4. `tools.allow` and `tools.deny` MUST union stably; denied tools MUST win when projected.
+5. Outfitter MUST retain declaring-agent provenance for inherited selections so parent-local skills and configuration resolve against the parent that declared them.
+6. Inheritance MUST NOT support subtraction syntax or arbitrary per-field merge operators.
+
+### OFTR-003.11: Prompt Source Controls
+
+1. `system_prompt`, `append_system_prompt`, and `prompt_template` MUST accept only explicit prompt source objects using exactly one of `file` or `repo_file`.
+2. `file` prompt sources MUST resolve relative to the `.agents` layer that owns the declaring agent and MUST fail on missing files, directories, path traversal, absolute paths, unsafe symlink targets, and reads outside that layer.
+3. `repo_file` prompt sources MUST resolve relative to the active project root, MUST remain contained after symlink resolution, and MUST be attributed as untrusted repository content.
+4. Missing optional `repo_file` prompt fragments SHOULD produce observable composition warnings instead of making reusable catalog agents fail across repositories.
+5. Prompt fragments MUST retain source kind, path or reference, declaring agent, owning layer, content, order, and trust provenance in the composition plan.
+6. Named prompt slug shorthand MUST NOT be accepted until its namespace, layer semantics, protocol compatibility, and dump behavior are specified in these requirements.

--- a/docs/requirements/OFTR-005-run-and-composite-profile.md
+++ b/docs/requirements/OFTR-005-run-and-composite-profile.md
@@ -1,6 +1,9 @@
 # OFTR-005: Run Command and Composite profile Lifecycle
 
-> **Transition (RFC [#165](https://github.com/ai-outfitter/outfitter/issues/165)):** **OFTR-005.1/005.2/005.3 are amended (2026-07-17)** to the run/composition model (run selects an agent + harness and resolves → composes → projects → launches). The remaining sections (005.4 watching, 005.6 state persistence, 005.7 prompt export) describe profile-era features that are **not yet reprojected** — the current run projects composed identity, skills, model, and thinking into an ephemeral runtime directory. Those features return incrementally with the fuller adapter parity. Target design: [docs/architecture/README.md](../architecture/README.md).
+> **Transition (RFC [#165](https://github.com/ai-outfitter/outfitter/issues/165)):** **OFTR-005.1/005.2/005.3 are amended (2026-07-17)** to the run/composition model (run selects an agent + harness and resolves → composes → projects → launches).
+> The remaining sections (005.4 watching, 005.6 state persistence, 005.7 prompt export) describe profile-era features that are **not yet reprojected** — the current run projects composed identity, skills, model, and thinking into an ephemeral runtime directory.
+> Those features return incrementally with the fuller adapter parity.
+> Target design: [docs/architecture/README.md](../architecture/README.md).
 
 ## Overview
 
@@ -10,7 +13,7 @@ The `run` command assembles a temporary agent-specific configuration directory c
 
 ### OFTR-005.1: Run Command Defaults
 
-_Amended (2026-07-17, RFC #165): `run` selects an agent slug and a harness, not a profile._
+Amended (2026-07-17, RFC #165): `run` selects an agent slug and a harness, not a profile.
 
 1. Outfitter MUST provide a `run` command.
 2. `run` MUST be the default command when no command is specified.
@@ -23,24 +26,27 @@ _Amended (2026-07-17, RFC #165): `run` selects an agent slug and a harness, not 
 
 ### OFTR-005.2: Composition Definition
 
-_Amended (2026-07-17, RFC #165): a run is defined by a harness-neutral composition, not a profile._
+Amended (2026-07-17, RFC #165): a run is defined by a harness-neutral composition, not a profile.
 
 1. Outfitter MUST compose a harness-neutral **composition plan** for a run from the effective resource set and a selected agent.
 2. A composition plan MUST be scoped to one selected agent slug and is projected per harness by an adapter.
-3. A composition plan MUST carry the composed identity (base `system-prompt.md`, shared `agents.md` context, and the agent's `agent.md` body) and the agent's resolved loadout.
+3. A composition plan MUST carry the composed identity (effective system prompt, shared `agents.md` context, appended prompt fragments, inherited agent bodies, prompt template provenance when selected) and the agent's resolved loadout.
 4. Composition MUST be deterministic: identical sources, refs, and selections produce an identical composition plan.
+5. A composition plan MUST expose the selected agent's inheritance chain and prompt-fragment provenance so dump and verbose surfaces can audit where each prompt part came from.
 
 ### OFTR-005.3: Composition Assembly
 
-_Amended (2026-07-17, RFC #165): composition assembles from the effective resource set._
+Amended (2026-07-17, RFC #165): composition assembles from the effective resource set.
 
-1. Outfitter MUST compose identity by layering the winning `system-prompt.md` as the base, the winning `agents.md` as shared context, and the selected agent's body on top, in that deterministic order.
-2. Outfitter MUST resolve each loadout slug (`skills`, `subagents`) against the effective resource set to its winning resource; skills use the selected agent's local namespace before catalog-wide fallback.
+1. Outfitter MUST compose identity in this deterministic order: nearest declared `system_prompt` or the winning root `system-prompt.md`; winning root `agents.md`; inherited then child `append_system_prompt` fragments; inherited then child agent bodies; runtime passthrough append prompts.
+2. Outfitter MUST resolve each inherited loadout slug against the declaring agent's local namespace before catalog-wide fallback; selected-child local resources MUST NOT accidentally satisfy parent-declared selections.
 3. Outfitter MUST report an error when the selected agent slug does not resolve or its definition is invalid.
 4. Outfitter MUST surface a loadout slug that does not resolve as a non-fatal composition warning.
 5. `list`, `validate`, `run`, and `dump` MUST share one resolver (a single effective resource set); the commands that create a selected composition (`run`, `dump`) MUST use the same shared composer.
 6. Runtime projection MUST materialize a selected agent-local skill with the same instructions, references, scripts, and assets as a catalog-wide skill.
 7. Dump MUST place selected agent-local skills under top-level `skills/<id>/` in its closure output so target harnesses discover them.
+8. `outfitter validate` MUST diagnose inheritance graph errors and prompt-source containment errors without requiring a harness launch.
+9. Existing agents that declare no inheritance or prompt-source controls MUST keep the same effective prompt order and equivalent launch arguments.
 
 ### OFTR-005.4: Composite profile Watching
 

--- a/docs/requirements/OFTR-006-agent-adapters.md
+++ b/docs/requirements/OFTR-006-agent-adapters.md
@@ -1,6 +1,8 @@
 # OFTR-006: Agent Adapters, Pi Support, and Claude Code Support
 
-> **Transition (RFC [#165](https://github.com/ai-outfitter/outfitter/issues/165)):** **OFTR-006.1 is amended (2026-07-17)** to the composition-projection model below (harnesses project a `CompositionPlan`, reporting unsupported _elements_). The pi/claude launch-control sections still describe profile-era behavior and richer parity (mcp reconciliation, session dirs, state persistence) is projected incrementally; the current implementation projects composed identity, skills, model, thinking, Pi extensions, and per-agent Pi configuration overlays. Target design: [docs/architecture/README.md](../architecture/README.md).
+> **Transition (RFC [#165](https://github.com/ai-outfitter/outfitter/issues/165)):** **OFTR-006.1 is amended (2026-07-17)** to the composition-projection model below (harnesses project a `CompositionPlan`, reporting unsupported _elements_).
+> The pi/claude launch-control sections still describe profile-era behavior and richer parity (mcp reconciliation, session dirs, state persistence) is projected incrementally; the current implementation projects composed identity, skills, model, thinking, Pi extensions, and per-agent Pi configuration overlays.
+> Target design: [docs/architecture/README.md](../architecture/README.md).
 
 ## Overview
 
@@ -11,13 +13,14 @@ Pi is the default and primary supported adapter; Claude Code is also supported t
 
 ### OFTR-006.1: Adapter Boundary
 
-_Amended (2026-07-17, RFC #165): adapters project a harness-neutral composition, not a profile._
+Amended (2026-07-17, RFC #165): adapters project a harness-neutral composition, not a profile.
 
 1. Outfitter MUST project a harness-neutral `CompositionPlan` to a native harness launch: a materialized runtime configuration root plus a launch plan (command, args, environment).
 2. Each harness projection MUST be identified by its harness (`pi` or `claude`).
 3. Each harness projection MUST report which composition loadout elements it cannot project (`getUnsupportedElements`).
 4. When a composition selects an element the harness cannot project, Outfitter MUST warn; `--strict` MUST make it fatal before launch.
 5. Composition (resolver + composer) MUST stay independent of harness-specific projection.
+6. Prompt templates MUST be projected only by harnesses that support a native prompt-template control; unsupported prompt-template use MUST be reported through `getUnsupportedElements` and MUST fail before launch under `--strict`.
 
 ### OFTR-006.2: Supported Adapter Availability
 
@@ -47,6 +50,7 @@ _Amended (2026-07-17, RFC #165): adapters project a harness-neutral composition,
 15. The pi adapter MUST NOT treat flat profile source roots as profile-bundled job folders unless a named DeepWork job resolves to a shared jobs root.
 16. The pi adapter MUST ignore inherited external `DEEPWORK_ADDITIONAL_JOBS_FOLDERS` values unless `controls.pi.allow_external_deepwork_jobs` is true.
 17. The pi adapter MUST overlay `agents/<agent>/pi/` directories from contributing `.agents` layers into the temporary `PI_CODING_AGENT_DIR`, with higher-precedence layers replacing matching paths, without following symlinks or projecting the overlay into non-Pi harnesses.
+18. The pi adapter MUST project composed prompt fragments in composition order by passing one `--system-prompt`, ordered `--append-system-prompt` arguments, and `--prompt-template` when the composition declares a prompt template.
 
 ### OFTR-006.4: Pi Startup Boundary
 
@@ -65,6 +69,7 @@ _Amended (2026-07-17, RFC #165): adapters project a harness-neutral composition,
 5. The Claude Code adapter SHOULD support `--model`, `--effort`, `--system-prompt`, `--append-system-prompt`, and `--plugin-dir` where native Claude Code flags exist.
 6. The Claude Code adapter SHOULD support `controls.session_directory` and `controls.claude.session_directory` by routing Claude `projects/` session state through Outfitter state persistence.
 7. The Claude Code adapter MUST return unsupported-control warnings for requested generic or `controls.claude` controls that it cannot translate.
+8. Until native support is implemented and tested, the Claude Code adapter MUST report `prompt_template` as unsupported and MUST NOT pass a pi-style prompt-template argument.
 
 ### OFTR-006.6: Pi Settings Reconciliation
 


### PR DESCRIPTION
## What changed

- add `inherits` to agent definitions, accepting one parent or an ordered list
- compose inheritance recursively, parent-first, with diamond de-duplication
- merge inherited identity, prompts, loadout fields, tools, and agent-local
  skills deterministically
- detect missing parents, self-inheritance, and indirect cycles during
  validation and composition
- add explicit `system_prompt`, `append_system_prompt`, and `prompt_template`
  sources from trusted catalog files or contained repository files
- project and dump the effective inherited composition rather than only the
  selected agent's direct definition
- document inheritance as identity/loadout composition, distinct from runtime
  `subagents` delegation

## Why

The Dotagents transition removed legacy profile inheritance, leaving shared
agent behavior limited to tree-wide context and repeated loadout declarations.
That made it difficult to define a general `engineer` once and specialize it
into roles such as `platform-engineer` without copying its prompt and
capabilities.

This restores composition at the agent resource boundary: a selected child
agent inherits reusable parent identities and loadouts before Outfitter
projects one effective composition into the chosen harness.

## User impact

Catalog authors can now write:

```yaml
name: platform-engineer
inherits: engineer
skills: [nix, kubernetes]
```

The child receives the parent's prompt and loadout while retaining predictable
child overrides. Inheritance does not expose the parent as a callable delegate;
that remains the role of `subagents`.

## Validation

- `npm run check-ci`
- 288 tests across 27 files
- lint and coverage
- documentation lint and production build
- dedicated inheritance run tests covering recursive and multiple inheritance,
  cycles, diamond graphs, prompt ordering, local skill ownership, dump, and
  projection behavior
