### PR TITLE
feat: add invocation-only runtime layers

### DIFF
--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -48,6 +48,8 @@ export interface RunAgentInput {
   readonly harness?: string;
   readonly strict?: boolean;
   readonly passThroughArgs?: readonly string[];
+  /** Invocation-only protocol resource roots, highest precedence first. */
+  readonly runtimeLayers?: readonly string[];
   /** `--append-prompt` documents appended to the system prompt after the agent's own, in order. */
   readonly appendPromptPaths?: readonly string[];
   readonly launcher: AgentProcessLauncher;
@@ -276,6 +278,11 @@ export const createRunAgentCommand = (dependencies: RunAgentDependencies = {}): 
       .addOption(new Option('--harness <harness>', 'Harness to launch.').choices([...HARNESSES]))
       .option('--strict', 'Treat composition warnings and unsupported loadout elements as fatal.')
       .option(
+        '--runtime-layer <path>',
+        'Add an invocation-only resource layer. Repeatable; earlier layers take precedence.',
+        (value: string, previous: readonly string[] = []) => [...previous, value],
+      )
+      .option(
         '--append-prompt <path>',
         'Append a Markdown document to the system prompt. Repeatable; applied in the order given.',
         (value: string, previous: readonly string[] = []) => [...previous, value],
@@ -285,7 +292,12 @@ export const createRunAgentCommand = (dependencies: RunAgentDependencies = {}): 
         async (
           agent: string | undefined,
           passThroughArgs: readonly string[],
-          options: { harness?: string; strict?: boolean; appendPrompt?: readonly string[] },
+          options: {
+            harness?: string;
+            strict?: boolean;
+            runtimeLayer?: readonly string[];
+            appendPrompt?: readonly string[];
+          },
         ) => {
           /* v8 ignore next 3 -- process/launcher defaults are exercised by the CLI entrypoint, not unit tests. */
           const homeDirectory = resolveHomeDirectory(dependencies.homeDirectory);
@@ -298,6 +310,7 @@ export const createRunAgentCommand = (dependencies: RunAgentDependencies = {}): 
             harness: options.harness,
             strict: options.strict,
             passThroughArgs,
+            runtimeLayers: options.runtimeLayer,
             appendPromptPaths: options.appendPrompt,
             launcher,
             setup: dependencies.setup ?? interactiveSetupRunner,

--- a/code/cli/src/resolver/Layer.ts
+++ b/code/cli/src/resolver/Layer.ts
@@ -1,6 +1,6 @@
-// Builds the ordered `.agents` layer stack (workspace over global over remote sources) from settings.
-import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+// Builds the ordered protocol resource layer stack used by the resolver.
+import { existsSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 
 import {
   createRemoteRepositoryCachePath,
@@ -15,6 +15,8 @@ import type { Layer } from './Resource.js';
 export interface LayerDiscoveryInput {
   readonly homeDirectory: string;
   readonly projectDirectory: string;
+  /** Invocation-only protocol resource roots, highest precedence first. */
+  readonly runtimeLayers?: readonly string[];
   readonly settings: Settings;
 }
 
@@ -38,6 +40,16 @@ const sourceLayer = (input: LayerDiscoveryInput, source: SourceReference): Layer
       )
     : { root: source.path, origin: 'source', label: source.path };
 
+const runtimeLayer = (projectDirectory: string, path: string): Layer => {
+  const root = resolve(projectDirectory, path);
+
+  if (statSync(root, { throwIfNoEntry: false })?.isDirectory() !== true) {
+    throw new Error(`Runtime layer '${path}' is not a directory.`);
+  }
+
+  return { root, origin: 'runtime', label: path };
+};
+
 export interface LayerDiscoveryResult {
   readonly layers: readonly Layer[];
   /**
@@ -50,11 +62,12 @@ export interface LayerDiscoveryResult {
 }
 
 /**
- * Orders layers highest precedence first: workspace `.agents`, then global `~/.agents`,
- * then configured sources in order. Only layers whose root exists on disk are included.
+ * Orders layers highest precedence first: invocation-only runtime layers, workspace `.agents`,
+ * global `~/.agents`, then configured sources. Runtime layers retain command-line order.
  */
 export const discoverLayers = (input: LayerDiscoveryInput): LayerDiscoveryResult => {
   const candidates: Layer[] = [
+    ...(input.runtimeLayers ?? []).map((path) => runtimeLayer(input.projectDirectory, path)),
     { root: agentsRoot(input.projectDirectory), origin: 'workspace', label: 'workspace' },
     { root: agentsRoot(input.homeDirectory), origin: 'global', label: 'global' },
   ];

--- a/code/cli/src/resolver/ResolverContext.ts
+++ b/code/cli/src/resolver/ResolverContext.ts
@@ -9,6 +9,8 @@ import { resolveResources } from './Resolver.js';
 export interface ResolveInput {
   readonly homeDirectory: string;
   readonly projectDirectory: string;
+  /** Invocation-only protocol resource roots, highest precedence first. */
+  readonly runtimeLayers?: readonly string[];
 }
 
 export interface ResolveResult {

--- a/code/cli/src/resolver/Resource.ts
+++ b/code/cli/src/resolver/Resource.ts
@@ -14,7 +14,7 @@ export const resourceKinds: readonly ResourceKind[] = ['agent', 'skill', 'knowle
 export const agentLocalKinds: readonly ResourceKind[] = ['skill', 'knowledge', 'command'];
 
 /** Where a layer originates, highest precedence first. */
-export type LayerOrigin = 'workspace' | 'global' | 'source';
+export type LayerOrigin = 'runtime' | 'workspace' | 'global' | 'source';
 
 export interface Layer {
   /** Absolute path to the `.agents` payload root for this layer. */

--- a/code/cli/tests/unit/runtime-layer.test.ts
+++ b/code/cli/tests/unit/runtime-layer.test.ts
@@ -1,0 +1,76 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { Command } from 'commander';
+import { afterEach, expect, it } from 'vitest';
+
+import { createRunAgentCommand, executeRunAgentCommand } from '../../src/cli/commands/RunAgentCommand.js';
+
+const roots: string[] = [];
+const temporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-runtime-layer-'));
+  roots.push(root);
+  return root;
+};
+const write = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+// THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.1.12).
+// YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+it('overlays repeatable invocation-only runtime layers in command-line order', async () => {
+  const root = temporaryRoot();
+  const home = join(root, 'home');
+  const project = join(root, 'project');
+  const first = join(root, 'first');
+  const second = join(root, 'second');
+  write(join(project, '.agents', 'agents', 'engineer', 'agent.md'), '---\nname: engineer\nskills: [wiki]\n---\n');
+  write(join(project, '.agents', 'skills', 'wiki', 'SKILL.md'), '---\nname: wiki\n---\n\nWorkspace.\n');
+  write(join(first, 'skills', 'wiki', 'SKILL.md'), '---\nname: wiki\n---\n\nFirst runtime layer.\n');
+  write(join(second, 'skills', 'wiki', 'SKILL.md'), '---\nname: wiki\n---\n\nSecond runtime layer.\n');
+  const program = new Command();
+  createRunAgentCommand({
+    homeDirectory: home,
+    projectDirectory: project,
+    writeLine: () => {},
+    launcher: (plan) => {
+      const runtime = plan.env.PI_CODING_AGENT_DIR;
+      expect(readFileSync(join(runtime, 'skills', 'wiki', 'SKILL.md'), 'utf8')).toContain('First runtime layer.');
+      return Promise.resolve(0);
+    },
+  }).register(program);
+
+  await program.parseAsync([
+    'node',
+    'outfitter',
+    'run',
+    'engineer',
+    '--runtime-layer',
+    first,
+    '--runtime-layer',
+    second,
+  ]);
+
+  expect(existsSync(join(project, '.agents', 'settings.yml'))).toBe(false);
+  expect(readFileSync(join(first, 'skills', 'wiki', 'SKILL.md'), 'utf8')).toContain('First runtime layer.');
+});
+
+it('rejects a runtime layer that is not a directory', async () => {
+  const root = temporaryRoot();
+
+  await expect(
+    executeRunAgentCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: join(root, 'project'),
+      runtimeLayers: ['missing'],
+      agent: 'engineer',
+      launcher: () => Promise.resolve(0),
+    }),
+  ).rejects.toThrow("Runtime layer 'missing' is not a directory.");
+});

--- a/docs/documentation/cli.md
+++ b/docs/documentation/cli.md
@@ -11,11 +11,12 @@ Global options:
 
 Resolve, compose, and launch an agent. `run` is the default command, so plain `outfitter` and `outfitter run` are equivalent.
 
-| Argument / Option     | Description                                                                      |
-| --------------------- | -------------------------------------------------------------------------------- |
-| `[agent]`             | Agent slug to run. Defaults to the settings `default_agent`.                     |
-| `--harness <harness>` | Harness to launch in: `pi`, `claude`, or `codex`. Defaults to `default_harness`. |
-| `--strict`            | Fail instead of warning when the adapter cannot project part of the composition. |
+| Argument / Option        | Description                                                                      |
+| ------------------------ | -------------------------------------------------------------------------------- |
+| `[agent]`                | Agent slug to run. Defaults to the settings `default_agent`.                     |
+| `--harness <harness>`    | Harness to launch in: `pi`, `claude`, or `codex`. Defaults to `default_harness`. |
+| `--runtime-layer <path>` | Add an invocation-only protocol resource root. Repeatable; earlier roots win.    |
+| `--strict`               | Fail instead of warning when the adapter cannot project part of the composition. |
 
 Any other arguments and unrecognized options are passed through to the launched harness:
 
@@ -24,6 +25,9 @@ outfitter run engineer --harness claude
 outfitter run engineer --harness codex -- exec "review this repo"
 outfitter run persona-reviewer -- --print "summarize this repo"
 ```
+
+A runtime layer is the contents of a `.agents` directory, not the directory containing it. It is
+resolved above the workspace for this run without changing the layer or persistent settings.
 
 ## `outfitter setup [source]`
 

--- a/docs/documentation/concepts.md
+++ b/docs/documentation/concepts.md
@@ -58,9 +58,10 @@ The same agent definition can be run directly or selected as a subagent elsewher
 
 Resources resolve across layers, following the protocol's overlay semantics:
 
-1. `<project>/.agents/` — the workspace layer, committed with a project.
-2. `~/.agents/` — the global layer for one developer.
-3. Remote sources — pinned `.agents` payloads from [catalog repositories](./catalogs.md), in configured order.
+1. `--runtime-layer` roots — optional, invocation-only inputs to `run`, in command-line order.
+2. `<project>/.agents/` — the workspace layer, committed with a project.
+3. `~/.agents/` — the global layer for one developer.
+4. Remote sources — pinned `.agents` payloads from [catalog repositories](./catalogs.md), in configured order.
 
 Resources merge **by ID**: a workspace `skills/wiki/` overrides a global or remote `skills/wiki/`. Agent-local skills merge by owner and ID, so `agents/actions/skills/debug/` is distinct from `agents/reviewer/skills/debug/`; the selected agent's local winner takes precedence over catalog-wide `skills/debug/`. JSON files such as `mcp.json` and `models.json` follow the protocol's JSON merge behavior. Standalone `.agents` repositories — where the repository root _is_ the payload — are the primary way to develop and share layers; see [Catalogs](./catalogs.md) and [Local development](./local-development.md).
 

--- a/docs/requirements/OFTR-005-run-and-composite-profile.md
+++ b/docs/requirements/OFTR-005-run-and-composite-profile.md
@@ -26,6 +26,7 @@ Amended (2026-07-17, RFC #165): `run` selects an agent slug and a harness, not a
 9. The `run` command MUST accept a repeatable `--append-prompt <path>`, appending each named document to the system prompt after the composition's own fragments, in the order given.
 10. The `run` command MUST reject an `--append-prompt` path that is not a readable file before launching, naming both the flag and the path.
 11. For a harness that exposes a native append-prompt flag, `--append-prompt` MUST project through that flag so a caller does not have to know which harness will launch. Passthrough after `--` cannot satisfy this, because it reaches the harness unaltered per OFTR-005.1.7. A harness without a native append flag MUST warn that the prompt cannot be projected, subject to the OFTR-006.1.4 `--strict` policy.
+12. The `run` command MUST accept repeatable `--runtime-layer <path>` protocol resource roots for that invocation only. Runtime layers MUST resolve above the workspace in command-line order and MUST NOT modify the supplied roots or persistent settings.
 
 ### OFTR-005.2: Composition Definition
 


### PR DESCRIPTION
## Why

Panopticon generates workflow and operation skills for one supervised agent run. Today it must either write those resources into the checkout or persistent user configuration, or translate them into Pi-, Claude-, or Codex-specific arguments itself.

The downstream flow is tracked in [Panopticon #353](https://github.com/ai-outfitter/panopticon/issues/353): [`container/agent.py`](https://github.com/ai-outfitter/panopticon/blob/main/src/panopticon/container/agent.py) prepares per-run workflow resources, then [`runner.py`](https://github.com/ai-outfitter/panopticon/blob/main/src/panopticon/runner.py) launches the selected harness. Outfitter should remain responsible for resolving those resources and projecting them through its existing adapters.

## What changes


```console
outfitter run engineer --runtime-layer /run/panopticon/resources
```

`--runtime-layer` accepts the contents of a protocol `.agents` directory for this invocation only. It is repeatable: runtime layers resolve above the workspace in command-line order, then the existing resolver and adapters behave unchanged.

The supplied roots and persistent settings are never modified.

## Deliberate boundaries

- This affects `run` only. `list`, `validate`, and `dump` do not have a demonstrated invocation-layer consumer.
- It does not change signal handling or process supervision; current main already owns that behavior through [#235](https://github.com/ai-outfitter/outfitter/pull/235).
- It adds no harness-specific projection. Pi, Claude, and Codex continue through the existing composition and adapter path.
- Generated overview text can use the existing `--append-prompt`; runtime layers are for protocol resources such as skills.

The focused contract test checks the three important properties: earlier runtime layers win, the winning skill reaches the projected runtime, and neither the input layer nor persistent settings are changed. The repository's full `check-ci` suite passes locally.

For review, the design questions are limited to whether a protocol resource root is the right input, whether invocation-above-workspace precedence is correct, and whether the non-persistence boundary is clear.
