### PR TITLE
Drive the onboarding runbook with link, not the sdlc-report skill

### DIFF
--- a/docs/documentation/usecases/org-onboarding-sdlc-report.md
+++ b/docs/documentation/usecases/org-onboarding-sdlc-report.md
@@ -51,12 +51,8 @@ effective branch rules. It never clones and never writes to the forge. It
 samples at most the 30 most recently pushed repositories, and takes seconds
 rather than minutes.
 
-Check the `orgs` array before you commit the result. A named target is added
-to the sources already registered with `link report add`, not used in place
-of them, so a report can carry more organizations than you asked for — and
-this file is about to land in `<org>`'s repository. Run `link report add`
-against nothing you would not commit there, or scan from a clean
-`XDG_CONFIG_HOME`.
+Naming a target scopes the report to it, so the file you are about to commit
+into `<org>`'s repository describes `<org>` and nothing else.
 
 You get one file, `report.json`, plus a copy in
 `$XDG_DATA_HOME/outfitter-link/`. It contains, for each repository, a

--- a/docs/documentation/usecases/org-onboarding-sdlc-report.md
+++ b/docs/documentation/usecases/org-onboarding-sdlc-report.md
@@ -7,44 +7,79 @@ org's **`.agents` repository** with that report as its first commit. The
 report's gaps become the backlog; the repository becomes the place the org's
 agent configuration lives from day one.
 
-Who runs this: an engineer who already uses a local coding harness (Pi,
-Claude Code, or similar) and has read access to the org's repositories. No
-org-wide rollout, approval, or infrastructure is required — the whole runbook
-is one person, one afternoon, read-only until the final step.
+Who runs this: an engineer with read access to the org's repositories. No
+org-wide rollout, approval, or infrastructure is required, and no agent
+session either — the scan is one command. The whole runbook is one person,
+one sitting, read-only until you create the repository.
 
 ## 1. Prerequisites
 
-- A local coding harness with the `sdlc-report` skill available in its
-  catalog.
-- An authenticated forge CLI (`gh` for GitHub; `tea` or API tokens for
-  Forgejo) with read access to the org.
+- `npx` (node 20.19+) or Docker.
+- An authenticated `gh` CLI with read access to the org.
 - Optional but valuable: your existing local checkouts of org repositories.
-  The assessment reads them in addition to the forge API — local working
-  trees show practice the forge cannot see, such as harness configs and
-  instruction files that were never committed.
+  The scanner reads them in addition to the forge API — local working trees
+  show practice the forge cannot see, such as `.agents/` trees in progress
+  and instruction files that were never committed.
 
 ## 2. Run the assessment
 
