### PR TITLE
feat: make the container a reusable agent runtime

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -91,6 +91,60 @@ jobs:
           docker run --rm --entrypoint /bin/sh "$IMAGE:$VERSION" -c \
             'nix --version && test -x /bin/bash && test -x /usr/bin/env'
 
+      # The two workflows this image exists to support. Neither was covered:
+      # the checks above only prove tools exist in the base, so a regression in
+      # extension or residency could still be published.
+      - name: Smoke test derivative image
+        run: |
+          set -euo pipefail
+          # A consumer extends the base with its own entrypoint. This failed
+          # before /etc/passwd carried root: the builder resolves USER against
+          # the base image's passwd file, so `USER root` aborted the build with
+          # "unknown user error looking up user root".
+          workdir="$(mktemp -d)"
+          printf '#!/bin/bash\nexec outfitter "$@"\n' > "$workdir/entrypoint"
+          cat > "$workdir/Dockerfile" <<DOCKERFILE
+          FROM $IMAGE:$VERSION
+          USER root
+          COPY entrypoint /opt/agent/entrypoint
+          RUN chmod 0755 /opt/agent/entrypoint
+          USER 1000:1000
+          ENTRYPOINT ["/opt/agent/entrypoint"]
+          DOCKERFILE
+          docker build -t outfitter-derivative:smoke "$workdir"
+          docker run --rm outfitter-derivative:smoke --version
+
+      - name: Smoke test resident termination
+        run: |
+          set -euo pipefail
+          # A resident agent must stay up until told to stop, then stop
+          # promptly. Outfitter installs no SIGTERM handler, so PID 1 has to
+          # forward the signal; without an init the container ignores
+          # termination and is SIGKILLed when the grace period expires.
+          #
+          # Run through tini, exactly as the shipped Entrypoint does. Using
+          # `--entrypoint /bin/sh` instead would replace PID 1 and bypass the
+          # init being tested, which fails on a correct image and would have
+          # made this check meaningless.
+          id="$(docker run -d --entrypoint /bin/tini "$IMAGE:$VERSION" -g -- /bin/sh -c 'sleep 300')"
+          trap 'docker rm -f "$id" >/dev/null 2>&1 || true' EXIT
+          sleep 2
+          if [ "$(docker inspect -f '{{.State.Running}}' "$id")" != "true" ]; then
+            echo "resident container exited immediately" >&2
+            docker logs "$id" >&2 || true
+            exit 1
+          fi
+          start="$(date +%s)"
+          docker stop --time 15 "$id" >/dev/null
+          elapsed=$(( $(date +%s) - start ))
+          code="$(docker inspect -f '{{.State.ExitCode}}' "$id")"
+          # 137 is SIGKILL: the grace period expired with nothing reacting to
+          # SIGTERM, which is precisely the defect this guards.
+          if [ "$code" = "137" ] || [ "$elapsed" -ge 15 ]; then
+            echo "container did not honor SIGTERM (exit $code after ${elapsed}s)" >&2
+            exit 1
+          fi
+
       - name: Log in to GitHub Container Registry
         if: inputs.publish
         uses: docker/login-action@v3

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -91,9 +91,11 @@ jobs:
           docker run --rm --entrypoint /bin/sh "$IMAGE:$VERSION" -c \
             'nix --version && test -x /bin/bash && test -x /usr/bin/env'
 
-      # The two workflows this image exists to support. Neither was covered:
-      # the checks above only prove tools exist in the base, so a regression in
-      # extension or residency could still be published.
+      # Extension is the workflow this image exists for, and nothing covered it:
+      # the checks above only prove tools are present in the base. Residency is
+      # covered at the CLI level instead — signal forwarding lives in
+      # spawnLauncher, so tests/unit/agent-launch.test.ts asserts it directly
+      # rather than inferring it from container exit codes.
       - name: Smoke test derivative image
         run: |
           set -euo pipefail
@@ -113,37 +115,6 @@ jobs:
           DOCKERFILE
           docker build -t outfitter-derivative:smoke "$workdir"
           docker run --rm outfitter-derivative:smoke --version
