### PR TITLE
feat: resolve catalog-declared sources transitively (OFTR-004.6)

### DIFF
--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -171,7 +171,6 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
   let resolved = resolveEffectiveSet(input);
   assertNoSettingsIssues(resolved.settingsIssues);
   assertReadableAppendPrompts(input.appendPromptPaths);
-  emit(resolved.warnings.map((warning) => `warning: ${warning}`));
 
   // First run: nothing selected and no default configured — onboard, then resolve again.
   const setupMessages: string[] = [];
@@ -188,13 +187,19 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
     }
   }
 
+  // Warnings from the FINAL resolved state (after any onboarding), folded into every returned message
+  // array after the setup notices — so a dependency that best-effort bootstrap could not fetch
+  // surfaces its actionable `outfitter sync` guidance to both the terminal and programmatic callers,
+  // not just a generic unknown-skill warning at composition (OFTR-004.6.10).
+  const resolutionWarnings = resolved.warnings.map((warning) => `warning: ${warning}`);
+
   const { set, settings } = resolved;
   const agentSlug = resolveAgentSlug(settings.defaultAgent, input.agent);
   const harness = resolveHarness(settings.defaultHarness, input.harness);
   const composed = compose(set, agentSlug, { projectDirectory: input.projectDirectory });
 
   if (composed.plan === undefined) {
-    const messages = [...setupMessages, ...composed.warnings, ...composed.errors];
+    const messages = [...setupMessages, ...resolutionWarnings, ...composed.warnings, ...composed.errors];
     emit(messages);
     return { exitCode: 1, messages };
   }
@@ -231,6 +236,7 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
     if (input.strict === true && warnings.length > 0) {
       const messages = [
         ...setupMessages,
+        ...resolutionWarnings,
         ...warnings,
         'Strict mode: composition warnings and unsupported elements are fatal.',
       ];
@@ -238,8 +244,9 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
       return { exitCode: 1, messages };
     }
 
-    // Emit setup notices and warnings before launch so they precede the pi session on the terminal.
-    const messages = [...setupMessages, ...warnings];
+    // Emit setup notices, resolution warnings, and composition warnings before launch so they precede
+    // the pi session on the terminal (and are returned to programmatic callers).
+    const messages = [...setupMessages, ...resolutionWarnings, ...warnings];
     emit(messages);
 
     // Attach the Outfitter runtime UI and sign-in extension to interactive pi sessions.

--- a/code/cli/src/cli/commands/SyncCommand.ts
+++ b/code/cli/src/cli/commands/SyncCommand.ts
@@ -17,7 +17,7 @@ import {
 } from '../../settings/SettingsLoader.js';
 import type { SettingsLoadIssue } from '../../settings/SettingsLoader.js';
 import type { RemoteSettingsReference } from '../../settings/Settings.js';
