### PR TITLE
docs(personas): cross-project tier, and composed identities without changing the default

### DIFF
--- a/docs/architecture/controllable-elements.md
+++ b/docs/architecture/controllable-elements.md
@@ -39,11 +39,11 @@ The directory where conversation sessions, transcripts, or run state are stored.
 ### Personas
 
 Not a composed key.
-A persona is a convention: a shared review [agent](../documentation/agents.md) plus one portable persona document appended at launch (see [Personas](../documentation/personas.md)).
-The controllable element underneath it is harness argument passthrough — `--append-system-prompt <file>` on the launch command — not a `personas` list.
+A persona is a convention: a shared review [agent](../documentation/agents.md) plus one or more portable persona documents appended at launch in caller-chosen order (see [Personas](../documentation/personas.md)).
+The controllable element underneath it is prompt append — `--append-prompt <file>` on the launch command, repeatable — not a `personas` list. The flag exists because the harnesses diverge here and passthrough cannot: pi reads a path from `--append-system-prompt` and accumulates repeats, while Claude Code needs `--append-system-prompt-file` and keeps only the last occurrence.
 
-- Pi name: `--system-prompt` / `--append-system-prompt` composition
-- Claude name: `--system-prompt` / `--append-system-prompt` composition
+- Pi name: `--system-prompt` / repeated `--append-system-prompt` composition
+- Claude name: `--system-prompt` / one `--append-system-prompt-file` over a concatenation
 
 ### Subagents
 

--- a/docs/documentation/concepts.md
+++ b/docs/documentation/concepts.md
@@ -49,7 +49,7 @@ The protocol resources Outfitter resolves and composes:
 Three related terms, none of which is a settings key or a separate file format:
 
 - A **[profile](./profiles.md)** is just an agent and its loadout. "The engineer profile" is the `engineer` agent with everything it composes. There is no `profile.yml` and no `profiles:` map — the loadout lives on the agent.
-- A **[persona](./personas.md)** is a _convention_, not a resource: one portable, committed Markdown document per persona — for example `docs/personas/platform-lead.md` — appended at launch to a shared review agent, or pasted into any tool as stakeholder context. Swapping the file swaps the persona.
+- A **[persona](./personas.md)** is a _convention_, not a resource: one portable, committed Markdown document per persona — `docs/personas/platform-lead.md` for a project's own readers, or `~/.agents/personas/platform-lead.md` for a reader who outlives one repository — appended at launch to a shared review agent, or pasted into any tool as stakeholder context. Swapping the file swaps the persona.
 - A **[subagent](./subagents.md)** is an agent projected into the harness's native delegation mechanism, selected in another agent's `subagents` loadout. A leader agent delegates to local coding-harness subagents or to issue- and action-backed subagents.
 
 The same agent definition can be run directly or selected as a subagent elsewhere; its loadout decides what it composes.

--- a/docs/documentation/personas.md
+++ b/docs/documentation/personas.md
@@ -32,18 +32,37 @@ Neither tier is a resource Outfitter resolves; both are ordinary directories of 
 
 ## Three ways to consume the same file
 