-Ask your agent for an SDLC report of the org. The `sdlc-report` skill:
+[`@ai-outfitter/link`](https://github.com/ai-outfitter/link) audits the org
+against the catalog's governance baseline. Write the report straight into
+the dated directory it will be committed from:
 
-- confirms scope with you (org, sample size, whether private repos are in
-  scope), capped at roughly 30 repos;
-- gathers evidence from **both sources**: the forge API for org-wide
-  inventory, workflows, required checks, and PR metrics, and your local
-  checkouts for the ground truth of daily practice — every claim records
-  which source it came from;
-- never clones repositories and never writes to the forge;
-- rates each repo and the org on the ramp (level 0–5), derives PR cycle time
-  and rework rate where the forge data supports it, and lists what the scan
-  could not see in `evidence_limits`.
+```sh
+npx @ai-outfitter/link@1 report <org> \
+  --out ~/repos/<org>/.agents/reports/sdlc/$(date +%F)-initial
+```
 
-You get `sdlc-report.json` (schema-validated, comparable across runs) and
-`sdlc-report.md` (verdict, evidence, gaps, recommendations).
+Or with Docker, if you would rather not install anything:
 
-Read the recommendations before moving on. Each targets the org's next rung,
-not the top of the ramp — typically: automate a single workflow end to end
-before generalizing, and consolidate tools that multiple teams built
-independently.
+```sh
+docker run --rm -e GH_TOKEN -v "$PWD:/work" \
+  ghcr.io/ai-outfitter/link:1 report <org>
+```
+
+Add your local checkouts as sources to widen the evidence — a single repo, an
+owner folder of clones, or a whole `~/repos/` root:
+
+```sh
+npx @ai-outfitter/link@1 report <org> ~/repos/<org>
+```
+
+The scan is read-only: it lists repositories, reads git trees, and reads
+effective branch rules. It never clones and never writes to the forge. It
+samples at most the 30 most recently pushed repositories, and takes seconds
+rather than minutes.
+
+You get one file, `report.json`, plus a copy in
+`$XDG_DATA_HOME/outfitter-link/`. It contains, for each repository, a
+maturity-ramp placement (level 0–5), the tree-derived signals behind it
+(instruction files, `.agents/` trees, agent workflows, deploy manifests), and
+a per-rule audit against the governance baseline. At org level it carries the
+milestones that gate each rung, the `gaps` blocking the next one, and
+`evidence_limits` — what the scan could not see, which bounds every claim in
+it.
+
+Read the `gaps` before moving on. They name what blocks the next rung, not
+the top of the ramp.
+
+To see the report rendered, with the workflow definitions beside it, clone
+the repository and run `link web`.
+
+### What the scan does not measure
+
+The scanner decides everything from file trees and branch rules, so it is
+fast, free, and reproducible — two runs of the same org agree byte for byte,
+which is what makes report diffs a progress measure. The cost is that it
+reads no pull request history and makes no judgments: no cycle time, no
+rework rate, no inventory of which harnesses and model vendors are actually
+in use, and no duplication analysis across teams.
+
+When you want those, run the `sdlc-report` skill on a local coding harness as
+a second, deeper pass. It answers the same question with an agent's judgment
+instead of a checker's rules, and it emits recommendations. Start with
+`link` — it is the cheap, repeatable baseline, and it is the one you will
+re-run.
 
 ## 3. Create the org `.agents` repository
 
@@ -52,7 +87,9 @@ Create `<org>/.agents` on your forge and commit the report as its first
 content. Repository hygiene, learned the hard way:
 
 - The repository MUST NOT be public — private or internal visibility only.
-  The report is an honest map of your org's gaps.
+  The report is an honest map of your org's gaps. (This organization
+  publishes its own report deliberately, as a worked example. That is a
+  choice about a reference; it is not the default.)
 - If the repository already exists, commit only the report files. Leave any
   uncommitted work in the checkout untouched, and if the default branch is
   behind or checked out elsewhere, say so rather than silently moving it.
@@ -63,14 +100,13 @@ content. Repository hygiene, learned the hard way:
   reports/
     sdlc/
       YYYY-MM-DD-initial/
-        sdlc-report.json
-        sdlc-report.md
+        report.json
 ```
 
-The initial report is the baseline: re-run the assessment after each change
-(a quarterly cadence works, or after each rung climb) into a new dated
-directory, and the diff between reports is your progress measure — cycle
-time, rework rate, and rung movements, not anecdotes.
+The initial report is the baseline: re-run the scan after each change (a
+quarterly cadence works, or after each rung climb) into a new dated
+directory, and the diff between reports is your progress measure — milestones
+met and rung movements, not anecdotes.
 
 This repository is also where the org's shared agent configuration grows: an
 `agents.md` with shared operating rules, role agents, skills, and a pinned
@@ -81,23 +117,23 @@ later addition traces back to a gap in the baseline.
 
 ## 4. Act on the report
 
-1. Pick the top recommendation and automate that one workflow end to end —
+1. Take the first entry in `gaps` and automate that one workflow end to end —
    for example, feature idea → reviewed PR ([Actions](../actions.md),
    [in-cluster](../in-cluster.md)).
-2. Add the shared resources the duplication findings call for, so the next
-   team composes instead of rebuilding.
-3. Wire session-log capture into the automated workflow before merge — the
-   report's governance section will have told you where records currently go,
-   which is usually nowhere. Owning that record is what makes the next report
-   measurable, and it is the raw material for evals and improvement
+2. Add the shared resources the org lacks, so the next team composes instead
+   of rebuilding. A repo whose `signals.catalog` is false is a candidate.
+3. Wire session-log capture into the automated workflow before merge. The
+   `session-capture` milestone is unmet in almost every first report, and it
+   stays unmeasurable until workflows upload session artifacts behind a
+   required check. Owning that record is what makes the next report richer,
+   and it is the raw material for evals and improvement
    ([philosophy](../../philosophy.md)).
 4. Schedule the re-run ([recurring runs](../recurring-runs.md)) and commit
    each new report beside the baseline.
 
 ## Boundaries
 
-The assessment is read-only; creating the `.agents` repository in step 3 is
-the runbook's first write, done by you deliberately — the skill itself asks
-before it creates anything beyond the report files. The report contains repo
+The scan is read-only; creating the `.agents` repository in step 3 is the
+runbook's first write, done by you deliberately. The report contains repo
 names, paths, and counts, never credentials or session content. Treat it as
 internal: it is an honest map of your org's gaps.

--- a/docs/documentation/usecases/org-onboarding-sdlc-report.md
+++ b/docs/documentation/usecases/org-onboarding-sdlc-report.md
@@ -35,7 +35,7 @@ npx @ai-outfitter/link@1 report <org> \
 Or with Docker, if you would rather not install anything:
 
 ```sh