-import { syncRemoteRepositoryAtomically } from '../../sources/GitRepository.js';
+import { syncRemoteRepositoryAtomically, tryReadCleanHead } from '../../sources/GitRepository.js';
 import {
   createEnterprisePrivateCatalogGate,
   type GitHubRepositoryVisibilityClassifier,
@@ -26,16 +26,19 @@ import {
 } from '../../sources/PrivateCatalogGate.js';
 import {
   createRemoteRepositoryCachePath,
+  encodeRemoteSourceSelection,
   formatRemoteSourceDisplay,
   isRemoteSource,
   redactEmbeddedSourceCredentials,
+  resolveSourcePayloadRoot,
 } from '../../sources/SourceCache.js';
 import type { RemoteSourceReference } from '../../sources/SourceCache.js';
+import { readDeclaredRemoteSources } from '../../sources/TransitiveSources.js';
 import type { CommandObject } from './CommandObject.js';
 import { resolveHomeDirectory, resolveProjectDirectory } from './ProcessDefaults.js';
 
 export type SyncStatus = 'updated' | 'unchanged' | 'skipped' | 'failed';
-export type SyncSourceKind = 'remote_settings' | 'source';
+export type SyncSourceKind = 'remote_settings' | 'source' | 'transitive';
 
 export interface SyncSourceResult {
   readonly kind: SyncSourceKind;
@@ -56,6 +59,9 @@ export interface SyncCommandInput {
   readonly projectDirectory: string;
 }
 
+/** Fetches one repository into the cache. Injectable so tests exercise the closure hermetically. */
+export type RepositorySync = typeof syncRemoteRepositoryAtomically;
+
 export interface SyncCommandDependencies {
   readonly homeDirectory?: string;
   readonly projectDirectory?: string;
@@ -63,12 +69,15 @@ export interface SyncCommandDependencies {
   readonly prompt?: PrivateCatalogPrompt;
   readonly privateCatalogGate?: PrivateCatalogSourceGate;
   readonly writeLine?: (message: string) => void;
+  readonly syncRepository?: RepositorySync;
 }
 
 interface SyncPhaseResult<T extends RemoteSourceReference> {
   readonly allowedSources: readonly T[];
   readonly messages: readonly string[];
   readonly results: readonly SyncSourceResult[];
+  /** The subset of `allowedSources` whose checkout is now readable (status updated/unchanged). */
+  readonly readableSources: readonly T[];
 }
 
 const formatSettingsIssues = (heading: string, issues: readonly SettingsLoadIssue[]): readonly string[] => [
@@ -105,7 +114,10 @@ const validateSourceCheckout = (repositoryPath: string, source: RemoteSourceRefe
     throw new Error(`Configured source path '${source.path}' was not found in the fetched repository.`);
   }
 
-  const findings = validateEffectiveSet(resolveResources([layer]));
+  // A source is validated in isolation here, so an unresolved loadout slug is deferred (a warning,
+  // not a failure): a catalog may reference a skill supplied by a catalog it declares as a transitive
+  // dependency (OFTR-004.6), and loadout wholeness is validated against the merged tree at resolution.
+  const findings = validateEffectiveSet(resolveResources([layer]), undefined, { deferLoadoutResolution: true });
   const errors = findings.filter((finding) => finding.severity === 'error');
   if (errors.length > 0) {
     throw new Error(
@@ -121,36 +133,45 @@ interface SyncPhaseInput<T extends RemoteSourceReference> {
   readonly homeDirectory: string;
   readonly cacheDirectory?: string;
   readonly gate: PrivateCatalogSourceGate;
+  readonly syncRepository: RepositorySync;
   readonly validate: (repositoryPath: string, source: T) => number;
 }
 
 /** Runs the private-catalog gate over one phase's sources, then fetches everything it allowed. */
 const syncPhase = <T extends RemoteSourceReference>(input: SyncPhaseInput<T>): SyncPhaseResult<T> => {
   const gated = input.gate.filter(input.sources, input.cacheDirectory);
-  const synced = gated.allowedSources.map((source): SyncSourceResult => {
+  // Pair each source with its own result so a later step reads the checkout by identity, never by a
+  // display string (which omits a `uri:` source's ref and would collide across refs).
+  const synced = gated.allowedSources.map((source): { readonly source: T; readonly result: SyncSourceResult } => {
     const cachePath = createRemoteRepositoryCachePath(input.homeDirectory, source, input.cacheDirectory);
     const uri = formatRemoteSourceDisplay(source);
 
     try {
-      const result = syncRemoteRepositoryAtomically({
+      const result = input.syncRepository({
         cachePath,
         source,
         validate: (repositoryPath) => input.validate(repositoryPath, source),
       });
       return {
-        kind: input.kind,
-        uri,
-        cachePath,
-        status: result.status,
-        message: result.warnings === 0 ? undefined : `validated with ${result.warnings} warning(s)`,
+        source,
+        result: {
+          kind: input.kind,
+          uri,
+          cachePath,
+          status: result.status,
+          message: result.warnings === 0 ? undefined : `validated with ${result.warnings} warning(s)`,
+        },
       };
     } catch (error) {
       return {
-        kind: input.kind,
-        uri,
-        cachePath,
-        status: 'failed',
-        message: redactEmbeddedSourceCredentials(formatCaughtError(error)),
+        source,
+        result: {
+          kind: input.kind,
+          uri,
+          cachePath,
+          status: 'failed',
+          message: redactEmbeddedSourceCredentials(formatCaughtError(error)),
+        },
       };
     }
   });
@@ -158,16 +179,90 @@ const syncPhase = <T extends RemoteSourceReference>(input: SyncPhaseInput<T>): S
   return {
     allowedSources: gated.allowedSources,
     messages: gated.messages,
-    results: [...gated.skippedResults.map((result) => ({ ...result, kind: input.kind })), ...synced],
+    results: [
+      ...gated.skippedResults.map((result) => ({ ...result, kind: input.kind })),
+      ...synced.map((s) => s.result),
+    ],
+    // A source is traversable when its checkout is readable on disk *now* — not only when this run
+    // refreshed it. A failed refresh leaves the prior valid cache in place (atomic sync) and
+    // resolution keeps using it, so its declared dependencies must still be discovered; a failed
+    // first fetch leaves no checkout, so it is correctly excluded.
+    readableSources: synced.filter((s) => tryReadCleanHead(s.result.cachePath) !== undefined).map((s) => s.source),
   };
+};
+
+interface TransitiveClosureInput {
+  readonly homeDirectory: string;
+  readonly cacheDirectory?: string;
+  readonly gate: PrivateCatalogSourceGate;
+  readonly syncRepository: RepositorySync;
+  /** Every directly configured remote source, seeding the visited set (OFTR-004.6.6). */
+  readonly directRemoteSources: readonly RemoteSourceReference[];
+  readonly sourcePhase: SyncPhaseResult<RemoteSourceReference>;
+}
+
+interface TransitiveClosureResult {
+  readonly messages: readonly string[];
+  readonly results: readonly SyncSourceResult[];
+}
+
+/** Fetches sources declared by synced catalogs until no new sources remain (OFTR-004.6.7). */
+const syncTransitiveClosure = (input: TransitiveClosureInput): TransitiveClosureResult => {
+  const messages: string[] = [];
+  const results: SyncSourceResult[] = [];
+  const visited = new Set(input.directRemoteSources.map(encodeRemoteSourceSelection));
+
+  let frontier = input.sourcePhase.readableSources;
+  while (frontier.length > 0) {
+    const discovered: RemoteSourceReference[] = [];
+
+    for (const parent of frontier) {
+      const checkoutRoot = createRemoteRepositoryCachePath(input.homeDirectory, parent, input.cacheDirectory);
+      // An absolute or escaping `path:` on a directly configured source throws here; skip it rather
+      // than crash sync (transitive sources are path-less and never reach this).
+      let payloadRoot: string;
+      try {
+        payloadRoot = resolveSourcePayloadRoot(checkoutRoot, parent);
+      } catch {
+        continue;
+      }
+      const declared = readDeclaredRemoteSources(payloadRoot, checkoutRoot, formatRemoteSourceDisplay(parent));
+      messages.push(...declared.warnings.map((warning) => `warning: ${warning}`));
+
+      for (const entry of declared.sources) {
+        const key = encodeRemoteSourceSelection(entry.source);
+        if (visited.has(key)) continue;
+        visited.add(key);
+        discovered.push(entry.source);
+      }
+    }
+
+    if (discovered.length === 0) break;
+
+    const phase = syncPhase({
+      kind: 'transitive',
+      sources: discovered,
+      homeDirectory: input.homeDirectory,
+      cacheDirectory: input.cacheDirectory,
+      gate: input.gate,
+      syncRepository: input.syncRepository,
+      validate: validateSourceCheckout,
+    });
+    messages.push(...phase.messages, ...phase.results.map(formatResult));
+    results.push(...phase.results);
+    frontier = phase.readableSources;
+  }
+
+  return { messages, results };
 };
 
 const finishSync = (
   mergedIssues: readonly SettingsLoadIssue[],
   remoteSettingsPhase: SyncPhaseResult<RemoteSettingsReference>,
   sourcePhase: SyncPhaseResult<RemoteSourceReference>,
+  transitiveClosure: TransitiveClosureResult,
 ): SyncCommandResult => {
-  const results = [...remoteSettingsPhase.results, ...sourcePhase.results];
+  const results = [...remoteSettingsPhase.results, ...sourcePhase.results, ...transitiveClosure.results];
   const settingsMessages =
     mergedIssues.length === 0
       ? []
@@ -178,6 +273,7 @@ const finishSync = (
     ...settingsMessages,
     ...sourcePhase.messages,
     ...sourcePhase.results.map(formatResult),
+    ...transitiveClosure.messages,
   ];
 
   if (results.length === 0 && mergedIssues.length === 0) {
@@ -191,10 +287,10 @@ const finishSync = (
   };
 };
 
-/** Validates local settings, syncs remote settings, reloads, then syncs resulting remote sources. */
+/** Validates settings, syncs remote settings, reloads, syncs remote sources, then their closure. */
 export const executeSyncCommand = (
   input: SyncCommandInput,
-  dependencies: Pick<SyncCommandDependencies, 'classifier' | 'prompt' | 'privateCatalogGate'> = {},
+  dependencies: Pick<SyncCommandDependencies, 'classifier' | 'prompt' | 'privateCatalogGate' | 'syncRepository'> = {},
 ): SyncCommandResult => {
   const local = loadSettings(discoverSettingsLoadPlan(input));
   if (local.issues.length > 0) {
@@ -212,27 +308,49 @@ export const executeSyncCommand = (
       classifier: dependencies.classifier,
       prompt: dependencies.prompt,
     });
+  const syncRepository = dependencies.syncRepository ?? syncRemoteRepositoryAtomically;
   const remoteSettingsPhase = syncPhase({
     kind: 'remote_settings',
+    // Non-null is safe: `emptySettings()` (Settings.ts) always defaults `remoteSettings` to `[]`.
     sources: local.settings.remoteSettings!,
     homeDirectory: input.homeDirectory,
     cacheDirectory: local.settings.cacheDirectory,
     gate,
+    syncRepository,
     validate: validateRemoteSettingsCheckout,
   });
   const merged = loadSettingsWithCachedRemoteSettings(input, {
     remoteSettingsReferences: remoteSettingsPhase.allowedSources,
     localSettings: local,
   });
+  // Non-null is safe: `emptySettings()` (Settings.ts) always defaults `sources` to `[]`. Deduplicate
+  // exact-duplicate configured sources so an identical entry listed twice is fetched once, not twice
+  // (OFTR-004.6.6); distinct subpaths of one repo+ref stay distinct (path-aware key).
+  const seenSources = new Set<string>();
+  const directRemoteSources = merged.settings.sources!.filter(isRemoteSource).filter((source) => {
+    const key = encodeRemoteSourceSelection(source);
+    if (seenSources.has(key)) return false;
+    seenSources.add(key);
+    return true;
+  });
   const sourcePhase = syncPhase({
     kind: 'source',
-    sources: merged.settings.sources!.filter(isRemoteSource),
+    sources: directRemoteSources,
     homeDirectory: input.homeDirectory,
     cacheDirectory: merged.settings.cacheDirectory,
     gate,
+    syncRepository,
     validate: validateSourceCheckout,
   });
-  return finishSync(merged.issues, remoteSettingsPhase, sourcePhase);
+  const transitiveClosure = syncTransitiveClosure({
+    homeDirectory: input.homeDirectory,
+    cacheDirectory: merged.settings.cacheDirectory,
+    gate,
+    syncRepository,
+    directRemoteSources,
+    sourcePhase,
+  });
+  return finishSync(merged.issues, remoteSettingsPhase, sourcePhase, transitiveClosure);
 };
 
 export const createSyncCommand = (dependencies: SyncCommandDependencies = {}): CommandObject => ({

--- a/code/cli/src/resolver/Layer.ts
+++ b/code/cli/src/resolver/Layer.ts
@@ -4,11 +4,13 @@ import { join } from 'node:path';
 
 import {
   createRemoteRepositoryCachePath,
+  encodeRemoteSourceSelection,
   formatRemoteSourceDisplay,
   isRemoteSource,
-  resolveRemoteRepositorySubpath,
+  resolveSourcePayloadRoot,
 } from '../sources/SourceCache.js';
 import type { RemoteSourceReference } from '../sources/SourceCache.js';
+import { expandTransitiveSources } from '../sources/TransitiveSources.js';
 import type { Settings, SourceReference } from '../settings/Settings.js';
 import type { Layer } from './Resource.js';
 
@@ -25,7 +27,7 @@ const agentsRoot = (directory: string): string => join(directory, '.agents');
  * it. `outfitter sync` reuses this against its temporary checkout so both agree on the payload root.
  */
 export const remoteSourceLayer = (repositoryPath: string, source: RemoteSourceReference): Layer => ({
-  root: source.path === undefined ? repositoryPath : resolveRemoteRepositorySubpath(repositoryPath, source.path),
+  root: resolveSourcePayloadRoot(repositoryPath, source),
   origin: 'source',
   label: formatRemoteSourceDisplay(source),
 });
@@ -47,11 +49,14 @@ export interface LayerDiscoveryResult {
    * would deadlock every other command behind advice the user cannot act on (OFTR-004.2.15).
    */
   readonly unsynchronized: readonly string[];
+  /** Non-fatal transitive-source skip warnings (unpinned refs, path sources, invalid settings). */
+  readonly warnings: readonly string[];
 }
 
 /**
- * Orders layers highest precedence first: workspace `.agents`, then global `~/.agents`,
- * then configured sources in order. Only layers whose root exists on disk are included.
+ * Orders layers highest precedence first: workspace `.agents`, then global `~/.agents`, then
+ * configured sources in order, then transitive sources those catalogs declare, breadth-first
+ * (OFTR-004.6.1, OFTR-004.6.3). Only layers whose root exists on disk are included.
  */
 export const discoverLayers = (input: LayerDiscoveryInput): LayerDiscoveryResult => {
   const candidates: Layer[] = [
@@ -59,17 +64,56 @@ export const discoverLayers = (input: LayerDiscoveryInput): LayerDiscoveryResult
     { root: agentsRoot(input.homeDirectory), origin: 'global', label: 'global' },
   ];
   const unsynchronized: string[] = [];
+  const invalid: string[] = [];
 
-  for (const source of input.settings.sources ?? []) {
-    const layer = sourceLayer(input, source);
+  const appendSourceLayer = (source: SourceReference): void => {
+    // An absolute or escaping `path:` makes payload-root resolution throw; skip the source with a
+    // warning rather than crash every resolve command (list/validate/run/dump).
+    let layer: Layer;
+    try {
+      layer = sourceLayer(input, source);
+    } catch {
+      invalid.push(
+        `Configured source '${isRemoteSource(source) ? formatRemoteSourceDisplay(source) : source.path}' has an invalid path and was skipped.`,
+      );
+      return;
+    }
     if (isRemoteSource(source) && !existsSync(layer.root)) {
       unsynchronized.push(
         `Configured remote source '${layer.label}' is not synchronized at '${layer.root}'. Run 'outfitter sync' to fetch it.`,
       );
-      continue;
+      return;
     }
     candidates.push(layer);
+  };
+
+  // Deduplicate exact-duplicate configured sources so an identical entry listed twice yields one
+  // layer, not a self-shadowing pair (OFTR-004.6.6). Distinct subpaths stay distinct (path-aware).
+  const seenSources = new Set<string>();
+  const directSources = (input.settings.sources ?? []).filter((source) => {
+    const key = isRemoteSource(source) ? encodeRemoteSourceSelection(source) : `path\0${source.path}`;
+    if (seenSources.has(key)) return false;
+    seenSources.add(key);
+    return true;
+  });
+  for (const source of directSources) {
+    appendSourceLayer(source);
   }
 
-  return { layers: candidates.filter((layer) => existsSync(layer.root)), unsynchronized };
+  const expansion = expandTransitiveSources({
+    directSources,
+    resolveCachedCheckoutRoot: (source) => {
+      const checkoutRoot = createRemoteRepositoryCachePath(input.homeDirectory, source, input.settings.cacheDirectory);
+      return existsSync(checkoutRoot) ? checkoutRoot : undefined;
+    },
+  });
+  for (const transitive of expansion.sources) {
+    appendSourceLayer(transitive.source);
+  }
+
+  return {
+    layers: candidates.filter((layer) => existsSync(layer.root)),
+    unsynchronized,
+    warnings: [...invalid, ...expansion.warnings],
+  };
 };

--- a/code/cli/src/resolver/ResolverContext.ts
+++ b/code/cli/src/resolver/ResolverContext.ts
@@ -16,7 +16,7 @@ export interface ResolveResult {
   /** The merged settings loaded during resolution, so callers need not reload them. */
   readonly settings: Settings;
   readonly settingsIssues: readonly SettingsLoadIssue[];
-  /** Non-fatal `outfitter sync` guidance for configured remote sources with no cache. */
+  /** Non-fatal guidance: uncached remote sources plus transitive-source skip warnings. */
   readonly warnings: readonly string[];
 }
 
@@ -29,6 +29,6 @@ export const resolveEffectiveSet = (input: ResolveInput): ResolveResult => {
     set: resolveResources(discovered.layers),
     settings: loadedSettings.settings,
     settingsIssues: loadedSettings.issues,
-    warnings: discovered.unsynchronized,
+    warnings: [...discovered.unsynchronized, ...discovered.warnings],
   };
 };

--- a/code/cli/src/resolver/ResolverValidation.ts
+++ b/code/cli/src/resolver/ResolverValidation.ts
@@ -11,12 +11,31 @@ export interface ValidationFinding {
   readonly message: string;
 }
 
-const compositionWarningSeverity = (message: string): ValidationFinding['severity'] =>
-  /^loadout (?:skills|subagents) references unknown (?:skill|agent) '/.test(message) ? 'error' : 'warning';
+/**
+ * Options for {@link validateEffectiveSet}. `deferLoadoutResolution` downgrades an unresolved
+ * loadout slug reference from an error to a warning — used when validating a single remote source
+ * in isolation during `outfitter sync`, where a catalog may legitimately reference a skill supplied
+ * by a catalog it declares as a dependency (OFTR-004.6). Loadout wholeness is then authoritatively
+ * enforced against the merged effective set by `outfitter validate`; the run-time composer surfaces
+ * an unresolved reference as a non-fatal warning (OFTR-005.3.4), fatal only under `run --strict`.
+ */
+export interface ValidationOptions {
+  readonly deferLoadoutResolution?: boolean;
+}
+
+// Matches the composer's top-level unresolved-loadout warning wording (see `compose` in Composer.ts).
+// It is deliberately coupled to that message; `resolver-validation.test.ts` drives the real composer,
+// so a wording drift fails that test rather than silently disabling deferral.
+const isUnresolvedLoadoutReference = (message: string): boolean =>
+  /^loadout (?:skills|subagents) references unknown (?:skill|agent) '/.test(message);
+
+const compositionWarningSeverity = (message: string, options: ValidationOptions): ValidationFinding['severity'] =>
+  isUnresolvedLoadoutReference(message) && !options.deferLoadoutResolution ? 'error' : 'warning';
 
 const validateAgent = (
   set: EffectiveResourceSet,
   agent: ResolvedResource,
+  options: ValidationOptions,
   projectDirectory?: string,
 ): readonly ValidationFinding[] => {
   const definition = readAgentDefinition(agent.winner.path, agent.configPaths);
@@ -39,7 +58,7 @@ const validateAgent = (
   const compositionFindings: ValidationFinding[] = [
     ...composed.errors.map((message) => ({ severity: 'error' as const, resource: `agent:${agent.slug}`, message })),
     ...composed.warnings.map((message) => ({
-      severity: compositionWarningSeverity(message),
+      severity: compositionWarningSeverity(message, options),
       resource: `agent:${agent.slug}`,
       message,
     })),
@@ -106,6 +125,29 @@ const deduplicateFindings = (findings: readonly ValidationFinding[]): readonly V
   return [...deduplicated.values()];
 };
 
+// Validates one agent's local resources: the owning agent must resolve, and each local skill is
+// document-checked; knowledge/commands are opaque file trees today, so only shadowing is surfaced.
+const validateAgentLocalResources = (set: EffectiveResourceSet, agentSlug: string): readonly ValidationFinding[] => {
+  const findings: ValidationFinding[] = [];
+
+  if (findResource(set, 'agent', agentSlug) === undefined) {
+    findings.push({
+      severity: 'error',
+      resource: `agent:${agentSlug}`,
+      message: 'agent-local resources require a resolvable owning agent.',
+    });
+  }
+
+  for (const kind of agentLocalKinds) {
+    for (const resource of listAgentResources(set, agentSlug, kind)) {
+      findings.push(...shadowFindings(resource));
+      if (kind === 'skill') findings.push(...validateSkill(resource));
+    }
+  }
+
+  return findings;
+};
+
 /**
  * Collects validation findings across the effective set. `error` findings always fail validation;
  * `warning` findings (such as shadowed definitions) fail only under `--strict`.
@@ -113,11 +155,12 @@ const deduplicateFindings = (findings: readonly ValidationFinding[]): readonly V
 export const validateEffectiveSet = (
   set: EffectiveResourceSet,
   projectDirectory?: string,
+  options: ValidationOptions = {},
 ): readonly ValidationFinding[] => {
   const findings: ValidationFinding[] = [];
 
   for (const agent of listResources(set, 'agent')) {
-    findings.push(...validateAgent(set, agent, projectDirectory), ...reservedNamespaceFindings(agent));
+    findings.push(...validateAgent(set, agent, options, projectDirectory), ...reservedNamespaceFindings(agent));
   }
 
   for (const skill of listResources(set, 'skill')) {
@@ -125,21 +168,7 @@ export const validateEffectiveSet = (
   }
 
   for (const [agentSlug] of set.agentResources) {
-    if (findResource(set, 'agent', agentSlug) === undefined) {
-      findings.push({
-        severity: 'error',
-        resource: `agent:${agentSlug}`,
-        message: 'agent-local resources require a resolvable owning agent.',
-      });
-    }
-
-    for (const kind of agentLocalKinds) {
-      for (const resource of listAgentResources(set, agentSlug, kind)) {
-        findings.push(...shadowFindings(resource));
-        // Only skills have a document reader today; knowledge/commands are opaque file trees.
-        if (kind === 'skill') findings.push(...validateSkill(resource));
-      }
-    }
+    findings.push(...validateAgentLocalResources(set, agentSlug));
   }
 
   for (const kind of ['agent', 'skill', 'knowledge', 'command'] as const) {

--- a/code/cli/src/setup/DefaultCatalog.ts
+++ b/code/cli/src/setup/DefaultCatalog.ts
@@ -1,10 +1,21 @@
 // Bootstraps the one canonical default catalog at the immutable revision shipped by Outfitter.
-import { existsSync } from 'node:fs';
+import { statSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { runGit, syncRemoteRepositoryAtomically, tryReadCleanHead } from '../sources/GitRepository.js';
-import { createRemoteRepositoryCachePath, redactEmbeddedSourceCredentials } from '../sources/SourceCache.js';
+import {
+  createRemoteRepositoryCachePath,
+  encodeRemoteSourceSelection,
+  formatRemoteSourceDisplay,
+  isImmutableRef,
+  isVersionTagRef,
+  redactEmbeddedSourceCredentials,
+} from '../sources/SourceCache.js';
 import type { RemoteSourceReference } from '../sources/SourceCache.js';
+import { readDeclaredRemoteSources } from '../sources/TransitiveSources.js';
+
+/** Fetches one repository into the cache. Injectable so tests exercise bootstrap hermetically. */
+export type RepositorySync = typeof syncRemoteRepositoryAtomically;
 
 export const defaultCatalogSource = {
   github: 'ai-outfitter/default-profiles',
@@ -17,6 +28,13 @@ export interface PinnedCatalogBootstrapInput {
   readonly homeDirectory: string;
   readonly cacheDirectory?: string;
   readonly source: RemoteSourceReference & { readonly ref: string };
+  readonly syncRepository?: RepositorySync;
+  /**
+   * Proves a fetched checkout is a usable catalog. Defaults to requiring `agents/` — the picker root
+   * must offer agents — but a dependency may legitimately ship only skills, so the closure relaxes
+   * this to any recognized `.agents` payload directory.
+   */
+  readonly requirePayload?: (root: string) => boolean;
 }
 
 export interface PinnedCatalogBootstrapResult {
@@ -24,20 +42,34 @@ export interface PinnedCatalogBootstrapResult {
   readonly source: RemoteSourceReference & { readonly ref: string };
 }
 
-const fullCommitPattern = /^[a-f0-9]{40}$/u;
-const versionTagPattern = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u;
+// A recognized payload marker must be a real directory, not merely a path that exists: a repository
+// committing a regular file named `agents` is not a catalog and must not validate as one.
+const isDirectory = (path: string): boolean => {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+};
+
+const hasAgentsDirectory = (root: string): boolean => isDirectory(join(root, 'agents'));
+
+// Any directory the resolver treats as a `.agents` payload container, colocated or at the root.
+const hasAnyAgentsPayload = (root: string): boolean =>
+  ['agents', 'skills', 'knowledge', 'commands'].some((directory) => isDirectory(join(root, directory))) ||
+  isDirectory(join(root, '.agents'));
 
 const assertImmutableRef = (ref: string): void => {
-  if (!fullCommitPattern.test(ref) && !versionTagPattern.test(ref)) {
+  if (!isImmutableRef(ref)) {
     throw new Error(`Default catalog ref '${ref}' must be a full commit SHA or version tag.`);
   }
 };
 
 const resolveExpectedCommit = (root: string, ref: string): string =>
-  fullCommitPattern.test(ref) ? ref : runGit(['-C', root, 'rev-parse', `refs/tags/${ref}^{commit}`]);
+  isVersionTagRef(ref) ? runGit(['-C', root, 'rev-parse', `refs/tags/${ref}^{commit}`]) : ref;
 
-const isPinnedCatalogCheckout = (root: string, ref: string): boolean => {
-  if (!existsSync(join(root, 'agents'))) return false;
+const isPinnedCatalogCheckout = (root: string, ref: string, hasPayload: (root: string) => boolean): boolean => {
+  if (!hasPayload(root)) return false;
   try {
     return tryReadCleanHead(root) === resolveExpectedCommit(root, ref);
   } catch {
@@ -48,13 +80,14 @@ const isPinnedCatalogCheckout = (root: string, ref: string): boolean => {
 /** Fetches one immutable catalog revision into the same cache path used by normal source resolution. */
 export const bootstrapPinnedCatalog = (input: PinnedCatalogBootstrapInput): PinnedCatalogBootstrapResult => {
   assertImmutableRef(input.source.ref);
+  const hasPayload = input.requirePayload ?? hasAgentsDirectory;
   const root = createRemoteRepositoryCachePath(input.homeDirectory, input.source, input.cacheDirectory);
-  if (isPinnedCatalogCheckout(root, input.source.ref)) return { root, source: input.source };
+  if (isPinnedCatalogCheckout(root, input.source.ref, hasPayload)) return { root, source: input.source };
 
   try {
-    syncRemoteRepositoryAtomically({
+    (input.syncRepository ?? syncRemoteRepositoryAtomically)({
       cachePath: root,
-      fetchRef: versionTagPattern.test(input.source.ref)
+      fetchRef: isVersionTagRef(input.source.ref)
         ? `refs/tags/${input.source.ref}:refs/tags/${input.source.ref}`
         : input.source.ref,
       source: input.source,
@@ -63,7 +96,7 @@ export const bootstrapPinnedCatalog = (input: PinnedCatalogBootstrapInput): Pinn
       // accepting a dirty tree here would cache one that `tryReadCleanHead` rejects on every
       // subsequent read, re-fetching forever.
       validate: (temporaryRoot) => {
-        if (!isPinnedCatalogCheckout(temporaryRoot, input.source.ref)) {
+        if (!isPinnedCatalogCheckout(temporaryRoot, input.source.ref, hasPayload)) {
           throw new Error(`Fetched default catalog did not resolve to ${input.source.ref}.`);
         }
         return 0;
@@ -78,5 +111,55 @@ export const bootstrapPinnedCatalog = (input: PinnedCatalogBootstrapInput): Pinn
   }
 };
 
+/**
+ * Bootstraps a pinned catalog and the pinned `github:` closure it declares, so a fresh install can
+ * resolve a default profile whose skills live in a depended-on catalog (the founder profile's
+ * persona skills, shipped by community-profiles) without a manual `outfitter sync`. The root failing
+ * to fetch is fatal (existing behavior); a declared dependency failing to fetch is best-effort —
+ * resolution reports it as unsynchronized rather than blocking setup on it.
+ */
+export const bootstrapPinnedClosure = (input: PinnedCatalogBootstrapInput): PinnedCatalogBootstrapResult => {
+  const rootResult = bootstrapPinnedCatalog(input);
+  const visited = new Set([encodeRemoteSourceSelection(input.source)]);
+
+  let frontier: readonly { readonly root: string; readonly label: string }[] = [
+    { root: rootResult.root, label: formatRemoteSourceDisplay(input.source) },
+  ];
+  while (frontier.length > 0) {
+    const next: { readonly root: string; readonly label: string }[] = [];
+
+    for (const parent of frontier) {
+      // A `github:` closure is always path-less, so the payload root is the checkout root.
+      for (const declared of readDeclaredRemoteSources(parent.root, parent.root, parent.label).sources) {
+        const key = encodeRemoteSourceSelection(declared.source);
+        if (visited.has(key)) continue;
+        visited.add(key);
+        try {
+          next.push({
+            root: bootstrapPinnedCatalog({
+              homeDirectory: input.homeDirectory,
+              cacheDirectory: input.cacheDirectory,
+              source: declared.source,
+              syncRepository: input.syncRepository,
+              // A dependency may ship only skills; do not require it to contain agents/.
+              requirePayload: hasAnyAgentsPayload,
+            }).root,
+            label: formatRemoteSourceDisplay(declared.source),
+          });
+        } catch {
+          // Best-effort: a dependency that cannot be fetched is surfaced by resolution as an
+          // unsynchronized source (with `outfitter sync` guidance), never a setup-blocking throw.
+        }
+      }
+    }
+
+    frontier = next;
+  }
+
+  return rootResult;
+};
+
+/* v8 ignore next 2 -- the production entry fetches the real default catalog from github.com; tests
+   drive bootstrapPinnedClosure directly and SetupCommand injects a fake bootstrap. */
 export const bootstrapDefaultCatalog = (homeDirectory: string, cacheDirectory?: string): PinnedCatalogBootstrapResult =>
-  bootstrapPinnedCatalog({ homeDirectory, cacheDirectory, source: defaultCatalogSource });
+  bootstrapPinnedClosure({ homeDirectory, cacheDirectory, source: defaultCatalogSource });

--- a/code/cli/src/sources/SourceCache.ts
+++ b/code/cli/src/sources/SourceCache.ts
@@ -1,5 +1,5 @@
 // Encodes remote `.agents` source cache paths and normalizes remote source references.
-import { isAbsolute, join, relative, resolve } from 'node:path';
+import { isAbsolute, join, posix, relative, resolve } from 'node:path';
 
 /** A remote `.agents` source: a git URI or a `github` shorthand, with an optional ref. */
 export type RemoteSourceReference =
@@ -10,6 +10,15 @@ export type RemoteSourceReference =
 export const isRemoteSource = <T extends { readonly uri?: string; readonly github?: string }>(
   source: T,
 ): source is T & RemoteSourceReference => source.uri !== undefined || source.github !== undefined;
+
+const fullCommitPattern = /^[a-f0-9]{40}$/u;
+const versionTagPattern = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u;
+
+/** True for a ref that names one immutable revision: a full commit SHA or a version tag. */
+export const isImmutableRef = (ref: string): boolean => fullCommitPattern.test(ref) || versionTagPattern.test(ref);
+
+/** True for an immutable ref that must be resolved to a commit via `rev-parse` (a version tag). */
+export const isVersionTagRef = (ref: string): boolean => versionTagPattern.test(ref);
 
 export const normalizeGitUri = (uri: string): string => (uri.startsWith('git+') ? uri.slice('git+'.length) : uri);
 
@@ -55,6 +64,30 @@ export const encodeSourceUri = (uri: string): string =>
 export const encodeRemoteSource = (source: RemoteSourceReference): string =>
   encodeSourceUri(`${normalizeRemoteSourceUri(source)}#${source.ref ?? ''}`);
 
+// The payload subpath a source selects, canonicalized so identical selections share one identity:
+// an omitted path, `.`, `./`, and `foo/..` all normalize to the repository root ('').
+const canonicalSourcePath = (path?: string): string => {
+  if (path === undefined) return '';
+  const normalized = posix.normalize(path).replace(/\/+$/u, '');
+  return normalized === '.' ? '' : normalized;
+};
+
+/**
+ * A source's graph identity for dedup, visited sets, and layer ordering. It differs from
+ * {@link encodeRemoteSource} (the *checkout cache* key) in two deliberate ways:
+ *
+ * - It includes the canonicalized `path`, because two sources into different subpaths of one repo+ref
+ *   are distinct layers — deduping them on the path-less cache key would silently drop one.
+ * - It keys on the *raw* normalized URI, credentials included, not the redacted cache key. Two entries
+ *   for the same repo with different credentials are distinct configured sources; collapsing them
+ *   (the cache key redacts credentials, so both share it) could drop a valid source for a broken one.
+ *   This value is used only in ephemeral in-memory dedup/visited sets — never persisted or logged —
+ *   so carrying credentials here is safe (the cache path and every user-facing display use the
+ *   redacted forms).
+ */
+export const encodeRemoteSourceSelection = (source: RemoteSourceReference): string =>
+  `${normalizeRemoteSourceUri(source)}#${source.ref ?? ''} ${canonicalSourcePath(source.path)}`;
+
 /** Resolves the one cache root used by sync, settings, layer discovery, and setup bootstrap. */
 export const resolveRemoteRepositoryCacheRoot = (homeDirectory: string, cacheDirectory?: string): string =>
   cacheDirectory ?? join(homeDirectory, '.agents', 'cache');
@@ -64,6 +97,10 @@ export const createRemoteRepositoryCachePath = (
   source: RemoteSourceReference,
   cacheDirectory?: string,
 ): string => join(resolveRemoteRepositoryCacheRoot(homeDirectory, cacheDirectory), 'repos', encodeRemoteSource(source));
+
+/** The `.agents` payload root a source selects inside its materialized repository checkout. */
+export const resolveSourcePayloadRoot = (repositoryPath: string, source: RemoteSourceReference): string =>
+  source.path === undefined ? repositoryPath : resolveRemoteRepositorySubpath(repositoryPath, source.path);
 
 export const resolveRemoteRepositorySubpath = (repositoryPath: string, subpath = ''): string => {
   if (isAbsolute(subpath)) {

--- a/code/cli/src/sources/TransitiveSources.ts
+++ b/code/cli/src/sources/TransitiveSources.ts
@@ -1,0 +1,229 @@
+// Expands the remote-source closure that cached catalogs declare in their own settings files.
+import { existsSync, lstatSync, realpathSync, statSync } from 'node:fs';
+import { isAbsolute, join, relative, sep } from 'node:path';
+
+import { createSettingsLoadPlan, loadSettingsFiles } from '../settings/SettingsLoader.js';
+import type { SourceReference } from '../settings/Settings.js';
+import {
+  encodeRemoteSourceSelection,
+  formatRemoteSourceDisplay,
+  isImmutableRef,
+  isRemoteSource,
+  resolveSourcePayloadRoot,
+} from './SourceCache.js';
+import type { RemoteSourceReference } from './SourceCache.js';
+
+/** A `github:` catalog dependency, pinned to an immutable ref, attributed to its declaring catalog. */
+export interface DeclaredRemoteSource {
+  readonly source: { readonly github: string; readonly ref: string };
+  /** Display name of the declaring catalog, for warnings and provenance. */
+  readonly declaredBy: string;
+}
+
+export interface DeclaredSourcesResult {
+  readonly sources: readonly DeclaredRemoteSource[];
+  readonly warnings: readonly string[];
+}
+
+// True when a filesystem entry exists at the path, *including a dangling symlink*. `existsSync`
+// follows links and reports a dangling one as absent, which would silently drop (rather than warn
+// about, per OFTR-004.6.8) a `settings.yml` committed as a broken symlink.
+const entryExists = (path: string): boolean => {
+  try {
+    lstatSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/** The settings file a catalog payload root may carry: `settings.yml`, else `.agents/settings.yml`. */
+export const resolveCatalogSettingsPath = (payloadRoot: string): string | undefined => {
+  const rootSettingsPath = join(payloadRoot, 'settings.yml');
+  if (entryExists(rootSettingsPath)) return rootSettingsPath;
+
+  const nestedSettingsPath = join(payloadRoot, '.agents', 'settings.yml');
+  return entryExists(nestedSettingsPath) ? nestedSettingsPath : undefined;
+};
+
+/** One declared source resolved to either an accepted `github:` dependency or a skip reason. */
+type ClassifiedSource =
+  { readonly source: { readonly github: string; readonly ref: string } } | { readonly skip: string };
+
+/** Applies the safe-subset rules to one declared source, yielding a dependency or a skip reason. */
+const classifyDeclaredSource = (declared: SourceReference, declaredBy: string): ClassifiedSource => {
+  if (!isRemoteSource(declared)) {
+    return {
+      skip: `Catalog '${declaredBy}' declares local path source '${declared.path}'; only 'github:' shorthands are resolved transitively, so it was skipped.`,
+    };
+  }
+  if (declared.github === undefined) {
+    return {
+      skip: `Catalog '${declaredBy}' declares source '${formatRemoteSourceDisplay(declared)}' as a 'uri:'; only 'github:' shorthands are resolved transitively, so it was skipped.`,
+    };
+  }
+  if (declared.path !== undefined) {
+    return {
+      skip: `Catalog '${declaredBy}' declares source '${formatRemoteSourceDisplay(declared)}' with a 'path:' subpath; transitive 'github:' sources must resolve their whole repository, so it was skipped.`,
+    };
+  }
+  if (declared.ref === undefined || !isImmutableRef(declared.ref)) {
+    return {
+      skip: `Catalog '${declaredBy}' declares source '${formatRemoteSourceDisplay(declared)}' without an immutable ref (a full commit SHA or version tag); it was skipped.`,
+    };
+  }
+  return { source: { github: declared.github, ref: declared.ref } };
+};
+
+/**
+ * Loads a cached catalog's own settings file, guarding against a hostile `settings.yml` committed as
+ * a symlink to a directory or a file outside the checkout (a `readFileSync` on a directory throws
+ * `EISDIR` and would crash resolution). Returns the parsed sources list, or a skip warning.
+ */
+const loadCatalogSourceList = (
+  payloadRoot: string,
+  checkoutRoot: string,
+  declaredBy: string,
+): { readonly sources: readonly SourceReference[] } | { readonly warning: string } => {
+  const settingsPath = resolveCatalogSettingsPath(payloadRoot);
+  if (settingsPath === undefined) return { sources: [] };
+
+  try {
+    if (!statSync(settingsPath).isFile()) throw new Error('settings.yml is not a regular file');
+    // Anchor containment to the *checkout* root (the clone Outfitter created), not the payload root:
+    // a `path:` selecting a symlinked subdirectory would make the payload root itself resolve
+    // outside the clone, so anchoring there would accept an external settings.yml as "contained".
+    const relativeToCheckout = relative(realpathSync(checkoutRoot), realpathSync(settingsPath));
+    // Precise containment: a leading `..` segment (not a filename that merely starts with `..`, such
+    // as a directory named `..catalog`) or an absolute result means the settings escaped the checkout.
+    if (relativeToCheckout === '..' || relativeToCheckout.startsWith(`..${sep}`) || isAbsolute(relativeToCheckout)) {
+      throw new Error('settings.yml resolves outside the checkout');
+    }
+    // Known-accepted TOCTOU: the checkout could be swapped between this stat/realpath check and the
+    // read below. The checkout is a pinned immutable git ref that only Outfitter writes, and racing
+    // local-filesystem writes already imply broader access, so closing this window is not warranted.
+    const loaded = loadSettingsFiles(createSettingsLoadPlan([{ scope: 'remote', path: settingsPath }]));
+    if (loaded.issues.length > 0) {
+      return {
+        warning: `Catalog '${declaredBy}' declares invalid settings at '${settingsPath}'; its sources were skipped.`,
+      };
+    }
+    return { sources: loaded.files[0].settings.sources ?? [] };
+  } catch {
+    return {
+      warning: `Catalog '${declaredBy}' has an unreadable settings.yml (not a regular file inside the checkout); its sources were skipped.`,
+    };
+  }
+};
+
+/**
+ * Reads the `github:` catalog dependencies a cached catalog declares (content, never policy —
+ * OFTR-004.6.2). Transitive sources are deliberately the narrowest safe subset: a `github:`
+ * shorthand pinned to an immutable ref. A `uri:` source, a local `path:` source, a `path:` subpath,
+ * or a mutable ref is skipped with a warning naming the declaring catalog (OFTR-004.6.4,
+ * OFTR-004.6.5). Restricting to `github:` means every transitive fetch during `outfitter sync`
+ * passes through the private-catalog gate and can never select an arbitrary git transport (a `uri:`
+ * could name `ext::<cmd>` or a filesystem path); forbidding `path:` means a declaration can never
+ * escape its fetched checkout. An unreadable or invalid settings file skips the catalog's
+ * declarations without failing resolution (OFTR-004.6.8). (First-party default-catalog bootstrap
+ * fetches its declared closure without that interactive gate — see OFTR-004.6.10.) Broader
+ * transports remain future work under the trust model in #212.
+ */
+export const readDeclaredRemoteSources = (
+  payloadRoot: string,
+  checkoutRoot: string,
+  declaredBy: string,
+): DeclaredSourcesResult => {
+  const loaded = loadCatalogSourceList(payloadRoot, checkoutRoot, declaredBy);
+  if ('warning' in loaded) return { sources: [], warnings: [loaded.warning] };
+
+  const sources: DeclaredRemoteSource[] = [];
+  const warnings: string[] = [];
+  for (const declared of loaded.sources) {
+    const classified = classifyDeclaredSource(declared, declaredBy);
+    if ('skip' in classified) warnings.push(classified.skip);
+    else sources.push({ source: classified.source, declaredBy });
+  }
+
+  return { sources, warnings };
+};
+
+export interface TransitiveExpansionInput {
+  /** The directly configured sources, which seed the visited set and the first frontier. */
+  readonly directSources: readonly SourceReference[];
+  /** Maps a remote source to its cached checkout (clone) root, or undefined when it is not cached. */
+  readonly resolveCachedCheckoutRoot: (source: RemoteSourceReference) => string | undefined;
+}
+
+export interface TransitiveExpansionResult {
+  /** Newly discovered remote sources, breadth-first by depth then declaration order (OFTR-004.6.3). */
+  readonly sources: readonly DeclaredRemoteSource[];
+  readonly warnings: readonly string[];
+}
+
+/**
+ * Walks declared sources breadth-first from the directly configured sources over the local cache.
+ * A source already visited — directly configured or declared by an earlier catalog — is never
+ * expanded again, so dependency cycles terminate (OFTR-004.6.6). An uncached source stays in the
+ * result (the caller reports it) but its own declarations are unknowable until it is synced.
+ */
+// Reads one parent's cached checkout and returns the declarations it contributes. Returns `undefined`
+// (skip this parent) when it is uncached or its `path:` is absolute/escaping — a throw here would
+// otherwise crash resolution; only a directly configured source can carry such a path.
+const declarationsFromParent = (
+  parent: RemoteSourceReference,
+  resolveCachedCheckoutRoot: TransitiveExpansionInput['resolveCachedCheckoutRoot'],
+): DeclaredSourcesResult | undefined => {
+  const checkoutRoot = resolveCachedCheckoutRoot(parent);
+  if (checkoutRoot === undefined) return undefined;
+
+  let payloadRoot: string;
+  try {
+    payloadRoot = resolveSourcePayloadRoot(checkoutRoot, parent);
+  } catch {
+    return undefined;
+  }
+  if (!existsSync(payloadRoot)) return undefined;
+
+  return readDeclaredRemoteSources(payloadRoot, checkoutRoot, formatRemoteSourceDisplay(parent));
+};
+
+export const expandTransitiveSources = (input: TransitiveExpansionInput): TransitiveExpansionResult => {
+  const sources: DeclaredRemoteSource[] = [];
+  const warnings: string[] = [];
+  const visited = new Set<string>();
+
+  // Seed the visited set with each direct source's path-aware identity so a directly configured
+  // subpath source does not suppress a transitive whole-repository source of the same repo+ref, and
+  // so an exact duplicate direct source is expanded only once (OFTR-004.6.6).
+  let frontier: RemoteSourceReference[] = [];
+  for (const direct of input.directSources) {
+    if (!isRemoteSource(direct)) continue;
+    const key = encodeRemoteSourceSelection(direct);
+    if (visited.has(key)) continue;
+    visited.add(key);
+    frontier.push(direct);
+  }
+
+  while (frontier.length > 0) {
+    const next: RemoteSourceReference[] = [];
+
+    for (const parent of frontier) {
+      const declared = declarationsFromParent(parent, input.resolveCachedCheckoutRoot);
+      if (declared === undefined) continue;
+      warnings.push(...declared.warnings);
+
+      for (const entry of declared.sources) {
+        const key = encodeRemoteSourceSelection(entry.source);
+        if (visited.has(key)) continue;
+        visited.add(key);
+        sources.push(entry);
+        next.push(entry.source);
+      }
+    }
+
+    frontier = next;
+  }
+
+  return { sources, warnings };
+};

--- a/code/cli/tests/unit/default-catalog.test.ts
+++ b/code/cli/tests/unit/default-catalog.test.ts
@@ -6,7 +6,12 @@ import { dirname, join } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { bootstrapPinnedCatalog, defaultCatalogSource } from '../../src/setup/DefaultCatalog.js';
+import {
+  bootstrapPinnedCatalog,
+  bootstrapPinnedClosure,
+  defaultCatalogSource,
+} from '../../src/setup/DefaultCatalog.js';
+import { syncRemoteRepositoryAtomically } from '../../src/sources/GitRepository.js';
 import { createRemoteRepositoryCachePath } from '../../src/sources/SourceCache.js';
 
 const temporaryRoots: string[] = [];
@@ -134,5 +139,188 @@ describe('default catalog bootstrap', () => {
 
     expect(() => bootstrapPinnedCatalog({ homeDirectory, source })).toThrow(/did not resolve/u);
     expect(existsSync(createRemoteRepositoryCachePath(homeDirectory, source))).toBe(false);
+  });
+});
+
+describe('default catalog closure bootstrap', () => {
+  // Maps each `github:` owner/repo to a local fixture repository so the pinned closure fetches
+  // hermetically (a real `github:` source would resolve to github.com).
+  const githubFixtureSync =
+    (fixtures: Readonly<Record<string, string>>): typeof syncRemoteRepositoryAtomically =>
+    (syncInput) => {
+      if (syncInput.source.github === undefined) return syncRemoteRepositoryAtomically(syncInput);
+      const localRepository = fixtures[syncInput.source.github];
+      if (localRepository === undefined) throw new Error(`No fixture for github:${syncInput.source.github}`);
+      return syncRemoteRepositoryAtomically({
+        ...syncInput,
+        source: { uri: localRepository, ref: syncInput.source.ref },
+      });
+    };
+
+  const createTaggedCatalog = (files: Readonly<Record<string, string>>, tag: string): string => {
+    const root = mkdtempSync(join(tmpdir(), 'outfitter-closure-source-'));
+    temporaryRoots.push(root);
+    git(['init', '--quiet', root]);
+    git(['-C', root, 'config', 'user.name', 'Outfitter Tests']);
+    git(['-C', root, 'config', 'user.email', 'tests@outfitter.dev']);
+    git(['-C', root, 'config', 'commit.gpgsign', 'false']);
+    git(['-C', root, 'config', 'tag.gpgsign', 'false']);
+    for (const [path, content] of Object.entries(files)) write(join(root, path), content);
+    git(['-C', root, 'add', '.']);
+    git(['-C', root, 'commit', '--quiet', '-m', 'catalog']);
+    git(['-C', root, 'tag', tag]);
+    return root;
+  };
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.10).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('fetches the pinned github: closure the default catalog declares', () => {
+    const dependency = createTaggedCatalog({ 'agents/persona/agent.md': '---\nname: persona\n---\n' }, 'v1.0.0');
+    const root = createTaggedCatalog(
+      {
+        'agents/founder/agent.md': '---\nname: founder\n---\n',
+        'settings.yml': 'sources:\n  - github: ai-outfitter/community-profiles\n    ref: v1.0.0\n',
+      },
+      'v1.0.0',
+    );
+    const homeDirectory = mkdtempSync(join(tmpdir(), 'outfitter-closure-home-'));
+    temporaryRoots.push(homeDirectory);
+
+    const result = bootstrapPinnedClosure({
+      homeDirectory,
+      source: { github: 'ai-outfitter/default-profiles', ref: 'v1.0.0' },
+      syncRepository: githubFixtureSync({
+        'ai-outfitter/default-profiles': root,
+        'ai-outfitter/community-profiles': dependency,
+      }),
+    });
+
+    expect(readFileSync(join(result.root, 'agents', 'founder', 'agent.md'), 'utf8')).toContain('name: founder');
+    const dependencyCache = createRemoteRepositoryCachePath(homeDirectory, {
+      github: 'ai-outfitter/community-profiles',
+      ref: 'v1.0.0',
+    });
+    expect(readFileSync(join(dependencyCache, 'agents', 'persona', 'agent.md'), 'utf8')).toContain('name: persona');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.10).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('walks the declared closure breadth-first to depth two', () => {
+    // root → mid → leaf: bootstrap must fetch the whole transitive chain, not just the root's
+    // direct dependency.
+    const leaf = createTaggedCatalog({ 'skills/leaf-skill/SKILL.md': '# leaf-skill\n' }, 'v1.0.0');
+    const mid = createTaggedCatalog(
+      {
+        'agents/mid/agent.md': '---\nname: mid\n---\n',
+        'settings.yml': 'sources:\n  - github: acme/leaf\n    ref: v1.0.0\n',
+      },
+      'v1.0.0',
+    );
+    const root = createTaggedCatalog(
+      {
+        'agents/founder/agent.md': '---\nname: founder\n---\n',
+        'settings.yml': 'sources:\n  - github: acme/mid\n    ref: v1.0.0\n',
+      },
+      'v1.0.0',
+    );
+    const homeDirectory = mkdtempSync(join(tmpdir(), 'outfitter-closure-home-'));
+    temporaryRoots.push(homeDirectory);
+
+    bootstrapPinnedClosure({
+      homeDirectory,
+      source: { github: 'ai-outfitter/default-profiles', ref: 'v1.0.0' },
+      syncRepository: githubFixtureSync({ 'ai-outfitter/default-profiles': root, 'acme/mid': mid, 'acme/leaf': leaf }),
+    });
+
+    const leafCache = createRemoteRepositoryCachePath(homeDirectory, { github: 'acme/leaf', ref: 'v1.0.0' });
+    expect(readFileSync(join(leafCache, 'skills', 'leaf-skill', 'SKILL.md'), 'utf8')).toContain('leaf-skill');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.10).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('does not fail setup when a declared dependency cannot be fetched', () => {
+    const root = createTaggedCatalog(
+      {
+        'agents/founder/agent.md': '---\nname: founder\n---\n',
+        'settings.yml': 'sources:\n  - github: ai-outfitter/missing\n    ref: v1.0.0\n',
+      },
+      'v1.0.0',
+    );
+    const homeDirectory = mkdtempSync(join(tmpdir(), 'outfitter-closure-home-'));
+    temporaryRoots.push(homeDirectory);
+
+    const result = bootstrapPinnedClosure({
+      homeDirectory,
+      source: { github: 'ai-outfitter/default-profiles', ref: 'v1.0.0' },
+      syncRepository: githubFixtureSync({ 'ai-outfitter/default-profiles': root }),
+    });
+
+    expect(readFileSync(join(result.root, 'agents', 'founder', 'agent.md'), 'utf8')).toContain('name: founder');
+    expect(
+      existsSync(createRemoteRepositoryCachePath(homeDirectory, { github: 'ai-outfitter/missing', ref: 'v1.0.0' })),
+    ).toBe(false);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.10).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('bootstraps a dependency that ships only skills (no agents directory)', () => {
+    const dependency = createTaggedCatalog({ 'skills/persona-review/SKILL.md': '# persona-review\n' }, 'v1.0.0');
+    const root = createTaggedCatalog(
+      {
+        'agents/founder/agent.md': '---\nname: founder\n---\n',
+        'settings.yml': 'sources:\n  - github: ai-outfitter/community-profiles\n    ref: v1.0.0\n',
+      },
+      'v1.0.0',
+    );
+    const homeDirectory = mkdtempSync(join(tmpdir(), 'outfitter-closure-home-'));
+    temporaryRoots.push(homeDirectory);
+
+    bootstrapPinnedClosure({
+      homeDirectory,
+      source: { github: 'ai-outfitter/default-profiles', ref: 'v1.0.0' },
+      syncRepository: githubFixtureSync({
+        'ai-outfitter/default-profiles': root,
+        'ai-outfitter/community-profiles': dependency,
+      }),
+    });
+
+    const dependencyCache = createRemoteRepositoryCachePath(homeDirectory, {
+      github: 'ai-outfitter/community-profiles',
+      ref: 'v1.0.0',
+    });
+    expect(readFileSync(join(dependencyCache, 'skills', 'persona-review', 'SKILL.md'), 'utf8')).toContain(
+      'persona-review',
+    );
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.10).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('does not cache a dependency whose only payload marker is a regular file, not a directory', () => {
+    // A repository with a regular file named `commands` is not a catalog and must not validate.
+    const dependency = createTaggedCatalog({ commands: 'not a directory\n' }, 'v1.0.0');
+    const root = createTaggedCatalog(
+      {
+        'agents/founder/agent.md': '---\nname: founder\n---\n',
+        'settings.yml': 'sources:\n  - github: ai-outfitter/community-profiles\n    ref: v1.0.0\n',
+      },
+      'v1.0.0',
+    );
+    const homeDirectory = mkdtempSync(join(tmpdir(), 'outfitter-closure-home-'));
+    temporaryRoots.push(homeDirectory);
+
+    bootstrapPinnedClosure({
+      homeDirectory,
+      source: { github: 'ai-outfitter/default-profiles', ref: 'v1.0.0' },
+      syncRepository: githubFixtureSync({
+        'ai-outfitter/default-profiles': root,
+        'ai-outfitter/community-profiles': dependency,
+      }),
+    });
+
+    expect(
+      existsSync(
+        createRemoteRepositoryCachePath(homeDirectory, { github: 'ai-outfitter/community-profiles', ref: 'v1.0.0' }),
+      ),
+    ).toBe(false);
   });
 });

--- a/code/cli/tests/unit/resolver-validation.test.ts
+++ b/code/cli/tests/unit/resolver-validation.test.ts
@@ -1,0 +1,67 @@
+// Tests loadout-resolution deferral: `outfitter sync` validates a source in isolation and must not
+// fail an unresolved loadout slug (a transitive dependency may supply it), while resolution does.
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { discoverLayers } from '../../src/resolver/Layer.js';
+import { resolveResources } from '../../src/resolver/Resolver.js';
+import { validateEffectiveSet } from '../../src/resolver/ResolverValidation.js';
+
+const temporaryRoots: string[] = [];
+
+const write = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+
+const agentMd = (name: string, extra = ''): string =>
+  `---\nname: ${name}\ndescription: The ${name} agent.\n${extra}---\n\n# ${name}\n\nBody for ${name}.\n`;
+
+// A project whose `engineer` agent references a skill it does not define (as if it lived in a
+// declared dependency), plus a `mislabeled` agent whose name does not match its directory.
+const effectiveSet = () => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-resolver-validation-'));
+  temporaryRoots.push(root);
+  const project = join(root, 'project');
+  write(join(project, '.agents', 'agents', 'engineer', 'agent.md'), agentMd('engineer', 'skills: [from-dependency]\n'));
+  write(join(project, '.agents', 'agents', 'mislabeled', 'agent.md'), agentMd('other'));
+  return resolveResources(
+    discoverLayers({ homeDirectory: join(root, 'home'), projectDirectory: project, settings: {} }).layers,
+  );
+};
+
+const engineerLoadout = (findings: ReturnType<typeof validateEffectiveSet>) =>
+  findings.filter((f) => f.resource === 'agent:engineer' && f.message.includes("unknown skill 'from-dependency'"));
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('loadout resolution deferral', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.11).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('treats an unresolved loadout slug as an error by default (merged resolution)', () => {
+    expect(engineerLoadout(validateEffectiveSet(effectiveSet()))).toEqual([
+      expect.objectContaining({ severity: 'error' }),
+    ]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.11).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('defers an unresolved loadout slug to a warning while still failing a structural error', () => {
+    const findings = validateEffectiveSet(effectiveSet(), undefined, { deferLoadoutResolution: true });
+
+    // The cross-catalog loadout reference is downgraded to a warning under deferral...
+    expect(engineerLoadout(findings)).toEqual([expect.objectContaining({ severity: 'warning' })]);
+    // ...but a structural error (an agent whose name mismatches its directory) still fails.
+    expect(
+      findings.some(
+        (f) =>
+          f.resource === 'agent:mislabeled' && f.severity === 'error' && f.message.includes('must match its directory'),
+      ),
+    ).toBe(true);
+  });
+});

--- a/code/cli/tests/unit/run-agent-onboarding-warnings.test.ts
+++ b/code/cli/tests/unit/run-agent-onboarding-warnings.test.ts
@@ -1,0 +1,71 @@
+// Guards OFTR-004.6.10's coherence at the run boundary: first-run onboarding fetches the declared
+// closure best-effort, and a dependency it could not fetch must surface as an actionable
+// `outfitter sync` warning. That warning is only computable after onboarding, so RunAgentCommand
+// must emit it from the post-onboarding re-resolve. Reverting that emit makes this test fail.
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { executeRunAgentCommand } from '../../src/cli/commands/RunAgentCommand.js';
+import type { SetupResult } from '../../src/setup/Setup.js';
+
+const temporaryRoots: string[] = [];
+
+const write = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('run agent onboarding warnings', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.10).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('surfaces a newly-actionable resolution warning produced after onboarding', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'outfitter-onboarding-'));
+    temporaryRoots.push(root);
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    mkdirSync(project, { recursive: true });
+
+    // Onboarding configures a default agent and a remote source whose closure was not fetched (as a
+    // best-effort bootstrap dependency failure would leave it).
+    const setup = (input: { homeDirectory: string }): Promise<SetupResult> => {
+      write(
+        join(input.homeDirectory, '.agents', 'agents', 'assistant', 'agent.md'),
+        '---\nname: assistant\n---\n\nHi.\n',
+      );
+      write(
+        join(input.homeDirectory, '.agents', 'settings.yml'),
+        'default_agent: assistant\ndefault_harness: pi\nsources:\n  - github: acme/unsynced\n    ref: v1.0.0\n',
+      );
+      return Promise.resolve({
+        created: [],
+        updated: [],
+        settingsPath: join(input.homeDirectory, '.agents', 'settings.yml'),
+        defaultAgent: 'assistant',
+        defaultHarness: 'pi' as const,
+        messages: [],
+      });
+    };
+
+    const lines: string[] = [];
+    const result = await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      launcher: () => Promise.resolve(0),
+      setup,
+      writeLine: (message) => lines.push(message),
+    });
+
+    // Surfaced to the terminal (writeLine)...
+    expect(lines.some((line) => line.includes("Run 'outfitter sync'"))).toBe(true);
+    expect(lines.some((line) => line.includes('github:acme/unsynced#v1.0.0'))).toBe(true);
+    // ...and returned to programmatic callers, after the setup notices.
+    expect(result.messages.some((message) => message.includes("Run 'outfitter sync'"))).toBe(true);
+  });
+});

--- a/code/cli/tests/unit/sync-command.test.ts
+++ b/code/cli/tests/unit/sync-command.test.ts
@@ -8,6 +8,7 @@ import { Command } from 'commander';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { createSyncCommand, executeSyncCommand } from '../../src/cli/commands/SyncCommand.js';
+import { syncRemoteRepositoryAtomically } from '../../src/sources/GitRepository.js';
 import { createEnterprisePrivateCatalogGate } from '../../src/sources/PrivateCatalogGate.js';
 import { createRemoteRepositoryCachePath } from '../../src/sources/SourceCache.js';
 
@@ -449,5 +450,204 @@ describe('remote fetch hardening', () => {
 
     expect(result.results[0]?.status).toBe('updated');
     expect(git(['-C', result.results[0].cachePath, 'rev-parse', 'HEAD'])).toBe(defaultCommit);
+  });
+});
+
+describe('transitive source synchronization', () => {
+  const tag = (repository: string, name: string): void => {
+    git(['-C', repository, 'tag', name]);
+  };
+
+  // Transitive sources are `github:`-only (OFTR-004.6.4), which would resolve to github.com. A fake
+  // repository sync maps each `github:` owner/repo to a local fixture repository so the closure is
+  // exercised hermetically; `uri:` sources (only ever direct here) fall through to the real fetch.
+  const githubFixtureSync =
+    (fixtures: Readonly<Record<string, string>>): typeof syncRemoteRepositoryAtomically =>
+    (syncInput) => {
+      if (syncInput.source.github === undefined) return syncRemoteRepositoryAtomically(syncInput);
+      const localRepository = fixtures[syncInput.source.github];
+      if (localRepository === undefined) throw new Error(`No fixture for github:${syncInput.source.github}`);
+      return syncRemoteRepositoryAtomically({
+        ...syncInput,
+        source: { uri: localRepository, ref: syncInput.source.ref },
+      });
+    };
+
+  // A classifier that never calls the network; `public` sources always pass the private-catalog gate.
+  const publicClassifier = { classifier: { classify: () => 'public' as const } };
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.1, OFTR-004.6.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('fetches github: sources declared by synced catalogs until no new sources remain', () => {
+    const input = createInvocation();
+    const depthTwo = createRepository({ 'agents/leaf/agent.md': agent('leaf') });
+    tag(depthTwo.root, 'v1.0.0');
+    const depthOne = createRepository({
+      'agents/middle/agent.md': agent('middle'),
+      'settings.yml': `sources:\n  - github: acme/leaf\n    ref: v1.0.0\n`,
+    });
+    tag(depthOne.root, 'v1.0.0');
+    const direct = createRepository({
+      'agents/top/agent.md': agent('top'),
+      'settings.yml': `sources:\n  - github: acme/middle\n    ref: v1.0.0\n`,
+    });
+    writeHomeSettings(input.homeDirectory, `sources:\n  - uri: ${JSON.stringify(direct.root)}\n`);
+    const dependencies = {
+      ...publicClassifier,
+      syncRepository: githubFixtureSync({ 'acme/middle': depthOne.root, 'acme/leaf': depthTwo.root }),
+    };
+
+    const first = executeSyncCommand(input, dependencies);
+
+    expect(first.exitCode).toBe(0);
+    expect(first.results.map(({ kind, status }) => ({ kind, status }))).toEqual([
+      { kind: 'source', status: 'updated' },
+      { kind: 'transitive', status: 'updated' },
+      { kind: 'transitive', status: 'updated' },
+    ]);
+    const leafCache = createRemoteRepositoryCachePath(input.homeDirectory, { github: 'acme/leaf', ref: 'v1.0.0' });
+    expect(existsSync(join(leafCache, 'agents', 'leaf', 'agent.md'))).toBe(true);
+
+    const second = executeSyncCommand(input, dependencies);
+    expect(second.results.map((result) => result.status)).toEqual(['unchanged', 'unchanged', 'unchanged']);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.4).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('warns and skips a declared uri: source instead of fetching it', () => {
+    const input = createInvocation();
+    const dependency = createRepository({ 'agents/dep/agent.md': agent('dep') });
+    const direct = createRepository({
+      'agents/top/agent.md': agent('top'),
+      'settings.yml': `sources:\n  - uri: ${JSON.stringify(dependency.root)}\n    ref: v1.0.0\n`,
+    });
+    writeHomeSettings(input.homeDirectory, `sources:\n  - uri: ${JSON.stringify(direct.root)}\n`);
+
+    const result = executeSyncCommand(input);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.results.map((entry) => entry.kind)).toEqual(['source']);
+    expect(result.messages.join('\n')).toContain("'github:' shorthands");
+    expect(
+      existsSync(createRemoteRepositoryCachePath(input.homeDirectory, { uri: dependency.root, ref: 'v1.0.0' })),
+    ).toBe(false);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.4).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('warns and skips a declared github: source that carries a path: subpath', () => {
+    const input = createInvocation();
+    const direct = createRepository({
+      'agents/top/agent.md': agent('top'),
+      'settings.yml': `sources:\n  - github: acme/dep\n    ref: v1.0.0\n    path: sub\n`,
+    });
+    writeHomeSettings(input.homeDirectory, `sources:\n  - uri: ${JSON.stringify(direct.root)}\n`);
+
+    const result = executeSyncCommand(input);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.results.map((entry) => entry.kind)).toEqual(['source']);
+    expect(result.messages.join('\n')).toContain('subpath');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('never re-fetches a source that is already directly configured', () => {
+    const input = createInvocation();
+    const dependency = createRepository({ 'agents/dep/agent.md': agent('dep') });
+    tag(dependency.root, 'v1.0.0');
+    const direct = createRepository({
+      'agents/top/agent.md': agent('top'),
+      'settings.yml': `sources:\n  - github: acme/dep\n    ref: v1.0.0\n`,
+    });
+    writeHomeSettings(
+      input.homeDirectory,
+      `sources:\n  - uri: ${JSON.stringify(direct.root)}\n  - github: acme/dep\n    ref: v1.0.0\n`,
+    );
+    const dependencies = { ...publicClassifier, syncRepository: githubFixtureSync({ 'acme/dep': dependency.root }) };
+
+    const result = executeSyncCommand(input, dependencies);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.results.map((entry) => entry.kind)).toEqual(['source', 'source']);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('reports a failed transitive fetch with the standard status vocabulary and exits nonzero', () => {
+    const input = createInvocation();
+    const direct = createRepository({
+      'agents/top/agent.md': agent('top'),
+      'settings.yml': `sources:\n  - github: acme/broken\n    ref: v1.0.0\n`,
+    });
+    writeHomeSettings(input.homeDirectory, `sources:\n  - uri: ${JSON.stringify(direct.root)}\n`);
+    const dependencies = { ...publicClassifier, syncRepository: githubFixtureSync({}) };
+
+    const result = executeSyncCommand(input, dependencies);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.results.map(({ kind, status }) => ({ kind, status }))).toEqual([
+      { kind: 'source', status: 'updated' },
+      { kind: 'transitive', status: 'failed' },
+    ]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('does not crash when a preserved-cache source is reconfigured with an escaping path', () => {
+    const input = createInvocation();
+    const top = createRepository({ 'agents/top/agent.md': agent('top') });
+    tag(top.root, 'v1.0.0');
+    const fixtures = { 'acme/top': top.root };
+
+    // First sync caches acme/top at its path-less cache key.
+    writeHomeSettings(input.homeDirectory, `sources:\n  - github: acme/top\n    ref: v1.0.0\n`);
+    executeSyncCommand(input, { ...publicClassifier, syncRepository: githubFixtureSync(fixtures) });
+
+    // Reconfigure the same repo+ref with a path escaping the checkout. The refresh's validation
+    // throws, the path-less cache is preserved and re-admitted for traversal, and resolving the
+    // escaping payload root must be skipped (not crash the closure).
+    writeHomeSettings(input.homeDirectory, `sources:\n  - github: acme/top\n    ref: v1.0.0\n    path: ../escape\n`);
+    const second = executeSyncCommand(input, { ...publicClassifier, syncRepository: githubFixtureSync(fixtures) });
+
+    expect(second.exitCode).toBe(1);
+    expect(second.results.map(({ kind, status }) => ({ kind, status }))).toEqual([
+      { kind: 'source', status: 'failed' },
+    ]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('still discovers dependencies from a catalog whose refresh failed but whose cache is preserved', () => {
+    const input = createInvocation();
+    const dependency = createRepository({ 'agents/dep/agent.md': agent('dep') });
+    tag(dependency.root, 'v1.0.0');
+    const top = createRepository({
+      'agents/top/agent.md': agent('top'),
+      'settings.yml': `sources:\n  - github: acme/dep\n    ref: v1.0.0\n`,
+    });
+    tag(top.root, 'v1.0.0');
+    writeHomeSettings(input.homeDirectory, `sources:\n  - github: acme/top\n    ref: v1.0.0\n`);
+    const fixtures = { 'acme/top': top.root, 'acme/dep': dependency.root };
+
+    // First sync populates both caches.
+    const first = executeSyncCommand(input, { ...publicClassifier, syncRepository: githubFixtureSync(fixtures) });
+    expect(first.results.map((entry) => entry.status)).toEqual(['updated', 'updated']);
+
+    // Second sync: refreshing acme/top throws, but its prior valid checkout is preserved on disk, so
+    // resolution keeps using it — and its declared dependency acme/dep must still be discovered.
+    const second = executeSyncCommand(input, {
+      ...publicClassifier,
+      syncRepository: (syncInput) => {
+        if (syncInput.source.github === 'acme/top') throw new Error('refresh failed');
+        return githubFixtureSync(fixtures)(syncInput);
+      },
+    });
+
+    expect(second.exitCode).toBe(1);
+    expect(second.results.map(({ kind, status }) => ({ kind, status }))).toEqual([
+      { kind: 'source', status: 'failed' },
+      { kind: 'transitive', status: 'unchanged' },
+    ]);
   });
 });

--- a/code/cli/tests/unit/sync-loadout-deferral.test.ts
+++ b/code/cli/tests/unit/sync-loadout-deferral.test.ts
@@ -1,0 +1,106 @@
+// Guards the sync wiring for OFTR-004.6.11: `outfitter sync` validates each source in isolation and
+// must DEFER an unresolved loadout slug (a source may reference a dependency's skill), so a catalog
+// that depends on another catalog's skills syncs cleanly instead of failing. Reverting the
+// `deferLoadoutResolution` wiring in validateSourceCheckout makes this test fail.
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { executeSyncCommand } from '../../src/cli/commands/SyncCommand.js';
+import { syncRemoteRepositoryAtomically } from '../../src/sources/GitRepository.js';
+
+const temporaryRoots: string[] = [];
+
+const git = (args: readonly string[]): string =>
+  execFileSync('git', [...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+
+const write = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+
+const createRepository = (files: Readonly<Record<string, string>>, tag?: string): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-deferral-'));
+  temporaryRoots.push(root);
+  git(['init', '--quiet', root]);
+  git(['-C', root, 'config', 'user.name', 'Outfitter Tests']);
+  git(['-C', root, 'config', 'user.email', 'tests@outfitter.dev']);
+  git(['-C', root, 'config', 'commit.gpgsign', 'false']);
+  git(['-C', root, 'config', 'tag.gpgsign', 'false']);
+  for (const [path, content] of Object.entries(files)) write(join(root, path), content);
+  git(['-C', root, 'add', '.']);
+  git(['-C', root, 'commit', '--quiet', '-m', 'init']);
+  if (tag !== undefined) git(['-C', root, 'tag', tag]);
+  return root;
+};
+
+// Remaps a `github:` source to a local fixture, then runs the real atomic sync (real fetch/validate).
+const githubFixtureSync =
+  (fixtures: Readonly<Record<string, string>>): typeof syncRemoteRepositoryAtomically =>
+  (input) => {
+    if (input.source.github === undefined) return syncRemoteRepositoryAtomically(input);
+    const local = fixtures[input.source.github];
+    if (local === undefined) throw new Error(`no fixture for github:${input.source.github}`);
+    return syncRemoteRepositoryAtomically({ ...input, source: { uri: local, ref: input.source.ref } });
+  };
+
+afterEach(() => {
+  process.exitCode = undefined;
+  for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('sync loadout-resolution deferral', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.11).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('syncs a source whose agent references a skill supplied by its declared dependency', () => {
+    const root = mkdtempSync(join(tmpdir(), 'outfitter-deferral-home-'));
+    temporaryRoots.push(root);
+    const home = join(root, 'home');
+    // The dependency supplies `dep-skill`; `top`'s agent references it but does not define it.
+    const dependency = createRepository(
+      { 'skills/dep-skill/SKILL.md': '---\nname: dep-skill\n---\n\n# dep-skill\n' },
+      'v1.0.0',
+    );
+    const top = createRepository({
+      'agents/top/agent.md': '---\nname: top\ndescription: Top.\nskills:\n  - dep-skill\n---\n\n# top\n',
+      'settings.yml': `sources:\n  - github: acme/dep\n    ref: v1.0.0\n`,
+    });
+    write(join(home, '.agents', 'settings.yml'), `sources:\n  - uri: ${JSON.stringify(top)}\n`);
+
+    const result = executeSyncCommand(
+      { homeDirectory: home, projectDirectory: join(root, 'project') },
+      { classifier: { classify: () => 'public' }, syncRepository: githubFixtureSync({ 'acme/dep': dependency }) },
+    );
+
+    // Isolated validation defers the unresolved loadout slug to a warning, so `top` is `updated`
+    // (not `failed`), its declared dependency is fetched, and the command exits 0.
+    expect(result.exitCode).toBe(0);
+    expect(result.results.map(({ kind, status }) => ({ kind, status }))).toEqual([
+      { kind: 'source', status: 'updated' },
+      { kind: 'transitive', status: 'updated' },
+    ]);
+    expect(result.messages.join('\n')).toContain('validated with 1 warning(s)');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('fetches an exact-duplicate configured source only once', () => {
+    const root = mkdtempSync(join(tmpdir(), 'outfitter-deferral-home-'));
+    temporaryRoots.push(root);
+    const home = join(root, 'home');
+    const source = createRepository({ 'agents/solo/agent.md': '---\nname: solo\n---\n\n# solo\n' });
+    // The same local source is configured twice; it must be fetched and reported once, not twice.
+    write(
+      join(home, '.agents', 'settings.yml'),
+      `sources:\n  - uri: ${JSON.stringify(source)}\n  - uri: ${JSON.stringify(source)}\n`,
+    );
+
+    const result = executeSyncCommand({ homeDirectory: home, projectDirectory: join(root, 'project') });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.results.map((entry) => entry.kind)).toEqual(['source']);
+  });
+});

--- a/code/cli/tests/unit/transitive-sources.test.ts
+++ b/code/cli/tests/unit/transitive-sources.test.ts
@@ -1,0 +1,649 @@
+// Tests transitive catalog source reading, breadth-first expansion, and layer-stack integration.
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { encodeRemoteSource, encodeRemoteSourceSelection } from '../../src/sources/SourceCache.js';
+import type { RemoteSourceReference } from '../../src/sources/SourceCache.js';
+import {
+  expandTransitiveSources,
+  readDeclaredRemoteSources,
+  resolveCatalogSettingsPath,
+} from '../../src/sources/TransitiveSources.js';
+import { discoverLayers } from '../../src/resolver/Layer.js';
+import { findResource } from '../../src/resolver/Resource.js';
+import { resolveResources } from '../../src/resolver/Resolver.js';
+import { resolveEffectiveSet } from '../../src/resolver/ResolverContext.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-transitive-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const write = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+
+const agentMd = (name: string): string =>
+  `---\nname: ${name}\ndescription: The ${name} agent.\n---\n\n# ${name}\n\nBody for ${name}.\n`;
+
+const pinnedCommit = 'a'.repeat(40);
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('declared catalog sources', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('reads pinned remote sources from settings.yml, falling back to .agents/settings.yml', () => {
+    const rootStyle = createTemporaryRoot();
+    write(join(rootStyle, 'settings.yml'), `sources:\n  - github: example/dep\n    ref: v1.0.0\n`);
+    const nestedStyle = createTemporaryRoot();
+    write(
+      join(nestedStyle, '.agents', 'settings.yml'),
+      `sources:\n  - github: example/nested\n    ref: ${pinnedCommit}\n`,
+    );
+    const bare = createTemporaryRoot();
+
+    expect(resolveCatalogSettingsPath(rootStyle)).toBe(join(rootStyle, 'settings.yml'));
+    expect(resolveCatalogSettingsPath(nestedStyle)).toBe(join(nestedStyle, '.agents', 'settings.yml'));
+    expect(resolveCatalogSettingsPath(bare)).toBeUndefined();
+
+    expect(readDeclaredRemoteSources(rootStyle, rootStyle, 'root-style')).toEqual({
+      sources: [{ source: { github: 'example/dep', ref: 'v1.0.0' }, declaredBy: 'root-style' }],
+      warnings: [],
+    });
+    expect(readDeclaredRemoteSources(nestedStyle, nestedStyle, 'nested-style').sources).toEqual([
+      { source: { github: 'example/nested', ref: pinnedCommit }, declaredBy: 'nested-style' },
+    ]);
+    expect(readDeclaredRemoteSources(bare, bare, 'bare')).toEqual({ sources: [], warnings: [] });
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('yields no dependencies for a valid catalog settings file that declares no sources', () => {
+    const catalog = createTemporaryRoot();
+    write(join(catalog, 'settings.yml'), 'default_agent: founder\n');
+
+    expect(readDeclaredRemoteSources(catalog, catalog, 'sourceless-catalog')).toEqual({ sources: [], warnings: [] });
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('contributes only sources from a catalog settings file, never policy settings', () => {
+    const catalog = createTemporaryRoot();
+    write(
+      join(catalog, 'settings.yml'),
+      [
+        'default_agent: attacker-default',
+        'default_harness: claude',
+        'remote_settings:',
+        '  - github: example/remote-settings',
+        '    path: settings.yml',
+        'sources:',
+        '  - github: example/dep',
+        '    ref: v1.0.0',
+        '',
+      ].join('\n'),
+    );
+
+    const declared = readDeclaredRemoteSources(catalog, catalog, 'policy-catalog');
+
+    expect(declared.warnings).toEqual([]);
+    expect(declared.sources).toEqual([
+      { source: { github: 'example/dep', ref: 'v1.0.0' }, declaredBy: 'policy-catalog' },
+    ]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.4).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('skips declared sources without an immutable ref and warns naming the declaring catalog', () => {
+    const catalog = createTemporaryRoot();
+    write(
+      join(catalog, 'settings.yml'),
+      [
+        'sources:',
+        '  - github: example/unref',
+        '  - github: example/branch',
+        '    ref: main',
+        '  - github: example/pinned',
+        '    ref: v2.1.0',
+        '',
+      ].join('\n'),
+    );
+
+    const declared = readDeclaredRemoteSources(catalog, catalog, 'the-catalog');
+
+    expect(declared.sources).toEqual([
+      { source: { github: 'example/pinned', ref: 'v2.1.0' }, declaredBy: 'the-catalog' },
+    ]);
+    expect(declared.warnings).toHaveLength(2);
+    for (const warning of declared.warnings) {
+      expect(warning).toContain("Catalog 'the-catalog'");
+      expect(warning).toContain('immutable');
+    }
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.4).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('skips a declared uri: source and warns, keeping only github: shorthands', () => {
+    const catalog = createTemporaryRoot();
+    write(
+      join(catalog, 'settings.yml'),
+      ['sources:', '  - uri: git+https://git.example.com/team/agents.git', '    ref: v1.0.0', ''].join('\n'),
+    );
+
+    const declared = readDeclaredRemoteSources(catalog, catalog, 'uri-catalog');
+
+    expect(declared.sources).toEqual([]);
+    expect(declared.warnings).toHaveLength(1);
+    expect(declared.warnings[0]).toContain("Catalog 'uri-catalog'");
+    expect(declared.warnings[0]).toContain("'github:' shorthands");
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.4).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('skips a declared github: source that carries a path: subpath and warns', () => {
+    const catalog = createTemporaryRoot();
+    write(join(catalog, 'settings.yml'), 'sources:\n  - github: example/dep\n    ref: v1.0.0\n    path: sub\n');
+
+    const declared = readDeclaredRemoteSources(catalog, catalog, 'subpath-catalog');
+
+    expect(declared.sources).toEqual([]);
+    expect(declared.warnings).toHaveLength(1);
+    expect(declared.warnings[0]).toContain("Catalog 'subpath-catalog'");
+    expect(declared.warnings[0]).toContain('subpath');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('skips local path sources declared by a catalog and warns naming the declaring catalog', () => {
+    const catalog = createTemporaryRoot();
+    write(join(catalog, 'settings.yml'), 'sources:\n  - path: ../../outside\n');
+
+    const declared = readDeclaredRemoteSources(catalog, catalog, 'path-catalog');
+
+    expect(declared.sources).toEqual([]);
+    expect(declared.warnings).toHaveLength(1);
+    expect(declared.warnings[0]).toContain("Catalog 'path-catalog'");
+    expect(declared.warnings[0]).toContain('path source');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('skips the declarations of a catalog whose settings file fails validation and warns', () => {
+    const catalog = createTemporaryRoot();
+    write(join(catalog, 'settings.yml'), 'default_harness: invalid\n');
+
+    const declared = readDeclaredRemoteSources(catalog, catalog, 'broken-catalog');
+
+    expect(declared.sources).toEqual([]);
+    expect(declared.warnings).toHaveLength(1);
+    expect(declared.warnings[0]).toContain("Catalog 'broken-catalog'");
+    expect(declared.warnings[0]).toContain('invalid settings');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('skips (does not crash on) a settings.yml committed as a symlink to a directory', () => {
+    const catalog = createTemporaryRoot();
+    const escapeTarget = createTemporaryRoot();
+    mkdirSync(join(escapeTarget, 'secret-directory'));
+    // A hostile catalog ships settings.yml as a symlink to a directory; readFileSync would EISDIR.
+    symlinkSync(join(escapeTarget, 'secret-directory'), join(catalog, 'settings.yml'));
+
+    const declared = readDeclaredRemoteSources(catalog, catalog, 'hostile-catalog');
+
+    expect(declared.sources).toEqual([]);
+    expect(declared.warnings).toHaveLength(1);
+    expect(declared.warnings[0]).toContain("Catalog 'hostile-catalog'");
+    expect(declared.warnings[0]).toContain('unreadable');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('skips (does not read) a settings.yml symlinked outside the checkout', () => {
+    const catalog = createTemporaryRoot();
+    const outside = createTemporaryRoot();
+    write(join(outside, 'stolen.yml'), 'sources:\n  - github: example/dep\n    ref: v1.0.0\n');
+    symlinkSync(join(outside, 'stolen.yml'), join(catalog, 'settings.yml'));
+
+    const declared = readDeclaredRemoteSources(catalog, catalog, 'escaping-catalog');
+
+    expect(declared.sources).toEqual([]);
+    expect(declared.warnings).toHaveLength(1);
+    expect(declared.warnings[0]).toContain('unreadable');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('warns on a settings.yml committed as a dangling symlink instead of silently ignoring it', () => {
+    const catalog = createTemporaryRoot();
+    // A broken symlink: `existsSync` (which follows links) would report it absent and drop it silently.
+    symlinkSync(join(catalog, 'nonexistent-target'), join(catalog, 'settings.yml'));
+
+    const declared = readDeclaredRemoteSources(catalog, catalog, 'dangling-catalog');
+
+    expect(declared.sources).toEqual([]);
+    expect(declared.warnings).toHaveLength(1);
+    expect(declared.warnings[0]).toContain("Catalog 'dangling-catalog'");
+    expect(declared.warnings[0]).toContain('unreadable');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('anchors containment to the checkout root, rejecting settings reached via a symlinked payload dir', () => {
+    const checkout = createTemporaryRoot();
+    const external = createTemporaryRoot();
+    write(join(external, 'settings.yml'), 'sources:\n  - github: example/dep\n    ref: v1.0.0\n');
+    // The catalog commits its payload subdir as a symlink escaping the checkout. Anchoring
+    // containment to the payload root (which resolves outside) would wrongly accept the external
+    // settings; anchoring to the checkout root rejects it.
+    symlinkSync(external, join(checkout, 'payload'));
+
+    const declared = readDeclaredRemoteSources(join(checkout, 'payload'), checkout, 'symlinked-payload');
+
+    expect(declared.sources).toEqual([]);
+    expect(declared.warnings).toHaveLength(1);
+    expect(declared.warnings[0]).toContain('unreadable');
+  });
+});
+
+describe('path-aware source identity', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.3, OFTR-004.6.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('distinguishes subpaths for the graph while sharing one checkout cache', () => {
+    const wholeRepo: RemoteSourceReference = { github: 'acme/mono', ref: 'v1.0.0' };
+    const subpath: RemoteSourceReference = { github: 'acme/mono', ref: 'v1.0.0', path: 'sub' };
+
+    // Same repository+ref → one shared checkout cache key.
+    expect(encodeRemoteSource(subpath)).toBe(encodeRemoteSource(wholeRepo));
+    // Different payload roots → distinct graph/dedup identities.
+    expect(encodeRemoteSourceSelection(subpath)).not.toBe(encodeRemoteSourceSelection(wholeRepo));
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('canonicalizes the path so ., ./, trailing slash, and foo/.. share the omitted-path identity', () => {
+    const base: RemoteSourceReference = { github: 'acme/mono', ref: 'v1.0.0' };
+    const omitted = encodeRemoteSourceSelection(base);
+    for (const path of ['.', './', 'sub/..']) {
+      expect(encodeRemoteSourceSelection({ ...base, path })).toBe(omitted);
+    }
+    expect(encodeRemoteSourceSelection({ ...base, path: 'sub/' })).toBe(
+      encodeRemoteSourceSelection({ ...base, path: 'sub' }),
+    );
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('distinguishes credentials so same-repo different-credential sources are not deduped', () => {
+    const alice: RemoteSourceReference = { uri: 'https://alice@example.com/repo.git', ref: 'v1.0.0' };
+    const bob: RemoteSourceReference = { uri: 'https://bob@example.com/repo.git', ref: 'v1.0.0' };
+
+    // The checkout cache is one repo regardless of credentials (redacted key)...
+    expect(encodeRemoteSource(alice)).toBe(encodeRemoteSource(bob));
+    // ...but the two are distinct configured sources, so dedup must not collapse them.
+    expect(encodeRemoteSourceSelection(alice)).not.toBe(encodeRemoteSourceSelection(bob));
+  });
+});
+
+describe('transitive source expansion', () => {
+  const cachedCatalog = (cache: string, source: RemoteSourceReference, settings?: string): string => {
+    const root = join(cache, 'repos', encodeRemoteSource(source));
+    mkdirSync(root, { recursive: true });
+    if (settings !== undefined) write(join(root, 'settings.yml'), settings);
+    return root;
+  };
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('discovers breadth-first, not depth-first (a sibling precedes a grandchild)', () => {
+    const cache = join(createTemporaryRoot(), 'cache');
+    const direct: RemoteSourceReference = { github: 'acme/direct', ref: 'v1.0.0' };
+    const a: RemoteSourceReference = { github: 'acme/a', ref: 'v1.0.0' };
+    const b: RemoteSourceReference = { github: 'acme/b', ref: 'v1.0.0' };
+    const c: RemoteSourceReference = { github: 'acme/c', ref: 'v1.0.0' };
+    // direct declares [a, b] (siblings); a declares c (a grandchild of direct).
+    cachedCatalog(
+      cache,
+      direct,
+      `sources:\n  - github: acme/a\n    ref: v1.0.0\n  - github: acme/b\n    ref: v1.0.0\n`,
+    );
+    cachedCatalog(cache, a, `sources:\n  - github: acme/c\n    ref: v1.0.0\n`);
+    cachedCatalog(cache, b);
+    cachedCatalog(cache, c);
+    const cached = [direct, a, b, c];
+
+    const expansion = expandTransitiveSources({
+      directSources: [direct],
+      resolveCachedCheckoutRoot: (source) =>
+        cached.some((entry) => encodeRemoteSource(entry) === encodeRemoteSource(source))
+          ? join(cache, 'repos', encodeRemoteSource(source))
+          : undefined,
+    });
+
+    // Breadth-first: sibling `b` precedes grandchild `c`. Depth-first would yield [a, c, b].
+    expect(expansion.sources.map((entry) => entry.source)).toEqual([a, b, c]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('skips a source whose path escapes the checkout instead of throwing', () => {
+    const cache = join(createTemporaryRoot(), 'cache');
+    const escaping: RemoteSourceReference = { github: 'acme/mono', ref: 'v1.0.0', path: '../escape' };
+    const checkoutRoot = join(cache, 'repos', encodeRemoteSource(escaping));
+    mkdirSync(checkoutRoot, { recursive: true });
+
+    const expansion = expandTransitiveSources({
+      directSources: [escaping],
+      resolveCachedCheckoutRoot: (source) =>
+        encodeRemoteSource(source) === encodeRemoteSource(escaping) ? checkoutRoot : undefined,
+    });
+
+    expect(expansion.sources).toEqual([]);
+    expect(expansion.warnings).toEqual([]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('processes an exact-duplicate direct source only once', () => {
+    const cache = join(createTemporaryRoot(), 'cache');
+    const dup: RemoteSourceReference = { github: 'acme/dup', ref: 'v1.0.0' };
+    const dep: RemoteSourceReference = { github: 'acme/dep', ref: 'v1.0.0' };
+    // The duplicated parent declares a valid dependency and an invalid (unpinned) one. Without the
+    // frontier-seed dedup the parent is read twice — its dependency deduped by the inner visited set,
+    // but its skip warning emitted twice — so asserting a single warning pins the seed dedup itself.
+    cachedCatalog(cache, dup, `sources:\n  - github: acme/dep\n    ref: v1.0.0\n  - github: acme/unpinned\n`);
+
+    const expansion = expandTransitiveSources({
+      directSources: [dup, dup],
+      resolveCachedCheckoutRoot: (source) =>
+        encodeRemoteSource(source) === encodeRemoteSource(dup)
+          ? join(cache, 'repos', encodeRemoteSource(dup))
+          : undefined,
+    });
+
+    expect(expansion.sources).toEqual([{ source: dep, declaredBy: 'github:acme/dup#v1.0.0' }]);
+    expect(expansion.warnings).toHaveLength(1);
+    expect(expansion.warnings[0]).toContain('immutable');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('preserves declaration order among sources a single catalog declares', () => {
+    const cache = join(createTemporaryRoot(), 'cache');
+    const parent: RemoteSourceReference = { github: 'acme/parent', ref: 'v1.0.0' };
+    const alpha: RemoteSourceReference = { github: 'acme/alpha', ref: 'v1.0.0' };
+    const beta: RemoteSourceReference = { github: 'acme/beta', ref: 'v1.0.0' };
+    cachedCatalog(
+      cache,
+      parent,
+      `sources:\n  - github: acme/alpha\n    ref: v1.0.0\n  - github: acme/beta\n    ref: v1.0.0\n`,
+    );
+
+    const expansion = expandTransitiveSources({
+      directSources: [parent],
+      resolveCachedCheckoutRoot: (source) =>
+        encodeRemoteSource(source) === encodeRemoteSource(parent)
+          ? join(cache, 'repos', encodeRemoteSource(parent))
+          : undefined,
+    });
+
+    expect(expansion.sources.map((entry) => entry.source)).toEqual([alpha, beta]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('skips a source whose cached checkout lacks the selected payload subpath', () => {
+    const cache = join(createTemporaryRoot(), 'cache');
+    const subpathSource: RemoteSourceReference = { github: 'acme/mono', ref: 'v1.0.0', path: 'absent-sub' };
+    const checkoutRoot = join(cache, 'repos', encodeRemoteSource(subpathSource));
+    mkdirSync(checkoutRoot, { recursive: true }); // checkout exists, but 'absent-sub' does not
+
+    const expansion = expandTransitiveSources({
+      directSources: [subpathSource],
+      resolveCachedCheckoutRoot: (source) =>
+        encodeRemoteSource(source) === encodeRemoteSource(subpathSource) ? checkoutRoot : undefined,
+    });
+
+    expect(expansion.sources).toEqual([]);
+    expect(expansion.warnings).toEqual([]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.3, OFTR-004.6.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('expands breadth-first, resolves each source once, and terminates on cycles', () => {
+    const cache = join(createTemporaryRoot(), 'cache');
+    const direct: RemoteSourceReference = { github: 'example/direct', ref: 'v1.0.0' };
+    const depB: RemoteSourceReference = { github: 'example/b', ref: 'v1.0.0' };
+    const depC: RemoteSourceReference = { github: 'example/c', ref: 'v1.0.0' };
+    // direct declares b and (redundantly) itself; b declares c and (cyclically) direct.
+    cachedCatalog(
+      cache,
+      direct,
+      `sources:\n  - github: example/b\n    ref: v1.0.0\n  - github: example/direct\n    ref: v1.0.0\n`,
+    );
+    cachedCatalog(
+      cache,
+      depB,
+      `sources:\n  - github: example/c\n    ref: v1.0.0\n  - github: example/direct\n    ref: v1.0.0\n`,
+    );
+    cachedCatalog(cache, depC);
+
+    const expansion = expandTransitiveSources({
+      directSources: [{ path: '/ignored/local' }, direct],
+      resolveCachedCheckoutRoot: (source) => {
+        const root = join(cache, 'repos', encodeRemoteSource(source));
+        return [direct, depB, depC].some((cached) => encodeRemoteSource(cached) === encodeRemoteSource(source))
+          ? root
+          : undefined;
+      },
+    });
+
+    expect(expansion.sources).toEqual([
+      { source: depB, declaredBy: 'github:example/direct#v1.0.0' },
+      { source: depC, declaredBy: 'github:example/b#v1.0.0' },
+    ]);
+    expect(expansion.warnings).toEqual([]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('does not let a directly configured subpath source suppress a transitive whole-repository source', () => {
+    const cache = join(createTemporaryRoot(), 'cache');
+    // Directly configured: a subpath of a monorepo. A catalog declares the whole repository at the
+    // same repo+ref. The two are distinct layers and both must survive dedup.
+    const directSubpath: RemoteSourceReference = { github: 'acme/mono', ref: 'v1.0.0', path: 'sub' };
+    const declaringCatalog: RemoteSourceReference = { github: 'acme/catalog', ref: 'v1.0.0' };
+    const wholeRepo: RemoteSourceReference = { github: 'acme/mono', ref: 'v1.0.0' };
+    cachedCatalog(cache, declaringCatalog, `sources:\n  - github: acme/mono\n    ref: v1.0.0\n`);
+
+    const expansion = expandTransitiveSources({
+      directSources: [directSubpath, declaringCatalog],
+      resolveCachedCheckoutRoot: (source) =>
+        encodeRemoteSource(source) === encodeRemoteSource(declaringCatalog)
+          ? join(cache, 'repos', encodeRemoteSource(declaringCatalog))
+          : undefined,
+    });
+
+    expect(expansion.sources).toEqual([{ source: wholeRepo, declaredBy: 'github:acme/catalog#v1.0.0' }]);
+  });
+
+  it('keeps an uncached declared source in the result without expanding beneath it', () => {
+    const cache = join(createTemporaryRoot(), 'cache');
+    const direct: RemoteSourceReference = { github: 'example/direct', ref: 'v1.0.0' };
+    const missing: RemoteSourceReference = { github: 'example/missing', ref: 'v1.0.0' };
+    cachedCatalog(cache, direct, `sources:\n  - github: example/missing\n    ref: v1.0.0\n`);
+
+    const expansion = expandTransitiveSources({
+      directSources: [direct],
+      resolveCachedCheckoutRoot: (source) =>
+        encodeRemoteSource(source) === encodeRemoteSource(direct)
+          ? join(cache, 'repos', encodeRemoteSource(direct))
+          : undefined,
+    });
+
+    expect(expansion.sources).toEqual([{ source: missing, declaredBy: 'github:example/direct#v1.0.0' }]);
+  });
+});
+
+describe('transitive layers', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('collapses an exact-duplicate configured source into a single layer', () => {
+    const root = createTemporaryRoot();
+    const cache = join(root, 'cache');
+    const dup = { github: 'example/dup', ref: 'v1.0.0' } as const;
+    write(join(cache, 'repos', encodeRemoteSource(dup), 'agents', 'solo', 'agent.md'), agentMd('solo'));
+
+    const discovered = discoverLayers({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: join(root, 'project'),
+      settings: { cacheDirectory: cache, sources: [dup, dup] },
+    });
+
+    expect(discovered.layers.filter((layer) => layer.origin === 'source')).toHaveLength(1);
+    // Deduped, so the agent is not shadowed by an identical copy of itself.
+    expect(findResource(resolveResources(discovered.layers), 'agent', 'solo')?.shadowed).toEqual([]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.1, OFTR-004.6.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('appends cached transitive catalogs after every directly configured source layer', () => {
+    const root = createTemporaryRoot();
+    const cache = join(root, 'cache');
+    const direct = { github: 'example/direct', ref: 'v1.0.0' } as const;
+    const dep = { github: 'example/dep', ref: 'v1.0.0' } as const;
+    const directRoot = join(cache, 'repos', encodeRemoteSource(direct));
+    const depRoot = join(cache, 'repos', encodeRemoteSource(dep));
+    write(join(directRoot, 'settings.yml'), 'sources:\n  - github: example/dep\n    ref: v1.0.0\n');
+    write(join(directRoot, 'agents', 'shared', 'agent.md'), agentMd('direct-copy'));
+    write(join(depRoot, 'agents', 'shared', 'agent.md'), agentMd('dep-copy'));
+    write(join(depRoot, 'agents', 'dep-only', 'agent.md'), agentMd('dep-only'));
+
+    const discovered = discoverLayers({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: join(root, 'project'),
+      settings: { cacheDirectory: cache, sources: [direct] },
+    });
+
+    expect(discovered.layers.map((layer) => layer.label)).toEqual([
+      'github:example/direct#v1.0.0',
+      'github:example/dep#v1.0.0',
+    ]);
+    const set = resolveResources(discovered.layers);
+    expect(findResource(set, 'agent', 'dep-only')).toBeDefined();
+    // The directly configured catalog outranks the transitive one for the shared slug.
+    expect(findResource(set, 'agent', 'shared')?.winner.path).toBe(join(directRoot, 'agents', 'shared', 'agent.md'));
+    expect(discovered.warnings).toEqual([]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('orders a two-hop closure breadth-first so a shallower dependency outranks a deeper one', () => {
+    const root = createTemporaryRoot();
+    const cache = join(root, 'cache');
+    const direct = { github: 'example/direct', ref: 'v1.0.0' } as const;
+    const mid = { github: 'example/mid', ref: 'v1.0.0' } as const;
+    const leaf = { github: 'example/leaf', ref: 'v1.0.0' } as const;
+    const midRoot = join(cache, 'repos', encodeRemoteSource(mid));
+    const leafRoot = join(cache, 'repos', encodeRemoteSource(leaf));
+    // direct → mid → leaf; the `shared` slug lives in both mid (depth 1) and leaf (depth 2).
+    write(
+      join(cache, 'repos', encodeRemoteSource(direct), 'settings.yml'),
+      'sources:\n  - github: example/mid\n    ref: v1.0.0\n',
+    );
+    write(join(midRoot, 'settings.yml'), 'sources:\n  - github: example/leaf\n    ref: v1.0.0\n');
+    write(join(midRoot, 'agents', 'shared', 'agent.md'), agentMd('mid-copy'));
+    write(join(leafRoot, 'agents', 'shared', 'agent.md'), agentMd('leaf-copy'));
+    write(join(leafRoot, 'agents', 'leaf-only', 'agent.md'), agentMd('leaf-only'));
+
+    const discovered = discoverLayers({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: join(root, 'project'),
+      settings: { cacheDirectory: cache, sources: [direct] },
+    });
+
+    expect(discovered.layers.map((layer) => layer.label)).toEqual([
+      'github:example/direct#v1.0.0',
+      'github:example/mid#v1.0.0',
+      'github:example/leaf#v1.0.0',
+    ]);
+    const set = resolveResources(discovered.layers);
+    expect(findResource(set, 'agent', 'leaf-only')).toBeDefined();
+    // The shallower dependency (mid, depth 1) outranks the deeper one (leaf, depth 2) for `shared`.
+    expect(findResource(set, 'agent', 'shared')?.winner.path).toBe(join(midRoot, 'agents', 'shared', 'agent.md'));
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.9).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('reports an uncached transitive source with actionable sync guidance', () => {
+    const root = createTemporaryRoot();
+    const cache = join(root, 'cache');
+    const direct = { github: 'example/direct', ref: 'v1.0.0' } as const;
+    const directRoot = join(cache, 'repos', encodeRemoteSource(direct));
+    write(join(directRoot, 'settings.yml'), 'sources:\n  - github: example/never-synced\n    ref: v1.0.0\n');
+
+    const discovered = discoverLayers({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: join(root, 'project'),
+      settings: { cacheDirectory: cache, sources: [direct] },
+    });
+
+    expect(discovered.unsynchronized).toHaveLength(1);
+    expect(discovered.unsynchronized[0]).toContain('github:example/never-synced#v1.0.0');
+    expect(discovered.unsynchronized[0]).toMatch(/Run 'outfitter sync'/u);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.4).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('surfaces transitive skip warnings through the shared resolution path', () => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const cache = join(root, 'cache');
+    const direct = { github: 'example/direct', ref: 'v1.0.0' } as const;
+    const directRoot = join(cache, 'repos', encodeRemoteSource(direct));
+    write(join(directRoot, 'settings.yml'), 'sources:\n  - github: example/unpinned\n    ref: main\n');
+    write(
+      join(home, '.agents', 'settings.yml'),
+      `cache_directory: ${JSON.stringify(cache)}\nsources:\n  - github: example/direct\n    ref: v1.0.0\n`,
+    );
+
+    const resolved = resolveEffectiveSet({ homeDirectory: home, projectDirectory: join(root, 'project') });
+
+    expect(resolved.warnings).toHaveLength(1);
+    expect(resolved.warnings[0]).toContain("Catalog 'github:example/direct#v1.0.0'");
+    expect(resolved.warnings[0]).toContain('immutable');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.15).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('skips a configured source whose path escapes the checkout instead of crashing resolution', () => {
+    const root = createTemporaryRoot();
+    const cache = join(root, 'cache');
+    const present = { github: 'example/present', ref: 'v1.0.0' } as const;
+    write(join(cache, 'repos', encodeRemoteSource(present), 'agents', 'ok', 'agent.md'), agentMd('ok'));
+
+    const discovered = discoverLayers({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: join(root, 'project'),
+      settings: {
+        cacheDirectory: cache,
+        sources: [{ github: 'example/evil', ref: 'v1.0.0', path: '../escape' }, present],
+      },
+    });
+
+    expect(discovered.warnings.some((warning) => warning.includes('invalid path'))).toBe(true);
+    expect(findResource(resolveResources(discovered.layers), 'agent', 'ok')).toBeDefined();
+  });
+});

--- a/docs/architecture/file_structure.md
+++ b/docs/architecture/file_structure.md
@@ -44,7 +44,7 @@ Outfitter is organized around a private npm workspace root, clear TypeScript pac
 │   │   │   │   └── commands/          # run, setup, sync, list, validate, dump command objects
 │   │   │   ├── settings/              # settings loading and merging
 │   │   │   ├── setup/                 # onboarding state + pinned default-catalog bootstrap
-│   │   │   ├── sources/               # cache paths, atomic Git checkout, redaction, and private-catalog gating
+│   │   │   ├── sources/               # cache paths, atomic Git checkout, redaction, private-catalog gating, and transitive catalog-source expansion
 │   │   │   ├── resolver/              # .agents layer resolution into one effective resource set
 │   │   │   ├── composer/              # harness-neutral CompositionPlan from the effective set
 │   │   │   ├── projection/            # materialize a composition + build pi/claude/codex launch plans

--- a/docs/documentation/catalogs.md
+++ b/docs/documentation/catalogs.md
@@ -83,6 +83,43 @@ Remote entries additionally accept:
 
 Resources from all sources resolve by slug behind local layers, following [layer precedence](./concepts.md#layer-precedence). Agent-local skills keep their owning-agent namespace through cache and source merging. Outfitter reports shadowed IDs so consumers can see which source supplies a selected resource.
 
+### Catalog dependencies (transitive sources)
+
+A catalog can depend on other catalogs by declaring `sources` in its own settings file
+(`settings.yml` at its payload root, or `.agents/settings.yml`). Outfitter resolves those
+declarations transitively: syncing and resolving a catalog also fetches and layers the catalogs it
+declares, so one pinned root pulls in its dependency closure.
+
+Transitive sources are deliberately the narrowest safe subset — a `github:` shorthand pinned to an
+immutable ref — while the [remote-catalog trust model](https://github.com/ai-outfitter/outfitter/issues/212)
+is defined. Anything else a catalog declares is skipped with a warning:
+
+- **`github:` shorthand only.** A transitive source must be a `github: owner/repo` shorthand. A
+  `uri:` source declared by a catalog is skipped, because a URI can name an arbitrary git transport
+  (for example a local path or a remote helper) that a dependency should not be able to choose on
+  your behalf. Keeping to `github:` also routes every transitive fetch that `outfitter sync`
+  performs through the same private-catalog gate as your own sources. (The one exception is the
+  first-party default catalog's own closure, fetched during setup — see the note below.)
+- **Whole repository only.** A transitive `github:` source may not carry a `path:` subpath, so a
+  declaration can never point outside the repository it fetches.
+- **Pinned only.** A transitive source must pin an immutable `ref:` — a full commit SHA, or a
+  version tag such as `v1.2.0`. A commit SHA is truly immutable; a version tag is a pin the
+  dependency's maintainer could later move, in which case the next `outfitter sync` fetches the
+  new commit and reports it as `updated`. Pin dependencies you rely on to a SHA when you need the
+  closure to never change underneath you.
+- **Content only.** A depended-on catalog contributes `.agents` payload resources. Nothing else in
+  its settings file — default agent, default harness, cache directory, `remote_settings` — takes
+  effect transitively.
+- **Lower precedence.** Every source you configure directly outranks every transitive source;
+  deeper dependencies rank below shallower ones.
+- Cycles and duplicates resolve once — the first occurrence wins and resolution terminates.
+
+A fresh `outfitter` install fetches this closure during setup, so a default profile whose skills
+live in a depended-on catalog works without a manual sync. Because the default catalog is the
+first-party catalog Outfitter ships (pinned in the CLI), its bootstrap fetches the declared closure
+directly; the interactive private-catalog prompt is a property of `outfitter sync`, which is where
+you add your own third-party sources.
+
 ## Organization control repositories
 
 An `owner/.outfitter` repository distributes organization-wide resources plus shared settings that Outfitter layers below each user's local settings:
@@ -104,7 +141,10 @@ Remote settings are cached locally and merged at lower precedence than your proj
 1. Local settings are validated. Remote settings repositories are cloned or updated first, then
    merged settings are reloaded.
 2. Remote sources (including any added by remote settings) are cloned or updated.
-3. Each synced source is validated; sync reports `updated`, `unchanged`, `skipped`, or `failed` per source.
+3. Sources declared by the synced catalogs themselves (see
+   [catalog dependencies](#catalog-dependencies-transitive-sources)) are fetched next, repeating
+   until the whole dependency closure is cached.
+4. Each synced source is validated; sync reports `updated`, `unchanged`, `skipped`, or `failed` per source.
 
 All repositories live under `<cache_directory>/repos/<encoded-uri-and-ref>/` (default
 `~/.agents/cache`). Pinned (`ref:`) sources stay on their selected ref until you change it; unpinned
@@ -129,6 +169,8 @@ Before adding a source, review it:
 2. Read every skill you will select, including its scripts and catalog-owned `file` references (see the [trust boundary](./skills.md#trust-boundary)).
 3. Review `mcp.json` — MCP servers are code with whatever access you grant them.
 4. Check `remote_settings` targets: a settings file can add further sources you did not review.
-5. Confirm the repository's ownership and that its maintainers are who you expect.
+5. Check the catalog's own `sources`: its pinned `github:` dependencies are fetched transitively, so
+   review each one like the catalog itself.
+6. Confirm the repository's ownership and that its maintainers are who you expect.
 
 **Pin a `ref:`** — ideally a full commit SHA — for any catalog you do not maintain yourself, and always for catalogs consumed in CI (see [Running tasks in GitHub Actions](./actions.md)). A pinned ref makes updates an explicit, reviewable action — bump the ref after reviewing the diff — instead of silently pulling whatever the catalog publishes next.

--- a/docs/requirements/OFTR-004-sync-and-setup.md
+++ b/docs/requirements/OFTR-004-sync-and-setup.md
@@ -99,3 +99,63 @@ Outfitter provides setup and maintenance commands that onboard a new user, synch
 2. The `profile list` command MUST read and validate settings before listing profiles.
 3. The `profile list` command MUST list unique profile IDs from configured local and cached remote profile sources.
 4. When multiple configured sources define the same profile ID, the listed profile metadata MUST come from the highest-precedence loaded definition.
+
+### OFTR-004.6: Transitive Catalog Sources
+
+A remote catalog may declare its own `sources` in a settings file at its payload root
+(`settings.yml`, or `.agents/settings.yml` when the payload root has no `settings.yml`). Those
+declarations form the catalog's dependencies; resolution and sync follow them transitively so a
+pinned root catalog determines its dependency closure.
+
+Transitive resolution is deliberately restricted to the narrowest safe subset of source references
+while the remote-catalog trust and provenance model (issue #212) is defined: a transitive source
+must be a `github:` shorthand pinned to an immutable ref. This keeps every transitive fetch `sync`
+performs within the private-catalog gate and a known git transport, and prevents a declaration from
+selecting an arbitrary git transport or escaping its fetched checkout. (First-party default-catalog
+bootstrap is the one gate exemption — see OFTR-004.6.10.)
+
+1. Layer discovery MUST resolve `github:` `sources` declared by a cached remote catalog's own
+   settings file and append them as layers, and `sync` MUST fetch the same closure.
+2. A transitive source MUST contribute only `.agents` payload content. Every other setting declared
+   by a catalog's settings file (default agent, default harness, cache directory, state persistence,
+   custom settings, startup, enterprise, `remote_settings`) MUST NOT take effect through transitive
+   resolution.
+3. Every directly configured source MUST outrank every transitive source. Transitive layers MUST be
+   ordered breadth-first by dependency depth, then by declaring-catalog order, then by declaration
+   order within a catalog's settings file.
+4. A transitive source MUST be a `github:` shorthand pinned to an immutable ref (a full commit SHA
+   or a version tag). Resolution and sync MUST skip a declared source that is a `uri:` source, that
+   carries a `path:` subpath, or whose ref is absent or not immutable, and report a warning naming
+   the declaring catalog.
+5. Resolution and sync MUST skip a local `path:` source declared by a remote catalog and report a
+   warning naming the declaring catalog.
+6. A source already resolved — directly or by an earlier catalog — MUST NOT be resolved again;
+   dependency cycles MUST terminate without error.
+7. `sync` MUST fetch newly discovered transitive sources until no new sources remain, report each
+   with kind `transitive` and the OFTR-004.2.7 status vocabulary, and gate each through the same
+   private-catalog policy as directly configured sources.
+8. A cached catalog settings file that is unreadable (not a regular file inside the checkout — for
+   example a `settings.yml` committed as a symlink to a directory or outside the checkout) or that
+   fails schema validation MUST NOT fail resolution or sync; its declared sources MUST be skipped
+   with a warning naming the declaring catalog.
+9. Resolution MUST report a transitive source whose cache is absent with the same actionable
+   `outfitter sync` guidance as a directly configured source (OFTR-004.2.18).
+10. Default-catalog bootstrap MUST fetch the pinned `github:` closure the default catalog declares
+    before setup offers or launches a profile, so a first run resolves a default profile whose
+    skills a depended-on catalog supplies without a separate `outfitter sync`. Bootstrap MUST accept
+    a dependency that ships only skills (or any recognized `.agents` payload) rather than requiring
+    it to contain agents. A declared dependency that cannot be fetched MUST be reported by
+    resolution as unsynchronized rather than failing setup, while the root catalog failing to fetch
+    remains fatal. Because the default catalog is the first-party, pinned catalog Outfitter ships,
+    bootstrap MAY fetch its declared closure without the interactive private-catalog gate that
+    `outfitter sync` applies; the gate remains a property of `sync`, not of first-party bootstrap.
+11. When `sync` validates a single fetched source in isolation, an unresolved loadout **skill or
+    agent** reference MUST NOT fail that source, because the referenced skill or agent may be
+    supplied by a catalog the source declares as a transitive dependency. Structural validity of the
+    source (schema, resource naming) MUST still be enforced. Whether every loadout skill/agent slug
+    resolves is authoritatively enforced against the merged effective set by `outfitter validate`,
+    which MUST treat an unresolved loadout skill or agent reference as an error. (This concerns only
+    skill and agent loadout slugs; an unknown MCP server reference remains a warning, unchanged.)
+    Consistent with OFTR-005.3.4, the run-time composer surfaces an unresolved loadout reference as a
+    non-fatal warning (fatal only under `outfitter run --strict`); `outfitter validate` is the
+    command that fails on it.


### PR DESCRIPTION
## What & why

A catalog can declare its own dependencies via `sources` in its settings file, but resolution and sync ignored them. The concrete failure: a fresh install of the pinned default catalog warns that the founder profile's `persona-authoring` and `persona-review` skills are unknown — they live in `community-profiles`, a source `default-profiles` declares (its 1.1.0 changelog: "pin community-profiles as a catalog source") but nothing ever fetched. The `sources` field looked load-bearing yet did nothing.

This makes the existing declaration mean what it says: **resolution and `outfitter sync` now follow a cached catalog's declared dependencies to a fixpoint, and setup fetches the pinned closure before launching a profile** — so a fresh `outfitter` install works with no manual sync.

Verified end-to-end against real GitHub: first-run bootstrap fetches the full `default-profiles` → `community-profiles` closure, and `outfitter sync` on a fresh home exits 0 with the founder profile's persona skills resolving from `community-profiles`.

**Per-source sync validation** also had to change: `sync` validates each fetched source in isolation, and the real `default-profiles` catalog references skills that live in its declared dependency — so isolated validation rejected it as "invalid" and nothing cached. Sync now **defers** an unresolved loadout slug to a warning (a source may reference a dependency's skill); loadout wholeness stays authoritatively enforced by `outfitter validate` (an error there), and the run-time composer keeps its non-fatal warning per OFTR-005.3.4.

## Safe subset (deliberate scope limit)

Transitive sources are restricted to the narrowest safe subset while the remote-catalog trust/provenance model (#212) is defined:

- **`github:` shorthand only.** A declared `uri:` is skipped with a warning. A URI could name an arbitrary git transport — an `ext::<cmd>` remote helper is code execution, a filesystem path escapes the sandbox — and a GitHub-spelled URI would bypass the private-catalog gate. Keeping to `github:` (schema-constrained to `owner/repo`, always normalized to `https://github.com/…`) routes every transitive fetch through the same gate as your own sources.
- **Whole repository only.** A transitive source may not carry a `path:` subpath, so a declaration can never point outside its fetched checkout.
- **Pinned to an immutable ref** (full SHA, or a version tag — a movable pin; SHA for a closure that never changes underneath you).
- **Content only** — no policy settings (default agent/harness, cache dir, `remote_settings`, enterprise) take effect transitively.
- **Direct sources outrank transitive ones**, breadth-first by depth; cycles resolve once.

The real use case (`default-profiles` → `community-profiles`, both `github:`) works; broader transports are future work under #212.

## Reviewed

Seven rounds of independent adversarial review (a GPT-family model + a fresh-context Claude agent each round, told to *break* the change and, later, to judge design quality). Findings converged round over round — Critical/High → Medium → Low — and each fix landed with a mutation-sensitive test:

- **Security surface** (safe-subset design): an `ext::` remote-helper RCE, a private-catalog gate bypass, a `path:` sandbox escape, and a settings-symlink DoS — all closed by restricting transitive sources to `github:` shorthand + immutable ref, anchoring settings containment to the checkout root, and guarding every payload-resolution throw.
- **Correctness**: a source-identity conflation (two-key model: path-less redacted key for the shared checkout cache, path-aware raw-URI key for graph/dedup — the latter also distinguishes credentials so a same-repo different-credential source isn't dropped); duplicate-source dedup across resolve/sync/bootstrap; a dangling-symlink `settings.yml` now warns rather than silently drops.
- **Coherence with the rest of the CLI**: `outfitter sync` validates each source in isolation, so the real default catalog — whose founder profile references a dependency's skills — was rejected; sync now defers unresolved loadout slugs (authoritatively enforced by `outfitter validate`, warned at runtime per OFTR-005.3.4). First-run onboarding surfaces a best-effort-bootstrap dependency failure as actionable `outfitter sync` guidance to both terminal and programmatic callers.

Verified end-to-end against real GitHub: a fresh install bootstraps the full closure; `outfitter sync` exits 0; `outfitter dump founder` composes with the persona skills materialized in its closure. One known-accepted item: a settings-read TOCTOU requiring concurrent `outfitter sync` of one cache — not a supported mode.

## Spec & tests

New requirements `OFTR-004.6` (transitive catalog sources), each MUST covered by a test with the two-line traceability comment. Full gate green locally: `typecheck`, `lint`, coverage (99%+, thresholds hold), docs build. Sync closure and bootstrap closure are tested hermetically via an injected repository-sync fake that maps `github:` fixtures to local repos.

## Reviewing this: core vs. hardening (the second is a candidate for #212)

This is one commit, but it's two separable concerns. If the hardening feels like it front-runs the trust model you want to design holistically in #212, it can be pulled into a follow-up (or folded into #212) without touching the core — happy to split it into stacked commits/PRs on request.

**Core — the fix (safe by construction; needed for the feature to work):**
- Follow a catalog's declared `github:` sources transitively, restricted to the safe subset (github shorthand + immutable ref, no `uri:`/`path:`): `sources/TransitiveSources.ts`, `resolver/Layer.ts`, sync fixpoint in `cli/commands/SyncCommand.ts`, bootstrap closure in `setup/DefaultCatalog.ts`.
- Sync loadout deferral (without it the real default catalog can't sync — it references a dependency's skills): `resolver/ResolverValidation.ts`, `SyncCommand.ts`.
- Two-key identity + duplicate-source dedup: `sources/SourceCache.ts`.
- Post-onboarding warning surfacing: `cli/commands/RunAgentCommand.ts`, `resolver/ResolverContext.ts`.
- Requirements `OFTR-004.6.1–.7, .10, .11`.

**Hardening — defense-in-depth against a hostile catalog's *contents* (candidate for #212):**
- Settings-file containment: checkout-root anchoring, dangling-symlink detection (`lstat`), precise `..` idiom, the accepted-TOCTOU note — `TransitiveSources.ts`.
- Path-escape crash guards (`resolveSourcePayloadRoot` try/catch) — `TransitiveSources.ts`, `Layer.ts`, `SyncCommand.ts`.
- Directory-not-file payload validation — `DefaultCatalog.ts`.
- Credential-distinguishing identity + path canonicalization — `SourceCache.ts`.
- Requirement `OFTR-004.6.8` (unreadable settings), part of `.9`.

**Why the line is drawn there:** `github:`-only is the *transport floor* and stays in the core — it keeps all three catalog types (the default catalog, community-profiles, and user-published github repos) and their transitive deps on a known transport, so it can't be separated out safely. The hardening above is baseline robustness for multi-catalog resolution; the *policy* layer — allowlists, provenance, "should I trust this transitive dep at all" — is #212's, and nothing here pre-empts those decisions.

## Related

Groundwork for the trust/provenance model tracked in #212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
