### PR TITLE
chore: add feature and bug issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+# Blank issues stay enabled: the triage agent can classify free-form issues
+# too — templates just give it (and contributors) more structure to work with.
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://github.com/ai-outfitter/outfitter/tree/main/docs
+    about: Architecture, requirements, and the ramp runbooks.
+  - name: Requirements
+    url: https://github.com/ai-outfitter/outfitter/tree/main/docs/requirements
+    about: The numbered OFTR-NNN obligations. Quote one if your issue is about a stated requirement.

--- a/.github/ISSUE_TEMPLATE/feat.yml
+++ b/.github/ISSUE_TEMPLATE/feat.yml
@@ -3,8 +3,8 @@ description: >-
   Request a new command, adapter, resolution behaviour, or a change to an
   existing one. The triage agent will label it and comment with a suggested
   plan.
-title: "feat: "
-labels: ["enhancement"]
+title: 'feat: '
+labels: ['enhancement']
 body:
   - type: dropdown
     id: area

--- a/.github/ISSUE_TEMPLATE/feat.yml
+++ b/.github/ISSUE_TEMPLATE/feat.yml
@@ -1,0 +1,68 @@
+name: New capability or change
+description: >-
+  Request a new command, adapter, resolution behaviour, or a change to an
+  existing one. The triage agent will label it and comment with a suggested
+  plan.
+title: "feat: "
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: What part of Outfitter does this touch?
+      options:
+        - Command surface (run, sync, setup, link, other)
+        - Profile composition or resolution
+        - Catalog sources (github, path, transitive)
+        - Harness adapter (pi, Claude Code, Codex, other)
+        - settings.yml schema or precedence
+        - Documentation
+        - Something else
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What can you not do today?
+      description: >-
+        The situation you are in, not the solution you have in mind. A request
+        stated as a problem survives a better idea than yours.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What should it do?
+      description: >-
+        The behaviour you want, in a few sentences. Include the command shape
+        if you have one in mind.
+    validations:
+      required: true
+  - type: input
+    id: requirement
+    attributes:
+      label: Related requirement
+      description: >-
+        If this changes a stated obligation, name it — `OFTR-NNN.M`. A change
+        that contradicts a requirement amends the requirement first.
+      placeholder: e.g. OFTR-004.6
+    validations:
+      required: false
+  - type: input
+    id: harnesses
+    attributes:
+      label: Harnesses affected
+      description: >-
+        Which agent CLIs this needs to work with. "All" is a valid answer, and
+        so is one.
+      placeholder: e.g. pi and Claude Code
+    validations:
+      required: false
+  - type: textarea
+    id: workaround
+    attributes:
+      label: What are you doing instead?
+      description: >-
+        The workaround, if you have one. It tells a reviewer how urgent this is
+        and often shows the shape the real fix should take.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feat.yml
+++ b/.github/ISSUE_TEMPLATE/feat.yml
@@ -4,6 +4,7 @@ description: >-
   existing one. The triage agent will label it and comment with a suggested
   plan.
 title: "feat: "
+labels: ["enhancement"]
 body:
   - type: dropdown
     id: area

--- a/.github/ISSUE_TEMPLATE/fix.yml
+++ b/.github/ISSUE_TEMPLATE/fix.yml
@@ -2,8 +2,8 @@ name: Something is broken
 description: >-
   A command, profile, adapter, or catalog resolution does not behave as
   documented. The triage agent will label it and comment with a suggested plan.
-title: "fix: "
-labels: ["bug"]
+title: 'fix: '
+labels: ['bug']
 body:
   - type: dropdown
     id: area

--- a/.github/ISSUE_TEMPLATE/fix.yml
+++ b/.github/ISSUE_TEMPLATE/fix.yml
@@ -3,6 +3,7 @@ description: >-
   A command, profile, adapter, or catalog resolution does not behave as
   documented. The triage agent will label it and comment with a suggested plan.
 title: "fix: "
+labels: ["bug"]
 body:
   - type: dropdown
     id: area

--- a/.github/ISSUE_TEMPLATE/fix.yml
+++ b/.github/ISSUE_TEMPLATE/fix.yml
@@ -1,0 +1,71 @@
+name: Something is broken
+description: >-
+  A command, profile, adapter, or catalog resolution does not behave as
+  documented. The triage agent will label it and comment with a suggested plan.
+title: "fix: "
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Where does it break?
+      options:
+        - Command (run, sync, setup, link, other)
+        - Profile composition or resolution
+        - Catalog sources (github, path, transitive)
+        - Harness adapter (pi, Claude Code, Codex, other)
+        - settings.yml parsing or precedence
+        - Documentation is wrong or out of date
+        - Something else
+    validations:
+      required: true
+  - type: input
+    id: command
+    attributes:
+      label: Command you ran
+      description: The full command, including flags.
+      placeholder: e.g. outfitter run sdlc-planner --profile reviewer
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `outfitter --version`. Say "from source" plus the commit if you built it.
+      placeholder: e.g. 1.5.0
+    validations:
+      required: true
+  - type: input
+    id: harness
+    attributes:
+      label: Harness and version
+      description: Which agent CLI it launched, if the failure involves one.
+      placeholder: e.g. pi 0.4.2, or Claude Code 2.1.0
+    validations:
+      required: false
+  - type: textarea
+    id: expected
+    attributes:
+      label: What should happen?
+      description: >-
+        If a numbered requirement covers this, quote it — `OFTR-NNN.M`. An
+        issue that names the obligation it breaks is one nobody has to
+        adjudicate first.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What happens instead?
+      description: Include the error output verbatim, not a paraphrase.
+    validations:
+      required: true
+  - type: textarea
+    id: settings
+    attributes:
+      label: Relevant settings
+      description: >-
+        The part of your `settings.yml` or profile that reproduces it. Redact
+        tokens and private source URLs — never paste a credential here.
+      render: yaml
+    validations:
+      required: false


### PR DESCRIPTION
Outfitter had no issue templates, so every incoming issue arrived as prose and a triage agent had to infer the command, the version, the harness, and whether a stated requirement was involved.

A template makes the issue body a **typed form** — the field ids are a schema, which turns triage from guessing at prose into reading named values. That is the prerequisite `link report` now names before it recommends running a triage agent at all, and this repository was not meeting it.

## What's here

| File | Purpose |
| --- | --- |
| `feat.yml` | New capability or change — area, problem, proposal, related `OFTR-NNN.M`, harnesses, workaround |
| `fix.yml` | Something is broken — area, command, version, harness, expected, actual, settings |
| `config.yml` | Blank issues stay **enabled**, plus links to docs and requirements |

Named `feat` and `fix` after the conventional commit types and seeding the title prefix, matching `ai-outfitter/community-profiles`. Blank issues stay enabled because the triage agent can classify free-form issues too, and a template that blocks reporting is worse than prose.

Both forms ask for the related requirement, because a change that contradicts a stated obligation amends the requirement first — the field puts that in front of the reporter rather than leaving it to review.

## Verified

`link report` on this branch reads `issue_templates=2` (`config.yml` correctly excluded), so the signal the remediation names is the signal these files set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)