### PR TITLE
feat(container): publish a Debian-based image as the primary tag

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       publish:
-        description: Push the validated image to GHCR
+        description: Push the validated images to GHCR
         required: false
         default: false
         type: boolean
@@ -25,7 +25,7 @@ on:
         default: v1.0.1
         type: string
       publish:
-        description: Push the validated image to GHCR
+        description: Push the validated images to GHCR
         required: false
         default: false
         type: boolean
@@ -40,7 +40,109 @@ permissions:
   packages: write
 
 jobs:
-  build:
+  # The primary published image. Debian-based so end users can extend it with
+  # an ordinary Dockerfile (FROM + apt-get install / COPY); the Nix closure
+  # image below could not be extended that way and is now the -nix variant.
+  debian:
+    name: Build and smoke test Debian image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.node-version'
+          cache: npm
+
+      - name: Sync release version
+        run: node scripts/sync-release-version.mjs "${{ inputs.version }}"
+
+      - name: Resolve image name
+        run: |
+          echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/outfitter" >> "$GITHUB_ENV"
+          echo "VERSION=${VERSION_INPUT#v}" >> "$GITHUB_ENV"
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build package
+        run: npm run build
+
+      # The image installs outfitter from this tarball, not the npm registry,
+      # so the build works for unreleased versions and in CI before publish.
+      - name: Pack CLI workspace tarball
+        run: |
+          npm pack --workspace @ai-outfitter/outfitter --pack-destination container/
+          mv container/ai-outfitter-outfitter-*.tgz container/outfitter.tgz
+
+      - name: Build image
+        run: docker build -t "$IMAGE:$VERSION" container/
+
+      - name: Smoke test image
+        run: |
+          set -euo pipefail
+          output="$(docker run --rm "$IMAGE:$VERSION" --version)"
+          if [ "$output" != "$VERSION" ]; then
+            echo "Expected outfitter --version to print '$VERSION' but got '$output'." >&2
+            exit 1
+          fi
+          docker run --rm --entrypoint /bin/sh "$IMAGE:$VERSION" -c '
+            set -eu
+            for command in node npm git ssh outfitter; do
+              command -v "$command"
+            done
+            test -f /etc/ssl/certs/ca-certificates.crt
+          '
+
+      # Extension is the workflow this image exists for. Prove the real
+      # end-user story: FROM the published image, apt-get install a tool,
+      # drop back to uid 1000, and the entrypoint still works. This is what
+      # the Nix closure image could not do — a downstream needed a 104-line
+      # repair Dockerfile to get here.
+      - name: Smoke test derivative image
+        run: |
+          set -euo pipefail
+          workdir="$(mktemp -d)"
+          cat > "$workdir/Dockerfile" <<DOCKERFILE
+          FROM $IMAGE:$VERSION
+          USER root
+          RUN apt-get update \
+            && apt-get install -y --no-install-recommends jq \
+            && rm -rf /var/lib/apt/lists/*
+          USER 1000
+          DOCKERFILE
+          docker build -t outfitter-derivative:smoke "$workdir"
+          docker run --rm outfitter-derivative:smoke --version
+          docker run --rm --entrypoint jq outfitter-derivative:smoke --version
+
+      - name: Log in to GitHub Container Registry
+        if: inputs.publish
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push version tag
+        if: inputs.publish
+        run: docker push "$IMAGE:$VERSION"
+
+      - name: Push latest tag
+        if: inputs.publish && !inputs.prerelease
+        run: |
+          docker tag "$IMAGE:$VERSION" "$IMAGE:latest"
+          docker push "$IMAGE:latest"
+
+  # The former primary image: the Nix closure built by flake.nix mkContainer,
+  # kept for lib.mkContainer consumers and published under the -nix suffix.
+  nix:
     name: Build and smoke test Nix image
     runs-on: ubuntu-latest
 
@@ -79,20 +181,19 @@ jobs:
         run: |
           nix build .#container
           docker load < result
-          docker tag outfitter:latest "$IMAGE:$VERSION"
+          docker tag outfitter:latest "$IMAGE:$VERSION-nix"
 
       - name: Smoke test image
         run: |
-          output="$(docker run --rm "$IMAGE:$VERSION" --version)"
+          output="$(docker run --rm "$IMAGE:$VERSION-nix" --version)"
           if [ "$output" != "$VERSION" ]; then
             echo "Expected outfitter --version to print '$VERSION' but got '$output'." >&2
             exit 1
           fi
-          docker run --rm --entrypoint /bin/sh "$IMAGE:$VERSION" -c \
+          docker run --rm --entrypoint /bin/sh "$IMAGE:$VERSION-nix" -c \
             'nix --version && test -x /bin/bash && test -x /usr/bin/env'
 
-      # Extension is the workflow this image exists for, and nothing covered it:
-      # the checks above only prove tools are present in the base. Residency is
+      # The checks above only prove tools are present in the base. Residency is
       # covered at the CLI level instead — signal forwarding lives in
       # spawnLauncher, so tests/unit/agent-launch.test.ts asserts it directly
       # rather than inferring it from container exit codes.
@@ -106,15 +207,15 @@ jobs:
           workdir="$(mktemp -d)"
           printf '#!/bin/bash\nexec outfitter "$@"\n' > "$workdir/entrypoint"
           cat > "$workdir/Dockerfile" <<DOCKERFILE
-          FROM $IMAGE:$VERSION
+          FROM $IMAGE:$VERSION-nix
           USER root
           COPY entrypoint /opt/agent/entrypoint
           RUN chmod 0755 /opt/agent/entrypoint
           USER 1000:1000
           ENTRYPOINT ["/opt/agent/entrypoint"]
           DOCKERFILE
-          docker build -t outfitter-derivative:smoke "$workdir"
-          docker run --rm outfitter-derivative:smoke --version
+          docker build -t outfitter-nix-derivative:smoke "$workdir"
+          docker run --rm outfitter-nix-derivative:smoke --version
 
       - name: Log in to GitHub Container Registry
         if: inputs.publish
@@ -126,10 +227,4 @@ jobs:
 
       - name: Push version tag
         if: inputs.publish
-        run: docker push "$IMAGE:$VERSION"
-
-      - name: Push latest tag
-        if: inputs.publish && !inputs.prerelease
-        run: |
-          docker tag "$IMAGE:$VERSION" "$IMAGE:latest"
-          docker push "$IMAGE:latest"
+        run: docker push "$IMAGE:$VERSION-nix"

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,0 +1,55 @@
+# Outfitter primary published image (ghcr.io/ai-outfitter/outfitter).
+#
+# Debian-based on purpose. The previous primary image was a Nix closure
+# (flake.nix mkContainer, still published as the `-nix` variant): end users
+# could not extend it conventionally — no apt, no /lib64 ELF interpreter for
+# foreign dynamic binaries, node/npm not on PATH (extension installs died with
+# `spawn npm ENOENT`), and the CA bundle at a non-default path. This image
+# makes the end-user story a plain Dockerfile: `FROM` this image, `apt-get
+# install` or `COPY` whatever the agent needs.
+#
+# The workflow builds the repo, packs the CLI workspace with `npm pack`, and
+# passes the tarball in — installing from the local build, not the registry,
+# keeps the image buildable for unreleased versions and in CI before publish.
+#
+# NODE_IMAGE tracks the `.node-version` major (24). The workflow may override
+# it to pin a digest, e.g. node:24-slim@sha256:<digest>.
+ARG NODE_IMAGE=node:24-slim
+FROM ${NODE_IMAGE}
+
+# Tarball path relative to the build context, produced by
+# `npm pack --workspace @ai-outfitter/outfitter`.
+ARG OUTFITTER_TARBALL=outfitter.tgz
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    git \
+    openssh-client \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY ${OUTFITTER_TARBALL} /tmp/outfitter.tgz
+RUN npm install -g /tmp/outfitter.tgz \
+  && rm /tmp/outfitter.tgz \
+  && npm cache clean --force
+
+# The runtime contract is uid/gid 1000 (the operator runs runAsUser: 1000,
+# fsGroup: 1000); only the uid matters to workloads. node:24-slim already
+# ships uid 1000 as `node` — rename it to `outfitter` and point its home at
+# /tmp so /etc/passwd agrees with the HOME below.
+RUN usermod -l outfitter -d /tmp node \
+  && groupmod -n outfitter node \
+  && mkdir -p /workspace \
+  && chown 1000:1000 /workspace
+
+# Deployments override HOME (e.g. HOME=/workspace onto a persistent volume);
+# /tmp is the writable default when they do not.
+ENV HOME=/tmp
+
+USER 1000:1000
+WORKDIR /workspace
+
+# No init shim and no CMD: outfitter >=1.4.0 forwards SIGTERM/SIGINT/SIGHUP
+# to its child itself (code/cli/src/agents/AgentLaunch.ts,
+# attachSignalForwarding), so PID 1 duty needs no tini.
+ENTRYPOINT ["outfitter"]

--- a/docs/architecture/file_structure.md
+++ b/docs/architecture/file_structure.md
@@ -28,7 +28,8 @@ Outfitter is organized around a private npm workspace root, clear TypeScript pac
 ├── .prettierrc.json                   # Prettier formatting configuration
 ├── .snapperrc.toml                    # Snapper Markdown formatting configuration
 ├── CONTRIBUTING.md                    # local install and contributor workflow guide
-├── flake.nix                          # Nix package and container outputs for the Outfitter CLI
+├── container/                         # Dockerfile for the primary Debian-based published image
+├── flake.nix                          # Nix package and `-nix` container variant outputs for the Outfitter CLI
 ├── flake.lock                         # pinned Nix flake inputs
 ├── code/                              # npm workspace packages and license-separated code areas
 │   ├── cli/                           # @ai-outfitter/outfitter npm package root

--- a/docs/documentation/README.md
+++ b/docs/documentation/README.md
@@ -33,7 +33,7 @@ Outfitter lays out conventions for iterating on and sharing agent configuration 
 The same composition runs on every surface; only the trigger changes.
 
 - [Running an agent in GitHub Actions](./actions.md) — headless runs on any workflow trigger.
-- [Container images](./containers.md) — run the published image persistently or add Nix-packaged tools.
+- [Container images](./containers.md) — run the published Debian-based image persistently, extend it with apt, or use the `-nix` variant.
 - [Recurring runs](./recurring-runs.md) — loops three ways: the local loop extension, Actions cron, cluster schedules.
 - [In-cluster agents](./in-cluster.md) — resident agents, CronJobs, and subagent Jobs via Link Operator.
 - [Hooks](./hooks.md) — harness hook wiring and the protocol gap.

--- a/docs/documentation/containers.md
+++ b/docs/documentation/containers.md
@@ -6,10 +6,15 @@ The published image is a generic Outfitter runtime:
 ghcr.io/ai-outfitter/outfitter:<version>
 ```
 
-It uses `outfitter` as its entrypoint and includes the Nix CLI, Bash, core
-utilities, Git, SSH, and CA certificates. It does not include agent profiles,
-credentials, channels, MCP servers, or other use-case behavior. The default
-runtime user and group are both `1000`, with `/tmp` as the home directory.
+It is Debian-based (`node:24-slim`), uses `outfitter` as its entrypoint, and
+includes Node.js, npm, Git, SSH, and CA certificates at their conventional
+Debian paths. It does not include agent profiles, credentials, channels, MCP
+servers, or other use-case behavior. The default runtime user and group are
+both `1000` (named `outfitter`), with `/tmp` as the home directory and
+`/workspace` as the working directory.
+
+A Nix closure variant of the image is also published under the `-nix` suffix;
+see [the `-nix` variant](#the--nix-variant) below.
 
 ## Run a resident agent
 
@@ -42,6 +47,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: agent
+          # The primary Debian-based image; append -nix for the Nix variant.
           image: ghcr.io/ai-outfitter/outfitter:<version>
           stdin: true
           workingDir: /workspace
@@ -75,16 +81,56 @@ resources or impose image, profile, or extension policy.
 
 ## Build a derivative image
 
-Being built with Nix does not normally imply that an image contains the Nix
-CLI. The published Outfitter image includes it intentionally, and the flake also
-exports `lib.mkContainer` for reproducible derivative images:
+The image is a normal Debian base: extend it with an ordinary Dockerfile.
+`apt-get` works, and so does `COPY`ing arbitrary binaries — including
+dynamically linked ones, since the standard ELF interpreter and shared
+libraries are present. Switch to `root` for the layers that install, then drop
+back to `1000`:
+
+```dockerfile
+FROM ghcr.io/ai-outfitter/outfitter:<version>
+
+USER root
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends jq ripgrep \
+  && rm -rf /var/lib/apt/lists/*
+COPY --chmod=0755 my-tool /usr/local/bin/my-tool
+USER 1000
+```
+
+Build and exercise the exact image:
+
+```sh
+docker build -t example-agent .
+docker run --rm example-agent --version
+docker run --rm --entrypoint /bin/sh example-agent \
+  -c 'jq --version && rg --version && my-tool --version'
+```
+
+The entrypoint stays `outfitter`; override `ENTRYPOINT` only when the derived
+image wraps the launch itself.
+
+## The `-nix` variant
+
+The Nix closure image that was previously the primary tag remains published
+for `lib.mkContainer` consumers:
+
+```text
+ghcr.io/ai-outfitter/outfitter:<version>-nix
+```
+
+It is built by the flake, includes the Nix CLI, Bash, core utilities, Git,
+SSH, and CA certificates, and its entrypoint is an absolute `/nix/store` path.
+It is not conventionally extensible — there is no apt, and foreign dynamic
+binaries do not run — so extend it through Nix instead: the flake exports
+`lib.mkContainer` for reproducible derivative images:
 
 ```nix
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     outfitter = {
-      url = "github:ai-outfitter/outfitter/v1.2.0";
+      url = "github:ai-outfitter/outfitter/v1.4.0";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
@@ -122,13 +168,14 @@ docker run --rm --entrypoint /bin/sh example-agent:latest \
 Prefer adding known runtime packages through `extraPackages`. The resulting
 image stays reproducible, and it avoids the trap below.
 
-**Do not mount an empty volume over `/nix`.** The image _is_ its Nix store: the
-entrypoint is an absolute store path and every binary in `/bin` is a symlink
-into `/nix/store`. Mounting a fresh volume there hides all of it, so the
-container cannot start — it fails before it could initialize the very store you
-mounted the volume to populate.
+**Do not mount an empty volume over `/nix` of the `-nix` variant.** That image
+_is_ its Nix store: the entrypoint is an absolute store path and every binary
+in `/bin` is a symlink into `/nix/store`. Mounting a fresh volume there hides
+all of it, so the container cannot start — it fails before it could initialize
+the very store you mounted the volume to populate. (The primary Debian image
+has no `/nix` and is not affected.)
 
-Runtime installation therefore needs one of:
+Runtime installation in the `-nix` variant therefore needs one of:
 
 - a volume **pre-populated** with the image's closure, seeded from the image
   before the agent starts (an init container copying `/nix` into the volume);

--- a/docs/documentation/containers.md
+++ b/docs/documentation/containers.md
@@ -82,10 +82,12 @@ resources or impose image, profile, or extension policy.
 ## Build a derivative image
 
 The image is a normal Debian base: extend it with an ordinary Dockerfile.
-`apt-get` works, and so does `COPY`ing arbitrary binaries — including
-dynamically linked ones, since the standard ELF interpreter and shared
-libraries are present. Switch to `root` for the layers that install, then drop
-back to `1000`:
+`apt-get` works, and so does `COPY`ing binaries. A dynamically linked binary
+runs when it matches the image — same architecture, glibc-linked, and its
+shared-library dependencies present. The standard ELF interpreter is where
+tools expect it (unlike the `-nix` variant), but the slim base ships a small
+library set: `apt-get install` a binary's runtime libraries when it needs more.
+Switch to `root` for the layers that install, then drop back to `1000`:
 
 ```dockerfile
 FROM ghcr.io/ai-outfitter/outfitter:<version>

--- a/docs/requirements/OFTR-009-release-publishing.md
+++ b/docs/requirements/OFTR-009-release-publishing.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Outfitter release publishing prepares package metadata from Conventional Commit release PRs and GitHub release tags, then publishes the `@ai-outfitter/outfitter` CLI workspace package through npm trusted publishing / OIDC and the flake-built container through GitHub Container Registry.
+Outfitter release publishing prepares package metadata from Conventional Commit release PRs and GitHub release tags, then publishes the `@ai-outfitter/outfitter` CLI workspace package through npm trusted publishing / OIDC and the container images — a Debian-based primary image and a flake-built `-nix` variant — through GitHub Container Registry.
 
 ## Requirements
 
@@ -36,10 +36,14 @@ Outfitter release publishing prepares package metadata from Conventional Commit 
 
 ### OFTR-009.4: Container Image Runtime
 
-1. The flake MUST expose the release container as the `container` package output.
-2. The container MUST use the Nix-built Outfitter package directly as its entrypoint.
-3. The release workflow MUST smoke test the image before publishing it.
-4. The published container MUST include the Nix CLI, a shell, core utilities, Git, SSH, and CA certificates so it can serve as a resident-agent base image.
-5. The flake MUST expose a container builder that accepts caller-selected runtime packages without rebuilding Outfitter through another package manager.
-6. The release workflow MUST smoke test Outfitter, Nix, and the conventional shell and environment executable paths.
-7. Documentation MUST define the persistent Kubernetes invocation and explain that callers own writable Nix state, profile configuration, credentials, and channel-specific extensions.
+1. The primary published container image MUST be Debian-based so end users can extend it with a conventional Dockerfile (`apt-get install`, `COPY` of dynamically linked binaries).
+2. The primary image MUST install Outfitter from the CLI workspace tarball built in the release workflow, not from the npm registry, so the image is buildable for unreleased versions and in CI before publish.
+3. The primary image MUST include Node.js matching the `.node-version` major, npm, Git, SSH, and CA certificates at their conventional Debian paths, and MUST use `outfitter` as its entrypoint.
+4. The primary image MUST run as UID/GID 1000 with `/workspace` as its working directory and `/tmp` as its default home directory.
+5. The release workflow MUST smoke test each image before publishing it, including `outfitter --version`, the presence of Node.js, npm, Git, and SSH, and the CA bundle at `/etc/ssl/certs/ca-certificates.crt` in the primary image.
+6. The release workflow MUST smoke test a derivative build of the primary image that installs a package with `apt-get` as root and returns to UID 1000.
+7. The Nix closure image MUST remain published under the `-nix` tag suffix for `lib.mkContainer` consumers.
+8. The flake MUST expose the `-nix` container as the `container` package output, and that container MUST use the Nix-built Outfitter package directly as its entrypoint.
+9. The `-nix` container MUST include the Nix CLI, a shell, core utilities, Git, SSH, and CA certificates, and the flake MUST expose a container builder that accepts caller-selected runtime packages without rebuilding Outfitter through another package manager.
+10. The release workflow MUST smoke test Outfitter, Nix, and the conventional shell and environment executable paths in the `-nix` image.
+11. Documentation MUST define the persistent Kubernetes invocation, describe conventional Dockerfile extension of the primary image, scope the writable-`/nix` guidance to the `-nix` variant, and explain that callers own profile configuration, credentials, and channel-specific extensions.


### PR DESCRIPTION
Implements the direction change posted on #234: the primary published image becomes Debian-based so end users extend it conventionally; the Nix closure keeps publishing as `<version>-nix`.

## Why

The closure image fails the "users extend the prebaked image" story structurally: no apt/apk, no `/lib64` ELF interpreter (foreign dynamic binaries fail with a bare "no such file or directory"), `PATH=/bin:/usr/bin` so a `COPY` into `/usr/local/bin` is invisible, node/npm unlinked (extension install dies `spawn npm ENOENT`, fatal under `--strict`), `SSL_CERT_FILE` unset with the bundle at a non-default path. A downstream consumer needed a 104-line repair Dockerfile to run one resident agent. Full analysis on #234.

## What

- **`container/Dockerfile`** (new): `node:24-slim` (matches `.node-version` major) + apt `ca-certificates git openssh-client` + the CLI installed from the workflow-built tarball (not the registry — buildable pre-publish and in CI). The base's `node` user is renamed to `outfitter`, keeping uid/gid 1000 (the operator contract). `ENV HOME=/tmp`, `WORKDIR /workspace`, `ENTRYPOINT ["outfitter"]`, no CMD, no init — signal forwarding lives in the CLI since 1.4.0 (`AgentLaunch.ts` `attachSignalForwarding`).
- **`container.yml`**: two jobs. `debian` builds/pushes `ghcr.io/ai-outfitter/outfitter:<version>` (+`latest` on non-prerelease); `nix` is the previous job verbatim, retagged `<version>-nix`. The derivative smoke test now proves the actual end-user story: `FROM $IMAGE` → `apt-get install -y jq` → run. (The `USER root` / `USER 1000` dance around apt is documented as part of the contract.)
- **`docs/documentation/containers.md`**: extension guidance rewritten around apt + `COPY` of ordinary (dynamic) binaries; Nix/`lib.mkContainer` material moved to a labeled `-nix` variant section; the `/nix`-volume warning scoped to it.
- **`docs/requirements/OFTR-009-release-publishing.md`**: OFTR-009.4 rewritten — Debian-primary MUSTs 1–6, Nix-variant MUSTs 7–10. **This is a normative requirements change; review deliberately.**

End state for a consumer:

```dockerfile
FROM ghcr.io/ai-outfitter/outfitter:1.5.0
RUN apt-get update && apt-get install -y --no-install-recommends <your-deps> && rm -rf /var/lib/apt/lists/*
# or COPY any binary into /usr/local/bin — it's on PATH and dynamic linking works
```

## Verification

Built locally (podman in docker-compat mode, networked): image smoke passes verbatim — `--version` equality, `command -v node npm git ssh outfitter`, CA bundle at the default `/etc/ssl/certs/ca-certificates.crt`, uid 1000. Derivative apt build passes: installs `jq`, runs both. The workflow smoke script re-run standalone: `SMOKE-OK`.

## Notes for review

- The old single `build` job is renamed (`debian`/`nix`) — if any required status check references the old job name, it needs updating (workflow is `workflow_call` from release, so merge-queue checks shouldn't be affected).
- `node:24-slim` is unpinned behind a `NODE_IMAGE` ARG; digest pinning is a workflow follow-up.
- No `latest-nix` floating tag — deliberate, say if wanted.
- Single-arch amd64, matching the current nix build.

Part of #234. Downstream follow-ups: agent-operator default image bump + nix-machinery gating; the consumer Dockerfile shrinking to the two lines above.