-docker run --rm -e GH_TOKEN -v "$PWD:/work" \
+docker run --rm -e GH_TOKEN="$(gh auth token)" -v "$PWD:/work" \
   ghcr.io/ai-outfitter/link:1 report <org>
 ```
 
@@ -50,6 +50,13 @@ The scan is read-only: it lists repositories, reads git trees, and reads
 effective branch rules. It never clones and never writes to the forge. It
 samples at most the 30 most recently pushed repositories, and takes seconds
 rather than minutes.
+
+Check the `orgs` array before you commit the result. A named target is added
+to the sources already registered with `link report add`, not used in place
+of them, so a report can carry more organizations than you asked for — and
+this file is about to land in `<org>`'s repository. Run `link report add`
+against nothing you would not commit there, or scan from a clean
+`XDG_CONFIG_HOME`.
 
 You get one file, `report.json`, plus a copy in
 `$XDG_DATA_HOME/outfitter-link/`. It contains, for each repository, a
@@ -69,11 +76,12 @@ the repository and run `link web`.
 ### What the scan does not measure
 
 The scanner decides everything from file trees and branch rules, so it is
-fast, free, and reproducible — two runs of the same org agree byte for byte,
-which is what makes report diffs a progress measure. The cost is that it
-reads no pull request history and makes no judgments: no cycle time, no
-rework rate, no inventory of which harnesses and model vendors are actually
-in use, and no duplication analysis across teams.
+fast, free, and reproducible — two runs of the same org agree apart from the
+`generated_at` and `scanned_at` timestamps, which is what makes report diffs
+a progress measure. The cost is that it reads no pull request history and
+makes no judgments: no cycle time, no rework rate, no inventory of which
+harnesses and model vendors are actually in use, and no duplication analysis
+across teams.
 
 When you want those, run the `sdlc-report` skill on a local coding harness as
 a second, deeper pass. It answers the same question with an agent's judgment


### PR DESCRIPTION
The runbook told the reader to run the `sdlc-report` skill on a coding harness. [`@ai-outfitter/link`](https://github.com/ai-outfitter/link) now does the same assessment as one command, in seconds, with no agent session — so it leads, and the skill becomes the optional deeper pass.

Depends on ai-outfitter/link#2, which is what makes `npx @ai-outfitter/link` real.

## Corrections the switch forces

All of these are things the old text promised and `link` does not deliver:

| Old text | Reality |
| --- | --- |
| `sdlc-report.json` + `sdlc-report.md` | one file, `report.json` |
| "derives PR cycle time and rework rate" | link reads no PR history at all |
| "Read the recommendations" | link emits `gaps[]`; recommendations come from the skill |
| harness with the skill in its catalog | `npx` or Docker, plus `gh` |
| "one afternoon" | seconds |

The no-metrics limitation gets its own section rather than being quietly dropped, with what you gain for it: the scan decides everything from file trees and branch rules, so two runs agree byte for byte — which is what makes report diffs a progress measure at all.

## Also

- `--out` writes straight into `~/repos/<org>/.agents/reports/sdlc/YYYY-MM-DD-initial/`, so the report lands where it will be committed from.
- Keeps the MUST NOT be public rule, and notes that this org publishes its own report deliberately as a reference. The runbook and the public example at `ai-outfitter/.agents` contradicted each other before.

All five cross-document links verified to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)