### PR TITLE
feat(pi): persist sessions across runs by default

### DIFF
--- a/code/cli/src/agents/PiSessionDirectory.ts
+++ b/code/cli/src/agents/PiSessionDirectory.ts
@@ -36,7 +36,8 @@ export const resolvePiUserSessionDirectory = (homeDirectory: string, projectDire
  * Session directory for a pi launch, or `undefined` when the launch should keep whatever
  * `PI_CODING_AGENT_SESSION_DIR` it inherits — an explicitly configured store, such as a resident
  * agent's workspace/PVC path, stays in control. `env`, `homeDirectory`, and `projectDirectory` are
- * injected so the resolution stays pure and unit-testable.
+ * injected so the resolution stays unit-testable; `projectDirectory` is the directory pi runs in
+ * (`process.cwd()`), which is what makes the result pi's own folder for the project.
  */
 export const resolvePiSessionDirectory = (
   env: Readonly<Record<string, string | undefined>>,

--- a/code/cli/src/agents/PiSessionDirectory.ts
+++ b/code/cli/src/agents/PiSessionDirectory.ts
@@ -1,0 +1,50 @@
+// Keeps pi session transcripts durable across runs. Outfitter launches pi with PI_CODING_AGENT_DIR
+// pointed at a per-run projection root that is deleted once the child exits, and pi stores sessions
+// under `<agent dir>/sessions/<encoded cwd>` by default (pi-coding-agent core/session-manager.js:
+// getDefaultSessionDirPath()). Left alone every transcript dies with the projection, so
+// `pi --continue`/`--resume` can never find the previous conversation (#223).
+//
+// Outfitter therefore points pi at the same per-project folder under pi's durable agent directory
+// that a standalone pi already writes to, so history is shared between `outfitter run` and a bare
+// `pi` in the same project, and `--continue` keeps pi's fast path instead of scanning every
+// project's transcripts.
+import { join, resolve } from 'node:path';
+
+import { resolvePiUserAgentDirectory } from './PiCredentialPersistence.js';
+
+/**
+ * pi's session-storage environment override. pi resolves the session directory as
+ * `--session-dir` → `PI_CODING_AGENT_SESSION_DIR` → `sessionDir` in settings.json, so a
+ * pass-through `-- --session-dir <dir>` still wins over the default Outfitter sets here.
+ */
+export const PI_SESSION_DIRECTORY_ENV = 'PI_CODING_AGENT_SESSION_DIR';
+
+// pi's own encoding of a project directory into a single session folder name: absolute path,
+// leading separator dropped, remaining separators and drive colons flattened to '-', wrapped in
+// '--'. Mirrored here so Outfitter runs share pi's native per-project folder rather than starting a
+// parallel layout.
+const encodeProjectDirectory = (projectDirectory: string): string =>
+  `--${resolve(projectDirectory)
+    .replace(/^[/\\]/u, '')
+    .replace(/[/\\:]/gu, '-')}--`;
+
+/** pi's durable session folder for one project: `~/.pi/agent/sessions/--<encoded project>--`. */
+export const resolvePiUserSessionDirectory = (homeDirectory: string, projectDirectory: string): string =>
+  join(resolvePiUserAgentDirectory(homeDirectory), 'sessions', encodeProjectDirectory(projectDirectory));
+
+/**
+ * Session directory for a pi launch, or `undefined` when the launch should keep whatever
+ * `PI_CODING_AGENT_SESSION_DIR` it inherits — an explicitly configured store, such as a resident
+ * agent's workspace/PVC path, stays in control. `env`, `homeDirectory`, and `projectDirectory` are
+ * injected so the resolution stays pure and unit-testable.
+ */
+export const resolvePiSessionDirectory = (
+  env: Readonly<Record<string, string | undefined>>,
+  homeDirectory: string,
+  projectDirectory: string,
+): string | undefined => {
+  const inherited = env[PI_SESSION_DIRECTORY_ENV];
+  if (inherited !== undefined && inherited.trim() !== '') return undefined;
+
+  return resolvePiUserSessionDirectory(homeDirectory, projectDirectory);
+};

--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -11,6 +11,7 @@ import {
   resolvePiUserAgentDirectory,
   seedPiCredentials,
 } from '../../agents/PiCredentialPersistence.js';
+import { resolvePiSessionDirectory } from '../../agents/PiSessionDirectory.js';
 import { compose } from '../../composer/Composer.js';
 import { ensurePiExtensions } from '../../extensions/PiExtensionCache.js';
 import type { PiInstallSpawner } from '../../extensions/PiExtensionCache.js';
@@ -122,6 +123,12 @@ const launchWithCredentialPersistence = async (
   return exitCode;
 };
 
+// pi writes sessions inside PI_CODING_AGENT_DIR — the projection root Outfitter deletes after the
+// run — so resolve pi's durable per-project store instead and let `--continue` outlive the run. An
+// inherited PI_CODING_AGENT_SESSION_DIR keeps precedence (undefined), as do non-pi harnesses.
+const resolveSessionDirectory = (input: RunAgentInput, harness: Harness): string | undefined =>
+  harness === 'pi' ? resolvePiSessionDirectory(process.env, input.homeDirectory, input.projectDirectory) : undefined;
+
 // Installs/caches the pi extensions for the composed agent (pi only) so they load at launch.
 const resolvePiExtensions = async (
   input: RunAgentInput,
@@ -190,6 +197,7 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
       harness,
       rootDirectory,
       homeDirectory: input.homeDirectory,
+      sessionDirectory: resolveSessionDirectory(input, harness),
       passThroughArgs: input.passThroughArgs,
       extensionLoadDirs: harness === 'pi' ? extensions.loadDirs : undefined,
       // ProjectHarness only overlays these for the pi harness, so pass them through unconditionally.

--- a/code/cli/src/projection/ProjectHarness.ts
+++ b/code/cli/src/projection/ProjectHarness.ts
@@ -1,4 +1,5 @@
 // Projects a harness-neutral CompositionPlan to a native pi or Claude Code launch.
+import { PI_SESSION_DIRECTORY_ENV } from '../agents/PiSessionDirectory.js';
 import type { CompositionPlan } from '../composer/Composition.js';
 import type { Harness } from '../settings/Settings.js';
 import { materializeComposition, materializeConfigurationOverlays } from './Materialize.js';
@@ -84,7 +85,15 @@ const buildLaunchPlan = (
       ...modelArgs(composition, input.harness),
       ...(input.passThroughArgs ?? []),
     ],
-    env: isPi ? { PI_CODING_AGENT_DIR: input.rootDirectory } : { CLAUDE_CONFIG_DIR: input.rootDirectory },
+    // The projection root is deleted after the run, so pi's default session store (a subdirectory
+    // of PI_CODING_AGENT_DIR) would take every transcript with it. A resolved session directory
+    // moves the store somewhere durable so `--continue`/`--resume` still find the last conversation.
+    env: isPi
+      ? {
+          PI_CODING_AGENT_DIR: input.rootDirectory,
+          ...(input.sessionDirectory === undefined ? {} : { [PI_SESSION_DIRECTORY_ENV]: input.sessionDirectory }),
+        }
+      : { CLAUDE_CONFIG_DIR: input.rootDirectory },
   };
 };
 

--- a/code/cli/src/projection/Projection.ts
+++ b/code/cli/src/projection/Projection.ts
@@ -19,6 +19,8 @@ export interface ProjectionInput {
   readonly harness: Harness;
   readonly rootDirectory: string;
   readonly homeDirectory: string;
+  /** Durable session store for the run (pi only); omitted to leave the harness default in place. */
+  readonly sessionDirectory?: string;
   readonly passThroughArgs?: readonly string[];
   /** Local pi extension install directories to load with `--extension` (pi only). */
   readonly extensionLoadDirs?: readonly string[];

--- a/code/cli/tests/unit/pi-session-directory.test.ts
+++ b/code/cli/tests/unit/pi-session-directory.test.ts
@@ -1,0 +1,174 @@
+// Verifies pi session transcripts survive Outfitter's ephemeral projection root: pi is pointed at
+// its durable per-project session store, so `--continue` finds the previous conversation next run.
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  PI_SESSION_DIRECTORY_ENV,
+  resolvePiSessionDirectory,
+  resolvePiUserSessionDirectory,
+} from '../../src/agents/PiSessionDirectory.js';
+import { executeRunAgentCommand } from '../../src/cli/commands/RunAgentCommand.js';
+import type { CompositionPlan } from '../../src/composer/Composition.js';
+import { projectComposition } from '../../src/projection/ProjectHarness.js';
+import type { AgentLaunchPlan } from '../../src/projection/Projection.js';
+
+const roots: string[] = [];
+const root = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), 'outfitter-session-'));
+  roots.push(dir);
+  return dir;
+};
+const write = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const dir of roots.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+const plan: CompositionPlan = {
+  agent: 'agent',
+  identity: { agentBody: 'Body.' },
+  loadout: {
+    skills: [],
+    delegateSkills: [],
+    subagents: [],
+    mcp: [],
+    mcpServers: {},
+    extensions: [],
+    plugins: [],
+  },
+  warnings: [],
+};
+
+describe('pi session directory resolution', () => {
+  // pi encodes a project's absolute path into one folder name under its durable sessions root
+  // (core/session-manager.js: getDefaultSessionDirPath), which Outfitter reuses so both share it.
+  it("mirrors pi's per-project folder under the durable agent directory", () => {
+    expect(resolvePiUserSessionDirectory('/home/u', '/home/u/repos/app')).toBe(
+      join('/home/u', '.pi', 'agent', 'sessions', '--home-u-repos-app--'),
+    );
+  });
+
+  it('defaults the session directory when the environment does not set one', () => {
+    expect(resolvePiSessionDirectory({}, '/home/u', '/home/u/repos/app')).toBe(
+      resolvePiUserSessionDirectory('/home/u', '/home/u/repos/app'),
+    );
+  });
+
+  it('treats a blank inherited session directory as unset', () => {
+    expect(resolvePiSessionDirectory({ [PI_SESSION_DIRECTORY_ENV]: '  ' }, '/home/u', '/home/u/repos/app')).toBe(
+      resolvePiUserSessionDirectory('/home/u', '/home/u/repos/app'),
+    );
+  });
+
+  it('yields no default when the environment already selects a session directory', () => {
+    expect(
+      resolvePiSessionDirectory(
+        { [PI_SESSION_DIRECTORY_ENV]: '/workspace/.pi/agent/sessions' },
+        '/home/u',
+        '/home/u/repos/app',
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe('projectComposition session directory', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.3.19).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('projects a resolved session directory for pi only', () => {
+    const piDir = root();
+    const claudeDir = root();
+    const home = root();
+    const sessionDirectory = join(home, 'sessions', '--project--');
+
+    const pi = projectComposition(plan, {
+      harness: 'pi',
+      rootDirectory: piDir,
+      homeDirectory: home,
+      sessionDirectory,
+    });
+    const claude = projectComposition(plan, {
+      harness: 'claude',
+      rootDirectory: claudeDir,
+      homeDirectory: home,
+      sessionDirectory,
+    });
+
+    // The session store sits outside the projection root, which is deleted after the run.
+    expect(pi.launch.env[PI_SESSION_DIRECTORY_ENV]).toBe(sessionDirectory);
+    expect(pi.launch.env.PI_CODING_AGENT_DIR).toBe(piDir);
+    expect(claude.launch.env[PI_SESSION_DIRECTORY_ENV]).toBeUndefined();
+  });
+
+  it('leaves the session directory unset when the run resolves none', () => {
+    const projection = root();
+    const home = root();
+
+    const projected = projectComposition(plan, { harness: 'pi', rootDirectory: projection, homeDirectory: home });
+
+    // Nothing is added to the launch env, so an inherited value reaches pi through the parent.
+    expect(projected.launch.env[PI_SESSION_DIRECTORY_ENV]).toBeUndefined();
+  });
+});
+
+describe('run agent session persistence', () => {
+  it('keeps a session written during the run after the projection is removed', async () => {
+    const base = root();
+    const home = join(base, 'home');
+    const project = join(base, 'project');
+    write(join(project, '.agents', 'agents', 'engineer', 'agent.md'), '---\nname: engineer\n---\n\nBody.\n');
+    vi.stubEnv(PI_SESSION_DIRECTORY_ENV, '');
+
+    const projectionRoots: string[] = [];
+    // A launcher that simulates pi recording a transcript into its session store.
+    const launcher = (launch: AgentLaunchPlan): Promise<number> => {
+      projectionRoots.push(launch.env.PI_CODING_AGENT_DIR ?? '');
+      const sessionDirectory = launch.env[PI_SESSION_DIRECTORY_ENV] ?? '';
+      mkdirSync(sessionDirectory, { recursive: true });
+      writeFileSync(join(sessionDirectory, `${projectionRoots.length}.jsonl`), '{"role":"user"}\n');
+      return Promise.resolve(0);
+    };
+    const run = async (passThroughArgs?: readonly string[]): Promise<void> => {
+      await executeRunAgentCommand({
+        homeDirectory: home,
+        projectDirectory: project,
+        agent: 'engineer',
+        harness: 'pi',
+        passThroughArgs,
+        launcher,
+      });
+    };
+
+    await run();
+    await run(['--continue']);
+
+    // The first run's projection is gone, but both transcripts remain in the durable store.
+    expect(existsSync(projectionRoots[0])).toBe(false);
+    expect(readdirSync(resolvePiUserSessionDirectory(home, project)).sort()).toEqual(['1.jsonl', '2.jsonl']);
+  });
+
+  it('leaves an inherited session directory in place for the pi launch', async () => {
+    const base = root();
+    const home = join(base, 'home');
+    const project = join(base, 'project');
+    write(join(project, '.agents', 'agents', 'engineer', 'agent.md'), '---\nname: engineer\n---\n\nBody.\n');
+    vi.stubEnv(PI_SESSION_DIRECTORY_ENV, join(base, 'workspace', 'sessions'));
+
+    const result = await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      agent: 'engineer',
+      harness: 'pi',
+      launcher: () => Promise.resolve(0),
+    });
+
+    expect(result.launchPlan?.env[PI_SESSION_DIRECTORY_ENV]).toBeUndefined();
+  });
+});

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -241,6 +241,7 @@ The adapter owns CLI-specific details: env vars, flags, state path declarations,
 Pi is the default adapter.
 Outfitter prefers native pi mechanisms: `PI_CODING_AGENT_DIR`, `PI_CODING_AGENT_SESSION_DIR`/`--session-dir`, `--extension`, `--skill`, `--prompt-template`, `--system-prompt`/`--append-system-prompt`, model/provider/thinking flags, and generated settings reconciliation where flags are not the right mechanism.
 Startup-order-impossible requests surface as adapter warnings (`--strict` makes them fatal).
+Because the projection root is removed after the run, launches default `PI_CODING_AGENT_SESSION_DIR` to pi's durable per-project session folder (`~/.pi/agent/sessions/--<encoded cwd>--`) so sessions outlive the projection and stay shared with a standalone pi; an inherited `PI_CODING_AGENT_SESSION_DIR` is left in place, and pass-through `--session-dir`/`--no-session` still win by pi's own precedence.
 If generic naming conflicts with pi behavior, prefer pi's terminology.
 
 ### Claude Code

--- a/docs/architecture/file_structure.md
+++ b/docs/architecture/file_structure.md
@@ -49,7 +49,7 @@ Outfitter is organized around a private npm workspace root, clear TypeScript pac
 │   │   │   ├── projection/            # materialize a composition + build a pi/claude launch plan
 │   │   │   ├── dump/                  # deterministic self-contained `.agents` tree output
 │   │   │   ├── merge/                 # deterministic value and array merge policy helpers
-│   │   │   ├── agents/                # AgentLaunch: bundled-pi resolution and process launch boundary
+│   │   │   ├── agents/                # bundled-pi resolution, process launch boundary, durable pi credential/session paths
 │   │   │   ├── paths/                 # Outfitter cache root and repository/packaged asset resolution
 │   │   │   ├── schemas/               # JSON Schema artifacts for persisted formats
 │   │   │   └── validation/            # shared validation helpers

--- a/docs/documentation/state.md
+++ b/docs/documentation/state.md
@@ -152,7 +152,7 @@ state_persistence:
   trust.json: symlink # Pi trust decisions.
   plugins/: symlink # Pi plugins.
   cache/: symlink # Pi cache data.
-  sessions/: symlink # Pi sessions.
+  sessions/: symlink # Pi sessions; the "Pi sessions" section covers how this works today.
   npm/: symlink # Pi npm package installs.
   git/: symlink # Pi git package checkouts.
   tmp/: symlink # Pi temporary runtime tree; allowed: symlink, discard.

--- a/docs/documentation/state.md
+++ b/docs/documentation/state.md
@@ -161,6 +161,33 @@ state_persistence:
   unknown: warn # Undeclared writes; allowed: discard, warn, error, prompt.
 ```
 
+## Pi sessions
+
+Pi stores conversation transcripts under its agent directory, and Outfitter points `PI_CODING_AGENT_DIR` at a baked composition that is deleted when the run ends. So that sessions are not deleted with it, every Pi launch sets `PI_CODING_AGENT_SESSION_DIR` to Pi's own durable per-project session folder:
+
+```text
+~/.pi/agent/sessions/--<your-project-path>--/
+```
+
+This is the same folder a standalone `pi` uses in that project, so history is shared both ways and resuming works after the baked composition is gone:
+
+```sh
+outfitter run                 # first session
+outfitter run -- --continue   # picks up where the previous run left off
+```
+
+The default applies to every Pi launch, interactive or not, so `outfitter run -p '…'` in a script or CI job records a session in the same place. Nothing is copied back after the run: Pi writes straight to the durable directory.
+
+To change or turn off session storage, pass Pi's native flags through, or set the environment variable yourself — Outfitter never overrides a session directory you have already chosen:
+
+```sh
+outfitter run -- --no-session                    # ephemeral: record nothing
+outfitter run -- --session-dir ./.pi/sessions    # keep this project's sessions in the repo
+PI_CODING_AGENT_SESSION_DIR=/workspace/.pi/agent/sessions outfitter run
+```
+
+The last form is how a resident or in-cluster agent keeps continuity across restarts: point the variable at a persistent volume.
+
 ## Claude Code state paths
 
 The Claude Code adapter declares these paths:

--- a/docs/requirements/OFTR-006-agent-adapters.md
+++ b/docs/requirements/OFTR-006-agent-adapters.md
@@ -51,6 +51,7 @@ Amended (2026-07-17, RFC #165): adapters project a harness-neutral composition, 
 16. The pi adapter MUST ignore inherited external `DEEPWORK_ADDITIONAL_JOBS_FOLDERS` values unless `controls.pi.allow_external_deepwork_jobs` is true.
 17. The pi adapter MUST overlay `agents/<agent>/pi/` directories from contributing `.agents` layers into the temporary `PI_CODING_AGENT_DIR`, with higher-precedence layers replacing matching paths, without following symlinks or projecting the overlay into non-Pi harnesses.
 18. The pi adapter MUST project composed prompt fragments in composition order by passing one `--system-prompt`, ordered `--append-system-prompt` arguments, and `--prompt-template` when the composition declares a prompt template.
+19. The pi adapter MUST default `PI_CODING_AGENT_SESSION_DIR` to pi's durable per-project session directory under pi's user agent directory, so sessions survive removal of the temporary `PI_CODING_AGENT_DIR`; it MUST leave an inherited `PI_CODING_AGENT_SESSION_DIR` in place, and MUST NOT override a pass-through `--session-dir` or `--no-session`.
 
 ### OFTR-006.4: Pi Startup Boundary
 


### PR DESCRIPTION
Closes #223.

## Problem

`outfitter run` launches pi with `PI_CODING_AGENT_DIR` pointed at a per-run projection root under the system temp directory, and `RunAgentCommand` deletes that root once the child exits. Pi stores transcripts under `<agent dir>/sessions/<encoded cwd>` (`pi-coding-agent` `core/session-manager.js: getDefaultSessionDirPath()`), so every session was destroyed with the projection and `pi --continue` / `--resume` could never find the previous conversation.

## Change

Default `PI_CODING_AGENT_SESSION_DIR` to pi's own durable per-project session folder, `~/.pi/agent/sessions/--<encoded cwd>--`.

Why that path rather than the sessions root:

- When pi is given an explicit session directory it writes **flat** into it and switches `--continue`/`--resume` to a cwd filter that reads every transcript header in the directory. Pointing at `~/.pi/agent/sessions` would pile every project into one folder and put resume on the slow path.
- The per-project folder is the exact directory a standalone `pi` uses in that project, so history is shared both ways and pi keeps its fast path (`dir === getDefaultSessionDirPath(cwd)`).

Nothing is copied back after the run — pi writes straight to the durable directory, unlike the `auth.json`/`models.json` seed-and-write-back in `PiCredentialPersistence`.

Escape hatches, all honoured by pi's own precedence (`--session-dir` → `PI_CODING_AGENT_SESSION_DIR` → `sessionDir` in settings.json):

- `outfitter run -- --no-session` — record nothing.
- `outfitter run -- --session-dir <dir>` — choose the store per run.
- An inherited `PI_CODING_AGENT_SESSION_DIR` is left untouched, so a resident agent's workspace/PVC path keeps winning (the footgun called out in #223).

The default applies to interactive and non-interactive pi launches alike; a split policy would make print-mode sessions quietly unfindable. Claude Code is unchanged — `CLAUDE_CONFIG_DIR` session state is a separate gap (OFTR-006.5.6, #187).

## Verification

Unit tests cover the path encoding, the inherited-value opt-out, the projected launch env for pi vs claude, and a two-run `executeRunAgentCommand` case asserting both transcripts survive after the first projection is removed.

Verified end-to-end against the bundled pi 0.80.3 with an isolated `HOME`:

- `outfitter run engineer -- -p "reply with exactly: alpha"` → transcript written to `<home>/.pi/agent/sessions/--<project>--/…jsonl`, projection removed.
- `outfitter run engineer -- --continue -p "what single word did you reply with a moment ago?"` → answered `alpha`, appending to the same session file.
- With `PI_CODING_AGENT_SESSION_DIR` exported, the session landed in the override directory and the durable folder was untouched.

## Acceptance criteria (#223)

- [x] Interactive `outfitter run` creates/resumes pi sessions from a durable directory by default.
- [x] A second `outfitter run -- --continue` in the same project sees the prior session after the first projection is removed.
- [x] Non-interactive modes have an explicit, documented policy (same durable default).
- [x] Tests cover the launch plan / session-dir behavior for pi.
- [x] Documentation explains the default and how to opt out.

Docs: new "Pi sessions" section in `docs/documentation/state.md`, pi adapter note in `docs/architecture/README.md`, and a new requirement OFTR-006.3.19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)