### PR TITLE
docs(architecture): record the forge credential model

### DIFF
--- a/docs/architecture/forge-credential-model.md
+++ b/docs/architecture/forge-credential-model.md
@@ -1,0 +1,82 @@
+# Forge Credential Model
+
+This document records why the runbooks pick the forge credentials they pick. It is not a chooser for users — the runbooks make the choice at the step where it comes up and link here for the reasoning. Read it when you are designing a variation, auditing a deployment, or disagreeing with a runbook.
+
+Outfitter does not collect or validate credentials; see [enterprise-private-catalog-boundary.md](enterprise-private-catalog-boundary.md). Not owning the mechanism does not stop this project from stating which credential a deployment should carry.
+
+## Two axes, not one ranking
+
+A credential has a capability and a reach, and they are independent. Ranking on reach alone produces the wrong answer.
+
+**Capability** is the first filter, and it eliminates more options than scope does. An SSH deploy key is a transport credential: it authenticates `git` over SSH to one repository and cannot call the REST API at all — no issues, no comments, no pull requests, no notifications. A token is an identity credential: it acts as an account.
+
+So the first question is never "how narrow is it" but "can it do the job at all":
+
+- The workload only moves Git objects → a deploy key is a candidate.
+- The workload must _be somebody_ on the forge → a deploy key is excluded at any scope.
+
+**Reach** is the second filter. Among the credentials that survive the first, prefer the shortest-lived, then the narrowest.
+
+## Ranked options
+
+| Rank | Credential                            | Lifetime                            | Reach                                               | Use when                                                                               |
+| ---- | ------------------------------------- | ----------------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| 1    | Workflow `GITHUB_TOKEN`               | the job                             | the workflow's repository, per the permission block | Anything running in Actions. Nothing standing exists to steal or rotate.               |
+| 2    | GitHub App installation token         | one hour                            | selected repositories, granted permissions          | A service acting across several repositories that needs real audit identity.           |
+| 3    | Read-only deploy key                  | no expiry                           | one repository, transport only                      | A long-running workload that reads one repository and never calls the API.             |
+| 4    | Fine-grained PAT on a machine account | expiring                            | selected repositories in exactly one resource owner | The App cannot be the actor you need — an assignee, a reviewer, a notification target. |
+| 5    | Classic PAT on a machine account      | no expiry, no organization boundary | every repository the account can reach              | Only where the forge accepts nothing else.                                             |
+
+Rank 3 sits above rank 4 on purpose, despite never expiring. A leaked deploy key yields read access to one repository and no API surface. A leaked classic PAT on an account that belongs to several organizations yields all of them. Narrow-and-standing beats broad-and-expiring when the narrow credential cannot do anything except clone.
+
+## Why a resident agent still holds a classic PAT
+
+GitHub's `GET /notifications` accepts classic personal access tokens only. It rejects a fine-grained token and it rejects an App installation token. An App also cannot be the assignee of an issue. The channels runbook records both constraints: [`channels/docs/runbooks/github-notifications-local.md`](https://github.com/ai-outfitter/channels/blob/main/docs/runbooks/github-notifications-local.md).
+
+These are two separable requirements:
+
+- **Assignability** needs a real account, because an App cannot be assigned. This holds regardless of the wake mechanism.
+- **Classic-ness** is required only by the notifications endpoint.
+
+The classic PAT is therefore not inherent to residency. It is a consequence of _polling_ as the wake mechanism. An agent woken by a webhook or by a message relay needs an account, but not a classic token.
+
+## Two tokens, not one
+
+Because only the wake path requires a classic token, the wake token and the work token are separate credentials. Channels already reads them separately — `githubConfigFromEnv` prefers `GITHUB_NOTIFY_TOKEN` and falls back to `GITHUB_TOKEN` only when it is absent:
+
+- `GITHUB_NOTIFY_TOKEN` — classic, with the `notifications` scope and nothing else.
+- `GITHUB_TOKEN` — fine-grained, scoped to one organization and the repositories the agent works.
+
+The scope discipline on the wake token is load-bearing. A fine-grained PAT has exactly one resource owner, which is a property of the credential rather than an organization policy someone can relax; an agent carrying one cannot reach another organization. A classic PAT has no such boundary, so if the wake token is ever minted with `repo` "to be safe", it silently becomes a cross-organization write credential and the containment argument inverts. Verify the granted scopes without exposing the token by reading the `X-OAuth-Scopes` response header on any API call.
+
+A classic PAT with `repo` scope can also create repositories through `POST /orgs/{org}/repos`, subject only to the organization's member repository-creation setting. A fine-grained PAT cannot, absent an explicit `Administration: write` grant. That difference comes from choosing fine-grained, not from personal access tokens as a class.
+
+## When a deploy key earns its place
+
+Use a read-only deploy key when all of these hold:
+
+- one repository;
+- read-only;
+- a long-running unattended workload, so no workflow token is available; and
+- no API call is needed.
+
+The decisive case is narrower than it first appears. If the agent already holds a fine-grained token scoped to the organization that owns the catalog, that token can read the catalog, and a deploy key adds operational surface while removing no reach. Blast radius is the union of what the workload holds; a narrow credential only helps when it _replaces_ a broad one.
+
+What a deploy key uniquely buys is **avoiding an organization membership**. A fine-grained PAT cannot span organizations by construction, so an agent in organization A that must read a catalog in organization B has two options: add its machine account to organization B — which widens the reach of every token that account holds, including the classic wake token — or attach a deploy key to that one repository, which requires no membership and no account at all. The same reasoning covers a workload that should not consume a seat.
+
+Do not use a deploy key when the workload needs any API call, when one service needs several repositories (that is an App), or when the audit record must name which agent fetched: a deploy key authenticates as the repository, not as an actor, and GitHub retains `git.clone` and `git.fetch` events for seven days unless the organization streams its audit log.
+
+## Credential material and the workspace
+
+A resident agent's workspace is a persistent volume. Copying key material onto it defeats the properties that make a Secret a Secret: deleting the Secret does not delete the copy, a pod restart does not delete it, any later workload with access to the volume can read it, and snapshots and backups retain it. File permissions do not help when the agent runs as the workspace user. Mount credentials for the operation that needs them and let them leave with the process.
+
+The same argument applies to executables. A binary copied onto the volume out-of-band is not covered by the image's provenance: no scanner sees it, no signature covers it, a restore can reintroduce an old copy, and nothing detects the drift. This matters most for an SSH client, which both handles the private key and validates the remote host — a substituted binary can disclose the key or accept an impersonating host.
+
+## Current gaps
+
+These are scaffolding, not doctrine. Each should disappear.
+
+- The `Organization` catalog declaration carries no credential reference, so a deployment that reads a private catalog supplies the credential itself. A first-class binding belongs on the `Agent`, naming a Secret and a transport mode rather than particular keys — the operator must not depend on the contents of a referenced object.
+- Wake by notification polling forces the classic token described above. A webhook or relay wake removes that requirement and lets the account hold a fine-grained token instead.
+
+Cite this document by heading rather than by line number. Cite code by symbol name, and requirements by identifier; both survive edits that line numbers do not.

