### PR TITLE
fix: track the action's v1 tag instead of a commit

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: ai-outfitter/actions@75ad9d37b968a8af76e15fac4d708a01dd802066
+      - uses: ai-outfitter/actions@v1
         id: agent
         with:
           # Fallback when no `agent:<slug>` label routes the issue.


### PR DESCRIPTION
Triage fails with `Unknown agent 'actions-agent'` on the pinned commit.

`75ad9d3` predates [actions#34](https://github.com/ai-outfitter/actions/pull/34): it writes `~/.outfitter/settings.yml`, the path settings occupied before they moved into the `.agents` tree (OFTR-002.1). The CLI reads `~/.agents/settings.yml`, so `outfitter sync` reported `No remote sources are configured` against a file the action had just written and printed.

Fixed in **actions v1.2.1**, which the floating `v1` tag now points at. Pinning `@v1` rather than the new commit: a SHA pin on an action this org owns means every fix needs one PR per consumer — six, for this one-line bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)