### PR TITLE
fix: present a manual dispatch as the issues/opened it stands in for

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -68,8 +68,13 @@ jobs:
 
             trigger_context:
               repository: ${{ github.repository }}
-              event_name: ${{ github.event_name }}
-              event_action: ${{ github.event.action || '' }}
+              # A manual dispatch exists to triage an issue that was missed or
+              # needs re-running, so it presents the same routing metadata a
+              # fresh issue would. Passing `workflow_dispatch` here selects no
+              # skill: the agent declines with "not a supported issues/opened
+              # trigger" and the run reports success having done nothing.
+              event_name: ${{ github.event_name == 'workflow_dispatch' && 'issues' || github.event_name }}
+              event_action: ${{ github.event_name == 'workflow_dispatch' && 'opened' || github.event.action }}
               issue_number: ${{ github.event.issue.number || inputs.issue }}
               issue_author: ${{ github.event.issue.user.login || '' }}
         env:


### PR DESCRIPTION
A dispatched triage run reports **success** and does nothing:

> `No action taken: 'workflow_dispatch' is not a supported 'issues/opened' trigger, so no skill was selected and issue #270 was not triaged.`

The agent is right to decline — its skill routes on the trigger and it refused to improvise. The bug is what the workflow told it. `workflow_dispatch` exists here for exactly one purpose: triage an issue that was missed or needs re-running. So it should present the routing metadata a fresh issue would.

```yaml
event_name: ${{ github.event_name == 'workflow_dispatch' && 'issues' || github.event_name }}
event_action: ${{ github.event_name == 'workflow_dispatch' && 'opened' || github.event.action }}
```

Only the two routing fields are rewritten; `issue_number` and `issue_author` stay as they are, and a real `issues` event is untouched.

Found by dispatching against [outfitter#270](https://github.com/ai-outfitter/outfitter/issues/270) — the run was green, and no label was applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)