### PR TITLE
docs: the autonomous-SDLC ramp, philosophy reorder, and org-onboarding runbook

### DIFF
--- a/docs/documentation/README.md
+++ b/docs/documentation/README.md
@@ -2,6 +2,11 @@
 
 Outfitter lays out conventions for iterating on and sharing agent configuration — agent profiles, skills, and loadouts. The docs follow that arc: **set up** your own, **understand** the pieces, **share** them across projects and your org, **automate** them on more surfaces, then contribute back. Each page keeps to one concept and links onward when you need the next one, so nothing here has to be read up front.
 
+Onboarding an organization? Start with
+[Onboard an organization with an SDLC report](./usecases/org-onboarding-sdlc-report.md) —
+one engineer runs the maturity assessment, then creates the org `.agents`
+repository with the baseline report as its first commit.
+
 ## Start (you)
 
 - [Getting started](./getting-started.md) — install, first run, default agent.

--- a/docs/documentation/usecases/org-onboarding-sdlc-report.md
+++ b/docs/documentation/usecases/org-onboarding-sdlc-report.md
@@ -1,0 +1,103 @@
+# Onboard an organization with an SDLC report
+
+A runbook for the first engineer who brings agentic engineering to their
+organization. The output is two artifacts: a baseline **SDLC report** that
+says where the org sits on the [adoption ramp](../../philosophy.md), and the
+org's **`.agents` repository** with that report as its first commit. The
+report's gaps become the backlog; the repository becomes the place the org's
+agent configuration lives from day one.
+
+Who runs this: an engineer who already uses a local coding harness (Pi,
+Claude Code, or similar) and has read access to the org's repositories. No
+org-wide rollout, approval, or infrastructure is required — the whole runbook
+is one person, one afternoon, read-only until the final step.
+
+## 1. Prerequisites
+
+- A local coding harness with the `sdlc-report` skill available in its
+  catalog.
+- An authenticated forge CLI (`gh` for GitHub; `tea` or API tokens for
+  Forgejo) with read access to the org.
+- Optional but valuable: your existing local checkouts of org repositories.
+  The assessment reads them in addition to the forge API — local working
+  trees show practice the forge cannot see, such as harness configs and
+  instruction files that were never committed.
+
+## 2. Run the assessment
+
+Ask your agent for an SDLC report of the org. The `sdlc-report` skill:
+
+- confirms scope with you (org, sample size, whether private repos are in
+  scope), capped at roughly 30 repos;
+- gathers evidence from **both sources**: the forge API for org-wide
+  inventory, workflows, required checks, and PR metrics, and your local
+  checkouts for the ground truth of daily practice — every claim records
+  which source it came from;
+- never clones repositories and never writes to the forge;
+- rates each repo and the org on the ramp (level 0–5), derives PR cycle time
+  and rework rate where the forge data supports it, and lists what the scan
+  could not see in `evidence_limits`.
+
+You get `sdlc-report.json` (schema-validated, comparable across runs) and
+`sdlc-report.md` (verdict, evidence, gaps, recommendations).
+
+Read the recommendations before moving on. Each targets the org's next rung,
+not the top of the ramp — typically: automate a single workflow end to end
+before generalizing, and consolidate tools that multiple teams built
+independently.
+
+## 3. Create the org `.agents` repository
+
+Create `<org>/.agents` on your forge and commit the report as its first
+content. Repository hygiene, learned the hard way:
+
+- The repository MUST NOT be public — private or internal visibility only.
+  The report is an honest map of your org's gaps.
+- If the repository already exists, commit only the report files. Leave any
+  uncommitted work in the checkout untouched, and if the default branch is
+  behind or checked out elsewhere, say so rather than silently moving it.
+
+```text
+<org>/.agents/
+  README.md                      # what this repo is; link to the report
+  reports/
+    sdlc/
+      YYYY-MM-DD-initial/
+        sdlc-report.json
+        sdlc-report.md
+```
+
+The initial report is the baseline: re-run the assessment after each change
+(a quarterly cadence works, or after each rung climb) into a new dated
+directory, and the diff between reports is your progress measure — cycle
+time, rework rate, and rung movements, not anecdotes.
+
+This repository is also where the org's shared agent configuration grows: an
+`agents.md` with shared operating rules, role agents, skills, and a pinned
+`settings.yml`, following the [organization catalog](./organization-profile-catalog.md)
+conventions. Starting it with the report means the catalog's first commit
+explains *why* the org is adopting agents and what it will measure — every
+later addition traces back to a gap in the baseline.
+
+## 4. Act on the report
+
+1. Pick the top recommendation and automate that one workflow end to end —
+   for example, feature idea → reviewed PR ([Actions](../actions.md),
+   [in-cluster](../in-cluster.md)).
+2. Add the shared resources the duplication findings call for, so the next
+   team composes instead of rebuilding.
+3. Wire session-log capture into the automated workflow before merge — the
+   report's governance section will have told you where records currently go,
+   which is usually nowhere. Owning that record is what makes the next report
+   measurable, and it is the raw material for evals and improvement
+   ([philosophy](../../philosophy.md)).
+4. Schedule the re-run ([recurring runs](../recurring-runs.md)) and commit
+   each new report beside the baseline.
+
+## Boundaries
+
+The assessment is read-only; creating the `.agents` repository in step 3 is
+the runbook's first write, done by you deliberately — the skill itself asks
+before it creates anything beyond the report files. The report contains repo
+names, paths, and counts, never credentials or session content. Treat it as
+internal: it is an honest map of your org's gaps.