-- **Appended at launch**: `outfitter run persona-reviewer -- --append-system-prompt docs/personas/platform-lead.md …` — the direct run is the underlying interface, and the reviewer adopts the file as its identity for that session only. An agent using the [`persona-review`](https://github.com/ai-outfitter/community-profiles/tree/main/skills/persona-review) skill can drive the same run in the background or synchronously and capture its report in a durable file. See [Persona reviews](./usecases/persona-reviews.md) for the runnable form of both.
+- **Appended at launch**: `outfitter run persona-reviewer --append-prompt docs/personas/platform-lead.md -- …` — the direct run is the underlying interface, and the reviewer adopts the file as its identity for that session only. Pass `--append-prompt` rather than spelling the harness flag yourself after `--`: pi and Claude Code take append-prompt documents through different flags, so a hand-written passthrough only works on the harness it was written for, and fails silently on the other. An agent using the [`persona-review`](https://github.com/ai-outfitter/community-profiles/tree/main/skills/persona-review) skill can drive the same run in the background or synchronously and capture its report in a durable file. See [Persona reviews](./usecases/persona-reviews.md) for the runnable form of both.
 - **Pasted into a web agent**: upload or paste the file unchanged into claude.ai project knowledge or a ChatGPT project as stakeholder context. Same artifact, zero conversion.
 - **Ordinary reading context**: any agent doing product planning, research, or writing can read the file to know who the work is for.
 
+## When one file is not enough
+
+Start with one file. Reach for a second only when part of an identity varies independently and would otherwise be copied into every persona that shares it — most often an **organization**: sector, scale, regulatory exposure, how the business weighs risk against speed. Three organizations against four roles is seven documents rather than twelve.
+
+```sh
+outfitter run persona-reviewer \
+  --append-prompt docs/personas/org.enterprise-insurance.md \
+  --append-prompt docs/personas/platform-lead.md \
+  -- --print "Review the onboarding flow. @README.md"
+```
+
+Order is meaning: earlier documents establish the context later ones are read against, so organization comes before role, and a named individual comes last. A role document written for composition must not name a sector or an employer — that is exactly what lets it read correctly under any organization.
+
+Each file is still ordinary Markdown that reads on its own, names no other file, and leaves no placeholder for one. Splitting for any other reason — to store a schema in filenames, to make files shorter, to mirror a template — is the failure mode the next section describes, and it remains the wrong move.
+
+Portability survives intact. Every document uploads unchanged into claude.ai project knowledge or a ChatGPT project; when an identity spans several, upload them in the same order, or `cat org.md role.md > persona.md` and upload the one file. The claim was never _one artifact_ — it is _no conversion step_, and `cat` is not a conversion step.
+
 ## Why a convention, not a key
 
-Modeling personas as their own resource — or as a `personas:` list you compose in order — duplicates what an agent already is and grows the surface area of the system. Keeping personas as "shared agent + one document" means a team maintains one review agent and a directory of cheap Markdown files, instead of a fleet of near-identical agents or a runtime chain of fragments.
+Modeling personas as their own resource — a `personas:` key that Outfitter resolves, merges across layers, validates, and projects — duplicates what an agent already is and grows the surface area of the system. Naming documents at launch is not that: Outfitter resolves nothing, merges nothing, validates nothing, and `outfitter dump` still carries no persona. Order is whatever you typed on the command line, not a precedence rule the system has to define and defend.
 
-Organization research, interviews, and individual detail are **authoring inputs**, not committed schema: interview from them, keep research notes however you like, but the committed canonical artifact is always one self-contained role file. Do not invent demographics, income, or biography the research does not support, and never generate an Outfitter agent per persona.
+Keeping personas as "shared agent plus committed Markdown" means a team maintains one review agent and a directory of cheap files, instead of a fleet of near-identical agents. A tenth persona is a tenth file; a second organization is one more file, not a copy of every role.
+
+Organization research, interviews, and individual detail are **authoring inputs**, not committed schema: interview from them, keep research notes however you like, but what gets committed is Markdown a person can read. Do not invent demographics, income, or biography the research does not support, and never generate an Outfitter agent per persona.
 
 ## Status
 
-Personas ride entirely on existing CLI behavior (`outfitter run` plus `--append-system-prompt` passthrough), so no `OFTR-*` requirement covers them. The reviewer runs as the selected agent; native Pi subagent projection is not a prerequisite. An `.agents`-native persona form (a protocol resource, or a settings layer pointing at persona documents) is a separate, deferred design; the portable file must never depend on it.
+Personas ride entirely on existing CLI behavior — `outfitter run` plus `--append-prompt`, which projects each document through whichever flag the selected harness actually reads — so no `OFTR-*` requirement covers them beyond the composition order in `OFTR-005.3.1`. The reviewer runs as the selected agent; native Pi subagent projection is not a prerequisite. An `.agents`-native persona form (a protocol resource, or a settings layer pointing at persona documents) is a separate, deferred design; the portable file must never depend on it.
 
 See [Persona reviews](./usecases/persona-reviews.md) for the worked author → run → paste-anywhere story, and the community catalog's [persona boundary doc](https://github.com/ai-outfitter/community-profiles/blob/main/docs/persona-review.md) for the setup and runtime responsibility split.

--- a/docs/documentation/personas.md
+++ b/docs/documentation/personas.md
@@ -13,15 +13,22 @@ A persona file is plain Markdown with no frontmatter and no schema:
 - First-person prose: an unheaded opening paragraph, then the recommended sections `## My work and context`, `## What I need`, `## How I decide`, and `## How I communicate`. Sections may be renamed or combined; connected prose beats bullet stacks.
 - Everything the persona knows — role, goals, constraints, decision signals, voice — is ordinary Markdown.
 
-It lives in normal project documentation, deliberately outside `.agents/`:
+The authoring template and completed reference personas ship in the community catalog's [`persona-authoring`](https://github.com/ai-outfitter/community-profiles/tree/main/skills/persona-authoring) skill.
+
+## Where personas live
+
+A persona file lives in normal documentation, deliberately outside `.agents/`, in one of two tiers:
 
 ```text
-docs/personas/
+docs/personas/            # project tier — readers of this project
   platform-lead.md
+~/.agents/personas/       # cross-project tier — readers who outlive one repository
   founder-operator.md
 ```
 
-A persona is project steering context rather than agent configuration, which is why `outfitter dump` does not carry it. The authoring template and completed reference personas ship in the community catalog's [`persona-authoring`](https://github.com/ai-outfitter/community-profiles/tree/main/skills/persona-authoring) skill.
+Use the **project tier** when the persona only makes sense next to the work it describes. Use the **cross-project tier** when the reader exists independently of any single repository — the file is then reachable from any working directory, including `~`. Filenames are lowercase and hyphenated and name the role rather than the person.
+
+Neither tier is a resource Outfitter resolves; both are ordinary directories of Markdown. A persona is project steering context rather than agent configuration, which is why `outfitter dump` does not carry it. The `persona-review` launcher searches the project tier before the cross-project one, so `--persona platform-lead` picks up a project override of a shared role without renaming anything.
 
 ## Three ways to consume the same file
 

--- a/docs/documentation/usecases/persona-reviews.md
+++ b/docs/documentation/usecases/persona-reviews.md
@@ -86,13 +86,12 @@ After `outfitter setup`, launch the shared reviewer directly with the persona ap
 
 ```sh
 mkdir -p docs/persona-reviews
-outfitter run persona-reviewer -- \
-  --append-system-prompt docs/personas/platform-lead.md \
+outfitter run persona-reviewer --append-prompt docs/personas/platform-lead.md -- \
   --print "Review the onboarding flow and write the report. @README.md" \
   > docs/persona-reviews/platform-lead-onboarding.md
 ```
 
-This is the portable interface: it works from the project containing the persona and does not assume a particular catalog checkout path. One shared agent adopts the file as its identity for that session only and writes a first-person, sourced report — evidence cited to the exact page or UI moment, assumptions labeled. The reviewer inherits the caller's configured model; reviews benefit from a strong reasoning model.
+This is the portable interface: it works from the project containing the persona, does not assume a particular catalog checkout path, and does not assume a harness — `--append-prompt` projects the document through whichever flag pi or Claude Code actually reads. Repeat it to compose an identity from several documents; see [When one file is not enough](../personas.md#when-one-file-is-not-enough). One shared agent adopts the file as its identity for that session only and writes a first-person, sourced report — evidence cited to the exact page or UI moment, assumptions labeled. The reviewer inherits the caller's configured model; reviews benefit from a strong reasoning model.
 
 ### Optional orchestration with the skill
 

--- a/docs/documentation/usecases/persona-reviews.md
+++ b/docs/documentation/usecases/persona-reviews.md
@@ -76,6 +76,8 @@ docs/personas/
   founder-operator.md
 ```
 
+A persona whose reader exists independently of any one repository goes in `~/.agents/personas/` instead, where every working directory can reach it. See [Where personas live](../personas.md#where-personas-live).
+
 Prefer generic role archetypes over named individuals. Research and interviews are authoring inputs; commit only the self-contained file, and invent nothing the research does not support.
 
 ## Run it under Outfitter
@@ -98,12 +100,12 @@ Use the [`persona-review`](https://github.com/ai-outfitter/community-profiles/tr
 
 ```sh
 bash skills/persona-review/scripts/persona-review.sh \
-  --persona docs/personas/platform-lead.md \
+  --persona platform-lead \
   --report docs/persona-reviews/platform-lead-onboarding.md \
   -- --print "Review the onboarding flow and write the report. @README.md"
 ```
 
-The reviewer runs directly as the selected agent. This journey does not require Pi's native subagent projection.
+A bare `--persona` name resolves against `docs/personas/`, then `.agents/personas/`, then `~/.agents/personas/`, so the same command works whether the persona is project-local or cross-project; pass a path to name a file directly. The reviewer runs directly as the selected agent. This journey does not require Pi's native subagent projection.
 
 ## Take the same file to the web
 


### PR DESCRIPTION
Two commits, reviewable separately.

## 1. `docs(personas): document the cross-project persona tier`

A persona whose reader outlives one repository lives in `~/.agents/personas/` and is reachable from any working directory; one that only makes sense beside the work it describes stays in that project's `docs/personas/`. Adds a "Where personas live" section and documents that `--persona <name>` resolves the project tier first, so a project override needs no renaming.

## 2. `docs(personas): allow composed identities without changing the default`

**One file per persona stays the convention and the definition.** Composition is an advanced affordance for the case that forces it: an organization shared across several roles, where inlining it means copying the same context into every role and re-editing all of them when it changes. Three organizations against four roles is seven documents rather than twelve.

The new "When one file is not enough" section sits *after* the format and the tiers, so a reader meets the concept before the escape hatch. Every introductory surface — `README.md`, `concepts.md`, `conventions.md`, the use case's `## One persona, one file` heading — still says one file, unchanged.

### Two claims had to move

`personas.md` previously rejected *"a `personas:` list you compose in order"* and *"a runtime chain of fragments"*. Those bundled two objections that now need separating:

- **Personas as a resolved resource** — a key Outfitter merges across layers, validates, and projects — is **still rejected**, and the argument is kept. Naming documents at launch is not that: Outfitter resolves nothing, `outfitter dump` still carries no persona, and order is what the caller typed rather than a precedence rule the system has to define and defend.
- **"A runtime chain of fragments"** is dropped, because it forecloses the case above. The surface-area argument it served survives, narrowed to what actually costs surface area.

### Examples move off passthrough

`-- --append-system-prompt <path>` becomes `--append-prompt <path>`. The old form was never portable, which is worth stating plainly: pi reads a path from `--append-system-prompt` and accumulates repeats, while Claude Code takes a prompt *string* there and keeps only the last occurrence. A passthrough written for one harness fails silently on the other — no error, no persona.

## Depends on

[#248](https://github.com/ai-outfitter/outfitter/pull/248), which adds `--append-prompt`. The documented commands are wrong until that lands; the tier commit is independent.

Prettier clean. No tests guard docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)