--- a/docs/documentation/README.md
+++ b/docs/documentation/README.md
@@ -7,6 +7,14 @@ Onboarding an organization? Start with
 one engineer runs the maturity assessment, then creates the org `.agents`
 repository with the baseline report as its first commit.
 
+## Climb the ramp (runbooks)
+
+One runbook per rung of [the adoption ramp](../philosophy.md#the-ramp-to-an-autonomous-lifecycle). Each starts where the previous one ended and closes with the one concrete step that begins the next rung. Their success checks are the signals an SDLC assessment reports, so "done" is something you run rather than something you judge.
+
+- [Share one catalog](../runbooks/share-one-catalog.md) — one pinned catalog the organization shares, instead of per-laptop configuration. (→ delegated)
+- [Run it without your laptop](../runbooks/run-without-your-laptop.md) — an event triggers the workflow, its output lands through review, and the session is captured. (→ automated)
+- [Give the agent a residence](../runbooks/give-the-agent-a-residence.md) — a named, assignable agent with an account and somewhere to live. (→ governed)
+
 ## Start (you)
 
 - [Getting started](./getting-started.md) — install, first run, default agent.

--- a/docs/documentation/catalogs.md
+++ b/docs/documentation/catalogs.md
@@ -119,6 +119,23 @@ synchronization; run sync explicitly when you want network updates.
 
 Private GitHub catalogs are an enterprise feature. When sync detects a private GitHub repository, it asks for confirmation before use and records the decision in your user settings. Review the Outfitter Enterprise license or your enterprise agreement before enabling private catalogs. Non-GitHub `uri:` sources use whatever git credentials your environment already has; credentials embedded in URIs are redacted from sync output.
 
+### How sync authenticates
+
+Outfitter does not collect, store, or validate credentials. It delegates to `git`, so a private catalog clones with whatever credentials the surrounding environment already gives `git` — which differs by where sync runs:
+
+| Where          | Credential                                                                                                                                        |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Your machine   | Your existing git configuration: SSH agent, credential helper, or `.netrc`.                                                                       |
+| GitHub Actions | The workflow token, configured for git — see [token-permissions.md](https://github.com/ai-outfitter/actions/blob/main/docs/token-permissions.md). |
+| A cluster pod  | Supplied by the deployment: `GIT_ASKPASS` over HTTPS, or `GIT_SSH_COMMAND` for a deploy key.                                                      |
+
+Two failure modes are worth knowing before you hit them:
+
+- **Credentials belong in the environment, not the URI.** Outfitter redacts credentials from a source URI before deriving its cache path, so a URI carrying a username produces a cache entry that later runs do not read. The source URI must be byte-identical everywhere it appears.
+- **`outfitter run` does not sync.** A runtime that has never synced has an empty cache and cannot resolve a profile from it, however good its credentials are.
+
+[The forge credential model](../architecture/forge-credential-model.md) covers which credential to use where, and why.
+
 ## Trust and review
 
 Adding a catalog source means trusting its authors with your agent runtime. A catalog's resources can shape prompts and policy (agents, `agents.md`, `system-prompt.md`), add MCP servers (`mcp.json`), and ship skills whose scripts execute on your machine.

--- a/docs/documentation/in-cluster.md
+++ b/docs/documentation/in-cluster.md
@@ -11,6 +11,8 @@ The Link Operator runs Outfitter-composed agents inside a Kubernetes cluster. Th
 
 The operator never interprets a profile, reads a secret's contents, or invokes the model — it provisions and starts; the agent layer does the rest.
 
+Because the operator does not look inside a Secret, the credentials a resident agent carries are the deployment's decision. A resident agent needs two forge tokens rather than one: the notification wake path accepts only a classic token, while its repository work should carry the narrowest credential available. [Give the agent a residence](../runbooks/give-the-agent-a-residence.md) is the procedure; [the forge credential model](../architecture/forge-credential-model.md) is the reasoning.
+
 ## Execution shapes
 
 | Shape                  | Kubernetes resource | Trigger                                                                                         |

--- a/docs/runbooks/give-the-agent-a-residence.md
+++ b/docs/runbooks/give-the-agent-a-residence.md
@@ -1,0 +1,66 @@
+# Give the agent a residence
+
+**You are here:** agents run from events, and their work lands through review. But each run starts cold and ends forgotten. You cannot assign an issue to an agent, because there is no account to assign it to.
+
+**This runbook gets you to:** an agent with a name, an account, and a place to live — one you assign work to and that answers, working from the same pinned catalog as everyone else. That is rung 4 of [the adoption ramp](../philosophy.md#the-ramp-to-an-autonomous-lifecycle) — governed.
+
+**Prerequisites:** [Share one catalog](./share-one-catalog.md) and [Run it without your laptop](./run-without-your-laptop.md). A resident agent resolves its profile from the catalog at a pin, and it must land changes through the same gate a triggered agent does. Residency does not relax either.
+
+## 1. Decide what the agent is
+
+A resident agent is a teammate, not a service. Name it, write its profile into the catalog, and cap what it may do — the profile is where you say it opens pull requests but does not merge them.
+
+Be honest about capability. An agent whose runtime cannot reach the forge cannot review; one with no write path cannot open a pull request. A profile that promises more than the deployment can do produces an agent that wakes, cannot act, and looks broken.
+
+## 2. Create its account
+
+The agent needs a real forge account, because an App cannot be assigned an issue.
+
+Give it its own account per organization where you can. A machine account that belongs to several organizations holds a token that can see all of them, so the account's membership list — not the token's scope — becomes the boundary.
+
+Do not put a handle into a manifest or a profile before the account exists. A runbook naming an account that returns 404 reads as finished when it is not.
+
+## 3. Give it two tokens
+
+Not one. The wake path and the work path have different requirements, and collapsing them gives the agent the broadest credential in the system for everything it does.
+
+| Variable              | Kind         | Scope                                       |
+| --------------------- | ------------ | ------------------------------------------- |
+| `GITHUB_NOTIFY_TOKEN` | classic      | `notifications` only                        |
+| `GITHUB_TOKEN`        | fine-grained | one organization, the repositories it works |
+
+The classic token is forced: `GET /notifications` rejects fine-grained tokens and App installation tokens alike. It is the one place the ranking bends, and it bends only here. The scope discipline is what keeps it contained — a classic token minted with `repo` "to be safe" becomes a cross-organization write credential, silently.
+
+The fine-grained work token has exactly one resource owner as a property of the credential, so the agent cannot reach another organization even if its account belongs to one. [The credential model](../architecture/forge-credential-model.md) sets out the full reasoning, including when a read-only deploy key earns its place.
+
+## 4. Deploy it
+
+[`ai-outfitter/agent-operator`](https://github.com/ai-outfitter/agent-operator) runs resident agents on Kubernetes: an `Organization` names the catalog and its pin, an `Agent` names the profile and the credentials it projects. [In-cluster agents](../documentation/in-cluster.md) covers the primitives.
+
+Two things to get right, because both fail quietly:
+
+- **Pin the catalog to a full commit SHA**, and move every copy of that revision together. A revision that differs between the organization pin and anything that reads it produces an agent resolving a catalog nobody meant to ship.
+- **Keep credential material out of the workspace volume.** It outlives the Secret, survives restarts, and is readable by anything that later mounts the volume. Mount a credential for the operation that needs it.
+
+A private catalog needs a credential the operator does not currently model — see [the private-catalog runbook](https://github.com/ai-outfitter/agent-operator/blob/main/docs/runbooks/private-catalog-resident-agent.md).
+
+## 5. Prove the loop, once
+
+Open a real issue. Assign it to the agent. Watch what happens, and write down what actually happened rather than what you designed.
+
+`Ready` means the workload runs. It does not mean the notification channel is configured, the wake arrives, or the agent can act on what it reads. Those are separate facts, and each needs its own check.
+
+## Done when
+
+Run an organization SDLC assessment:
+
+- `bot-identity` — agent actions carry a capped identity rather than a human's.
+- `strict-governance` — the catalog's governance policy names the agents you actually run.
+
+A governance file capping an agent that does not exist, while the agents you run go unmentioned, satisfies neither. Check that the names match reality.
+
+## Your first step on the next rung
+
+You now have transcripts, an audit record, and an agent that runs the same loop repeatedly. That is the raw material for evaluation.
+
+Take one loop the agent ran and score it: did it produce what the acceptance criteria asked for? Write the result down next to the transcript. A handful of scored runs is the beginning of an eval set, and an eval set is what turns "the agent seems fine" into evidence — the start of rung 5, where the record feeds improvement and humans keep only the goal and the gate.

--- a/docs/runbooks/run-without-your-laptop.md
+++ b/docs/runbooks/run-without-your-laptop.md
@@ -1,0 +1,70 @@
+# Run it without your laptop
+
+**You are here:** your team shares a catalog, and an agent does real work — but only while someone sits in front of it. Close the laptop and the work stops. Nothing an agent did is reviewable after the terminal scrolls away.
+
+**This runbook gets you to:** a workflow an event triggers, whose output lands through the same review gate a human's would, with the session transcript attached. That is rung 3 of [the adoption ramp](../philosophy.md#the-ramp-to-an-autonomous-lifecycle) — automated.
+
+**Prerequisite:** [Share one catalog](./share-one-catalog.md). A triggered agent resolves its profile from a catalog; without one you are pinning nothing and every run can differ.
+
+## 1. Pick a workflow you already do by hand
+
+Not the most valuable one — the one you understand best. Issue triage, a release note, a dependency bump, a first-pass review.
+
+Never automate a workflow you have not first done manually. If you cannot write down what a good result looks like, you cannot tell whether the automated version worked, and you will end up trusting it because it ran rather than because it was right.
+
+Write the acceptance criteria down before you write the workflow.
+
+## 2. Give it a trigger
+
+[`ai-outfitter/actions`](https://github.com/ai-outfitter/actions) runs an Outfitter profile as a GitHub Actions step. Point it at your catalog, pinned:
+
+```yaml
+- uses: ai-outfitter/actions@v1
+  with:
+    profile: triage
+    profile-source: acme/.agents
+    profile-source-ref: v0.1.0
+    prompt: >-
+      Triage issue #${{ github.event.issue.number }} …
+```
+
+The trigger is whatever event fits: `issues`, `pull_request`, `schedule`, `workflow_dispatch`. Start with the narrowest one that covers your case.
+
+**Credentials.** Use the workflow `GITHUB_TOKEN` with an explicit `permissions:` block. It exists only for the job, so there is no standing credential to steal or rotate — the best case available, and the default you should have to argue your way out of.
+
+You need more only when the agent must _be somebody_: assignable, requestable as a reviewer, or opening pull requests that trigger CI. That is a machine account with a **fine-grained** token — see [bot-account.md](https://github.com/ai-outfitter/actions/blob/main/docs/bot-account.md) and [token-permissions.md](https://github.com/ai-outfitter/actions/blob/main/docs/token-permissions.md). Never a classic PAT here; [the credential model](../architecture/forge-credential-model.md) explains why the ranking comes out this way.
+
+## 3. Make the output land through a gate
+
+An agent that can merge its own work is not automated, it is unsupervised. Protect the default branch and let the agent open pull requests that a human merges. Required checks apply to the agent exactly as they apply to a person.
+
+Keep the bot out of `CODEOWNERS`, so its approval never satisfies a required review by itself.
+
+## 4. Capture the session
+
+The transcript is the difference between "the agent did something" and an auditable record. The action uploads the full session as a workflow artifact:
+
+```yaml
+- uses: ai-outfitter/actions@v1
+  with:
+    transcript-artifact: agent-session
+    # …
+```
+
+`transcript-artifact-url` comes back as a step output, so the workflow can post the link on the pull request it opened. A reviewer then reads what the agent was asked and what it did, not just the diff.
+
+Capture the session before the change lands, not after. A transcript attached to a merged change nobody read is a log; a transcript on the pull request is evidence a reviewer can use.
+
+## Done when
+
+Run an organization SDLC assessment. Three signals define this rung:
+
+- `triggered-agents` — agents run from events rather than from a laptop.
+- `protected-landing` — every repository where an agent lands changes enforces branch protection.
+- `session-capture` — sessions are captured before a change lands.
+
+## Your first step on the next rung
+
+Notice what the workflow above cannot do: it wakes for one event, in one repository, and forgets everything when the job ends. It cannot be assigned an issue and pick it up, and it has no memory between runs.
+
+Give one agent a name, an account, and somewhere to live — [Give the agent a residence](./give-the-agent-a-residence.md).

--- a/docs/runbooks/share-one-catalog.md
+++ b/docs/runbooks/share-one-catalog.md
@@ -1,0 +1,68 @@
+# Share one catalog
+
+**You are here:** every engineer configures their own agent. Prompts, skills, and MCP servers differ per laptop, so two people asking the same question get different answers, and an improvement one person makes stays on their machine.
+
+**This runbook gets you to:** one catalog the organization shares, pinned to a revision, consumed by the repositories that matter. That is rung 2 of [the adoption ramp](../philosophy.md#the-ramp-to-an-autonomous-lifecycle) — delegated.
+
+Do this one first. The two runbooks above it both assume a catalog exists: an agent triggered in CI resolves its profile from one, and a resident agent cannot start without one.
+
+## Before you start
+
+You need a forge organization, write access to create one repository in it, and Outfitter installed locally. Nothing runs in CI or a cluster yet.
+
+## 1. Create the catalog repository
+
+The convention is a standalone `.agents` repository, or an `owner/.outfitter` control repository carrying a `.agents/` payload. [Catalogs](../documentation/catalogs.md) covers both shapes and when each fits.
+
+Start with what people already run. A catalog assembled from the prompts and skills your team uses today beats one designed from scratch, because it inherits their judgment.
+
+```text
+acme/.agents/
+  agents.md              # rules every agent inherits
+  agents/
+    engineer/agent.md
+  settings.yml
+```
+
+[Organization Catalog](../documentation/usecases/organization-profile-catalog.md) works through a fuller example with several role agents.
+
+## 2. Consume it, pinned
+
+Each consumer names the catalog and the revision it trusts:
+
+```yaml
+# ~/.agents/settings.yml
+sources:
+  - github: acme/.agents
+    ref: v0.1.0
+```
+
+Pin it. An unpinned source runs whatever the catalog publishes next, which means a change nobody reviewed reaches every consumer at once. Pinning turns a catalog update into a reviewable bump.
+
+Tag the catalog rather than pinning a branch, so the pin reads as a decision and moving it is deliberate.
+
+## 3. Verify
+
+```sh
+outfitter sync
+outfitter run
+```
+
+Sync reports each source as `updated`, `unchanged`, `skipped`, or `failed`. A source that fails is not silently ignored — sync exits nonzero.
+
+**Private catalog?** Private GitHub catalogs are an enterprise capability, and the credential is supplied by your environment rather than by Outfitter. See [Private repositories](../documentation/catalogs.md#private-repositories) for how sync authenticates in each context.
+
+## Done when
+
+Run an organization SDLC assessment. Two signals flip:
+
+- `shared-catalog` — a catalog exists carrying validated workflows and a governance policy.
+- `catalog-consumed` — repositories resolve it, at a pin.
+
+Those are the machine-checkable definition of rung 2. If the report still shows either as unmet, it names what it could not find.
+
+## Your first step on the next rung
+
+Take one workflow your team already does by hand — triage, a changelog, a dependency bump — and add its instructions to the catalog as a skill. Do it manually a few times with the agent assisting.
+
+Never automate a workflow you have not first done manually. When you understand it well enough to write its acceptance criteria, [Run it without your laptop](./run-without-your-laptop.md) gives it a trigger.


### PR DESCRIPTION
The runbooks pick forge credentials at several steps, and a reader who wants to know why has nowhere to look.

Ranking credentials by scope alone gives the wrong answer, because capability and reach are independent axes: a deploy key cannot call the API at any scope, and `GET /notifications` accepts a classic token only. This records the reasoning once — the ranked options, why a resident agent still holds a classic PAT, why the wake token and the work token are separate, when a deploy key actually earns its place, and why credential material must not land on a workspace volume.

Reference material, not a chooser: the ladder runbooks state the choice at the step and link here.

Two current gaps are recorded as scaffolding rather than doctrine — the missing catalog credential binding on `Agent`, and notification polling as the wake mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)