--- a/docs/documentation/usecases/org-onboarding-sdlc-report.md
+++ b/docs/documentation/usecases/org-onboarding-sdlc-report.md
@@ -76,7 +76,7 @@ This repository is also where the org's shared agent configuration grows: an
 `agents.md` with shared operating rules, role agents, skills, and a pinned
 `settings.yml`, following the [organization catalog](./organization-profile-catalog.md)
 conventions. Starting it with the report means the catalog's first commit
-explains *why* the org is adopting agents and what it will measure — every
+explains _why_ the org is adopting agents and what it will measure — every
 later addition traces back to a gap in the baseline.
 
 ## 4. Act on the report

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -2,6 +2,14 @@
 
 Make, share, and switch the agent profiles your coding agents use — manually or programmatically. A profile is just an agent and the loadout it composes; there is no separate profile format.
 
+## Trust through evidence
+
+An agent is trusted the same way a new teammate is: small scopes, reviewed work, and a paper trail. Outfitter treats all three as configuration. A profile bounds what an agent can do per environment — the planning agent that has write tools at your desk has none in the cluster. Adversarial review is a workflow step rather than a virtue, and workflows are built so that every transition writes to the record.
+
+## Own your session data
+
+The session record — what was asked, what the agent did, what it touched, what the review found — serves you as much as it serves the auditor. It answers "what happened and was it allowed" for an audit, and the same records are the inputs to evals, policy tuning, and eventually training. Organizations that let session data evaporate at the end of each run discard the asset that makes the whole system improvable. Store clean records first and decide on dashboards later — dashboards can always be built over clean records; records cannot be reconstructed from dashboards.
+
 ## Expeditious agents
 
 An agent is defined by its agency: its ability to make good decisions on the way to completing a task. Outfitter exists to make agents _expeditious_ — not just effective, but fast.
@@ -23,3 +31,15 @@ The same mechanism scales up a stair-step:
 - **Enterprises** publish and pin curated catalogs, keeping agent configuration reviewable, versioned, and consistent across the organization.
 
 At every level the goal is the same: the right profile, at the right moment, with nothing extra along for the ride.
+
+## The ramp to an autonomous lifecycle
+
+Outfitter's destination is a fully autonomous software development lifecycle: humans define goals and acceptance gates, agents own the middle. Nobody jumps there in one step. Adoption is a ramp with five rungs, and each Outfitter component targets a rung, so a user or an organization climbs without discarding the previous rung. This section is the canonical definition; the org README and the `sdlc-report` assessment skill compress or extend it.
+
+1. **Assisted** — autocomplete and chat; a human's hands stay on the keyboard.
+2. **Delegated** — a local agent does the task; the human defines the idea and reviews the PR.
+3. **Automated** — a workflow runs without a laptop: an issue, a message, or a schedule triggers agents in CI or a cluster, adversarial review is part of the pipeline, and session logs are captured before merge.
+4. **Governed** — the organization shares one pinned catalog of agents, skills, and policy; every agent action lands in an auditable record; resident agents work as onboarded teammates.
+5. **Self-improving** — the audit record feeds evals and model improvement; humans set goals and acceptance gates, agents own the middle.
+
+Two rules keep the climb honest. Never automate a workflow you have not first done manually — run it as an agent-assisted skill until you understand it, then promote it. And expand scope by moving the human locus of control outward one layer at a time: first the implementation, then the review, then the idea, until what remains human is the goal and the gate.


### PR DESCRIPTION
Adds the autonomous-SDLC ramp and the trust/session-data-ownership sections to the philosophy (trust and owning session data lead), makes the philosophy's ramp the canonical definition, and adds the org-onboarding SDLC-report runbook (assessment via forge APIs plus local checkouts, then an org `.agents` repo seeded with the baseline report), linked from the top of the docs index.

Companion changes already landed: the reframed org profile README (ai-outfitter/.github@dfe68cb) and the `sdlc-report` skill (ncrmro/.agents), dogfooded today against this org and Unsupervisedcom — both baseline reports are committed in the respective `.agents` repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)