### PR TITLE
feat(cli): add supervised runtime contract

### DIFF
--- a/code/cli/src/agents/AgentLaunch.ts
+++ b/code/cli/src/agents/AgentLaunch.ts
@@ -1,13 +1,30 @@
 // Turns a logical agent launch plan into an actual launched process: resolves the bundled pi
 // binary, runs the launcher, and translates a missing agent CLI into actionable install guidance.
 import { existsSync, readFileSync } from 'node:fs';
+import { constants } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import type { AgentLaunchPlan } from '../projection/Projection.js';
 
+export interface AgentSpawnOptions {
+  readonly stdio: 'inherit';
+  readonly env: NodeJS.ProcessEnv;
+  readonly detached: boolean;
+}
+
+export const createAgentSpawnOptions = (plan: AgentLaunchPlan): AgentSpawnOptions => ({
+  stdio: 'inherit',
+  env: { ...process.env, ...plan.env },
+  detached: process.platform !== 'win32',
+});
+
+export type AgentProcessResult =
+  | { readonly status: 'exited'; readonly exitCode: number }
+  | { readonly status: 'signaled'; readonly signal: NodeJS.Signals; readonly exitCode: number };
+
 export interface AgentProcessLauncher {
-  launch(plan: AgentLaunchPlan): Promise<number>;
+  launch(plan: AgentLaunchPlan): Promise<AgentProcessResult>;
 }
 
 export const launchAgentProcess = async (
@@ -16,7 +33,7 @@ export const launchAgentProcess = async (
   agentId: string,
 ): Promise<number> => {
   try {
-    return await launcher.launch(launchPlan);
+    return (await launcher.launch(launchPlan)).exitCode;
   } catch (error) {
     if (isCommandNotFoundError(error)) {
       throw new Error(formatMissingAgentCliMessage(agentId, launchPlan.command), { cause: error });
@@ -24,6 +41,92 @@ export const launchAgentProcess = async (
 
     throw error;
   }
+};
+
+export const signalExitCode = (signal: NodeJS.Signals): number => 128 + constants.signals[signal];
+
+export interface SpawnedAgentProcess {
+  readonly pid?: number;
+  once(event: 'error', listener: (error: Error) => void): this;
+  once(event: 'close', listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
+  kill(signal?: NodeJS.Signals): boolean;
+}
+
+export interface TerminationSignalSource {
+  on(signal: 'SIGINT' | 'SIGTERM', listener: (signal: NodeJS.Signals) => void): this;
+  off(signal: 'SIGINT' | 'SIGTERM', listener: (signal: NodeJS.Signals) => void): this;
+}
+
+export interface SpawnWaitDependencies {
+  readonly signalSource?: TerminationSignalSource;
+  readonly forwardSignal?: (child: SpawnedAgentProcess, signal: 'SIGINT' | 'SIGTERM') => void;
+}
+
+/* v8 ignore start -- real OS process-group signalling is exercised by smoke usage, not unit tests. */
+const defaultForwardSignal = (child: SpawnedAgentProcess, signal: 'SIGINT' | 'SIGTERM'): void => {
+  if (process.platform === 'win32' || child.pid === undefined) {
+    child.kill(signal);
+    return;
+  }
+
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    // A platform may reject process-group signalling even though the child is still addressable.
+    child.kill(signal);
+  }
+};
+/* v8 ignore stop */
+
+/**
+ * Waits for one foreground harness process, forwarding the first parent termination signal to the
+ * whole child process group. Listeners exist only for the lifetime of this child.
+ */
+export const waitForSpawnedAgentProcess = (
+  child: SpawnedAgentProcess,
+  dependencies: SpawnWaitDependencies = {},
+): Promise<AgentProcessResult> => {
+  const signalSource = dependencies.signalSource ?? process;
+  const forwardSignal = dependencies.forwardSignal ?? defaultForwardSignal;
+
+  return new Promise<AgentProcessResult>((resolve, reject) => {
+    let forwardedSignal: 'SIGINT' | 'SIGTERM' | undefined;
+    let settled = false;
+
+    const cleanup = (): void => {
+      signalSource.off('SIGINT', onSignal);
+      signalSource.off('SIGTERM', onSignal);
+    };
+    const settle = (result: AgentProcessResult): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(result);
+    };
+    const fail = (error: Error): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    function onSignal(signal: NodeJS.Signals): void {
+      if (forwardedSignal !== undefined || (signal !== 'SIGINT' && signal !== 'SIGTERM')) return;
+      forwardedSignal = signal;
+      forwardSignal(child, signal);
+    }
+
+    signalSource.on('SIGINT', onSignal);
+    signalSource.on('SIGTERM', onSignal);
+    child.once('error', fail);
+    child.once('close', (code, childSignal) => {
+      const signal = childSignal ?? forwardedSignal;
+      settle(
+        signal === undefined
+          ? { status: 'exited', exitCode: code ?? 0 }
+          : { status: 'signaled', signal, exitCode: signalExitCode(signal) },
+      );
+    });
+  });
 };
 
 // Pi is bundled with Outfitter, so prefer the bundled binary launched through the current Node
@@ -57,13 +160,10 @@ export const resolveAgentLaunchExecutable = (launchPlan: AgentLaunchPlan): Agent
 
 /* v8 ignore start -- real process spawn is covered by end-to-end smoke usage, not unit tests. */
 export const spawnLauncher: AgentProcessLauncher = {
-  async launch(plan: AgentLaunchPlan): Promise<number> {
+  async launch(plan: AgentLaunchPlan): Promise<AgentProcessResult> {
     const { default: spawn } = await import('cross-spawn');
-    return await new Promise<number>((resolve, reject) => {
-      const child = spawn(plan.command, [...plan.args], { stdio: 'inherit', env: { ...process.env, ...plan.env } });
-      child.on('error', reject); // ENOENT surfaces as an actionable install message
-      child.on('close', (code, signal) => resolve(code ?? (signal ? 1 : 0)));
-    });
+    const child = spawn(plan.command, [...plan.args], createAgentSpawnOptions(plan));
+    return await waitForSpawnedAgentProcess(child);
   },
 };
 /* v8 ignore stop */

--- a/code/cli/src/cli/commands/DumpCommand.ts
+++ b/code/cli/src/cli/commands/DumpCommand.ts
@@ -1,6 +1,6 @@
 // Provides `outfitter dump --agent <id> --out <dir>` over the effective resource set.
 
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 
 import { dumpAgent } from '../../dump/Dump.js';
 import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
@@ -11,6 +11,7 @@ import { resolveHomeDirectory, resolveProjectDirectory } from './ProcessDefaults
 export interface DumpInput {
   readonly homeDirectory: string;
   readonly projectDirectory: string;
+  readonly runtimeLayers?: readonly string[];
   readonly agent?: string;
   readonly out: string;
 }
@@ -70,12 +71,21 @@ export const createDumpCommand = (dependencies: DumpCommandDependencies = {}): C
       new Command('dump')
         .description('Write the composed .agents tree for an agent to a directory.')
         .option('--agent <id>', 'Agent slug to dump (default: settings default_agent).')
+        .addOption(
+          new Option(
+            '--runtime-layer <path>',
+            'Invocation-only .agents payload root (repeatable; earlier layers take precedence).',
+          )
+            .argParser((path: string, previous: readonly string[]): readonly string[] => [...previous, path])
+            .default([]),
+        )
         .option('--out <dir>', 'Output directory.', './outfitter-dump')
-        .action((options: { agent?: string; out: string }) => {
+        .action((options: { agent?: string; runtimeLayer: readonly string[]; out: string }) => {
           const result = executeDumpCommand({
             /* v8 ignore next 2 -- process defaults are exercised by the CLI entrypoint, not unit tests. */
             homeDirectory: resolveHomeDirectory(dependencies.homeDirectory),
             projectDirectory: resolveProjectDirectory(dependencies.projectDirectory),
+            runtimeLayers: options.runtimeLayer,
             agent: options.agent,
             out: options.out,
           });

--- a/code/cli/src/cli/commands/ListCommand.ts
+++ b/code/cli/src/cli/commands/ListCommand.ts
@@ -1,6 +1,6 @@
 // Provides `outfitter list [kind]` over the effective resource set.
 
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 
 import type { ResourceKind } from '../../resolver/Resource.js';
 import {
@@ -21,6 +21,7 @@ export interface ListInput {
   readonly projectDirectory: string;
   readonly kind?: string;
   readonly agent?: string;
+  readonly runtimeLayers?: readonly string[];
 }
 
 export interface ListResult {
@@ -112,13 +113,22 @@ export const createListCommand = (dependencies: ListCommandDependencies = {}): C
           '--agent <id>',
           'Resolve resources in an agent context, including its agent-local skills/knowledge/commands.',
         )
-        .action((kind: string | undefined, options: { agent?: string }) => {
+        .addOption(
+          new Option(
+            '--runtime-layer <path>',
+            'Invocation-only .agents payload root (repeatable; earlier layers take precedence).',
+          )
+            .argParser((path: string, previous: readonly string[]): readonly string[] => [...previous, path])
+            .default([]),
+        )
+        .action((kind: string | undefined, options: { agent?: string; runtimeLayer: readonly string[] }) => {
           const result = executeListCommand({
             /* v8 ignore next 2 -- process defaults are exercised by the CLI entrypoint, not unit tests. */
             homeDirectory: resolveHomeDirectory(dependencies.homeDirectory),
             projectDirectory: resolveProjectDirectory(dependencies.projectDirectory),
             kind,
             agent: options.agent,
+            runtimeLayers: options.runtimeLayer,
           });
 
           for (const message of result.messages) {

--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -43,6 +43,7 @@ export type SetupRunner = (input: {
 export interface RunAgentInput {
   readonly homeDirectory: string;
   readonly projectDirectory: string;
+  readonly runtimeLayers?: readonly string[];
   readonly agent?: string;
   readonly harness?: string;
   readonly strict?: boolean;
@@ -240,6 +241,8 @@ export { launchThroughSpawn } from '../../agents/AgentLaunch.js';
 /* v8 ignore next -- wiring to the real spawn boundary; launchThroughSpawn itself is unit-tested. */
 const defaultLauncher: AgentProcessLauncher = (plan) => launchThroughSpawn(spawnLauncher, plan);
 
+const collectRuntimeLayer = (path: string, previous: readonly string[]): readonly string[] => [...previous, path];
+
 export const createRunAgentCommand = (dependencies: RunAgentDependencies = {}): CommandObject => ({
   name: 'run',
   description: 'Resolve, compose, and launch an agent in the selected harness.',
@@ -250,13 +253,21 @@ export const createRunAgentCommand = (dependencies: RunAgentDependencies = {}): 
       .argument('[agent]', 'Agent slug to run (default: settings default_agent).')
       .argument('[args...]', 'Arguments passed through to the harness after --.')
       .addOption(new Option('--harness <harness>', 'Harness to launch.').choices([...HARNESSES]))
+      .addOption(
+        new Option(
+          '--runtime-layer <path>',
+          'Invocation-only .agents payload root (repeatable; earlier layers take precedence).',
+        )
+          .argParser(collectRuntimeLayer)
+          .default([]),
+      )
       .option('--strict', 'Treat composition warnings and unsupported loadout elements as fatal.')
       .allowUnknownOption(true)
       .action(
         async (
           agent: string | undefined,
           passThroughArgs: readonly string[],
-          options: { harness?: string; strict?: boolean },
+          options: { harness?: string; runtimeLayer: readonly string[]; strict?: boolean },
         ) => {
           /* v8 ignore next 3 -- process/launcher defaults are exercised by the CLI entrypoint, not unit tests. */
           const homeDirectory = resolveHomeDirectory(dependencies.homeDirectory);
@@ -265,6 +276,7 @@ export const createRunAgentCommand = (dependencies: RunAgentDependencies = {}): 
           const result = await executeRunAgentCommand({
             homeDirectory,
             projectDirectory,
+            runtimeLayers: options.runtimeLayer,
             agent,
             harness: options.harness,
             strict: options.strict,

--- a/code/cli/src/cli/commands/ValidateCommand.ts
+++ b/code/cli/src/cli/commands/ValidateCommand.ts
@@ -1,6 +1,6 @@
 // Provides `outfitter validate [--strict] [--json]` over the effective resource set.
 
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 
 import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
 import type { ValidationFinding } from '../../resolver/ResolverValidation.js';
@@ -12,6 +12,7 @@ import { resolveHomeDirectory, resolveProjectDirectory } from './ProcessDefaults
 export interface ValidateInput {
   readonly homeDirectory: string;
   readonly projectDirectory: string;
+  readonly runtimeLayers?: readonly string[];
   readonly strict?: boolean;
   readonly json?: boolean;
 }
@@ -67,15 +68,24 @@ export const createValidateCommand = (dependencies: ValidateCommandDependencies 
     program.addCommand(
       new Command('validate')
         .description('Validate the resolved .agents tree: schemas, loadout slugs, and shadowing.')
+        .addOption(
+          new Option(
+            '--runtime-layer <path>',
+            'Invocation-only .agents payload root (repeatable; earlier layers take precedence).',
+          )
+            .argParser((path: string, previous: readonly string[]): readonly string[] => [...previous, path])
+            .default([]),
+        )
         .option('--strict', 'Treat warnings (such as shadowed definitions) as failures.')
         .option('--json', 'Emit findings as JSON.')
-        .action((options: { strict?: boolean; json?: boolean }) => {
+        .action((options: { runtimeLayer: readonly string[]; strict?: boolean; json?: boolean }) => {
           /* v8 ignore next 2 -- process defaults are exercised by the CLI entrypoint, not unit tests. */
           const homeDirectory = resolveHomeDirectory(dependencies.homeDirectory);
           const projectDirectory = resolveProjectDirectory(dependencies.projectDirectory);
           const result = executeValidateCommand({
             homeDirectory,
             projectDirectory,
+            runtimeLayers: options.runtimeLayer,
             strict: options.strict,
             json: options.json,
           });

--- a/code/cli/src/resolver/Layer.ts
+++ b/code/cli/src/resolver/Layer.ts
@@ -1,6 +1,6 @@
-// Builds the ordered `.agents` layer stack (workspace over global over remote sources) from settings.
-import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+// Builds the ordered `.agents` layer stack: runtime, workspace, global, then remote sources.
+import { existsSync, statSync } from 'node:fs';
+import { isAbsolute, join, resolve } from 'node:path';
 
 import {
   createRemoteRepositoryCachePath,
@@ -15,6 +15,8 @@ import type { Layer } from './Resource.js';
 export interface LayerDiscoveryInput {
   readonly homeDirectory: string;
   readonly projectDirectory: string;
+  /** Invocation-only `.agents` payload roots, highest precedence first. */
+  readonly runtimeLayers?: readonly string[];
   readonly settings: Settings;
 }
 
@@ -38,6 +40,20 @@ const sourceLayer = (input: LayerDiscoveryInput, source: SourceReference): Layer
       )
     : { root: source.path, origin: 'source', label: source.path };
 
+const runtimeLayer = (projectDirectory: string, path: string): Layer => {
+  const root = isAbsolute(path) ? path : resolve(projectDirectory, path);
+
+  if (!existsSync(root)) {
+    throw new Error(`Runtime layer '${path}' does not exist at '${root}'.`);
+  }
+
+  if (!statSync(root).isDirectory()) {
+    throw new Error(`Runtime layer '${path}' is not a directory.`);
+  }
+
+  return { root, origin: 'runtime', label: path };
+};
+
 export interface LayerDiscoveryResult {
   readonly layers: readonly Layer[];
   /**
@@ -50,11 +66,13 @@ export interface LayerDiscoveryResult {
 }
 
 /**
- * Orders layers highest precedence first: workspace `.agents`, then global `~/.agents`,
- * then configured sources in order. Only layers whose root exists on disk are included.
+ * Orders layers highest precedence first: invocation-only runtime layers in CLI order, workspace
+ * `.agents`, global `~/.agents`, then configured sources in order. Only discovered layers whose
+ * root exists on disk are included; an explicitly requested runtime layer must exist.
  */
 export const discoverLayers = (input: LayerDiscoveryInput): LayerDiscoveryResult => {
   const candidates: Layer[] = [
+    ...(input.runtimeLayers ?? []).map((path) => runtimeLayer(input.projectDirectory, path)),
     { root: agentsRoot(input.projectDirectory), origin: 'workspace', label: 'workspace' },
     { root: agentsRoot(input.homeDirectory), origin: 'global', label: 'global' },
   ];

--- a/code/cli/src/resolver/ResolverContext.ts
+++ b/code/cli/src/resolver/ResolverContext.ts
@@ -9,6 +9,8 @@ import { resolveResources } from './Resolver.js';
 export interface ResolveInput {
   readonly homeDirectory: string;
   readonly projectDirectory: string;
+  /** Invocation-only `.agents` payload roots, highest precedence first. */
+  readonly runtimeLayers?: readonly string[];
 }
 
 export interface ResolveResult {

--- a/code/cli/src/resolver/Resource.ts
+++ b/code/cli/src/resolver/Resource.ts
@@ -14,7 +14,7 @@ export const resourceKinds: readonly ResourceKind[] = ['agent', 'skill', 'knowle
 export const agentLocalKinds: readonly ResourceKind[] = ['skill', 'knowledge', 'command'];
 
 /** Where a layer originates, highest precedence first. */
-export type LayerOrigin = 'workspace' | 'global' | 'source';
+export type LayerOrigin = 'runtime' | 'workspace' | 'global' | 'source';
 
 export interface Layer {
   /** Absolute path to the `.agents` payload root for this layer. */

--- a/code/cli/tests/unit/agent-launch.test.ts
+++ b/code/cli/tests/unit/agent-launch.test.ts
@@ -1,12 +1,30 @@
 // Tests the launch boundary: bundled-pi resolution, process launch, and missing-CLI guidance.
-import { describe, expect, it } from 'vitest';
+import { EventEmitter } from 'node:events';
 
-import { launchAgentProcess, resolveAgentLaunchExecutable } from '../../src/agents/AgentLaunch.js';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createAgentSpawnOptions,
+  launchAgentProcess,
+  resolveAgentLaunchExecutable,
+  signalExitCode,
+  waitForSpawnedAgentProcess,
+} from '../../src/agents/AgentLaunch.js';
+import type { SpawnedAgentProcess, TerminationSignalSource } from '../../src/agents/AgentLaunch.js';
 import type { AgentLaunchPlan } from '../../src/projection/Projection.js';
 
 const plan = (command: string): AgentLaunchPlan => ({ command, args: ['--system-prompt', '/x'], env: { A: '1' } });
 
 describe('agent launch', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('inherits standard I/O and launches a dedicated process group where supported', () => {
+    const options = createAgentSpawnOptions(plan('pi'));
+    expect(options.stdio).toBe('inherit');
+    expect(options.env.A).toBe('1');
+    expect(options.detached).toBe(process.platform !== 'win32');
+  });
+
   it('passes non-pi launch plans through unchanged', () => {
     const claudePlan = plan('claude');
     expect(resolveAgentLaunchExecutable(claudePlan)).toBe(claudePlan);
@@ -21,7 +39,11 @@ describe('agent launch', () => {
   });
 
   it('returns the exit code from a successful launcher', async () => {
-    const exitCode = await launchAgentProcess({ launch: () => Promise.resolve(3) }, plan('pi'), 'pi');
+    const exitCode = await launchAgentProcess(
+      { launch: () => Promise.resolve({ status: 'exited', exitCode: 3 }) },
+      plan('pi'),
+      'pi',
+    );
     expect(exitCode).toBe(3);
   });
 
@@ -37,5 +59,85 @@ describe('agent launch', () => {
     await expect(launchAgentProcess({ launch: async () => Promise.reject(other) }, plan('pi'), 'pi')).rejects.toThrow(
       'boom',
     );
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('forwards the first termination signal once and removes listeners after child exit', async () => {
+    const signalSource = new EventEmitter();
+    const child = new EventEmitter() as EventEmitter & { pid: number; kill: ReturnType<typeof vi.fn> };
+    child.pid = 123;
+    child.kill = vi.fn(() => true);
+    const forwardSignal = vi.fn();
+
+    const resultPromise = waitForSpawnedAgentProcess(child as unknown as SpawnedAgentProcess, {
+      signalSource: signalSource as unknown as TerminationSignalSource,
+      forwardSignal,
+    });
+
+    expect(signalSource.listenerCount('SIGINT')).toBe(1);
+    expect(signalSource.listenerCount('SIGTERM')).toBe(1);
+    signalSource.emit('SIGTERM', 'SIGTERM');
+    signalSource.emit('SIGTERM', 'SIGTERM');
+    signalSource.emit('SIGINT', 'SIGINT');
+    expect(forwardSignal).toHaveBeenCalledTimes(1);
+    expect(forwardSignal).toHaveBeenCalledWith(child, 'SIGTERM');
+
+    child.emit('close', null, null);
+    await expect(resultPromise).resolves.toEqual({ status: 'signaled', signal: 'SIGTERM', exitCode: 143 });
+    expect(signalSource.listenerCount('SIGINT')).toBe(0);
+    expect(signalSource.listenerCount('SIGTERM')).toBe(0);
+  });
+
+  it('distinguishes normal, child-signalled, and spawn-error outcomes across sequential launches', async () => {
+    const signalSource = new EventEmitter() as unknown as TerminationSignalSource;
+    const first = new EventEmitter() as unknown as SpawnedAgentProcess;
+    const firstResult = waitForSpawnedAgentProcess(first, { signalSource, forwardSignal: vi.fn() });
+    (first as unknown as EventEmitter).emit('close', 7, null);
+    await expect(firstResult).resolves.toEqual({ status: 'exited', exitCode: 7 });
+
+    const second = new EventEmitter() as unknown as SpawnedAgentProcess;
+    const secondResult = waitForSpawnedAgentProcess(second, { signalSource, forwardSignal: vi.fn() });
+    (second as unknown as EventEmitter).emit('close', null, 'SIGINT');
+    await expect(secondResult).resolves.toEqual({ status: 'signaled', signal: 'SIGINT', exitCode: 130 });
+
+    const third = new EventEmitter() as unknown as SpawnedAgentProcess;
+    const thirdResult = waitForSpawnedAgentProcess(third, { signalSource, forwardSignal: vi.fn() });
+    (third as unknown as EventEmitter).emit('error', new Error('spawn failed'));
+    await expect(thirdResult).rejects.toThrow('spawn failed');
+
+    expect(signalExitCode('SIGINT')).toBe(130);
+    expect(signalExitCode('SIGTERM')).toBe(143);
+    expect((signalSource as unknown as EventEmitter).eventNames()).toEqual([]);
+  });
+
+  it('uses process defaults, maps a null close to zero, and ignores late duplicate terminal events', async () => {
+    const closed = new EventEmitter() as unknown as SpawnedAgentProcess;
+    const closedResult = waitForSpawnedAgentProcess(closed);
+    (closed as unknown as EventEmitter).emit('close', null, null);
+    (closed as unknown as EventEmitter).emit('error', new Error('late error'));
+    await expect(closedResult).resolves.toEqual({ status: 'exited', exitCode: 0 });
+
+    const failed = new EventEmitter() as unknown as SpawnedAgentProcess;
+    const failedResult = waitForSpawnedAgentProcess(failed);
+    (failed as unknown as EventEmitter).emit('error', new Error('first error'));
+    (failed as unknown as EventEmitter).emit('close', 0, null);
+    await expect(failedResult).rejects.toThrow('first error');
+  });
+
+  it('forwards a parent SIGINT as a conventional signalled outcome', async () => {
+    const signalSource = new EventEmitter();
+    const child = new EventEmitter() as unknown as SpawnedAgentProcess;
+    const forwardSignal = vi.fn();
+    const result = waitForSpawnedAgentProcess(child, {
+      signalSource: signalSource as unknown as TerminationSignalSource,
+      forwardSignal,
+    });
+
+    signalSource.emit('SIGINT', 'SIGINT');
+    (child as unknown as EventEmitter).emit('close', 0, null);
+
+    await expect(result).resolves.toEqual({ status: 'signaled', signal: 'SIGINT', exitCode: 130 });
+    expect(forwardSignal).toHaveBeenCalledWith(child, 'SIGINT');
   });
 });

--- a/code/cli/tests/unit/dump-cli.test.ts
+++ b/code/cli/tests/unit/dump-cli.test.ts
@@ -1,5 +1,5 @@
 // Exercises the dump command object through Commander and covers copy/closure branches.
-import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
@@ -44,6 +44,34 @@ const program = (root: string, lines: string[]): Command => {
 };
 
 describe('dump command object', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('dumps repeated invocation runtime layers in command-line precedence order', async () => {
+    const root = createTemporaryRoot();
+    const first = join(root, 'first');
+    const second = join(root, 'second');
+    write(join(first, 'agents', 'engineer', 'agent.md'), '---\nname: engineer\n---\n\nFirst runtime.\n');
+    write(join(second, 'agents', 'engineer', 'agent.md'), '---\nname: engineer\n---\n\nSecond runtime.\n');
+    const out = join(createTemporaryRoot(), 'out');
+
+    await program(root, []).parseAsync([
+      'node',
+      'outfitter',
+      'dump',
+      '--agent',
+      'engineer',
+      '--runtime-layer',
+      first,
+      '--runtime-layer',
+      second,
+      '--out',
+      out,
+    ]);
+
+    expect(existsSync(join(root, 'project', '.agents', 'settings.yml'))).toBe(false);
+    expect(readFileSync(join(out, '.agents', 'agents', 'engineer', 'agent.md'), 'utf8')).toContain('First runtime');
+  });
+
   it('dumps via parseAsync using default_agent, copying nested files and skipping inner symlinks', async () => {
     const root = createTemporaryRoot();
     const project = join(root, 'project');

--- a/code/cli/tests/unit/pi-credential-persistence.test.ts
+++ b/code/cli/tests/unit/pi-credential-persistence.test.ts
@@ -84,4 +84,46 @@ describe('run agent credential write-back', () => {
       '{"anthropic":"logged-in"}',
     );
   });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('persists credentials and removes the projection only after a cancelled child terminates', async () => {
+    const base = root();
+    const home = join(base, 'home');
+    const project = join(base, 'project');
+    write(join(project, '.agents', 'agents', 'engineer', 'agent.md'), '---\nname: engineer\n---\n\nBody.\n');
+    let projection = '';
+    let releaseChild!: (exitCode: number) => void;
+    let markLaunched!: () => void;
+    const childExit = new Promise<number>((resolve) => {
+      releaseChild = resolve;
+    });
+    const launched = new Promise<void>((resolve) => {
+      markLaunched = resolve;
+    });
+
+    const running = executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      agent: 'engineer',
+      harness: 'pi',
+      launcher: (plan) => {
+        projection = plan.env.PI_CODING_AGENT_DIR ?? '';
+        writeFileSync(join(projection, 'auth.json'), '{"anthropic":"cancelled-session"}');
+        markLaunched();
+        return childExit;
+      },
+    });
+
+    await launched;
+    expect(existsSync(join(resolvePiUserAgentDirectory(home), 'auth.json'))).toBe(false);
+    expect(existsSync(projection)).toBe(true);
+
+    releaseChild(143);
+    await expect(running).resolves.toMatchObject({ exitCode: 143 });
+    expect(readFileSync(join(resolvePiUserAgentDirectory(home), 'auth.json'), 'utf8')).toBe(
+      '{"anthropic":"cancelled-session"}',
+    );
+    expect(existsSync(projection)).toBe(false);
+  });
 });

--- a/code/cli/tests/unit/resolver-cli.test.ts
+++ b/code/cli/tests/unit/resolver-cli.test.ts
@@ -60,6 +60,21 @@ const buildProgram = (root: string, lines: string[]): Command => {
 };
 
 describe('resolver command objects', () => {
+  it('accepts the same runtime layer input for list and validate', async () => {
+    const root = createTemporaryRoot();
+    const runtime = join(root, 'runtime');
+    write(join(runtime, 'agents', 'runtime-agent', 'agent.md'), '---\nname: runtime-agent\n---\n\nBody.\n');
+    const lines: string[] = [];
+    const cli = buildProgram(root, lines);
+
+    await cli.parseAsync(['node', 'outfitter', 'list', 'agents', '--runtime-layer', runtime]);
+    expect(lines.join('\n')).toContain('runtime-agent  [' + runtime + ']');
+
+    lines.length = 0;
+    await cli.parseAsync(['node', 'outfitter', 'validate', '--runtime-layer', runtime]);
+    expect(lines).toContain('✓ No issues found.');
+  });
+
   it('list forwards the positional kind and writes through the injected writer', async () => {
     const lines: string[] = [];
     await buildProgram(project(), lines).parseAsync(['node', 'outfitter', 'list', 'agents']);

--- a/code/cli/tests/unit/run-agent.test.ts
+++ b/code/cli/tests/unit/run-agent.test.ts
@@ -551,7 +551,7 @@ describe('run agent', () => {
   // (regression: the default launcher's agentId once ignored the resolved harness).
   it('reports the launched harness and its install hint when the CLI is missing', async () => {
     const enoent = Object.assign(new Error('spawn claude ENOENT'), { code: 'ENOENT' });
-    const failingSpawn = { launch: (): Promise<number> => Promise.reject(enoent) };
+    const failingSpawn = { launch: () => Promise.reject(enoent) };
     const claudePlan: AgentLaunchPlan = { command: 'claude', args: [], env: { CLAUDE_CONFIG_DIR: '/tmp/x' } };
 
     await expect(launchThroughSpawn(failingSpawn, claudePlan)).rejects.toThrow(

--- a/code/cli/tests/unit/runtime-layer.test.ts
+++ b/code/cli/tests/unit/runtime-layer.test.ts
@@ -1,0 +1,144 @@
+// Covers invocation-only `.agents` layers across resolver precedence and harness projection.
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { Command } from 'commander';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createRunAgentCommand, executeRunAgentCommand } from '../../src/cli/commands/RunAgentCommand.js';
+import { executeValidateCommand } from '../../src/cli/commands/ValidateCommand.js';
+import type { AgentLaunchPlan } from '../../src/projection/Projection.js';
+import { discoverLayers } from '../../src/resolver/Layer.js';
+import { findResource } from '../../src/resolver/Resource.js';
+import { resolveResources } from '../../src/resolver/Resolver.js';
+
+const roots: string[] = [];
+
+const temporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-runtime-layer-'));
+  roots.push(root);
+  return root;
+};
+
+const write = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+
+const agent = (name: string, extra = ''): string => `---\nname: ${name}\n${extra}---\n\n# ${name}\n`;
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('runtime layer resolution', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('orders invocation-only runtime layers above workspace in command-line order', () => {
+    const root = temporaryRoot();
+    const project = join(root, 'project');
+    const first = join(root, 'first');
+    const second = join(root, 'second');
+    write(join(first, 'agents', 'shared', 'agent.md'), agent('shared', 'model: first\n'));
+    write(join(second, 'agents', 'shared', 'agent.md'), agent('shared', 'model: second\n'));
+    write(join(project, '.agents', 'agents', 'shared', 'agent.md'), agent('shared', 'model: workspace\n'));
+
+    const discovered = discoverLayers({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+      runtimeLayers: [first, second],
+      settings: {},
+    });
+    const resolved = findResource(resolveResources(discovered.layers), 'agent', 'shared')!;
+
+    expect(discovered.layers.map((layer) => layer.origin)).toEqual(['runtime', 'runtime', 'workspace']);
+    expect(resolved.winner.layer.root).toBe(first);
+    expect(resolved.shadowed.map((definition) => definition.layer.root)).toEqual([second, join(project, '.agents')]);
+  });
+
+  it('resolves relative roots from the project and rejects missing or non-directory roots', () => {
+    const root = temporaryRoot();
+    const project = join(root, 'project');
+    write(join(project, 'generated', 'agents', 'x', 'agent.md'), agent('x'));
+    write(join(project, 'not-a-layer'), 'file');
+    const input = { homeDirectory: join(root, 'home'), projectDirectory: project, settings: {} };
+
+    expect(discoverLayers({ ...input, runtimeLayers: ['generated'] }).layers[0].root).toBe(join(project, 'generated'));
+    expect(() => discoverLayers({ ...input, runtimeLayers: ['missing'] })).toThrow(/does not exist/);
+    expect(() => discoverLayers({ ...input, runtimeLayers: ['not-a-layer'] })).toThrow(/not a directory/);
+  });
+
+  it('validates runtime-layer resources through the shared schema boundary', () => {
+    const root = temporaryRoot();
+    const runtime = join(root, 'runtime');
+    write(join(runtime, 'agents', 'invalid', 'agent.md'), '---\ndescription: missing name\n---\n\nBody.\n');
+
+    const result = executeValidateCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: join(root, 'project'),
+      runtimeLayers: [runtime],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings.some((finding) => finding.resource.includes('invalid'))).toBe(true);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.8, OFTR-006.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('projects the winning runtime resource through both harness adapters without persisting it', async () => {
+    const root = temporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    const first = join(root, 'first');
+    const second = join(root, 'second');
+    write(join(project, '.agents', 'agents', 'engineer', 'agent.md'), agent('engineer', 'skills: [wiki]\n'));
+    write(join(project, '.agents', 'skills', 'wiki', 'SKILL.md'), '---\nname: wiki\n---\n\nWorkspace.\n');
+    write(join(first, 'skills', 'wiki', 'SKILL.md'), '---\nname: wiki\n---\n\nFirst runtime.\n');
+    write(join(second, 'skills', 'wiki', 'SKILL.md'), '---\nname: wiki\n---\n\nSecond runtime.\n');
+
+    for (const harness of ['pi', 'claude'] as const) {
+      const launches: AgentLaunchPlan[] = [];
+      const result = await executeRunAgentCommand({
+        homeDirectory: home,
+        projectDirectory: project,
+        runtimeLayers: [first, second],
+        agent: 'engineer',
+        harness,
+        passThroughArgs: ['--runtime-argument'],
+        launcher: (plan) => {
+          launches.push(plan);
+          const runtime = plan.env.PI_CODING_AGENT_DIR ?? plan.env.CLAUDE_CONFIG_DIR ?? '';
+          expect(readFileSync(join(runtime, 'skills', 'wiki', 'SKILL.md'), 'utf8')).toContain('First runtime');
+          return Promise.resolve(0);
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(launches[0].args).toContain('--runtime-argument');
+    }
+
+    expect(existsSync(join(project, '.agents', 'settings.yml'))).toBe(false);
+    expect(readFileSync(join(first, 'skills', 'wiki', 'SKILL.md'), 'utf8')).toContain('First runtime');
+  });
+
+  it('accepts a runtime layer through the run command parser', async () => {
+    const root = temporaryRoot();
+    const project = join(root, 'project');
+    const runtime = join(root, 'runtime');
+    write(join(runtime, 'agents', 'engineer', 'agent.md'), agent('engineer'));
+    const program = new Command();
+    let launched = false;
+    createRunAgentCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+      launcher: () => {
+        launched = true;
+        return Promise.resolve(0);
+      },
+    }).register(program);
+
+    await program.parseAsync(['node', 'outfitter', 'run', 'engineer', '--runtime-layer', runtime]);
+    expect(launched).toBe(true);
+  });
+});

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -81,12 +81,14 @@ Outfitter resolves protocol resources from layered `.agents` trees:
   settings.local.yml
 ```
 
-Remote sources (catalog repositories) supply additional layers below the local ones, in configured order.
+Invocation-only runtime layers supplied on the command line resolve above the workspace in argument
+order. Remote sources (catalog repositories) supply additional layers below the local ones, in configured order.
 A standalone catalog repository's root _is_ the payload; a colocated source nests it under `.agents/` (selected with the source's `path:`).
 
 ### Resolution semantics
 
-- Resources merge **by ID** across layers: workspace over global over remote sources in configured order.
+- Resources merge **by ID** across layers: invocation runtime layers in argument order, then
+  workspace, global, and remote sources in configured order.
   The winning definition replaces lower ones; there is no partial merge of markdown resources.
 - After layer resolution, an agent's `inherits` graph resolves through that same effective set.
   Traversal is recursive parent-first, multiple parents retain authored order, diamond ancestors contribute once, and cycles or missing parents fail with their chain.
@@ -209,6 +211,10 @@ The Pi adapter reconciles generated runtime `settings.json` and `keybindings.jso
 Interactive Pi launches inject the Outfitter bootstrap extension for build/plan mode switching; non-interactive launches skip it.
 
 During `outfitter run`, the Outfitter process remains alive while the child agent CLI runs and owns the temporary composition lifecycle.
+It inherits standard I/O, forwards the first `SIGINT` or `SIGTERM` to the harness process group,
+waits for termination, then persists declared native credential state and removes the projection.
+The calling supervisor—not Outfitter—owns liveness, cancellation grace/kill policy, retries,
+registration, and placement cleanup.
 
 ## Agent Adapter Boundary
 

--- a/docs/architecture/file_structure.md
+++ b/docs/architecture/file_structure.md
@@ -53,7 +53,7 @@ Outfitter is organized around a private npm workspace root, clear TypeScript pac
 │   │   │   ├── paths/                 # Outfitter cache root and repository/packaged asset resolution
 │   │   │   ├── schemas/               # JSON Schema artifacts for persisted formats
 │   │   │   └── validation/            # shared validation helpers
-│   │   ├── tests/                     # automated CLI package tests and fixtures
+│   │   ├── tests/                     # automated CLI tests; focused unit contracts live under tests/unit/
 │   │   ├── tsconfig.json              # strict package typecheck configuration
 │   │   ├── tsconfig.build.json        # production emission from code/cli/src/ to code/cli/dist/
 │   │   └── vitest.config.ts           # package test and coverage configuration

--- a/docs/documentation/cli.md
+++ b/docs/documentation/cli.md
@@ -11,11 +11,12 @@ Global options:
 
 Resolve, compose, and launch an agent. `run` is the default command, so plain `outfitter` and `outfitter run` are equivalent.
 
-| Argument / Option     | Description                                                                      |
-| --------------------- | -------------------------------------------------------------------------------- |
-| `[agent]`             | Agent slug to run. Defaults to the settings `default_agent`.                     |
-| `--harness <harness>` | Harness to launch in: `pi` or `claude`. Defaults to `default_harness`.           |
-| `--strict`            | Fail instead of warning when the adapter cannot project part of the composition. |
+| Argument / Option        | Description                                                                                     |
+| ------------------------ | ----------------------------------------------------------------------------------------------- |
+| `[agent]`                | Agent slug to run. Defaults to the settings `default_agent`.                                    |
+| `--harness <harness>`    | Harness to launch in: `pi` or `claude`. Defaults to `default_harness`.                          |
+| `--runtime-layer <path>` | Add an invocation-only `.agents` payload root. Repeatable; earlier occurrences take precedence. |
+| `--strict`               | Fail instead of warning when the adapter cannot project part of the composition.                |
 
 Any other arguments and unrecognized options are passed through to the launched harness:
 
@@ -23,6 +24,11 @@ Any other arguments and unrecognized options are passed through to the launched 
 outfitter run engineer --harness claude
 outfitter run persona-reviewer -- --print "summarize this repo"
 ```
+
+`run` launches the harness in the foreground with inherited standard input, output, and error
+streams. If Outfitter receives `SIGINT` or `SIGTERM`, it forwards the first signal to the harness
+process group and waits for it to terminate before persisting native credential state or removing
+the temporary projection. A harness terminated by `SIGINT` exits as 130; `SIGTERM` exits as 143.
 
 ## `outfitter setup [source]`
 
@@ -55,26 +61,55 @@ resolution tells you to run `outfitter sync`.
 
 List resolvable resources across all layers, with the winning source for each slug and any shadowed IDs.
 
-| Argument | Description                                                   |
-| -------- | ------------------------------------------------------------- |
-| `[kind]` | Optional filter: `agents`, `skills`, `knowledge`, `commands`. |
+| Argument / Option        | Description                                                                                     |
+| ------------------------ | ----------------------------------------------------------------------------------------------- |
+| `[kind]`                 | Optional filter: `agents`, `skills`, `knowledge`, `commands`.                                   |
+| `--runtime-layer <path>` | Add an invocation-only `.agents` payload root. Repeatable; earlier occurrences take precedence. |
 
 ## `outfitter validate`
 
 Validate the effective resource set: protocol layout, frontmatter, unresolved slugs in agent loadouts, broken or escaping skill references, and settings schema.
 
-| Option     | Description                              |
-| ---------- | ---------------------------------------- |
-| `--strict` | Exit non-zero when warnings are present. |
-| `--json`   | Print diagnostics as JSON.               |
+| Option                   | Description                                                                                     |
+| ------------------------ | ----------------------------------------------------------------------------------------------- |
+| `--runtime-layer <path>` | Add an invocation-only `.agents` payload root. Repeatable; earlier occurrences take precedence. |
+| `--strict`               | Exit non-zero when warnings are present.                                                        |
+| `--json`                 | Print diagnostics as JSON.                                                                      |
 
 ## `outfitter dump`
 
 Write the composed resource tree as a self-contained `.agents/` directory for review, vendoring, or air-gapped use. Identical sources, refs, and selections produce byte-identical output; dumps never contain credentials, sessions, caches, or other mutable runtime state.
 
-| Option         | Description                                          |
-| -------------- | ---------------------------------------------------- |
-| `--agent <id>` | Restrict the dump to one agent's transitive closure. |
-| `--out <dir>`  | Destination directory (default `./.agents`).         |
+| Option                   | Description                                                                                     |
+| ------------------------ | ----------------------------------------------------------------------------------------------- |
+| `--agent <id>`           | Restrict the dump to one agent's transitive closure.                                            |
+| `--runtime-layer <path>` | Add an invocation-only `.agents` payload root. Repeatable; earlier occurrences take precedence. |
+| `--out <dir>`            | Destination directory (default `./.agents`).                                                    |
 
 > **Tasks and `outfitter task bake`** — baking a task and its inputs into an immutable execution artifact — are the subject of a separate upcoming RFC and are not part of this command surface yet. See [Tasks](./tasks.md).
+
+## Invocation-only runtime layers
+
+`--runtime-layer <path>` points directly at a protocol-shaped payload root—the directory containing
+`agents/`, `skills/`, `knowledge/`, and other `.agents` entries, not a parent directory containing
+another `.agents/` folder. Relative paths resolve from the active project directory.
+
+Runtime layers are useful when a supervisor generates workflow resources for one invocation without
+editing the checked-out project or writing harness-native Pi or Claude files:
+
+```bash
+outfitter run engineer \
+  --harness pi \
+  --runtime-layer /run/task/workflow.agents \
+  --strict -- --print "Continue the assigned task"
+```
+
+Runtime layers have higher precedence than the project workspace, user tree, and configured sources.
+When the option is repeated, the first occurrence has the highest precedence. They participate in
+the same resolver used by `list`, `validate`, `run`, and `dump`, are never persisted into settings,
+and do not change source trees.
+
+The invocation is transport-neutral: a local Docker/tmux supervisor, GitHub Actions job, or
+Kubernetes Job supplies the workspace as the current directory, materializes any runtime layer, and
+starts the same foreground command. Placement, liveness, cancellation grace periods, retries,
+credentials injection, and workspace cleanup remain the supervisor's responsibility.

--- a/docs/documentation/concepts.md
+++ b/docs/documentation/concepts.md
@@ -58,11 +58,16 @@ The same agent definition can be run directly or selected as a subagent elsewher
 
 Resources resolve across layers, following the protocol's overlay semantics:
 
-1. `<project>/.agents/` — the workspace layer, committed with a project.
-2. `~/.agents/` — the global layer for one developer.
-3. Remote sources — pinned `.agents` payloads from [catalog repositories](./catalogs.md), in configured order.
+1. Invocation runtime layers passed with `--runtime-layer`, in command-line order.
+2. `<project>/.agents/` — the workspace layer, committed with a project.
+3. `~/.agents/` — the global layer for one developer.
+4. Remote sources — pinned `.agents` payloads from [catalog repositories](./catalogs.md), in configured order.
 
 Resources merge **by ID**: a workspace `skills/wiki/` overrides a global or remote `skills/wiki/`. Agent-local skills merge by owner and ID, so `agents/actions/skills/debug/` is distinct from `agents/reviewer/skills/debug/`; the selected agent's local winner takes precedence over catalog-wide `skills/debug/`. JSON files such as `mcp.json` and `models.json` follow the protocol's JSON merge behavior. Standalone `.agents` repositories — where the repository root _is_ the payload — are the primary way to develop and share layers; see [Catalogs](./catalogs.md) and [Local development](./local-development.md).
+
+Runtime layers use that same standalone payload-root convention. They are invocation-only, resolve
+above the workspace, and are never added to settings. Earlier repeated `--runtime-layer` options
+have higher precedence.
 
 ## Settings scopes
 
@@ -88,10 +93,18 @@ Agents write state during a run — auth, native settings, plugins, sessions. Ea
 
 ## Layer precedence
 
-When several layers define the same resource ID or setting, higher layers win:
+When several layers define the same resource ID, higher layers win:
+
+1. Invocation runtime layers (in command-line order; resources only)
+2. Project (`<project>/.agents/`)
+3. User (`~/.agents/`)
+4. Cached remote sources (in configured source order)
+
+Settings precedence remains independent because runtime layers are not settings inputs:
 
 1. Project-local settings (`<project>/.agents/settings.local.yml`)
-2. Project (`<project>/.agents/`)
-3. User (`~/.agents/`, with `settings.local.yml` above `settings.yml`)
-4. Cached remote sources (in configured source order)
-5. Built-in defaults
+2. Project settings (`<project>/.agents/settings.yml`)
+3. User-local settings (`~/.agents/settings.local.yml`)
+4. User settings (`~/.agents/settings.yml`)
+5. Cached remote settings
+6. Built-in defaults

--- a/docs/requirements/OFTR-005-run-and-composite-profile.md
+++ b/docs/requirements/OFTR-005-run-and-composite-profile.md
@@ -93,3 +93,19 @@ Amended (2026-07-17, RFC #165): composition assembles from the effective resourc
 9. Outfitter MUST NOT mutate cache-backed or remote selected profile owners for generated prompt export and MUST emit an actionable warning when export is skipped for that reason.
 10. Generated prompt export MUST NOT change launch args except for Outfitter's own runtime export extension plumbing, launch environment except for the export-path handoff, composite profile contents, or state persistence behavior.
 11. During live composite profile updates, Outfitter SHOULD refresh generated prompt fallback artifacts when enabled.
+
+### OFTR-005.8: Invocation Layers and Supervised Runtime
+
+Added (2026-07-31): generic invocation-only layers and foreground process behavior for supervised
+runtime integrations.
+
+1. `list`, `validate`, `run`, and `dump` MUST accept a repeatable `--runtime-layer <path>` option whose path names a protocol-shaped `.agents` payload root.
+2. A relative runtime-layer path MUST resolve from the active project directory.
+3. Runtime layers MUST have higher resource precedence than the workspace layer; repeated options MUST retain command-line order with the earlier occurrence at higher precedence.
+4. Runtime layers MUST be invocation-only and MUST NOT be written to settings or mutate the workspace, user, or source trees.
+5. Runtime layers MUST enter the same effective resolver used by `list`, `validate`, `run`, and `dump`; persisted YAML and resource frontmatter MUST continue through their existing schema-validation read boundaries.
+6. `run` MUST launch the selected harness in the foreground with inherited standard I/O and remain alive until the harness process terminates.
+7. While the harness is active, Outfitter MUST forward the first parent `SIGINT` or `SIGTERM` exactly once to the harness process group and MUST remove its signal listeners after the harness terminates or fails to spawn.
+8. A harness exit MUST preserve its numeric status. Harness termination by `SIGINT` and `SIGTERM` MUST map to conventional CLI statuses 130 and 143 respectively; spawn errors MUST remain distinguishable errors.
+9. Outfitter MUST persist declared native credential state and remove its temporary projection only after the harness process has terminated, including a forwarded-signal path.
+10. Outfitter MUST NOT own supervisor liveness, cancellation grace periods, forced termination, retries, registration, or placement cleanup.


### PR DESCRIPTION
## Why this change

Panopticon needs to launch current Outfitter inside each task container without taking over Outfitter's job or reviving the profile system removed by RFC #165.

The experimental Panopticon adapter currently targets Outfitter 0.11.0. It:

- interprets Panopticon's `starting_model` as an Outfitter profile ID;
- discovers and parses legacy `profile.yml` files;
- writes `.outfitter/settings.yml` and profile-source configuration;
- reconstructs Pi-native `--extension`, `--append-system-prompt`, and `--skill` arguments outside Outfitter.

That adapter is visible at [`src/panopticon/harnesses/outfitter.py`](https://github.com/tylerwillis/panopticon/blob/4ccddf6aaae8bc4c64506f817959adb199dcb01f/src/panopticon/harnesses/outfitter.py). It is incompatible with current Outfitter, whose product boundary is `.agents` resolution → harness-neutral composition → Pi/Claude projection.

This PR supplies the two missing generic Outfitter seams needed to replace that legacy integration:

1. an invocation-only `.agents` layer so a supervisor can provide generated workflow resources without modifying the checked-out repository or writing Pi/Claude-native files; and
2. foreground process-group behavior so a supervisor can cancel Outfitter and receive a meaningful harness exit status.

The corresponding Panopticon implementation is specified in [Unsupervisedcom/panopticon#353](https://github.com/Unsupervisedcom/panopticon/issues/353). Placement backends remain tracked separately in [Panopticon #347](https://github.com/Unsupervisedcom/panopticon/issues/347).

## What this enables in Panopticon

The target in-container launch becomes one opaque Outfitter command:

```text
outfitter run "$PANOPTICON_OUTFITTER_AGENT" \
  --harness "$PANOPTICON_OUTFITTER_HARNESS" \
  [--strict] \
  [--runtime-layer <generated-workflow-payload>] -- \
  [initial-or-resume harness arguments]
```

Panopticon can materialize its workflow overview, task skills, and workflow-operation skills as a temporary protocol-shaped payload and pass that root with `--runtime-layer`. Outfitter then resolves those resources with the selected project/user/catalog layers and decides how Pi or Claude represents them.

The runtime layer resolves above the workspace and is never persisted into settings. Repeated flags preserve command-line order, with the first occurrence winning. `list`, `validate`, `run`, and `dump` all use the same effective resolver, so Panopticon can inspect exactly what it will launch.

When Panopticon cancels a task, its primary supervisor forwards `SIGINT` or `SIGTERM` to Outfitter. Outfitter forwards the first signal to the harness process group, waits for termination, persists declared native credential state, removes the temporary projection, and returns 130 or 143. Panopticon retains ownership of grace periods and forced termination.

## Panopticon execution flow and source map

These are the downstream seams to read alongside this PR:

1. [`sessionservice/runner.py`](https://github.com/Unsupervisedcom/panopticon/blob/9f8cdee0a8602e86dab1b008a38c1ac9fae54727/src/panopticon/sessionservice/runner.py) defines the placement-neutral `spawn`/`stop` boundary.
2. [`sessionservice/spawner.py`](https://github.com/Unsupervisedcom/panopticon/blob/9f8cdee0a8602e86dab1b008a38c1ac9fae54727/src/panopticon/sessionservice/spawner.py) claims a task, prepares its workspace/image/secrets, and delegates launch to the runner.
3. [`sessionservice/local_runner.py`](https://github.com/Unsupervisedcom/panopticon/blob/9f8cdee0a8602e86dab1b008a38c1ac9fae54727/src/panopticon/sessionservice/local_runner.py) starts the local container/tmux execution unit and injects `PANOPTICON_*` runtime state.
4. [`container/entrypoint.py`](https://github.com/Unsupervisedcom/panopticon/blob/9f8cdee0a8602e86dab1b008a38c1ac9fae54727/src/panopticon/container/entrypoint.py) is the primary supervisor: it owns REST registration/liveness and receives platform cancellation.
5. [`container/agent.py`](https://github.com/Unsupervisedcom/panopticon/blob/9f8cdee0a8602e86dab1b008a38c1ac9fae54727/src/panopticon/container/agent.py) bootstraps workflow resources and launches the selected harness in the foreground.
6. The experimental [`harnesses/outfitter.py`](https://github.com/tylerwillis/panopticon/blob/4ccddf6aaae8bc4c64506f817959adb199dcb01f/src/panopticon/harnesses/outfitter.py) shows the legacy behavior that #353 will replace.

The intended downstream change is concentrated around `container/agent.py` plus a modern Outfitter harness adapter. The runner, spawner, entrypoint, and placement model should not need to understand `.agents`, Outfitter catalogs, `CompositionPlan`, or Pi/Claude loadout flags.

## Ownership boundary

| Concern | Panopticon | Outfitter |
| --- | --- | --- |
| Task/workflow state | Authoritative | No ownership |
| Placement, claim, workspace, image | Authoritative | Reads supplied cwd/files |
| Registration and REST liveness | Primary supervisor | No ownership |
| Agent and harness selection | Supplies opaque IDs | Validates, resolves, projects |
| Workflow resources | Materializes protocol payload | Resolves through `--runtime-layer` |
| Pi/Claude files and flags | Must not reconstruct | Authoritative adapter projection |
| Credentials | Selects and injects | Consumes native state; persists declared Pi state |
| Cancellation grace/kill policy | Authoritative | Forwards first signal and waits |
| Exit classification and retries | Authoritative | Returns harness exit status |
| Temporary projection cleanup | No ownership | Authoritative |

This division is why Outfitter is a supervised child rather than PID 1: Panopticon must keep its liveness connection active until the child exits or its cancellation grace period expires.

## What changed here

- Added repeatable `--runtime-layer <path>` to `list`, `validate`, `run`, and `dump`.
- Added a `runtime` resource-layer origin above workspace/global/configured sources.
- Kept runtime layers invocation-only; they do not become settings inputs or mutate source trees.
- Added typed normal/signalled child outcomes and conventional signal exit mapping.
- Spawned supported harnesses as foreground process groups with inherited stdio.
- Forwarded the first parent `SIGINT`/`SIGTERM` exactly once and removed listeners after termination/error.
- Delayed Pi credential copy-back and projection cleanup until child termination.
- Formalized the contract as OFTR-005.8 and documented the transport-neutral invocation.

## How to review this PR

The core design questions are:

1. **Resolver boundary:** Is a direct protocol payload root the right generic invocation input, and is `runtime layers → workspace → global → configured sources` the right precedence?
2. **Command parity:** Should all resolver-facing commands accept the same runtime layers so inspection matches execution?
3. **Process ownership:** Does Outfitter forward signals and preserve statuses without taking over the supervisor's grace/kill/liveness policy?
4. **Cross-harness behavior:** Do Pi and Claude continue to receive only adapter-native projection from one harness-neutral composition?
5. **Containment:** Are generated layers non-persistent and still governed by existing schema and symlink/containment checks?

Suggested reading order:

- `code/cli/src/resolver/Layer.ts` and `ResolverContext.ts`
- `code/cli/src/cli/commands/RunAgentCommand.ts` plus the smaller list/validate/dump command changes
- `code/cli/src/agents/AgentLaunch.ts`
- `code/cli/tests/unit/runtime-layer.test.ts`, `agent-launch.test.ts`, and `pi-credential-persistence.test.ts`
- `docs/requirements/OFTR-005-run-and-composite-profile.md` (OFTR-005.8)
- [Panopticon #353](https://github.com/Unsupervisedcom/panopticon/issues/353) for the downstream implementation contract

## Explicit non-goals

- No Panopticon-specific Outfitter command, settings field, environment schema, or adapter.
- No restoration of `.outfitter/profiles`, `--profile`, or legacy parsing.
- No machine event stream or capabilities protocol; provider design is tracked by #240.
- No immutable task bake/launch manifest; tracked by #205.
- No source trust/provenance expansion; tracked by #212.
- No GitHub Actions or Kubernetes runner implementation; tracked by Panopticon #347.
- No supervisor heartbeat, registration, retry, grace-period, forced-kill, or placement logic in Outfitter.
- No public serialization of internal `CompositionPlan`.

## Follow-up design work

- #240 — versioned machine protocol for supervised runtimes
- #212 — source trust and immutable provenance
- #205 — task contracts and deterministic task baking
- [Unsupervisedcom/panopticon#353](https://github.com/Unsupervisedcom/panopticon/issues/353) — consume the modern supervised `.agents` contract
- [Unsupervisedcom/panopticon#347](https://github.com/Unsupervisedcom/panopticon/issues/347) — GitHub Actions and Kubernetes placement runners

Plan artifact: `panopticon://tasks/87327d6be3cc4f84b1cd3920d316462b/artifacts/plan.md`