-
-      - name: Smoke test resident termination
-        run: |
-          set -euo pipefail
-          # A resident agent must stay up until told to stop, then stop
-          # promptly. Outfitter installs no SIGTERM handler, so PID 1 has to
-          # forward the signal; without an init the container ignores
-          # termination and is SIGKILLed when the grace period expires.
-          #
-          # Run through tini, exactly as the shipped Entrypoint does. Using
-          # `--entrypoint /bin/sh` instead would replace PID 1 and bypass the
-          # init being tested, which fails on a correct image and would have
-          # made this check meaningless.
-          id="$(docker run -d --entrypoint /bin/tini "$IMAGE:$VERSION" -g -- /bin/sh -c 'sleep 300')"
-          trap 'docker rm -f "$id" >/dev/null 2>&1 || true' EXIT
-          sleep 2
-          if [ "$(docker inspect -f '{{.State.Running}}' "$id")" != "true" ]; then
-            echo "resident container exited immediately" >&2
-            docker logs "$id" >&2 || true
-            exit 1
-          fi
-          start="$(date +%s)"
-          docker stop --time 15 "$id" >/dev/null
-          elapsed=$(( $(date +%s) - start ))
-          code="$(docker inspect -f '{{.State.ExitCode}}' "$id")"
-          # 137 is SIGKILL: the grace period expired with nothing reacting to
-          # SIGTERM, which is precisely the defect this guards.
-          if [ "$code" = "137" ] || [ "$elapsed" -ge 15 ]; then
-            echo "container did not honor SIGTERM (exit $code after ${elapsed}s)" >&2
-            exit 1
-          fi
 
       - name: Log in to GitHub Container Registry
         if: inputs.publish

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -88,6 +88,8 @@ jobs:
             echo "Expected outfitter --version to print '$VERSION' but got '$output'." >&2
             exit 1
           fi
+          docker run --rm --entrypoint /bin/sh "$IMAGE:$VERSION" -c \
+            'nix --version && test -x /bin/bash && test -x /usr/bin/env'
 
       - name: Log in to GitHub Container Registry
         if: inputs.publish

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,10 @@ Outfitter assembles a temporary composite profile under the system temp director
 ## Docker
 
 Each published release builds the `container` output from `flake.nix` and pushes a `linux/amd64` image to GitHub Container Registry as `ghcr.io/ai-outfitter/outfitter:<version>` and `ghcr.io/ai-outfitter/outfitter:latest` (see the `publish-docker` job in `.github/workflows/release.yml`).
-The minimal image bundles the Nix-built Outfitter package and uses `outfitter` directly as its entrypoint.
+The image uses the Nix-built Outfitter package directly as its entrypoint and
+includes the Nix CLI, Bash, core utilities, Git, SSH, and CA certificates. See
+[Container images](docs/documentation/containers.md) for the persistent runtime
+contract and the reusable Nix image builder.
 Use the manually dispatched `Container` workflow to reproduce and smoke test a release image without publishing it. Its Nix store paths are cached between GitHub Actions runs; the normal pull-request and push CI workflow does not build the image.
 
 Run the published image:

--- a/code/cli/src/agents/AgentLaunch.ts
+++ b/code/cli/src/agents/AgentLaunch.ts
@@ -1,6 +1,7 @@
 // Turns a logical agent launch plan into an actual launched process: resolves the bundled pi
 // binary, runs the launcher, and translates a missing agent CLI into actionable install guidance.
 import { existsSync, readFileSync } from 'node:fs';
+import os from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -55,14 +56,70 @@ export const resolveAgentLaunchExecutable = (launchPlan: AgentLaunchPlan): Agent
   };
 };
 
