### PR TITLE
fix(engines): publish an unbounded node range

### DIFF
--- a/code/cli/package.json
+++ b/code/cli/package.json
@@ -60,7 +60,7 @@
     "vitest": "^4.1.7"
   },
   "engines": {
-    "node": ">=24.18.0 <25"
+    "node": ">=22.19.0"
   },
   "keywords": [
     "agent",

--- a/code/cli/tests/cli.test.ts
+++ b/code/cli/tests/cli.test.ts
@@ -39,7 +39,7 @@ const rootPackageJson = readJson<PackageJson>('../../../package.json');
 const docSitePackageJson = readJson<PackageJson>('../../../code/doc_site/package.json');
 const packageLockJson = readJson<PackageLockJson>('../../../package-lock.json');
 const nodeVersion = readFileSync(new URL('../../../.node-version', import.meta.url), 'utf8').trim();
-const supportedNodeRange = `>=${nodeVersion} <25`;
+const supportedNodeRange = '>=22.19.0';
 const tsconfig = readJson<TypeScriptConfig>('../tsconfig.json');
 const buildTsconfig = readJson<TypeScriptConfig>('../tsconfig.build.json');
 const eslintConfigSource = readFileSync(new URL('../eslint.config.js', import.meta.url), 'utf8');

--- a/code/cli/tests/unit/published-engines-range.test.ts
+++ b/code/cli/tests/unit/published-engines-range.test.ts
@@ -1,0 +1,45 @@
+// Guards the published `engines.node` range across every manifest. npm resolves a bare
+// `npm install -g @ai-outfitter/outfitter` as a version range and silently prefers the newest release
+// whose engines the running Node satisfies, so an unsatisfiable upper bound does not warn — it hands
+// the user an older major. The tested runtime belongs in `.node-version`, never in `engines`.
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+interface ManifestEngines {
+  engines?: { node?: string };
+}
+
+const readJson = (relativePath: string): ManifestEngines =>
+  JSON.parse(readFileSync(new URL(relativePath, import.meta.url), 'utf8')) as ManifestEngines;
+
+const manifests = [
+  ['code/cli/package.json', '../../package.json'],
+  ['package.json', '../../../../package.json'],
+  ['code/doc_site/package.json', '../../../doc_site/package.json'],
+] as const;
+
+describe('published engines range', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-001.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it.each(manifests)('declares an unbounded node range in %s', (_label, relativePath) => {
+    const nodeRange = readJson(relativePath).engines?.node;
+
+    expect(nodeRange).toBe('>=22.19.0');
+    // `<`/`<=` bounds and the `x.y.z`-pinning `~`/`^` shorthands all cap the range.
+    expect(nodeRange).not.toMatch(/[<~^]/u);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-001.1).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('keeps the pinned development runtime at or above the published floor', () => {
+    const order = (version: string): number[] => version.split('.').map(Number);
+    const pinned = order(readFileSync(new URL('../../../../.node-version', import.meta.url), 'utf8').trim());
+    const floor = order('22.19.0');
+
+    // The CI pin may lead the floor, but it must never fall below what consumers may install on.
+    const compared = pinned.findIndex((part, index) => part !== floor[index]);
+
+    expect(compared === -1 || pinned[compared] > floor[compared]).toBe(true);
+  });
+});

--- a/code/doc_site/package.json
+++ b/code/doc_site/package.json
@@ -26,6 +26,6 @@
     "typescript-eslint": "^8.60.0"
   },
   "engines": {
-    "node": ">=24.18.0 <25"
+    "node": ">=22.19.0"
   }
 }

--- a/docs/requirements/OFTR-001-project-foundation.md
+++ b/docs/requirements/OFTR-001-project-foundation.md
@@ -9,13 +9,24 @@ This document specifies the baseline runtime, language, test, lint, and document
 
 ### OFTR-001.1: Runtime, Package Manager, and Language
 
+Amendment (2026-08-08): statement 2 tied the published `engines.node` range to
+the pinned development runtime, which shipped `>=24.18.0 <25` in every 1.x
+release. npm resolves a bare `npm install -g @ai-outfitter/outfitter` as a
+version range and silently selects the newest release whose `engines` the
+running Node satisfies, so the upper bound did not warn — it installed 0.11.0
+on Node 22.19+, 23.x, and 25+. Statement 2 now separates the two concerns and
+statements 8 and 9 forbid an upper bound, because `.node-version` already
+pins the tested runtime for CI.
+
 1. The project MUST use TypeScript as its primary implementation language.
