### PR TITLE
fix(claude): append prompt documents through the flag Claude actually reads

### DIFF
--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -48,6 +48,8 @@ export interface RunAgentInput {
   readonly harness?: string;
   readonly strict?: boolean;
   readonly passThroughArgs?: readonly string[];
+  /** `--append-prompt` documents appended to the system prompt after the agent's own, in order. */
+  readonly appendPromptPaths?: readonly string[];
   readonly launcher: AgentProcessLauncher;
   /** Onboarding to run once when no agent is selected and settings define no `default_agent`. */
   readonly setup?: SetupRunner;
@@ -199,6 +201,7 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
       homeDirectory: input.homeDirectory,
       sessionDirectory: resolveSessionDirectory(input, harness),
       passThroughArgs: input.passThroughArgs,
+      appendPromptPaths: input.appendPromptPaths,
       extensionLoadDirs: harness === 'pi' ? extensions.loadDirs : undefined,
       // ProjectHarness only overlays these for the pi harness, so pass them through unconditionally.
       configurationOverlayDirectories: configurationOverlays,
@@ -259,12 +262,17 @@ export const createRunAgentCommand = (dependencies: RunAgentDependencies = {}): 
       .argument('[args...]', 'Arguments passed through to the harness after --.')
       .addOption(new Option('--harness <harness>', 'Harness to launch.').choices([...HARNESSES]))
       .option('--strict', 'Treat composition warnings and unsupported loadout elements as fatal.')
+      .option(
+        '--append-prompt <path>',
+        'Append a Markdown document to the system prompt. Repeatable; applied in the order given.',
+        (value: string, previous: readonly string[] = []) => [...previous, value],
+      )
       .allowUnknownOption(true)
       .action(
         async (
           agent: string | undefined,
           passThroughArgs: readonly string[],
-          options: { harness?: string; strict?: boolean },
+          options: { harness?: string; strict?: boolean; appendPrompt?: readonly string[] },
         ) => {
           /* v8 ignore next 3 -- process/launcher defaults are exercised by the CLI entrypoint, not unit tests. */
           const homeDirectory = resolveHomeDirectory(dependencies.homeDirectory);
@@ -277,6 +285,7 @@ export const createRunAgentCommand = (dependencies: RunAgentDependencies = {}): 
             harness: options.harness,
             strict: options.strict,
             passThroughArgs,
+            appendPromptPaths: options.appendPrompt,
             launcher,
             setup: dependencies.setup ?? interactiveSetupRunner,
             // executeRunAgentCommand emits messages (before launch) through this sink.

--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -1,5 +1,5 @@
 // `outfitter run [agent]` — resolve → compose → project → launch on the .agents model.
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -151,6 +151,17 @@ const piConfigurationOverlays = (
 ): readonly string[] =>
   [...(plan.contributingAgents ?? [selectedAgent])].reverse().flatMap((agent) => agent.piConfigDirectories ?? []);
 
+// Validated before launch rather than inside projection: pi never reads these paths itself, so an
+// unreadable one would otherwise fail differently per harness — a raw ENOENT out of the Claude
+// concatenation, and a harness-generated error on pi.
+const assertReadableAppendPrompts = (paths: readonly string[] | undefined): void => {
+  const unreadable = (paths ?? []).filter((path) => statSync(path, { throwIfNoEntry: false })?.isFile() !== true);
+
+  if (unreadable.length > 0) {
+    throw new Error(`--append-prompt: not a readable file: ${unreadable.join(', ')}`);
+  }
+};
+
 export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunAgentResult> => {
   // Flush messages to the terminal (before launch); they are also returned so callers can inspect them.
   const emit = (messages: readonly string[]): void => {
@@ -159,6 +170,7 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
 
   let resolved = resolveEffectiveSet(input);
   assertNoSettingsIssues(resolved.settingsIssues);
+  assertReadableAppendPrompts(input.appendPromptPaths);
   emit(resolved.warnings.map((warning) => `warning: ${warning}`));
 
   // First run: nothing selected and no default configured — onboard, then resolve again.

--- a/code/cli/src/projection/ProjectHarness.ts
+++ b/code/cli/src/projection/ProjectHarness.ts
@@ -41,19 +41,24 @@ export const unsupportedElements = (composition: CompositionPlan, input: Project
   loadoutElementsInUse(composition).filter((element) => !supportedElements(input).includes(element));
 
 /**
- * The two harnesses take append-prompt documents through incompatible flags, verified against
- * pi 0.x via `outfitter run` and Claude Code 2.1.x directly:
+ * The two harnesses take prompt documents through incompatible flags, verified against pi 0.x via
+ * `outfitter run` and Claude Code 2.1.x directly:
  *
  * | | pi | claude |
- * | `--append-system-prompt <path>` | reads the file, repeatable, accumulates | appends the path *text* |
- * | `--append-system-prompt-file <path>` | rejected: `Unknown option` | reads the file |
- * | repeated flags | accumulate | last one wins |
+ * | `--system-prompt <path>` / `--append-system-prompt <path>` | reads the file | appends the path *text* |
+ * | `--system-prompt-file` / `--append-system-prompt-file` | rejected: `Unknown option` | reads the file |
+ * | repeated append flags | accumulate | last one wins |
  *
- * So pi gets a repeated flag per document, while Claude gets a single
- * `--append-system-prompt-file` over a concatenation — one flag because repeats overwrite, and the
- * `-file` form because the bare flag would otherwise append the literal path and silently drop
- * every document. Emitting the pi form to Claude loses the content without an error.
+ * pi therefore takes paths on the bare flags, and Claude takes the `-file` forms. Claude's are
+ * undocumented — neither appears in `claude --help` — but both apply the file's contents, while the
+ * bare flags silently append the path string and drop the document. Getting this wrong produces no
+ * error, just an agent launched without its identity.
+ *
+ * Claude also gets a single append flag over a concatenation, because repeats overwrite.
  */
+const promptPathArg = (harness: Harness, flag: 'system-prompt' | 'append-system-prompt'): string =>
+  harness === 'pi' ? `--${flag}` : `--${flag}-file`;
+
 const appendPromptArgs = (harness: Harness, rootDirectory: string, paths: readonly string[]): readonly string[] => {
   /* v8 ignore next 2 -- unreachable through composition, which always contributes the agent body;
      kept because projectComposition is exported and an empty list must not name an empty file. */
@@ -61,9 +66,11 @@ const appendPromptArgs = (harness: Harness, rootDirectory: string, paths: readon
   if (harness === 'pi') return paths.flatMap((path) => ['--append-system-prompt', path]);
 
   const combinedPath = join(rootDirectory, 'append-system-prompt.md');
-  // A trailing newline per document so a file that lacks one cannot glue onto the next.
-  writeFileSync(combinedPath, paths.map((path) => `${readFileSync(path, 'utf8')}\n`).join(''));
-  return ['--append-system-prompt-file', combinedPath];
+  // A blank line between documents: one newline would let a document that ends mid-sentence merge
+  // into the next one's opening paragraph, or turn it into a setext heading.
+  const documents = paths.map((path) => readFileSync(path, 'utf8').replace(/\n*$/, '\n'));
+  writeFileSync(combinedPath, documents.join('\n'));
+  return [promptPathArg(harness, 'append-system-prompt'), combinedPath];
 };
 
 const promptArgs = (
@@ -72,7 +79,7 @@ const promptArgs = (
   systemPromptPath: string,
   appendPromptPaths: readonly string[],
 ): readonly string[] => [
-  '--system-prompt',
+  promptPathArg(input.harness, 'system-prompt'),
   systemPromptPath,
   ...appendPromptArgs(input.harness, input.rootDirectory, appendPromptPaths),
   ...(input.harness === 'pi' && composition.identity.promptTemplate !== undefined

--- a/code/cli/src/projection/ProjectHarness.ts
+++ b/code/cli/src/projection/ProjectHarness.ts
@@ -1,4 +1,6 @@
 // Projects a harness-neutral CompositionPlan to a native pi or Claude Code launch.
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { PI_SESSION_DIRECTORY_ENV } from '../agents/PiSessionDirectory.js';
 import type { CompositionPlan } from '../composer/Composition.js';
 import type { Harness } from '../settings/Settings.js';
@@ -38,6 +40,32 @@ const loadoutElementsInUse = (composition: CompositionPlan): readonly string[] =
 export const unsupportedElements = (composition: CompositionPlan, input: ProjectionInput): readonly string[] =>
   loadoutElementsInUse(composition).filter((element) => !supportedElements(input).includes(element));
 
+/**
+ * The two harnesses take append-prompt documents through incompatible flags, verified against
+ * pi 0.x via `outfitter run` and Claude Code 2.1.x directly:
+ *
+ * | | pi | claude |
+ * | `--append-system-prompt <path>` | reads the file, repeatable, accumulates | appends the path *text* |
+ * | `--append-system-prompt-file <path>` | rejected: `Unknown option` | reads the file |
+ * | repeated flags | accumulate | last one wins |
+ *
+ * So pi gets a repeated flag per document, while Claude gets a single
+ * `--append-system-prompt-file` over a concatenation — one flag because repeats overwrite, and the
+ * `-file` form because the bare flag would otherwise append the literal path and silently drop
+ * every document. Emitting the pi form to Claude loses the content without an error.
+ */
+const appendPromptArgs = (harness: Harness, rootDirectory: string, paths: readonly string[]): readonly string[] => {
+  /* v8 ignore next 2 -- unreachable through composition, which always contributes the agent body;
+     kept because projectComposition is exported and an empty list must not name an empty file. */
+  if (paths.length === 0) return [];
+  if (harness === 'pi') return paths.flatMap((path) => ['--append-system-prompt', path]);
+
+  const combinedPath = join(rootDirectory, 'append-system-prompt.md');
+  // A trailing newline per document so a file that lacks one cannot glue onto the next.
+  writeFileSync(combinedPath, paths.map((path) => `${readFileSync(path, 'utf8')}\n`).join(''));
+  return ['--append-system-prompt-file', combinedPath];
+};
+
 const promptArgs = (
   composition: CompositionPlan,
   input: ProjectionInput,
@@ -46,7 +74,7 @@ const promptArgs = (
 ): readonly string[] => [
   '--system-prompt',
   systemPromptPath,
-  ...appendPromptPaths.flatMap((path) => ['--append-system-prompt', path]),
+  ...appendPromptArgs(input.harness, input.rootDirectory, appendPromptPaths),
   ...(input.harness === 'pi' && composition.identity.promptTemplate !== undefined
     ? ['--prompt-template', `${input.rootDirectory}/prompt-template.md`]
     : []),
@@ -103,7 +131,11 @@ export const projectComposition = (composition: CompositionPlan, input: Projecti
     materializeConfigurationOverlays(input.configurationOverlayDirectories ?? [], input.rootDirectory);
   }
   const materialized = materializeComposition(composition, input.rootDirectory);
-  const launch = buildLaunchPlan(composition, input, materialized.systemPromptPath, materialized.appendPromptPaths);
+  // Caller documents follow the composition's own, so a persona is read against the agent it adopts.
+  const launch = buildLaunchPlan(composition, input, materialized.systemPromptPath, [
+    ...materialized.appendPromptPaths,
+    ...(input.appendPromptPaths ?? []),
+  ]);
   const unsupported = [
     ...unsupportedElements(composition, input),
     ...materialized.skippedSkills.map((slug) => `skill:${slug} (escaping symlink)`),

--- a/code/cli/src/projection/Projection.ts
+++ b/code/cli/src/projection/Projection.ts
@@ -22,6 +22,12 @@ export interface ProjectionInput {
   /** Durable session store for the run (pi only); omitted to leave the harness default in place. */
   readonly sessionDirectory?: string;
   readonly passThroughArgs?: readonly string[];
+  /**
+   * Caller-supplied documents appended to the system prompt after the composition's own, in the
+   * order given — typically a persona, by absolute path from outside the projection root. Projected
+   * per harness, since pi and claude take append-prompt documents through incompatible flags.
+   */
+  readonly appendPromptPaths?: readonly string[];
   /** Local pi extension install directories to load with `--extension` (pi only). */
   readonly extensionLoadDirs?: readonly string[];
   /** Harness-native configuration directories, highest precedence first, overlaid into the root. */

--- a/code/cli/tests/unit/run-agent-append-prompt.test.ts
+++ b/code/cli/tests/unit/run-agent-append-prompt.test.ts
@@ -10,9 +10,10 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'nod
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
+import { Command } from 'commander';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { executeRunAgentCommand } from '../../src/cli/commands/RunAgentCommand.js';
+import { createRunAgentCommand, executeRunAgentCommand } from '../../src/cli/commands/RunAgentCommand.js';
 
 const roots: string[] = [];
 
@@ -48,11 +49,75 @@ const appendFilePaths = (args: readonly string[]): readonly string[] =>
     .map((arg, index) => (arg === '--append-system-prompt-file' ? args[index + 1] : undefined))
     .filter((path): path is string => path !== undefined);
 
+/** The path named by `--system-prompt` or `--system-prompt-file`, whichever the harness takes. */
+const systemPromptArg = (args: readonly string[]): { readonly flag: string; readonly path: string } => {
+  const index = args.findIndex((arg) => arg === '--system-prompt' || arg === '--system-prompt-file');
+  return { flag: args[index], path: args[index + 1] };
+};
+
 afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
 describe('append-prompt projection', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.5.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  //
+  // Both Claude prompt flags take a prompt *string*, so a path arrives as literal text and the
+  // document is silently dropped. The `-file` forms apply the contents. They are undocumented —
+  // neither appears in `claude --help` — but both were verified against the shipped 2.1.x binary.
+  it('names Claude prompt documents with the -file flags, and pi with the bare ones', async () => {
+    const { home, project } = tree();
+
+    for (const [harness, expected] of [
+      ['claude', '--system-prompt-file'],
+      ['pi', '--system-prompt'],
+    ] as const) {
+      const result = await executeRunAgentCommand({
+        homeDirectory: home,
+        projectDirectory: project,
+        agent: 'engineer',
+        harness,
+        passThroughArgs: ['--print'],
+        launcher: (plan) => {
+          expect(systemPromptArg(plan.args).flag).toBe(expected);
+          expect(readFileSync(systemPromptArg(plan.args).path, 'utf8')).toBe('SYSTEM');
+          return Promise.resolve(0);
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+    }
+  });
+
+  it('rejects an unreadable --append-prompt path before launching, on either harness', async () => {
+    const { home, project, root } = tree();
+    const missing = join(root, 'absent.md');
+
+    for (const harness of ['claude', 'pi'] as const) {
+      let launched = false;
+      // Rejects rather than returning, matching assertNoSettingsIssues; cli.ts prints the message
+      // and exits 1. Without this the two harnesses fail differently — a raw ENOENT out of the
+      // Claude concatenation, and a harness-generated error on pi, since pi opens the path itself.
+      await expect(
+        executeRunAgentCommand({
+          homeDirectory: home,
+          projectDirectory: project,
+          agent: 'engineer',
+          harness,
+          appendPromptPaths: [missing],
+          passThroughArgs: ['--print'],
+          launcher: () => {
+            launched = true;
+            return Promise.resolve(0);
+          },
+        }),
+      ).rejects.toThrow(`--append-prompt: not a readable file: ${missing}`);
+
+      expect(launched).toBe(false);
+    }
+  });
+
   it('gives Claude one --append-system-prompt-file over a concatenation, never a repeated flag', async () => {
     const { home, project } = tree();
 
@@ -69,7 +134,7 @@ describe('append-prompt projection', () => {
         const files = appendFilePaths(plan.args);
         expect(files).toHaveLength(1);
         // Repeats are last-wins on Claude, so every document has to arrive in the one file.
-        expect(readFileSync(files[0], 'utf8')).toBe('SHARED\nENGINEER BODY\n\n');
+        expect(readFileSync(files[0], 'utf8')).toBe('SHARED\n\nENGINEER BODY\n');
         return Promise.resolve(0);
       },
     });
@@ -96,6 +161,9 @@ describe('append-prompt projection', () => {
     expect(result.exitCode).toBe(0);
   });
 
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.3.1 — "runtime passthrough append prompts",
+  // the final element of the composition order).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('appends --append-prompt documents after the agent composition, in the order given', async () => {
     const { home, project, root } = tree();
     const org = join(root, 'org.md');
@@ -141,7 +209,7 @@ describe('append-prompt projection', () => {
       launcher: (plan) => {
         const files = appendFilePaths(plan.args);
         expect(files).toHaveLength(1);
-        expect(readFileSync(files[0], 'utf8')).toBe('SHARED\nENGINEER BODY\n\nORG CONTEXT\nROLE CONTEXT\n');
+        expect(readFileSync(files[0], 'utf8')).toBe('SHARED\n\nENGINEER BODY\n\nORG CONTEXT\n\nROLE CONTEXT\n');
         return Promise.resolve(0);
       },
     });
@@ -165,13 +233,57 @@ describe('append-prompt projection', () => {
       passThroughArgs: ['--print'],
       launcher: (plan) => {
         const composed = readFileSync(appendFilePaths(plan.args)[0], 'utf8');
-        // Without the separator the two headings would glue into `# First# Second`.
-        expect(composed).toContain('# First\n# Second\n');
+        // With a single newline these would merge into one Markdown block; `# Second` would
+        // become a setext heading for the preceding line rather than its own heading.
+        expect(composed).toContain('# First\n\n# Second\n');
         return Promise.resolve(0);
       },
     });
 
     expect(result.exitCode).toBe(0);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.1.9, OFTR-005.3.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  //
+  // Enters through Commander rather than executeRunAgentCommand, so it covers the repeat collector,
+  // the kebab-to-camel option name, and the interaction with allowUnknownOption plus the variadic
+  // passthrough argument — none of which the direct-call tests exercise.
+  it('collects repeated --append-prompt through the public Commander run path', async () => {
+    const { home, project, root } = tree();
+    const org = join(root, 'org.md');
+    const role = join(root, 'role.md');
+    write(org, 'ORG CONTEXT');
+    write(role, 'ROLE CONTEXT');
+    const program = new Command();
+    let appended: readonly string[] = [];
+    createRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      writeLine: () => undefined,
+      launcher: (plan) => {
+        appended = appendPaths(plan.args).map((path) => readFileSync(path, 'utf8'));
+        return Promise.resolve(0);
+      },
+    }).register(program);
+
+    await program.parseAsync([
+      'node',
+      'outfitter',
+      'run',
+      'engineer',
+      '--harness',
+      'pi',
+      '--append-prompt',
+      org,
+      '--append-prompt',
+      role,
+      '--',
+      '--print',
+      'review this',
+    ]);
+
+    expect(appended).toEqual(['SHARED', 'ENGINEER BODY\n', 'ORG CONTEXT', 'ROLE CONTEXT']);
   });
 
   it('keeps passthrough arguments last so a caller can still override the harness', async () => {

--- a/code/cli/tests/unit/run-agent-append-prompt.test.ts
+++ b/code/cli/tests/unit/run-agent-append-prompt.test.ts
@@ -1,0 +1,197 @@
+// Tests harness-aware projection of append-prompt documents, and the --append-prompt run flag.
+//
+// pi and Claude Code take these documents through incompatible flags. Verified against the shipped
+// binaries: pi's `--append-system-prompt` reads a file path and accumulates across repeats, while
+// Claude's takes a prompt *string* — handed a path it appends the path text — and needs
+// `--append-system-prompt-file`, which pi rejects outright, and keeps only the last occurrence.
+// Emitting pi's form to Claude therefore drops every document without an error, which is what these
+// tests exist to prevent regressing.
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { executeRunAgentCommand } from '../../src/cli/commands/RunAgentCommand.js';
+
+const roots: string[] = [];
+
+const temporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-run-append-prompt-'));
+  roots.push(root);
+  return root;
+};
+
+const write = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+
+const tree = (): { readonly home: string; readonly project: string; readonly root: string } => {
+  const root = temporaryRoot();
+  const project = join(root, 'project');
+  write(join(project, '.agents', 'system-prompt.md'), 'SYSTEM');
+  write(join(project, '.agents', 'agents.md'), 'SHARED');
+  write(join(project, '.agents', 'agents', 'engineer', 'agent.md'), '---\nname: engineer\n---\n\nENGINEER BODY\n');
+  return { home: join(root, 'home'), project, root };
+};
+
+/** Paths named by each `--append-system-prompt`, in order. */
+const appendPaths = (args: readonly string[]): readonly string[] =>
+  args
+    .map((arg, index) => (arg === '--append-system-prompt' ? args[index + 1] : undefined))
+    .filter((path): path is string => path !== undefined);
+
+/** Paths named by each `--append-system-prompt-file`, in order. */
+const appendFilePaths = (args: readonly string[]): readonly string[] =>
+  args
+    .map((arg, index) => (arg === '--append-system-prompt-file' ? args[index + 1] : undefined))
+    .filter((path): path is string => path !== undefined);
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('append-prompt projection', () => {
+  it('gives Claude one --append-system-prompt-file over a concatenation, never a repeated flag', async () => {
+    const { home, project } = tree();
+
+    const result = await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      agent: 'engineer',
+      harness: 'claude',
+      passThroughArgs: ['--print'],
+      launcher: (plan) => {
+        // A bare --append-system-prompt would append the literal path and silently lose the content.
+        expect(appendPaths(plan.args)).toEqual([]);
+
+        const files = appendFilePaths(plan.args);
+        expect(files).toHaveLength(1);
+        // Repeats are last-wins on Claude, so every document has to arrive in the one file.
+        expect(readFileSync(files[0], 'utf8')).toBe('SHARED\nENGINEER BODY\n\n');
+        return Promise.resolve(0);
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('keeps pi on repeated --append-system-prompt, which it accumulates natively', async () => {
+    const { home, project } = tree();
+
+    const result = await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      agent: 'engineer',
+      harness: 'pi',
+      passThroughArgs: ['--print'],
+      launcher: (plan) => {
+        expect(appendFilePaths(plan.args)).toEqual([]);
+        expect(appendPaths(plan.args).map((path) => readFileSync(path, 'utf8'))).toEqual(['SHARED', 'ENGINEER BODY\n']);
+        return Promise.resolve(0);
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('appends --append-prompt documents after the agent composition, in the order given', async () => {
+    const { home, project, root } = tree();
+    const org = join(root, 'org.md');
+    const role = join(root, 'role.md');
+    write(org, 'ORG CONTEXT');
+    write(role, 'ROLE CONTEXT');
+
+    const result = await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      agent: 'engineer',
+      harness: 'pi',
+      appendPromptPaths: [org, role],
+      passThroughArgs: ['--print'],
+      launcher: (plan) => {
+        expect(appendPaths(plan.args).map((path) => readFileSync(path, 'utf8'))).toEqual([
+          'SHARED',
+          'ENGINEER BODY\n',
+          'ORG CONTEXT',
+          'ROLE CONTEXT',
+        ]);
+        return Promise.resolve(0);
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('folds --append-prompt documents into the Claude concatenation in the same order', async () => {
+    const { home, project, root } = tree();
+    const org = join(root, 'org.md');
+    const role = join(root, 'role.md');
+    write(org, 'ORG CONTEXT');
+    write(role, 'ROLE CONTEXT');
+
+    const result = await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      agent: 'engineer',
+      harness: 'claude',
+      appendPromptPaths: [org, role],
+      passThroughArgs: ['--print'],
+      launcher: (plan) => {
+        const files = appendFilePaths(plan.args);
+        expect(files).toHaveLength(1);
+        expect(readFileSync(files[0], 'utf8')).toBe('SHARED\nENGINEER BODY\n\nORG CONTEXT\nROLE CONTEXT\n');
+        return Promise.resolve(0);
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('separates documents that lack a trailing newline', async () => {
+    const { home, project, root } = tree();
+    const first = join(root, 'first.md');
+    const second = join(root, 'second.md');
+    write(first, '# First');
+    write(second, '# Second');
+
+    const result = await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      agent: 'engineer',
+      harness: 'claude',
+      appendPromptPaths: [first, second],
+      passThroughArgs: ['--print'],
+      launcher: (plan) => {
+        const composed = readFileSync(appendFilePaths(plan.args)[0], 'utf8');
+        // Without the separator the two headings would glue into `# First# Second`.
+        expect(composed).toContain('# First\n# Second\n');
+        return Promise.resolve(0);
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('keeps passthrough arguments last so a caller can still override the harness', async () => {
+    const { home, project, root } = tree();
+    const persona = join(root, 'persona.md');
+    write(persona, 'PERSONA');
+
+    const result = await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      agent: 'engineer',
+      harness: 'claude',
+      appendPromptPaths: [persona],
+      passThroughArgs: ['--print', 'review this'],
+      launcher: (plan) => {
+        expect(plan.args.slice(-2)).toEqual(['--print', 'review this']);
+        return Promise.resolve(0);
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/code/cli/tests/unit/run-agent-inheritance.test.ts
+++ b/code/cli/tests/unit/run-agent-inheritance.test.ts
@@ -74,16 +74,15 @@ describe('run inherited agent', () => {
     expect(result.exitCode).toBe(0);
   });
 
-  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.3, OFTR-006.5).
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.3, OFTR-006.5.6, OFTR-006.5.7).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   //
   // The requirement — deterministic composition order — has not changed. The projection it asserts
   // against has. This previously expected a repeated `--append-system-prompt` naming each fragment
   // by path, which Claude cannot honor: that flag takes a prompt *string*, so a path arrives as
   // literal text, and repeats overwrite instead of accumulating. Order was being verified against a
-  // launch that discarded every fragment. Claude now receives one `--append-system-prompt-file` over
-  // a concatenation — the native flag OFTR-006.5.5 scopes prompt control to — and the composition
-  // order is observable as the order within that file.
+  // launch that discarded every fragment. OFTR-006.5.6 and .7 were added for exactly this, and the
+  // composition order is now observable as the order within the single concatenated file.
   it('projects exact inherited prompt order through the Claude adapter', async () => {
     const { home, project } = tree();
     write(join(project, '.agents', 'prompts', 'base.md'), 'BASE APPEND');
@@ -108,8 +107,9 @@ describe('run inherited agent', () => {
         // Exactly one, because a second occurrence would silently discard the first.
         expect(composedPaths).toHaveLength(1);
         expect(plan.args).not.toContain('--append-system-prompt');
+        // Blank-line separated, so a fragment ending mid-sentence cannot merge into the next.
         expect(readFileSync(composedPaths[0], 'utf8')).toBe(
-          ['SHARED', 'BASE APPEND', 'BASE BODY\n', 'CHILD BODY\n'].map((fragment) => `${fragment}\n`).join(''),
+          ['SHARED', 'BASE APPEND', 'BASE BODY', 'CHILD BODY'].map((fragment) => `${fragment}\n`).join('\n'),
         );
         return Promise.resolve(0);
       },

--- a/code/cli/tests/unit/run-agent-inheritance.test.ts
+++ b/code/cli/tests/unit/run-agent-inheritance.test.ts
@@ -74,8 +74,16 @@ describe('run inherited agent', () => {
     expect(result.exitCode).toBe(0);
   });
 
-  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.3, OFTR-006.3).
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.3, OFTR-006.5).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  //
+  // The requirement — deterministic composition order — has not changed. The projection it asserts
+  // against has. This previously expected a repeated `--append-system-prompt` naming each fragment
+  // by path, which Claude cannot honor: that flag takes a prompt *string*, so a path arrives as
+  // literal text, and repeats overwrite instead of accumulating. Order was being verified against a
+  // launch that discarded every fragment. Claude now receives one `--append-system-prompt-file` over
+  // a concatenation — the native flag OFTR-006.5.5 scopes prompt control to — and the composition
+  // order is observable as the order within that file.
   it('projects exact inherited prompt order through the Claude adapter', async () => {
     const { home, project } = tree();
     write(join(project, '.agents', 'prompts', 'base.md'), 'BASE APPEND');
@@ -94,15 +102,15 @@ describe('run inherited agent', () => {
       agent: 'engineer',
       harness: 'claude',
       launcher: (plan) => {
-        const appendPaths = plan.args
-          .map((arg, index) => (arg === '--append-system-prompt' ? plan.args[index + 1] : undefined))
+        const composedPaths = plan.args
+          .map((arg, index) => (arg === '--append-system-prompt-file' ? plan.args[index + 1] : undefined))
           .filter((path): path is string => path !== undefined);
-        expect(appendPaths.map((path) => readFileSync(path, 'utf8'))).toEqual([
-          'SHARED',
-          'BASE APPEND',
-          'BASE BODY\n',
-          'CHILD BODY\n',
-        ]);
+        // Exactly one, because a second occurrence would silently discard the first.
+        expect(composedPaths).toHaveLength(1);
+        expect(plan.args).not.toContain('--append-system-prompt');
+        expect(readFileSync(composedPaths[0], 'utf8')).toBe(
+          ['SHARED', 'BASE APPEND', 'BASE BODY\n', 'CHILD BODY\n'].map((fragment) => `${fragment}\n`).join(''),
+        );
         return Promise.resolve(0);
       },
     });

--- a/docs/requirements/OFTR-005-run-and-composite-profile.md
+++ b/docs/requirements/OFTR-005-run-and-composite-profile.md
@@ -23,6 +23,9 @@ Amended (2026-07-17, RFC #165): `run` selects an agent slug and a harness, not a
 6. The `run` command MUST accept `--harness <pi|claude>`, defaulting to `default_harness` then `pi`.
 7. The `run` command MUST pass unrecognized arguments through to the selected harness CLI unaltered.
 8. The `run` command MUST resolve, compose, project, and launch through the shared resolver and composer.
+9. The `run` command MUST accept a repeatable `--append-prompt <path>`, appending each named document to the system prompt after the composition's own fragments, in the order given.
+10. The `run` command MUST reject an `--append-prompt` path that is not a readable file before launching, naming both the flag and the path.
+11. `--append-prompt` MUST project through whichever native flag the selected harness reads, so a caller does not have to know which harness will launch. Passthrough after `--` cannot satisfy this, because it reaches the harness unaltered per OFTR-005.1.7.
 
 ### OFTR-005.2: Composition Definition
 

--- a/docs/requirements/OFTR-006-agent-adapters.md
+++ b/docs/requirements/OFTR-006-agent-adapters.md
@@ -67,10 +67,12 @@ Amended (2026-07-17, RFC #165): adapters project a harness-neutral composition, 
 2. The Claude Code adapter MUST launch the native `claude` command.
 3. The Claude Code adapter MUST support profile-controlled environment variables.
 4. The Claude Code adapter MUST support profile-controlled pass-through Claude Code CLI arguments.
-5. The Claude Code adapter SHOULD support `--model`, `--effort`, `--system-prompt`, `--append-system-prompt`, and `--plugin-dir` where native Claude Code flags exist.
-6. The Claude Code adapter SHOULD support `controls.session_directory` and `controls.claude.session_directory` by routing Claude `projects/` session state through Outfitter state persistence.
-7. The Claude Code adapter MUST return unsupported-control warnings for requested generic or `controls.claude` controls that it cannot translate.
-8. Until native support is implemented and tested, the Claude Code adapter MUST report `prompt_template` as unsupported and MUST NOT pass a pi-style prompt-template argument.
+5. The Claude Code adapter SHOULD support `--model`, `--effort`, prompt control, and `--plugin-dir` where native Claude Code flags exist.
+6. The Claude Code adapter MUST pass prompt documents with `--system-prompt-file` and `--append-system-prompt-file`, never the bare `--system-prompt` or `--append-system-prompt`. The bare flags take a prompt string, so a path is appended as literal text and the document is silently discarded.
+7. The Claude Code adapter MUST pass at most one `--append-system-prompt-file`, concatenating the composed fragments in composition order, because a repeated occurrence discards every earlier one.
+8. The Claude Code adapter SHOULD support `controls.session_directory` and `controls.claude.session_directory` by routing Claude `projects/` session state through Outfitter state persistence.
+9. The Claude Code adapter MUST return unsupported-control warnings for requested generic or `controls.claude` controls that it cannot translate.
+10. Until native support is implemented and tested, the Claude Code adapter MUST report `prompt_template` as unsupported and MUST NOT pass a pi-style prompt-template argument.
 
 ### OFTR-006.6: Pi Settings Reconciliation
 


### PR DESCRIPTION
## The defect

The Claude adapter emitted one `--append-system-prompt <path>` per fragment. That flag takes a prompt **string** — handed a path it appends the path text, so the document contents never reach the model. Repeats are also last-wins, so even with the right form only the final fragment would survive.

An agent declaring `append_system_prompt` therefore launched on Claude with none of it applied, and nothing errored.

## Verified against the shipped binaries

Not inferred from the source:

```
claude --append-system-prompt      /tmp/a.md   -> path text, content lost
claude --append-system-prompt-file /tmp/a.md   -> content applied
claude --append-system-prompt-file a --append-system-prompt-file b -> only b
pi     --append-system-prompt a --append-system-prompt b           -> both
```

Reversing argument order reverses which survives on Claude, so the last-wins result is not a model-attention artifact.

## The fix

Claude now receives a single `--append-system-prompt-file` over a concatenation of the fragments in composition order — the native flag `OFTR-006.5.5` scopes prompt control to.

Pi is unchanged. Its `--append-system-prompt` reads a file path and accumulates across repeats, and it rejects the `-file` form outright (`Unknown option`). The two harnesses have no common spelling, so the divergence has to live in the adapter.

## New: `outfitter run --append-prompt <path>`

Repeatable, for documents the caller supplies at launch — a persona, typically. These land after the agent's own fragments, which is the position `OFTR-005.3.1` already reserved for *"runtime passthrough append prompts"*.

Passthrough after `--` cannot serve this: those arguments reach the harness verbatim, so a caller would have to know which harness will be launched and spell the flag its way — exactly the trap above. Every persona launcher and doc in the wider ecosystem currently passes a bare path this way, which works on pi and silently no-ops on Claude.

## A test asserted the bug

`run-agent-inheritance.test.ts`'s Claude ordering test expected repeated `--append-system-prompt` naming each fragment by path, and passed. That is why this survived in a shipped, tested feature.

Its requirement is unchanged — composition order is still asserted exactly, now observed inside the composed file. Its citation is corrected from `OFTR-006.3` (pi launch controls) to `OFTR-006.5` (Claude launch controls), and it carries a comment recording why the mechanism moved.

## Verification

- 308 tests pass; typecheck, eslint, prettier, coverage clean.
- 6 new tests: both harnesses, ordering, `--append-prompt` folding, trailing-newline separation, passthrough staying last.
- End-to-end with the built `cli.js` — Claude emits one `-file` flag containing agent body then persona in order; a real pi run returned the persona's codeword.

**Limits:** a live Claude run through `outfitter run` is auth-gated (the projection points `CLAUDE_CONFIG_DIR` at a throwaway root), so the Claude leg was verified at the launch-plan boundary rather than against a live model. The `paths.length === 0` guard is unreachable through composition and carries a `v8 ignore` explaining why it is kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)