+// Signals we forward to the harness. SIGKILL is deliberately absent: it cannot be caught, and the
+// kernel delivers it to us directly.
+const FORWARDED_SIGNALS: readonly NodeJS.Signals[] = ['SIGTERM', 'SIGINT', 'SIGHUP'];
+
+// How long the harness gets to exit after a forwarded signal before we stop being polite. Kubernetes
+// defaults to a 30s grace period and SIGKILLs the pod afterwards, so this has to be comfortably
+// shorter or the escalation never runs.
+const TERMINATION_GRACE_MS = 10_000;
+
+/**
+ * Forwards termination signals from this process to a spawned harness, resolving once the harness
+ * actually exits.
+ *
+ * Without this, a resident agent cannot shut down. Node installs no default forwarding, so the
+ * harness never learns the session is ending: under Kubernetes it is SIGKILLed when the grace period
+ * expires, skipping credential persistence and projection cleanup. The same gap shows up outside
+ * containers — Ctrl-C in a terminal, or a cancelled CI job — which is why this belongs here rather
+ * than in a container init.
+ *
+ * Installing a handler suppresses Node's default termination, so every path must resolve, and the
+ * listeners must come off afterwards or repeated launches in one process leak them.
+ */
+export const attachSignalForwarding = (
+  child: { kill(signal?: NodeJS.Signals): boolean; killed: boolean },
+  emitter: NodeJS.EventEmitter = process,
+  graceMs: number = TERMINATION_GRACE_MS,
+): (() => void) => {
+  let escalation: NodeJS.Timeout | undefined;
+
+  const forward = (signal: NodeJS.Signals) => (): void => {
+    if (child.killed) return;
+    child.kill(signal);
+    // A harness that ignores or hangs on the signal would otherwise keep us alive until the
+    // orchestrator's own SIGKILL, losing the chance to exit cleanly first.
+    escalation ??= setTimeout(() => child.kill('SIGKILL'), graceMs);
+    escalation.unref?.();
+  };
+
+  const handlers = FORWARDED_SIGNALS.map((signal) => [signal, forward(signal)] as const);
+  for (const [signal, handler] of handlers) emitter.on(signal, handler);
+
+  return () => {
+    for (const [signal, handler] of handlers) emitter.removeListener(signal, handler);
+    if (escalation) clearTimeout(escalation);
+  };
+};
+
 /* v8 ignore start -- real process spawn is covered by end-to-end smoke usage, not unit tests. */
 export const spawnLauncher: AgentProcessLauncher = {
   async launch(plan: AgentLaunchPlan): Promise<number> {
     const { default: spawn } = await import('cross-spawn');
     return await new Promise<number>((resolve, reject) => {
       const child = spawn(plan.command, [...plan.args], { stdio: 'inherit', env: { ...process.env, ...plan.env } });
-      child.on('error', reject); // ENOENT surfaces as an actionable install message
-      child.on('close', (code, signal) => resolve(code ?? (signal ? 1 : 0)));
+      const detach = attachSignalForwarding(child);
+      child.on('error', (error) => {
+        detach();
+        reject(error); // ENOENT surfaces as an actionable install message
+      });
+      child.on('close', (code, signal) => {
+        detach();
+        // 128+n is the shell convention for "died on signal n", and it is what a caller inspecting
+        // our exit status expects to see when the harness was terminated rather than returning.
+        resolve(code ?? (signal ? 128 + (os.constants.signals[signal] ?? 0) : 0));
+      });
     });
   },
 };

--- a/code/cli/tests/unit/agent-launch.test.ts
+++ b/code/cli/tests/unit/agent-launch.test.ts
@@ -1,10 +1,26 @@
-// Tests the launch boundary: bundled-pi resolution, process launch, and missing-CLI guidance.
-import { describe, expect, it } from 'vitest';
+// Tests the launch boundary: bundled-pi resolution, process launch, missing-CLI guidance, and
+// termination forwarding.
+import { EventEmitter } from 'node:events';
 
-import { launchAgentProcess, resolveAgentLaunchExecutable } from '../../src/agents/AgentLaunch.js';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  attachSignalForwarding,
+  launchAgentProcess,
+  resolveAgentLaunchExecutable,
+} from '../../src/agents/AgentLaunch.js';
 import type { AgentLaunchPlan } from '../../src/projection/Projection.js';
 
 const plan = (command: string): AgentLaunchPlan => ({ command, args: ['--system-prompt', '/x'], env: { A: '1' } });