-2. The project MUST declare Node.js `>=24.18.0 <25` as the supported runtime range and pin the exact tested version in `.node-version`.
+2. The project MUST pin the exact tested development and CI runtime version in `.node-version`.
 3. TypeScript configuration MUST enable strict type checking.
 4. The CLI workspace MUST provide a separate build TypeScript configuration that emits production files from `code/cli/src/` to `code/cli/dist/`.
 5. The project MUST use npm as its package manager for the first version.
 6. The project MUST commit `package-lock.json` after dependency installation or updates.
 7. When an implementation library choice remains unclear, the project SHOULD prefer the same library or convention used by pi.dev.
+8. Every published manifest MUST declare the same `engines.node` range, and that range MUST be `>=22.19.0`.
+9. The `engines.node` range MUST NOT declare an upper bound, because npm answers an unsatisfiable bound by installing an older major release instead of failing.
 
 ### OFTR-001.2: Test Framework and Coverage
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "check-ci": "prettier --check . && npm run lint && npm run coverage && npm run docs:ci"
   },
   "engines": {
-    "node": ">=24.18.0 <25"
+    "node": ">=22.19.0"
   }
 }


### PR DESCRIPTION
## The bug

`npm install -g @ai-outfitter/outfitter` installs **0.11.0** on Node 22.19+, 23.x, and 25+ — while `dist-tags.latest` is 1.5.0. Reported by a user who had been getting 0.11.0 since the 1.x line began.

Reproduced on Node 22.22.1 / npm 10.9.4:

```
npm install -g @ai-outfitter/outfitter   →   0.11.0
```

No error. **No `EBADENGINE` warning** — the down-select path is silent, which is why this reads as a registry problem rather than a manifest one.

## Cause

Every 1.x release publishes `engines.node: ">=24.18.0 <25"`; 0.11.0 publishes `">=22.19.0"`. That range came from `795f4ed` *"fix(ci): standardize Node runtime on latest LTS"* — a CI runtime pin that leaked into the published consumer contract.

npm resolves a bare `npm i -g <name>` as a **range** and prefers the newest version whose `engines` the running Node satisfies. On Node 22.19+ no 1.x qualifies, so 0.11.0 wins.

| Node | before | after |
| --- | --- | --- |
| 18, 20, ≤22.18 | 1.5.0 (nothing satisfies → falls back) | 1.5.x |
| **22.19 – 23.x** | **0.11.0** | 1.5.x |
| 24.x | 1.5.0 | 1.5.x |
| **≥ 25** | **0.11.0** | 1.5.x |

The `<25` ceiling excluded the current Node line, not just Node 22 LTS, and would have kept excluding every future major.

## Why `>=22.19.0` and not just dropping the ceiling

Evidence, not preference:

- No dependency requires more than Node 22.19.0 (audited every `engines.node` in the installed tree — the only manifest excluding 22.19.0 was our own).
- The **full suite passes on Node 22.22.1**: 33 files, 360 tests.
- Published 1.5.0 installed explicitly under Node 22 runs correctly (`--version`, `--help`).

`.node-version` already pins 24.18.0 and every CI job consumes it via `node-version-file`, so `engines` was doing no CI work whatsoever.

## Requirement amendment

The bad range was pinned by a hard requirement, so this follows `docs/requirements/README.md` in order — requirement, then pinned test, then implementation:

- **OFTR-001.1 statement 2** no longer conflates the tested runtime with the supported consumer range.
- **New statements 8 and 9** require one range across all three manifests and forbid an upper bound.
- `cli.test.ts` updated under the amendment trace.

## Guard

Adds `published-engines-range.test.ts`, pinned to OFTR-001.1. Verified it *fails* against the original `>=24.18.0 <25` rather than only passing against the fix.

## Verification

- 360 tests pass on Node 24.18.0 and Node 22.22.1
- lint, typecheck, prettier clean; coverage gate unchanged
- Resolver simulation with the corrected range returns 1.5.1 on every Node from 18 through 26

## Note for release

`engines` is baked into each published manifest, so no dist-tag change repairs the already-published 1.x releases — **this needs a release to reach users.** Until then the workaround is an explicit tag, which skips engine filtering: `npm i -g @ai-outfitter/outfitter@latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)