### PR TITLE
fix: tell the agent which labels this repository has

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -64,7 +64,8 @@ jobs:
             Handle this GitHub event using your system-prompt rules. Treat
             trigger_context as routing metadata, select only the relevant
             skill, then fetch the source material that skill needs with
-            trusted tools.
+            trusted tools. Apply exactly one label, chosen from
+            available_labels.
 
             trigger_context:
               repository: ${{ github.repository }}
@@ -77,6 +78,11 @@ jobs:
               event_action: ${{ github.event_name == 'workflow_dispatch' && 'opened' || github.event.action }}
               issue_number: ${{ github.event.issue.number || inputs.issue }}
               issue_author: ${{ github.event.issue.user.login || '' }}
+              # The labels this repository actually has. Without them the
+              # agent classifies into its own vocabulary (fix/feature/idea)
+              # and the apply is rejected: it triages correctly, comments,
+              # and lands no label.
+              available_labels: bug, enhancement, question, documentation
         env:
           # The provider config lives in the org catalog (ai-outfitter/.agents
           # models.json) and names this key by variable, so only the value is


### PR DESCRIPTION
Triage works; the label doesn't land. The agent reported the reason itself:

> `Triaged issue #270 as a fix and posted a detailed implementation plan; the 'fix' label could not be applied because it does not exist`

The triage skill classifies into `fix` / `feature` / `idea` — the vocabulary `community-profiles` and `actions` use. This repository has GitHub's defaults: `bug`, `enhancement`, `question`, `documentation`. Nothing told the agent that, so it applied a label that isn't here.

Passes `available_labels` in `trigger_context` and instructs the agent to choose exactly one from it. Each repository keeps its own vocabulary rather than having one imposed.

Verified on [#270](https://github.com/ai-outfitter/outfitter/issues/270): [run](https://github.com/ai-outfitter/outfitter/actions/runs/31526584384) is green, the comment is a correct classification with a plan, and `labels:` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)