### PR TITLE
fix(extensions): compare the pinned git ref before trusting a cached extension

### DIFF
--- a/code/cli/src/extensions/PiExtensionCache.ts
+++ b/code/cli/src/extensions/PiExtensionCache.ts
@@ -17,7 +17,7 @@
 // Offline, a checkout that provably mismatches its pin is dropped with a warning — the same
 // severity the offline path already applies to a missing extension (fatal only under `--strict`).
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve, sep } from 'node:path';
 
 import { launchThroughSpawn, spawnLauncher } from '../agents/AgentLaunch.js';
 import { runGit } from '../sources/GitRepository.js';
@@ -51,12 +51,20 @@ interface PiExtensionSource {
 const exactSemverPattern = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u;
 const fullShaPattern = /^[0-9a-f]{40}$/iu;
 
+// Specifier text becomes filesystem path segments (and the stale-reinstall path runs `rm -rf` on
+// the joined result), so a segment that traverses (`..`, `.`) or smuggles a separator (`\`, which
+// `join` does not split but Windows resolves) must be rejected before any path is built.
+const unsafePathSegment = (segment: string): boolean => segment === '.' || segment === '..' || segment.includes('\\');
+
 const mapGitSpecifier = (specifier: string): PiExtensionSource | { readonly unsupported: string } => {
   const rest = specifier.slice('git:'.length);
   const pathPart = rest.includes('@') ? rest.slice(0, rest.lastIndexOf('@')) : rest;
   const ref = rest.includes('@') ? rest.slice(rest.lastIndexOf('@') + 1) : '';
   const segments = pathPart.split('/').filter((part) => part !== '');
   if (segments.length < 2) return { unsupported: `extension '${specifier}' is not a valid git source` };
+  if (segments.some(unsafePathSegment)) {
+    return { unsupported: `extension '${specifier}' contains an unsafe path segment` };
+  }
   return {
     source: specifier,
     installSegments: ['git', ...segments],
@@ -70,6 +78,9 @@ export const mapSpecifierToPiSource = (specifier: string): PiExtensionSource | {
     const rest = specifier.slice('npm:'.length);
     const name = rest.replace(/@[^@/]+$/u, ''); // strip a trailing @version, keep a scope's leading @
     if (name === '') return { unsupported: `extension '${specifier}' has no package name` };
+    if (name.split('/').some(unsafePathSegment)) {
+      return { unsupported: `extension '${specifier}' contains an unsafe path segment` };
+    }
     const version = rest.length > name.length ? rest.slice(name.length + 1) : undefined;
     return {
       source: specifier,
@@ -91,6 +102,20 @@ const installedVersion = (installDir: string): string | undefined => {
     return manifest.version;
   } catch {
     return undefined;
+  }
+};
+
+/**
+ * Defense in depth behind segment validation: refuses an install dir that resolves outside the
+ * cache root before any filesystem access (the stale-git path runs `rm -rf` on the install dir).
+ * Strict containment also keeps the `<installDir>.outfitter-ref.json` marker sibling inside the
+ * cache, since a contained install dir is at least one level below the root. Exported for tests;
+ * segment validation in mapSpecifierToPiSource should make this unreachable.
+ */
+export const assertInstallDirInsideCache = (installDir: string, cacheAgentDir: string, specifier: string): void => {
+  const root = resolve(cacheAgentDir);
+  if (!resolve(installDir).startsWith(root + sep)) {
+    throw new Error(`extension '${specifier}' resolves outside the extension cache; refusing to touch it.`);
   }
 };
 
@@ -193,6 +218,7 @@ const ensureOneExtension = async (
   if ('unsupported' in mapped) return { warning: mapped.unsupported };
 
   const installDir = join(input.cacheAgentDir, ...mapped.installSegments);
+  assertInstallDirInsideCache(installDir, input.cacheAgentDir, specifier);
   const decision = evaluateCachedInstall(installDir, mapped, input.offline);
   if (decision.serve) return { loadDir: installDir };
   if (decision.staleWarning !== undefined) return { warning: decision.staleWarning };

--- a/code/cli/src/extensions/PiExtensionCache.ts
+++ b/code/cli/src/extensions/PiExtensionCache.ts
@@ -5,10 +5,22 @@
 //   npm:  <cacheAgentDir>/npm/node_modules/<pkg>
 // Outfitter's `git:`/`npm:` specifiers are already pi's `install` source grammar, so the source is
 // passed through unchanged; only the install directory is reconstructed to check the cache.
-import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+//
+// A cached git checkout is only trusted when it still matches the specifier's `@ref` pin:
+//   - full-SHA ref: `git -C <installDir> rev-parse HEAD` is compared against the pin (offline-safe,
+//     no network); a mismatch or an unreadable HEAD reinstalls when online.
+//   - branch/tag ref: the ref string is recorded in a `<installDir>.outfitter-ref.json` marker at
+//     install time and only a *changed* ref string triggers a reinstall — a moved remote branch tip
+//     is deliberately not chased, so pinned launches never hit the network.
+//   - branch/tag ref with no marker (a pre-marker cache): served as-is when offline (no evidence it
+//     is wrong), refreshed once when online, which writes the marker.
+// Offline, a checkout that provably mismatches its pin is dropped with a warning — the same
+// severity the offline path already applies to a missing extension (fatal only under `--strict`).
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { launchThroughSpawn, spawnLauncher } from '../agents/AgentLaunch.js';
+import { runGit } from '../sources/GitRepository.js';
 
 /** Spawns `pi install <source>` against the cache agent dir; injectable so tests avoid the network. */
 export type PiInstallSpawner = (input: { readonly source: string; readonly cacheAgentDir: string }) => Promise<number>;
@@ -30,11 +42,27 @@ export interface EnsurePiExtensionsResult {
 interface PiExtensionSource {
   readonly source: string;
   readonly installSegments: readonly string[];
-  /** Exact semver to verify against a cached install; undefined for ranges/tags/git refs. */
+  /** Exact semver to verify against a cached npm install; undefined for ranges and tags. */
   readonly pinnedVersion?: string;
+  /** The `@ref` of a git specifier, to verify against a cached checkout; undefined when unpinned. */
+  readonly pinnedGitRef?: string;
 }
 
 const exactSemverPattern = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u;
+const fullShaPattern = /^[0-9a-f]{40}$/iu;
+
+const mapGitSpecifier = (specifier: string): PiExtensionSource | { readonly unsupported: string } => {
+  const rest = specifier.slice('git:'.length);
+  const pathPart = rest.includes('@') ? rest.slice(0, rest.lastIndexOf('@')) : rest;
+  const ref = rest.includes('@') ? rest.slice(rest.lastIndexOf('@') + 1) : '';
+  const segments = pathPart.split('/').filter((part) => part !== '');
+  if (segments.length < 2) return { unsupported: `extension '${specifier}' is not a valid git source` };
+  return {
+    source: specifier,
+    installSegments: ['git', ...segments],
+    pinnedGitRef: ref === '' ? undefined : ref,
+  };
+};
 
 /** Translates an Outfitter extension specifier to a pi `install` source + its cache install path. */
 export const mapSpecifierToPiSource = (specifier: string): PiExtensionSource | { readonly unsupported: string } => {
@@ -50,13 +78,7 @@ export const mapSpecifierToPiSource = (specifier: string): PiExtensionSource | {
     };
   }
 
-  if (specifier.startsWith('git:')) {
-    const rest = specifier.slice('git:'.length);
-    const pathPart = rest.includes('@') ? rest.slice(0, rest.lastIndexOf('@')) : rest;
-    const segments = pathPart.split('/').filter((part) => part !== '');
-    if (segments.length < 2) return { unsupported: `extension '${specifier}' is not a valid git source` };
-    return { source: specifier, installSegments: ['git', ...segments] };
-  }
+  if (specifier.startsWith('git:')) return mapGitSpecifier(specifier);
 
   return { unsupported: `extension '${specifier}' uses an unsupported source (only git: and npm: project to pi)` };
 };
@@ -70,6 +92,84 @@ const installedVersion = (installDir: string): string | undefined => {
   } catch {
     return undefined;
   }
+};
+
+/** Marker recording which git ref an install satisfied, kept beside (never inside) the checkout. */
+const refMarkerPath = (installDir: string): string => `${installDir}.outfitter-ref.json`;
+
+const cachedGitHead = (installDir: string): string | undefined => {
+  try {
+    return runGit(['-C', installDir, 'rev-parse', 'HEAD']);
+  } catch {
+    return undefined;
+  }
+};
+
+const recordedInstallRef = (installDir: string): string | undefined => {
+  try {
+    const marker = JSON.parse(readFileSync(refMarkerPath(installDir), 'utf8')) as { readonly ref?: string };
+    return marker.ref;
+  } catch {
+    return undefined;
+  }
+};
+
+/** After installing a branch/tag-pinned git extension, records the ref (and resolved SHA). */
+const recordInstalledGitRef = (installDir: string, mapped: PiExtensionSource): void => {
+  if (mapped.pinnedGitRef === undefined || fullShaPattern.test(mapped.pinnedGitRef)) return;
+  const marker = { ref: mapped.pinnedGitRef, headSha: cachedGitHead(installDir) };
+  writeFileSync(refMarkerPath(installDir), JSON.stringify(marker));
+};
+
+// Remove-then-install for a stale git pin: `pi install` owns the directory layout, so
+// GitRepository's atomic fetch-and-swap cannot apply here. A failure between the remove and the
+// install leaves neither a directory nor a marker, which the next run detects as plain missing.
+// The npm path keeps its original behavior: `pi install` is spawned over the existing dir.
+const removeStaleGitInstall = (installDir: string, mapped: PiExtensionSource): void => {
+  if (mapped.pinnedGitRef === undefined) return;
+  rmSync(installDir, { recursive: true, force: true });
+  rmSync(refMarkerPath(installDir), { force: true });
+};
+
+interface GitCacheStatus {
+  readonly state: 'fresh' | 'stale' | 'unverified';
+  /** What the cache actually holds, for the stale warning: the HEAD SHA or the recorded ref. */
+  readonly found: string;
+}
+
+/** Compares a cached checkout against its `@ref` pin per the policy in the file header. */
+const gitCacheStatus = (installDir: string, ref: string): GitCacheStatus => {
+  if (fullShaPattern.test(ref)) {
+    const head = cachedGitHead(installDir);
+    return {
+      state: head?.toLowerCase() === ref.toLowerCase() ? 'fresh' : 'stale',
+      found: head ?? 'no readable git HEAD',
+    };
+  }
+  const recorded = recordedInstallRef(installDir);
+  if (recorded === undefined) return { state: 'unverified', found: 'no recorded install ref' };
+  return { state: recorded === ref ? 'fresh' : 'stale', found: recorded };
+};
+
+type CacheDecision = { readonly serve: true } | { readonly serve: false; readonly staleWarning?: string };
+
+/** Decides whether an existing install satisfies the specifier's pin (git ref or exact semver). */
+const evaluateCachedInstall = (installDir: string, mapped: PiExtensionSource, offline: boolean): CacheDecision => {
+  if (!existsSync(installDir)) return { serve: false };
+  if (mapped.pinnedGitRef === undefined) {
+    return { serve: mapped.pinnedVersion === undefined || installedVersion(installDir) === mapped.pinnedVersion };
+  }
+  const status = gitCacheStatus(installDir, mapped.pinnedGitRef);
+  if (status.state === 'fresh' || (status.state === 'unverified' && offline)) return { serve: true };
+  if (offline) {
+    return {
+      serve: false,
+      staleWarning:
+        `extension '${mapped.source}' is cached at the wrong revision ` +
+        `(pinned ${mapped.pinnedGitRef}, found ${status.found}) and cannot be reinstalled offline.`,
+    };
+  }
+  return { serve: false };
 };
 
 /* v8 ignore start -- real `pi install` subprocess; ensurePiExtensions is unit-tested with a fake spawner. */
@@ -93,13 +193,13 @@ const ensureOneExtension = async (
   if ('unsupported' in mapped) return { warning: mapped.unsupported };
 
   const installDir = join(input.cacheAgentDir, ...mapped.installSegments);
-  const cached =
-    existsSync(installDir) &&
-    (mapped.pinnedVersion === undefined || installedVersion(installDir) === mapped.pinnedVersion);
-  if (cached) return { loadDir: installDir };
+  const decision = evaluateCachedInstall(installDir, mapped, input.offline);
+  if (decision.serve) return { loadDir: installDir };
+  if (decision.staleWarning !== undefined) return { warning: decision.staleWarning };
 
   if (input.offline) return { warning: `extension '${specifier}' is not cached and cannot be installed offline.` };
 
+  removeStaleGitInstall(installDir, mapped);
   mkdirSync(input.cacheAgentDir, { recursive: true });
   try {
     const exitCode = await spawn({ source: mapped.source, cacheAgentDir: input.cacheAgentDir });
@@ -110,6 +210,7 @@ const ensureOneExtension = async (
     return { warning: `extension '${specifier}' failed to install (${String(error)}).` };
   }
 
+  recordInstalledGitRef(installDir, mapped);
   return { loadDir: installDir };
 };
 

--- a/code/cli/tests/unit/pi-extension-cache.test.ts
+++ b/code/cli/tests/unit/pi-extension-cache.test.ts
@@ -1,5 +1,6 @@
 // Tests specifier→pi-install mapping and the install/cache/offline behavior of ensurePiExtensions.
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -23,6 +24,26 @@ const writePackage = (dir: string, version: string): void => {
   writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'x', version }));
 };
 
+const git = (arguments_: readonly string[]): string =>
+  execFileSync('git', [...arguments_], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+
+/** Creates a one-commit git checkout at `dir` (as `pi install` would) and returns its HEAD SHA. */
+const createGitCheckout = (dir: string): string => {
+  mkdirSync(dir, { recursive: true });
+  git(['init', '--quiet', dir]);
+  git(['-C', dir, 'config', 'user.name', 'Outfitter Tests']);
+  git(['-C', dir, 'config', 'user.email', 'tests@outfitter.dev']);
+  // Isolate from the developer's global config; a global commit.gpgsign would fail every commit.
+  git(['-C', dir, 'config', 'commit.gpgsign', 'false']);
+  writeFileSync(join(dir, 'index.js'), '');
+  git(['-C', dir, 'add', '.']);
+  git(['-C', dir, 'commit', '--quiet', '-m', 'install']);
+  return git(['-C', dir, 'rev-parse', 'HEAD']);
+};
+
+const deepworkDir = (cache: string): string => join(cache, 'git', 'github.com', 'ai-outfitter', 'deepwork');
+const deepworkSpec = (ref: string): string => `git:github.com/ai-outfitter/deepwork@${ref}`;
+
 describe('mapSpecifierToPiSource', () => {
   it('maps npm specifiers, stripping a trailing version and keeping a scope', () => {
     expect(mapSpecifierToPiSource('npm:pi-nolo')).toEqual({
@@ -41,13 +62,24 @@ describe('mapSpecifierToPiSource', () => {
     });
   });
 
-  it('maps git specifiers to git/<host>/<owner>/<repo>, dropping any ref', () => {
+  it('maps git specifiers to git/<host>/<owner>/<repo>, keeping any ref as the pin', () => {
     expect(mapSpecifierToPiSource('git:github.com/ai-outfitter/deepwork')).toEqual({
       source: 'git:github.com/ai-outfitter/deepwork',
       installSegments: ['git', 'github.com', 'ai-outfitter', 'deepwork'],
     });
     expect(mapSpecifierToPiSource('git:github.com/ai-outfitter/deepwork@v1.0.0')).toEqual({
       source: 'git:github.com/ai-outfitter/deepwork@v1.0.0',
+      installSegments: ['git', 'github.com', 'ai-outfitter', 'deepwork'],
+      pinnedGitRef: 'v1.0.0',
+    });
+    const sha = 'a'.repeat(40);
+    expect(mapSpecifierToPiSource(`git:github.com/ai-outfitter/deepwork@${sha}`)).toEqual({
+      source: `git:github.com/ai-outfitter/deepwork@${sha}`,
+      installSegments: ['git', 'github.com', 'ai-outfitter', 'deepwork'],
+      pinnedGitRef: sha,
+    });
+    expect(mapSpecifierToPiSource('git:github.com/ai-outfitter/deepwork@')).toEqual({
+      source: 'git:github.com/ai-outfitter/deepwork@',
       installSegments: ['git', 'github.com', 'ai-outfitter', 'deepwork'],
     });
   });
@@ -200,7 +232,7 @@ describe('ensurePiExtensions', () => {
     expect(result.warnings[0]).toContain('pi install exited 0');
   });
 
-  it('reinstalls a pinned extension when the cached install has no readable manifest', async () => {
+  it('reinstalls a pinned npm extension when the cached install has no readable manifest', async () => {
     const dir = cacheDir();
     mkdirSync(join(dir, 'npm', 'node_modules', 'pi-subagents'), { recursive: true }); // present, but no package.json
     let spawned = 0;
@@ -215,5 +247,147 @@ describe('ensurePiExtensions', () => {
     });
     expect(spawned).toBe(1);
     expect(result.loadDirs).toEqual([join(dir, 'npm', 'node_modules', 'pi-subagents')]);
+  });
+});
+
+describe('ensurePiExtensions git revision pinning', () => {
+  const markerPath = (cache: string): string => `${deepworkDir(cache)}.outfitter-ref.json`;
+  const readMarker = (cache: string): { readonly ref?: string; readonly headSha?: string } =>
+    JSON.parse(readFileSync(markerPath(cache), 'utf8')) as { readonly ref?: string; readonly headSha?: string };
+
+  const run = async (
+    specifier: string,
+    cache: string,
+    offline: boolean,
+    create?: (cacheAgentDir: string) => void,
+  ): Promise<{
+    readonly loadDirs: readonly string[];
+    readonly warnings: readonly string[];
+    readonly spawned: number;
+  }> => {
+    let spawned = 0;
+    const result = await ensurePiExtensions([specifier], {
+      cacheAgentDir: cache,
+      offline,
+      spawn: (input) => {
+        spawned += 1;
+        create?.(input.cacheAgentDir);
+        return Promise.resolve(0);
+      },
+    });
+    return { ...result, spawned };
+  };
+
+  it('serves a cached checkout whose HEAD matches the pinned SHA without spawning', async () => {
+    const cache = cacheDir();
+    const head = createGitCheckout(deepworkDir(cache));
+    const result = await run(deepworkSpec(head), cache, false);
+    expect(result.spawned).toBe(0);
+    expect(result.loadDirs).toEqual([deepworkDir(cache)]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('removes and reinstalls a checkout whose HEAD does not match the pinned SHA', async () => {
+    const cache = cacheDir();
+    createGitCheckout(deepworkDir(cache));
+    const pinned = 'a'.repeat(40);
+    const result = await run(deepworkSpec(pinned), cache, false, (cacheAgentDir) => {
+      // The stale checkout must be removed before `pi install` runs.
+      expect(existsSync(deepworkDir(cacheAgentDir))).toBe(false);
+      createGitCheckout(deepworkDir(cacheAgentDir));
+    });
+    expect(result.spawned).toBe(1);
+    expect(result.loadDirs).toEqual([deepworkDir(cache)]);
+    expect(existsSync(markerPath(cache))).toBe(false); // SHA pins verify via git HEAD, not a marker
+  });
+
+  it('warns and drops a stale pinned-SHA checkout when offline, naming both revisions', async () => {
+    const cache = cacheDir();
+    const head = createGitCheckout(deepworkDir(cache));
+    const pinned = 'a'.repeat(40);
+    const result = await run(deepworkSpec(pinned), cache, true);
+    expect(result.spawned).toBe(0);
+    expect(result.loadDirs).toEqual([]);
+    expect(result.warnings[0]).toContain(`pinned ${pinned}, found ${head}`);
+    expect(result.warnings[0]).toContain('cannot be reinstalled offline');
+  });
+
+  it('treats a pinned-SHA install dir that is not a git checkout as stale', async () => {
+    const cache = cacheDir();
+    writePackage(deepworkDir(cache), '1.0.0'); // present, but no git HEAD to verify
+    const result = await run(deepworkSpec('b'.repeat(40)), cache, true);
+    expect(result.loadDirs).toEqual([]);
+    expect(result.warnings[0]).toContain('found no readable git HEAD');
+  });
+
+  it('records the ref and resolved SHA in a marker when installing a branch/tag pin', async () => {
+    const cache = cacheDir();
+    let head = '';
+    const result = await run(deepworkSpec('v1.0.0'), cache, false, (cacheAgentDir) => {
+      head = createGitCheckout(deepworkDir(cacheAgentDir));
+    });
+    expect(result.spawned).toBe(1);
+    expect(result.loadDirs).toEqual([deepworkDir(cache)]);
+    expect(readMarker(cache)).toEqual({ ref: 'v1.0.0', headSha: head });
+  });
+
+  it('serves a branch/tag pin whose marker matches without spawning, even offline', async () => {
+    const cache = cacheDir();
+    createGitCheckout(deepworkDir(cache));
+    writeFileSync(markerPath(cache), JSON.stringify({ ref: 'v1.0.0' }));
+    const result = await run(deepworkSpec('v1.0.0'), cache, true);
+    expect(result.spawned).toBe(0);
+    expect(result.loadDirs).toEqual([deepworkDir(cache)]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('reinstalls and rewrites the marker when the pinned branch/tag ref changes', async () => {
+    const cache = cacheDir();
+    createGitCheckout(deepworkDir(cache));
+    writeFileSync(markerPath(cache), JSON.stringify({ ref: 'v1.0.0' }));
+    const result = await run(deepworkSpec('v2.0.0'), cache, false, (cacheAgentDir) => {
+      createGitCheckout(deepworkDir(cacheAgentDir));
+    });
+    expect(result.spawned).toBe(1);
+    expect(readMarker(cache).ref).toBe('v2.0.0');
+  });
+
+  it('warns and drops a branch/tag pin whose marker mismatches when offline', async () => {
+    const cache = cacheDir();
+    createGitCheckout(deepworkDir(cache));
+    writeFileSync(markerPath(cache), JSON.stringify({ ref: 'v1.0.0' }));
+    const result = await run(deepworkSpec('v2.0.0'), cache, true);
+    expect(result.spawned).toBe(0);
+    expect(result.loadDirs).toEqual([]);
+    expect(result.warnings[0]).toContain('pinned v2.0.0, found v1.0.0');
+  });
+
+  it('serves a pre-marker branch/tag cache as-is when offline', async () => {
+    const cache = cacheDir();
+    createGitCheckout(deepworkDir(cache));
+    const result = await run(deepworkSpec('v1.0.0'), cache, true);
+    expect(result.loadDirs).toEqual([deepworkDir(cache)]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('refreshes a pre-marker branch/tag cache once when online, writing the marker', async () => {
+    const cache = cacheDir();
+    createGitCheckout(deepworkDir(cache));
+    const result = await run(deepworkSpec('v1.0.0'), cache, false, (cacheAgentDir) => {
+      writePackage(deepworkDir(cacheAgentDir), '1.0.0'); // an install that is not a git checkout
+    });
+    expect(result.spawned).toBe(1);
+    expect(readMarker(cache)).toEqual({ ref: 'v1.0.0' }); // no readable HEAD → no headSha recorded
+  });
+
+  it('treats an unreadable marker as unverified and refreshes it when online', async () => {
+    const cache = cacheDir();
+    createGitCheckout(deepworkDir(cache));
+    writeFileSync(markerPath(cache), 'not json');
+    const result = await run(deepworkSpec('v1.0.0'), cache, false, (cacheAgentDir) => {
+      createGitCheckout(deepworkDir(cacheAgentDir));
+    });
+    expect(result.spawned).toBe(1);
+    expect(readMarker(cache).ref).toBe('v1.0.0');
   });
 });

--- a/code/cli/tests/unit/pi-extension-cache.test.ts
+++ b/code/cli/tests/unit/pi-extension-cache.test.ts
@@ -6,7 +6,11 @@ import { join } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { ensurePiExtensions, mapSpecifierToPiSource } from '../../src/extensions/PiExtensionCache.js';
+import {
+  assertInstallDirInsideCache,
+  ensurePiExtensions,
+  mapSpecifierToPiSource,
+} from '../../src/extensions/PiExtensionCache.js';
 import type { PiInstallSpawner } from '../../src/extensions/PiExtensionCache.js';
 
 const roots: string[] = [];
@@ -94,6 +98,29 @@ describe('mapSpecifierToPiSource', () => {
     expect(mapSpecifierToPiSource('npm:')).toEqual({ unsupported: "extension 'npm:' has no package name" });
     expect(mapSpecifierToPiSource('git:justhost')).toEqual({
       unsupported: "extension 'git:justhost' is not a valid git source",
+    });
+  });
+
+  it('rejects traversal and backslash segments that would escape the cache directory', () => {
+    for (const specifier of [
+      'git:../../victim@v1',
+      'git:host/..@v1',
+      'git:host/./repo@v1',
+      String.raw`git:host/owner\..\x@v1`,
+      'npm:../evil',
+      String.raw`npm:evil\..\x`,
+    ]) {
+      expect(mapSpecifierToPiSource(specifier)).toEqual({
+        unsupported: `extension '${specifier}' contains an unsafe path segment`,
+      });
+    }
+  });
+
+  it('flattens an absolute-path-ish git specifier into relative segments under the cache', () => {
+    expect(mapSpecifierToPiSource('git:/etc/passwd@v1')).toEqual({
+      source: 'git:/etc/passwd@v1',
+      installSegments: ['git', 'etc', 'passwd'],
+      pinnedGitRef: 'v1',
     });
   });
 });
@@ -389,5 +416,41 @@ describe('ensurePiExtensions git revision pinning', () => {
     });
     expect(result.spawned).toBe(1);
     expect(readMarker(cache).ref).toBe('v1.0.0');
+  });
+});
+
+describe('extension cache path containment', () => {
+  it('never deletes a directory outside the cache root for a traversal specifier', async () => {
+    const cache = cacheDir();
+    const victim = join(cache, 'victim');
+    writeFileSync(join(mkdirSync(victim, { recursive: true }) ?? victim, 'keep.txt'), 'data');
+    const root = join(cache, 'agent'); // cache root beside the victim: git/../../victim escapes it
+    let spawned = 0;
+    const result = await ensurePiExtensions(['git:../../victim@v1'], {
+      cacheAgentDir: root,
+      offline: false,
+      spawn: () => {
+        spawned += 1;
+        return Promise.resolve(0);
+      },
+    });
+    expect(spawned).toBe(0);
+    expect(result.loadDirs).toEqual([]);
+    expect(result.warnings[0]).toContain('unsafe path segment');
+    expect(existsSync(join(victim, 'keep.txt'))).toBe(true);
+  });
+
+  it('refuses an install dir that resolves outside the cache root before any filesystem access', () => {
+    const cache = cacheDir();
+    const outside = join(cache, 'outside');
+    mkdirSync(outside, { recursive: true });
+    const root = join(cache, 'agent');
+    expect(() => assertInstallDirInsideCache(join(root, 'git', '..', '..', 'outside'), root, 'git:x/y@v1')).toThrow(
+      "extension 'git:x/y@v1' resolves outside the extension cache",
+    );
+    // The cache root itself is not strictly inside the cache root.
+    expect(() => assertInstallDirInsideCache(root, root, 'git:x/y@v1')).toThrow('outside the extension cache');
+    expect(existsSync(outside)).toBe(true);
+    expect(() => assertInstallDirInsideCache(join(root, 'git', 'h', 'o', 'r'), root, 'git:h/o/r')).not.toThrow();
   });
 });


### PR DESCRIPTION
The pi-extensions git cache is revision-blind: `ensureOneExtension` checks only `existsSync(installDir)`, so an existing cached checkout wins regardless of the profile's `@ref` pin. Bumping a pinned extension revision in a profile silently no-ops — observed in production, where a downstream deployment carries a shell script that parses the pin out of `agent.md` and `rm -rf`s the cache directory whenever it moves. This PR makes the cache verify the pin and obsoletes that workaround.

## Behavior

- **40-hex SHA pins**: the cached checkout's `git rev-parse HEAD` is compared to the pin — offline-safe, no network. Mismatch or unreadable HEAD → reinstall.
- **Branch/tag refs**: a sibling marker `<installDir>.outfitter-ref.json` records `{ref, headSha}` at install time; reinstall only when the requested ref *string* changes. A moved remote branch tip is deliberately not chased — pinned launches never hit the network.
- **Legacy caches without a marker** (non-SHA): served as-is offline (dropping them would break air-gapped deployments on upgrade), refreshed once when online, which writes the marker.
- **Offline + provably stale**: warn-and-drop, naming the extension, the pin, and what was found — mirroring exactly how the offline path treats a missing extension (warning; fatal only under `--strict`).
- **Reinstall is remove-then-install**: `pi install` owns the directory layout, so a mid-way failure leaves neither dir nor marker and reads as plain-missing next run.
- npm specifiers byte-for-byte unchanged.

## Verification

11 new tests (SHA hit/stale, offline+stale warning, marker lifecycle, ref-change, legacy paths, garbage marker). Full suite 328/328, coverage 99.12% statements against 98 thresholds; tsc/eslint/prettier/build clean.

Unblocks the downstream cleanup tracked in ai-outfitter/outfitter#234's consumer story.