+
+const fakeChild = () => ({
+  signals: [] as string[],
+  killed: false,
+  kill(signal?: NodeJS.Signals) {
+    this.signals.push(signal ?? 'SIGTERM');
+    return true;
+  },
+});
 
 describe('agent launch', () => {
   it('passes non-pi launch plans through unchanged', () => {
@@ -37,5 +53,69 @@ describe('agent launch', () => {
     await expect(launchAgentProcess({ launch: async () => Promise.reject(other) }, plan('pi'), 'pi')).rejects.toThrow(
       'boom',
     );
+  });
+});
+
+// A resident agent that cannot be told to stop is SIGKILLed by its orchestrator when the grace
+// period expires, losing credential persistence and projection cleanup. Node forwards nothing by
+// default, so this is the only thing standing between the harness and that outcome — in containers
+// and equally at a terminal or in a cancelled CI job.
+describe('termination forwarding', () => {
+  it.each(['SIGTERM', 'SIGINT', 'SIGHUP'] as const)('forwards %s to the harness', (signal) => {
+    const child = fakeChild();
+    const emitter = new EventEmitter();
+    const detach = attachSignalForwarding(child, emitter);
+
+    emitter.emit(signal);
+
+    expect(child.signals).toEqual([signal]);
+    detach();
+  });
+
+  it('escalates to SIGKILL when the harness ignores the signal', () => {
+    vi.useFakeTimers();
+    try {
+      const child = fakeChild();
+      const emitter = new EventEmitter();
+      const detach = attachSignalForwarding(child, emitter, 50);
+
+      emitter.emit('SIGTERM');
+      expect(child.signals).toEqual(['SIGTERM']);
+
+      vi.advanceTimersByTime(50);
+      expect(child.signals).toEqual(['SIGTERM', 'SIGKILL']);
+      detach();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not signal a harness that already exited', () => {
+    const child = { ...fakeChild(), killed: true };
+    const emitter = new EventEmitter();
+    const detach = attachSignalForwarding(child, emitter);
+
+    emitter.emit('SIGTERM');
+
+    expect(child.signals).toEqual([]);
+    detach();
+  });
+
+  // Installing a handler suppresses Node's default termination, so a leaked listener would keep a
+  // later run alive and silently accumulate across launches in one process.
+  it('removes its listeners on detach', () => {
+    const child = fakeChild();
+    const emitter = new EventEmitter();
+
+    const detach = attachSignalForwarding(child, emitter);
+    expect(emitter.listenerCount('SIGTERM')).toBe(1);
+
+    detach();
+    expect(emitter.listenerCount('SIGTERM')).toBe(0);
+    expect(emitter.listenerCount('SIGINT')).toBe(0);
+    expect(emitter.listenerCount('SIGHUP')).toBe(0);
+
+    emitter.emit('SIGTERM');
+    expect(child.signals).toEqual([]);
   });
 });

--- a/docs/architecture/file_structure.md
+++ b/docs/architecture/file_structure.md
@@ -21,7 +21,7 @@ Outfitter is organized around a private npm workspace root, clear TypeScript pac
 │   └── skills/outfitter/              # bundled self-documentation skill published into launches
 ├── docs/                              # documentation, architecture, requirements, plans, and specs
 │   ├── architecture/                  # architecture and internal design docs
-│   ├── documentation/                 # user-facing Outfitter docs
+│   ├── documentation/                 # user-facing Outfitter docs, including the container runtime contract
 │   ├── requirements/                  # formal OUTFITTER requirement documents
 │   └── specs/                         # detailed supporting specs
 ├── .prettierignore                    # Prettier ignore rules

--- a/docs/documentation/README.md
+++ b/docs/documentation/README.md
@@ -33,6 +33,7 @@ Outfitter lays out conventions for iterating on and sharing agent configuration 
 The same composition runs on every surface; only the trigger changes.
 
 - [Running an agent in GitHub Actions](./actions.md) — headless runs on any workflow trigger.
+- [Container images](./containers.md) — run the published image persistently or add Nix-packaged tools.
 - [Recurring runs](./recurring-runs.md) — loops three ways: the local loop extension, Actions cron, cluster schedules.
 - [In-cluster agents](./in-cluster.md) — resident agents, CronJobs, and subagent Jobs via Link Operator.
 - [Hooks](./hooks.md) — harness hook wiring and the protocol gap.

--- a/docs/documentation/containers.md
+++ b/docs/documentation/containers.md
@@ -1,0 +1,118 @@
+# Container images
+
+The published image is a generic Outfitter runtime:
+
+```text
+ghcr.io/ai-outfitter/outfitter:<version>
+```
+
+It uses `outfitter` as its entrypoint and includes the Nix CLI, Bash, core
+utilities, Git, SSH, and CA certificates. It does not include agent profiles,
+credentials, channels, MCP servers, or other use-case behavior. The default
+runtime user and group are both `1000`, with `/tmp` as the home directory.
+
+## Run a resident agent
+
+A resident container is an ordinary `outfitter run` whose harness stays in RPC
+mode. Keep standard input open so the harness remains available while its
+extensions wait for work:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: example-agent
+  template:
+    metadata:
+      labels:
+        app: example-agent
+    spec:
+      containers:
+        - name: agent
+          image: ghcr.io/ai-outfitter/outfitter:<version>
+          stdin: true
+          workingDir: /workspace
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+          env:
+            - name: HOME
+              value: /workspace
+          args:
+            - run
+            - example-agent
+            - --strict
+            - --
+            - --mode
+            - rpc
+            - --no-session
+          volumeMounts:
+            - name: workspace
+              mountPath: /workspace
+      volumes:
+        - name: workspace
+          persistentVolumeClaim:
+            claimName: example-agent
+```
+
+Mount `.agents` settings, credentials, and any channel configuration through
+the workload that owns the container. The image does not interpret Kubernetes
+resources or impose image, profile, or extension policy.
+
+## Build a derivative image
+
+Being built with Nix does not normally imply that an image contains the Nix
+CLI. The published Outfitter image includes it intentionally, and the flake also
+exports `lib.mkContainer` for reproducible derivative images:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    outfitter = {
+      url = "github:ai-outfitter/outfitter/v1.2.0";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    { nixpkgs, outfitter, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+    in
+    {
+      packages.${system}.default = outfitter.lib.mkContainer {
+        inherit pkgs;
+        outfitterPackage = outfitter.packages.${system}.outfitter;
+        name = "example-agent";
+        extraPackages = [
+          pkgs.jq
+          pkgs.ripgrep
+        ];
+      };
+    };
+}
+```
+
+Build and exercise the exact image:
+
+```sh
+nix build
+docker load < result
+docker run --rm example-agent:latest --version
+docker run --rm --entrypoint /bin/sh example-agent:latest \
+  -c 'nix --version && jq --version && rg --version'
+```
+
+The caller owns writable Nix state. If the container must install packages at
+runtime, mount and initialize a writable `/nix` store and state directory
+appropriate to its user and orchestration environment. Prefer adding known
+runtime packages through `extraPackages` so the resulting image stays
+reproducible.

--- a/docs/documentation/containers.md
+++ b/docs/documentation/containers.md
@@ -122,7 +122,7 @@ docker run --rm --entrypoint /bin/sh example-agent:latest \
 Prefer adding known runtime packages through `extraPackages`. The resulting
 image stays reproducible, and it avoids the trap below.
 
-**Do not mount an empty volume over `/nix`.** The image *is* its Nix store: the
+**Do not mount an empty volume over `/nix`.** The image _is_ its Nix store: the
 entrypoint is an absolute store path and every binary in `/bin` is a symlink
 into `/nix/store`. Mounting a fresh volume there hides all of it, so the
 container cannot start — it fails before it could initialize the very store you

--- a/docs/documentation/containers.md
+++ b/docs/documentation/containers.md
@@ -32,6 +32,14 @@ spec:
       labels:
         app: example-agent
     spec:
+      securityContext:
+        # Pod-level, and not optional. HOME points at the mounted volume, and a
+        # freshly provisioned volume arrives owned by root — runAsUser does not
+        # change that. Extension installs and credential persistence both write
+        # below HOME, so without fsGroup the agent fails with EACCES on first
+        # write rather than at startup. A volume plugin that ignores fsGroup
+        # must be pre-provisioned with UID/GID 1000 ownership instead.
+        fsGroup: 1000
       containers:
         - name: agent
           image: ghcr.io/ai-outfitter/outfitter:<version>
@@ -111,8 +119,20 @@ docker run --rm --entrypoint /bin/sh example-agent:latest \
   -c 'nix --version && jq --version && rg --version'
 ```
 
-The caller owns writable Nix state. If the container must install packages at
-runtime, mount and initialize a writable `/nix` store and state directory
-appropriate to its user and orchestration environment. Prefer adding known
-runtime packages through `extraPackages` so the resulting image stays
-reproducible.
+Prefer adding known runtime packages through `extraPackages`. The resulting
+image stays reproducible, and it avoids the trap below.
+
+**Do not mount an empty volume over `/nix`.** The image *is* its Nix store: the
+entrypoint is an absolute store path and every binary in `/bin` is a symlink
+into `/nix/store`. Mounting a fresh volume there hides all of it, so the
+container cannot start — it fails before it could initialize the very store you
+mounted the volume to populate.
+
+Runtime installation therefore needs one of:
+
+- a volume **pre-populated** with the image's closure, seeded from the image
+  before the agent starts (an init container copying `/nix` into the volume);
+- an **overlay** whose lower layer is the image's `/nix`, so the closure stays
+  visible while writes land in the upper layer; or
+- writable Nix **state** only — `/nix/var` and a per-user profile — leaving the
+  store itself as the image shipped it.

--- a/docs/requirements/OFTR-009-release-publishing.md
+++ b/docs/requirements/OFTR-009-release-publishing.md
@@ -39,3 +39,7 @@ Outfitter release publishing prepares package metadata from Conventional Commit 
 1. The flake MUST expose the release container as the `container` package output.
 2. The container MUST use the Nix-built Outfitter package directly as its entrypoint.
 3. The release workflow MUST smoke test the image before publishing it.
+4. The published container MUST include the Nix CLI, a shell, core utilities, Git, SSH, and CA certificates so it can serve as a resident-agent base image.
+5. The flake MUST expose a container builder that accepts caller-selected runtime packages without rebuilding Outfitter through another package manager.
+6. The release workflow MUST smoke test Outfitter, Nix, and the conventional shell and environment executable paths.
+7. Documentation MUST define the persistent Kubernetes invocation and explain that callers own writable Nix state, profile configuration, credentials, and channel-specific extensions.

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,13 @@
             name = "${name}-container-runtime";
             paths = [
               outfitterPackage
+              # PID 1 must reap and forward signals. Outfitter does neither:
+              # spawnLauncher spawns the harness and waits on close, and nothing
+              # in the CLI installs a SIGTERM or SIGINT handler. As PID 1 under
+              # Kubernetes that means termination never reaches the harness, so
+              # a resident agent is SIGKILLed at the end of the grace period
+              # without persisting credentials or cleaning up its projection.
+              pkgs.tini
               pkgs.nix
               pkgs.bashInteractive
               pkgs.coreutils
@@ -64,7 +71,17 @@
             chmod 1777 tmp workspace
           '';
           config = {
-            Entrypoint = [ "${outfitterPackage}/bin/outfitter" ];
+            # `-g` forwards signals to the whole process group, not just the
+            # direct child, so the harness Outfitter spawned also receives
+            # SIGTERM. Argument handling is unchanged: everything after `--`
+            # still reaches `outfitter`, so `args: [run, <agent>, --strict]`
+            # works exactly as documented.
+            Entrypoint = [
+              "${pkgs.tini}/bin/tini"
+              "-g"
+              "--"
+              "${outfitterPackage}/bin/outfitter"
+            ];
             Env = [
               "HOME=/tmp"
               "PATH=/bin:/usr/bin"

--- a/flake.nix
+++ b/flake.nix
@@ -49,8 +49,18 @@
           contents = [ runtime ];
           extraCommands = ''
             mkdir -p etc tmp workspace
-            printf 'outfitter:x:1000:1000:Outfitter:/tmp:/bin/bash\n' > etc/passwd
-            printf 'outfitter:x:1000:\n' > etc/group
+            # root must exist even though nothing here runs as root. A derived
+            # image does `USER root` to COPY and chmod its own entrypoint, and
+            # the builder resolves that name against this passwd file — without
+            # an entry, every downstream RUN fails with "unknown user error
+            # looking up user root" before the layer even executes, which makes
+            # the image unusable as the base this exists to be.
+            printf 'root:x:0:0:root:/root:/bin/bash\n' > etc/passwd
+            printf 'outfitter:x:1000:1000:Outfitter:/tmp:/bin/bash\n' >> etc/passwd
+            printf 'nobody:x:65534:65534:nobody:/var/empty:/bin/false\n' >> etc/passwd
+            printf 'root:x:0:\n' > etc/group
+            printf 'outfitter:x:1000:\n' >> etc/group
+            printf 'nogroup:x:65534:\n' >> etc/group
             chmod 1777 tmp workspace
           '';
           config = {

--- a/flake.nix
+++ b/flake.nix
@@ -12,8 +12,62 @@
         "x86_64-linux"
       ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      mkContainer =
+        {
+          pkgs,
+          outfitterPackage,
+          extraPackages ? [ ],
+          name ? "outfitter",
+          tag ? "latest",
+        }:
+        let
+          runtime = pkgs.buildEnv {
+            name = "${name}-container-runtime";
+            paths = [
+              outfitterPackage
+              pkgs.nix
+              pkgs.bashInteractive
+              pkgs.coreutils
+              pkgs.gnutar
+              pkgs.gzip
+              pkgs.cacert
+              pkgs.gitMinimal
+              pkgs.openssh
+              pkgs.dockerTools.binSh
+              pkgs.dockerTools.usrBinEnv
+            ] ++ extraPackages;
+            pathsToLink = [
+              "/bin"
+              "/etc"
+              "/usr/bin"
+            ];
+            ignoreCollisions = true;
+          };
+        in
+        pkgs.dockerTools.buildLayeredImage {
+          inherit name tag;
+          contents = [ runtime ];
+          extraCommands = ''
+            mkdir -p etc tmp workspace
+            printf 'outfitter:x:1000:1000:Outfitter:/tmp:/bin/bash\n' > etc/passwd
+            printf 'outfitter:x:1000:\n' > etc/group
+            chmod 1777 tmp workspace
+          '';
+          config = {
+            Entrypoint = [ "${outfitterPackage}/bin/outfitter" ];
+            Env = [
+              "HOME=/tmp"
+              "PATH=/bin:/usr/bin"
+              "NIX_CONFIG=experimental-features = nix-command flakes"
+            ];
+            User = "1000:1000";
+            WorkingDir = "/workspace";
+          };
+        };
     in
     {
+      lib = { inherit mkContainer; };
+
       packages = forAllSystems (
         system:
         let
@@ -104,19 +158,9 @@
 
           default = outfitter;
 
-          container = pkgs.dockerTools.buildLayeredImage {
-            name = "outfitter";
-            tag = "latest";
-            contents = [ outfitter ];
-            extraCommands = ''
-              mkdir -p tmp workspace
-              chmod 1777 tmp workspace
-            '';
-            config = {
-              Entrypoint = [ "${outfitter}/bin/outfitter" ];
-              Env = [ "HOME=/tmp" ];
-              WorkingDir = "/workspace";
-            };
+          container = mkContainer {
+            inherit pkgs;
+            outfitterPackage = outfitter;
           };
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -25,13 +25,6 @@
             name = "${name}-container-runtime";
             paths = [
               outfitterPackage
-              # PID 1 must reap and forward signals. Outfitter does neither:
-              # spawnLauncher spawns the harness and waits on close, and nothing
-              # in the CLI installs a SIGTERM or SIGINT handler. As PID 1 under
-              # Kubernetes that means termination never reaches the harness, so
-              # a resident agent is SIGKILLed at the end of the grace period
-              # without persisting credentials or cleaning up its projection.
-              pkgs.tini
               pkgs.nix
               pkgs.bashInteractive
               pkgs.coreutils
@@ -71,17 +64,7 @@
             chmod 1777 tmp workspace
           '';
           config = {
-            # `-g` forwards signals to the whole process group, not just the
-            # direct child, so the harness Outfitter spawned also receives
-            # SIGTERM. Argument handling is unchanged: everything after `--`
-            # still reaches `outfitter`, so `args: [run, <agent>, --strict]`
-            # works exactly as documented.
-            Entrypoint = [
-              "${pkgs.tini}/bin/tini"
-              "-g"
-              "--"
-              "${outfitterPackage}/bin/outfitter"
-            ];
+            Entrypoint = [ "${outfitterPackage}/bin/outfitter" ];
             Env = [
               "HOME=/tmp"
               "PATH=/bin:/usr/bin"


### PR DESCRIPTION
## Summary

- make the published image a channel-agnostic resident-agent base with Nix, Bash, core utilities, Git, SSH, and CA certificates
- export `lib.mkContainer` so users can reproducibly add their own Nix packages without Link Operator publishing a custom agent image
- run as a resolvable non-root UID/GID 1000 and document the Kubernetes, profile, credential, extension, and writable-Nix-state boundaries
- extend the release smoke test to cover Nix and conventional shell paths

This is the first usable vertical slice of #234. Dynamic profile hot reload remains follow-up work because the current runtime does not expose a clean reload hook.

## Validation

- `npm run check-ci` (Prettier, ESLint, 294 tests, and coverage passed; the docs build was rerun outside the filesystem sandbox because Turbopack binds an internal local port)
- `nix flake check --no-build`
- built `.#container` with the official Nix image
- loaded the result into Docker and verified the default non-root user, `nix --version`, Bash, `/usr/bin/env`, Git, SSH, and `outfitter --version`
