### PR TITLE
feat(sources): fail on ambiguous resolution under --strict

### DIFF
--- a/code/cli/src/cli/commands/DumpCommand.ts
+++ b/code/cli/src/cli/commands/DumpCommand.ts
@@ -3,6 +3,7 @@
 import { Command } from 'commander';
 
 import { dumpAgent } from '../../dump/Dump.js';
+import { strictAmbiguityFailureMessage } from '../../resolver/AmbiguityWarnings.js';
 import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
 import type { Settings } from '../../settings/Settings.js';
 import type { CommandObject } from './CommandObject.js';
@@ -13,6 +14,7 @@ export interface DumpInput {
   readonly projectDirectory: string;
   readonly agent?: string;
   readonly out: string;
+  readonly strict?: boolean;
 }
 
 export interface DumpCommandResult {
@@ -40,13 +42,21 @@ const resolveAgentSlug = (settings: Settings, requested: string | undefined): st
 };
 
 export const executeDumpCommand = (input: DumpInput): DumpCommandResult => {
-  const { set, settings, settingsIssues, warnings } = resolveEffectiveSet(input);
+  const { set, settings, settingsIssues, warnings, ambiguityWarnings } = resolveEffectiveSet(input);
 
   if (settingsIssues.length > 0) {
     throw new Error(`Cannot dump with invalid settings: ${settingsIssues.map((issue) => issue.message).join('; ')}`);
   }
 
   const syncWarnings = warnings.map((warning) => `warning: ${warning}`);
+
+  if (input.strict === true && ambiguityWarnings.length > 0) {
+    return {
+      writtenPaths: [],
+      messages: [...syncWarnings, `error: ${strictAmbiguityFailureMessage}`],
+      ok: false,
+    };
+  }
 
   const agentSlug = resolveAgentSlug(settings, input.agent);
   const result = dumpAgent(set, agentSlug, input.out, input.projectDirectory);
@@ -71,13 +81,15 @@ export const createDumpCommand = (dependencies: DumpCommandDependencies = {}): C
         .description('Write the composed .agents tree for an agent to a directory.')
         .option('--agent <id>', 'Agent slug to dump (default: settings default_agent).')
         .option('--out <dir>', 'Output directory.', './outfitter-dump')
-        .action((options: { agent?: string; out: string }) => {
+        .option('--strict', 'Treat ambiguous source resolution as fatal.')
+        .action((options: { agent?: string; out: string; strict?: boolean }) => {
           const result = executeDumpCommand({
             /* v8 ignore next 2 -- process defaults are exercised by the CLI entrypoint, not unit tests. */
             homeDirectory: resolveHomeDirectory(dependencies.homeDirectory),
             projectDirectory: resolveProjectDirectory(dependencies.projectDirectory),
             agent: options.agent,
             out: options.out,
+            strict: options.strict,
           });
 
           for (const message of result.messages) {

--- a/code/cli/src/cli/commands/ListCommand.ts
+++ b/code/cli/src/cli/commands/ListCommand.ts
@@ -2,7 +2,8 @@
 
 import { Command } from 'commander';
 
-import type { ResourceKind } from '../../resolver/Resource.js';
+import { strictAmbiguityFailureMessage } from '../../resolver/AmbiguityWarnings.js';
+import type { EffectiveResourceSet, ResourceKind } from '../../resolver/Resource.js';
 import {
   agentLocalKinds,
   compareSlugs,
@@ -21,9 +22,11 @@ export interface ListInput {
   readonly projectDirectory: string;
   readonly kind?: string;
   readonly agent?: string;
+  readonly strict?: boolean;
 }
 
 export interface ListResult {
+  readonly exitCode: number;
   readonly messages: readonly string[];
 }
 
@@ -61,8 +64,14 @@ const resolveKindFilter = (kind: string | undefined): readonly ResourceKind[] =>
   return [resolved];
 };
 
+const assertKnownAgent = (set: EffectiveResourceSet, agent: string | undefined): void => {
+  if (agent !== undefined && findResource(set, 'agent', agent) === undefined) {
+    throw new Error(`Unknown agent '${agent}'. Run 'outfitter list agents' to see resolvable agents.`);
+  }
+};
+
 export const executeListCommand = (input: ListInput): ListResult => {
-  const { set, settingsIssues, warnings } = resolveEffectiveSet(input);
+  const { set, settingsIssues, warnings, ambiguityWarnings } = resolveEffectiveSet(input);
 
   if (settingsIssues.length > 0) {
     const detail = settingsIssues.map(formatSettingsIssue).join('; ');
@@ -71,9 +80,11 @@ export const executeListCommand = (input: ListInput): ListResult => {
 
   const messages: string[] = warnings.map((warning) => `warning: ${warning}`);
 
-  if (input.agent !== undefined && findResource(set, 'agent', input.agent) === undefined) {
-    throw new Error(`Unknown agent '${input.agent}'. Run 'outfitter list agents' to see resolvable agents.`);
+  if (input.strict === true && ambiguityWarnings.length > 0) {
+    return { exitCode: 1, messages: [...messages, `error: ${strictAmbiguityFailureMessage}`] };
   }
+
+  assertKnownAgent(set, input.agent);
 
   for (const kind of resolveKindFilter(input.kind)) {
     const hasAgentContext = input.agent !== undefined && agentLocalKinds.includes(kind);
@@ -97,7 +108,7 @@ export const executeListCommand = (input: ListInput): ListResult => {
     );
   }
 
-  return { messages };
+  return { exitCode: 0, messages };
 };
 
 export const createListCommand = (dependencies: ListCommandDependencies = {}): CommandObject => ({
@@ -108,23 +119,27 @@ export const createListCommand = (dependencies: ListCommandDependencies = {}): C
       new Command('list')
         .description('List resolvable resources (agents, skills, knowledge, commands).')
         .argument('[kind]', 'Restrict to one kind: agents, skills, knowledge, or commands.')
+        .option('--strict', 'Treat ambiguous source resolution as fatal.')
         .option(
           '--agent <id>',
           'Resolve resources in an agent context, including its agent-local skills/knowledge/commands.',
         )
-        .action((kind: string | undefined, options: { agent?: string }) => {
+        .action((kind: string | undefined, options: { agent?: string; strict?: boolean }) => {
           const result = executeListCommand({
             /* v8 ignore next 2 -- process defaults are exercised by the CLI entrypoint, not unit tests. */
             homeDirectory: resolveHomeDirectory(dependencies.homeDirectory),
             projectDirectory: resolveProjectDirectory(dependencies.projectDirectory),
             kind,
             agent: options.agent,
+            strict: options.strict,
           });
 
           for (const message of result.messages) {
             /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
             (dependencies.writeLine ?? console.log)(message);
           }
+
+          if (result.exitCode !== 0) process.exitCode = result.exitCode;
         }),
     );
   },

--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -24,6 +24,7 @@ import type { PiInstallSpawner } from '../../extensions/PiExtensionCache.js';
 import { resolveOutfitterCacheDir } from '../../paths/OutfitterCache.js';
 import { projectComposition } from '../../projection/ProjectHarness.js';
 import type { AgentLaunchPlan } from '../../projection/Projection.js';
+import { strictAmbiguityFailureMessage } from '../../resolver/AmbiguityWarnings.js';
 import { findResource } from '../../resolver/Resource.js';
 import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
 import type { Harness } from '../../settings/Settings.js';
@@ -214,6 +215,12 @@ const assertReadableAppendPrompts = (paths: readonly string[] | undefined): void
   }
 };
 
+const shouldRunSetup = (
+  input: RunAgentInput,
+  resolved: ReturnType<typeof resolveEffectiveSet>,
+): input is RunAgentInput & { readonly setup: NonNullable<RunAgentInput['setup']> } =>
+  input.agent === undefined && resolved.settings.defaultAgent === undefined && input.setup !== undefined;
+
 export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunAgentResult> => {
   // Flush messages to the terminal (before launch); they are also returned so callers can inspect them.
   const emit = (messages: readonly string[]): void => {
@@ -226,7 +233,7 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
 
   // First run: nothing selected and no default configured — onboard, then resolve again.
   const setupMessages: string[] = [];
-  if (input.agent === undefined && resolved.settings.defaultAgent === undefined && input.setup !== undefined) {
+  if (shouldRunSetup(input, resolved)) {
     const setupResult = await input.setup({
       homeDirectory: input.homeDirectory,
       projectDirectory: input.projectDirectory,
@@ -244,6 +251,12 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
   // surfaces its actionable `outfitter sync` guidance to both the terminal and programmatic callers,
   // not just a generic unknown-skill warning at composition (OFTR-004.6.10).
   const resolutionWarnings = resolved.warnings.map((warning) => `warning: ${warning}`);
+
+  if (input.strict === true && resolved.ambiguityWarnings.length > 0) {
+    const messages = [...setupMessages, ...resolutionWarnings, strictAmbiguityFailureMessage];
+    emit(messages);
+    return { exitCode: 1, messages };
+  }
 
   const { set, settings } = resolved;
   const agentSlug = resolveAgentSlug(settings.defaultAgent, input.agent);
@@ -339,7 +352,7 @@ export const createRunAgentCommand = (dependencies: RunAgentDependencies = {}): 
       .argument('[agent]', 'Agent slug to run (default: settings default_agent).')
       .argument('[args...]', 'Arguments passed through to the harness after --.')
       .addOption(new Option('--harness <harness>', 'Harness to launch.').choices([...HARNESSES]))
-      .option('--strict', 'Treat composition warnings and unsupported loadout elements as fatal.')
+      .option('--strict', 'Treat ambiguity, composition warnings, and unsupported loadout elements as fatal.')
       .option(
         '--append-prompt <path>',
         'Append a Markdown document to the system prompt. Repeatable; applied in the order given.',

--- a/code/cli/src/cli/commands/SyncCommand.ts
+++ b/code/cli/src/cli/commands/SyncCommand.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs';
 
 import { Command } from 'commander';
 
+import { strictAmbiguityFailureMessage } from '../../resolver/AmbiguityWarnings.js';
 import { remoteSourceLayer } from '../../resolver/Layer.js';
 import { resolveResources } from '../../resolver/Resolver.js';
 import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
@@ -58,6 +59,7 @@ export interface SyncCommandResult {
 export interface SyncCommandInput {
   readonly homeDirectory: string;
   readonly projectDirectory: string;
+  readonly strict?: boolean;
 }
 
 /** Fetches one repository into the cache. Injectable so tests exercise the closure hermetically. */
@@ -352,8 +354,17 @@ export const executeSyncCommand = (
     sourcePhase,
   });
   const result = finishSync(merged.issues, remoteSettingsPhase, sourcePhase, transitiveClosure);
-  const ambiguityWarnings = resolveEffectiveSet(input).ambiguityWarnings.map((warning) => `warning: ${warning}`);
-  return { ...result, messages: [...result.messages, ...ambiguityWarnings] };
+  const ambiguityWarnings = resolveEffectiveSet(input).ambiguityWarnings;
+  const strictFailure = input.strict === true && ambiguityWarnings.length > 0;
+  return {
+    ...result,
+    exitCode: strictFailure ? 1 : result.exitCode,
+    messages: [
+      ...result.messages,
+      ...ambiguityWarnings.map((warning) => `warning: ${warning}`),
+      ...(strictFailure ? [`failed: ${strictAmbiguityFailureMessage}`] : []),
+    ],
+  };
 };
 
 export const createSyncCommand = (dependencies: SyncCommandDependencies = {}): CommandObject => ({
@@ -363,11 +374,13 @@ export const createSyncCommand = (dependencies: SyncCommandDependencies = {}): C
     program.addCommand(
       new Command('sync')
         .description('Synchronize configured remote settings and sources into the local cache.')
-        .action(() => {
+        .option('--strict', 'Treat ambiguous source resolution as fatal.')
+        .action((options: { strict?: boolean }) => {
           const result = executeSyncCommand(
             {
               homeDirectory: resolveHomeDirectory(dependencies.homeDirectory),
               projectDirectory: resolveProjectDirectory(dependencies.projectDirectory),
+              strict: options.strict,
             },
             dependencies,
           );

--- a/code/cli/src/cli/commands/ValidateCommand.ts
+++ b/code/cli/src/cli/commands/ValidateCommand.ts
@@ -67,7 +67,7 @@ export const createValidateCommand = (dependencies: ValidateCommandDependencies 
     program.addCommand(
       new Command('validate')
         .description('Validate the resolved .agents tree: schemas, loadout slugs, and shadowing.')
-        .option('--strict', 'Treat warnings (such as shadowed definitions) as failures.')
+        .option('--strict', 'Treat warnings, including ambiguous source resolution, as failures.')
         .option('--json', 'Emit findings as JSON.')
         .action((options: { strict?: boolean; json?: boolean }) => {
           /* v8 ignore next 2 -- process defaults are exercised by the CLI entrypoint, not unit tests. */

--- a/code/cli/src/resolver/AmbiguityWarnings.ts
+++ b/code/cli/src/resolver/AmbiguityWarnings.ts
@@ -17,6 +17,8 @@ interface SourceDeclaration {
   readonly declaredBy: string;
 }
 
+export const strictAmbiguityFailureMessage = 'Strict mode: ambiguous resolution is fatal.';
+
 const repositoryKey = (source: RemoteSourceReference): string =>
   redactSourceUriCredentials(normalizeGitUri(normalizeRemoteSourceUri(source)));
 

--- a/code/cli/tests/unit/ambiguity-warnings.test.ts
+++ b/code/cli/tests/unit/ambiguity-warnings.test.ts
@@ -2,11 +2,13 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
+import { Command } from 'commander';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { executeListCommand } from '../../src/cli/commands/ListCommand.js';
+import { createDumpCommand } from '../../src/cli/commands/DumpCommand.js';
+import { createListCommand, executeListCommand } from '../../src/cli/commands/ListCommand.js';
 import { executeRunAgentCommand } from '../../src/cli/commands/RunAgentCommand.js';
-import { executeSyncCommand } from '../../src/cli/commands/SyncCommand.js';
+import { createSyncCommand, executeSyncCommand } from '../../src/cli/commands/SyncCommand.js';
 import { executeValidateCommand } from '../../src/cli/commands/ValidateCommand.js';
 import { findResource } from '../../src/resolver/Resource.js';
 import { resolveEffectiveSet } from '../../src/resolver/ResolverContext.js';
@@ -32,7 +34,19 @@ const resource = (root: string, kind: 'agents' | 'skills', slug: string): void =
 const resolve = (root: string) =>
   resolveEffectiveSet({ homeDirectory: join(root, 'home'), projectDirectory: join(root, 'project') });
 
+const runnableAgent = (root: string): void => resource(join(root, 'project', '.agents'), 'agents', 'engineer');
+
+const run = (root: string, strict: boolean) =>
+  executeRunAgentCommand({
+    homeDirectory: join(root, 'home'),
+    projectDirectory: join(root, 'project'),
+    agent: 'engineer',
+    strict,
+    launcher: () => Promise.resolve(0),
+  });
+
 afterEach(() => {
+  process.exitCode = undefined;
   for (const root of temporaryRoots.splice(0)) {
     rmSync(root, { recursive: true, force: true });
   }
@@ -170,5 +184,216 @@ describe('ambiguous source resolution warnings', () => {
     expect(warnings[0]).toContain("source 'github:acme/catalog'");
     expect(warnings[0]).toContain(join(root, 'home', '.agents', 'settings.yml'));
     expect(warnings[0]).toContain(join(root, 'project', '.agents', 'settings.yml'));
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.7.1, OFTR-004.7.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('makes a source ref conflict fatal for run under strict mode', async () => {
+    const root = createTemporaryRoot();
+    runnableAgent(root);
+    write(
+      join(root, 'project', '.agents', 'settings.yml'),
+      'sources:\n  - github: acme/catalog\n    ref: v1\n  - github: acme/catalog\n    ref: v2\n',
+    );
+
+    const result = await run(root, true);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(
+      result.messages.some((message) => message.includes("Ambiguous source repository 'github:acme/catalog'")),
+    ).toBe(true);
+    expect(result.messages.at(-1)).toBe('Strict mode: ambiguous resolution is fatal.');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.7.3, OFTR-004.7.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('makes a supplier slug collision fatal for run under strict mode', async () => {
+    const root = createTemporaryRoot();
+    const first = join(root, 'first');
+    const second = join(root, 'second');
+    runnableAgent(root);
+    resource(first, 'skills', 'shared');
+    resource(second, 'skills', 'shared');
+    write(join(root, 'project', '.agents', 'settings.yml'), `sources:\n  - path: ${first}\n  - path: ${second}\n`);
+
+    const result = await run(root, true);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.messages.some((message) => message.includes("Ambiguous skill slug 'shared'"))).toBe(true);
+    expect(result.messages.at(-1)).toBe('Strict mode: ambiguous resolution is fatal.');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.7.2, OFTR-004.7.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('makes a dropped-source replacement fatal for run under strict mode', async () => {
+    const root = createTemporaryRoot();
+    runnableAgent(root);
+    write(join(root, 'home', '.agents', 'settings.yml'), 'sources:\n  - github: acme/user-catalog\n');
+    write(join(root, 'project', '.agents', 'settings.yml'), 'sources: []\n');
+
+    const result = await run(root, true);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.messages.some((message) => message.includes("source 'github:acme/user-catalog'"))).toBe(true);
+    expect(result.messages.at(-1)).toBe('Strict mode: ambiguous resolution is fatal.');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.7.4, OFTR-004.7.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('gates ambiguity in strict sync, validate, and list while a clean strict configuration succeeds', async () => {
+    const ambiguousRoot = createTemporaryRoot();
+    const first = join(ambiguousRoot, 'first');
+    const second = join(ambiguousRoot, 'second');
+    resource(first, 'skills', 'shared');
+    resource(second, 'skills', 'shared');
+    write(
+      join(ambiguousRoot, 'project', '.agents', 'settings.yml'),
+      `sources:\n  - path: ${first}\n  - path: ${second}\n`,
+    );
+    const ambiguousInput = {
+      homeDirectory: join(ambiguousRoot, 'home'),
+      projectDirectory: join(ambiguousRoot, 'project'),
+      strict: true,
+    };
+
+    expect(executeSyncCommand(ambiguousInput).exitCode).not.toBe(0);
+    expect(executeValidateCommand(ambiguousInput).ok).toBe(false);
+    expect(executeListCommand({ ...ambiguousInput, kind: 'agents' }).exitCode).not.toBe(0);
+
+    const cleanRoot = createTemporaryRoot();
+    runnableAgent(cleanRoot);
+    const cleanInput = {
+      homeDirectory: join(cleanRoot, 'home'),
+      projectDirectory: join(cleanRoot, 'project'),
+      strict: true,
+    };
+
+    expect(executeSyncCommand(cleanInput).exitCode).toBe(0);
+    expect(executeValidateCommand(cleanInput).ok).toBe(true);
+    expect(executeListCommand({ ...cleanInput, kind: 'agents' }).exitCode).toBe(0);
+    expect((await run(cleanRoot, true)).exitCode).toBe(0);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.7.4, OFTR-004.7.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('accepts --strict through the sync and list command-line interfaces', async () => {
+    const root = createTemporaryRoot();
+    const first = join(root, 'first');
+    const second = join(root, 'second');
+    resource(first, 'skills', 'shared');
+    resource(second, 'skills', 'shared');
+    write(join(root, 'project', '.agents', 'settings.yml'), `sources:\n  - path: ${first}\n  - path: ${second}\n`);
+    const lines: string[] = [];
+    const dependencies = {
+      homeDirectory: join(root, 'home'),
+      projectDirectory: join(root, 'project'),
+      writeLine: (message: string) => lines.push(message),
+    };
+
+    const syncProgram = new Command();
+    createSyncCommand(dependencies).register(syncProgram);
+    await syncProgram.parseAsync(['node', 'outfitter', 'sync', '--strict']);
+    expect(process.exitCode).toBe(1);
+    expect(lines.at(-1)).toBe('failed: Strict mode: ambiguous resolution is fatal.');
+
+    process.exitCode = undefined;
+    lines.length = 0;
+    const listProgram = new Command();
+    createListCommand(dependencies).register(listProgram);
+    await listProgram.parseAsync(['node', 'outfitter', 'list', 'agents', '--strict']);
+    expect(process.exitCode).toBe(1);
+    expect(lines.at(-1)).toBe('error: Strict mode: ambiguous resolution is fatal.');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.7.4, OFTR-004.7.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('gates dump ambiguity under --strict while keeping it advisory by default', async () => {
+    const root = createTemporaryRoot();
+    const first = join(root, 'first');
+    const second = join(root, 'second');
+    resource(first, 'agents', 'engineer');
+    resource(second, 'agents', 'engineer');
+    write(join(root, 'project', '.agents', 'settings.yml'), `sources:\n  - path: ${first}\n  - path: ${second}\n`);
+    const lines: string[] = [];
+    const dependencies = {
+      homeDirectory: join(root, 'home'),
+      projectDirectory: join(root, 'project'),
+      writeLine: (message: string) => lines.push(message),
+    };
+
+    const strictProgram = new Command();
+    createDumpCommand(dependencies).register(strictProgram);
+    await strictProgram.parseAsync([
+      'node',
+      'outfitter',
+      'dump',
+      '--agent',
+      'engineer',
+      '--out',
+      join(root, 'strict-dump'),
+      '--strict',
+    ]);
+    expect(process.exitCode).toBe(1);
+    expect(lines.some((message) => message.includes("Ambiguous agent slug 'engineer'"))).toBe(true);
+    expect(lines.at(-1)).toBe('error: Strict mode: ambiguous resolution is fatal.');
+
+    process.exitCode = undefined;
+    lines.length = 0;
+    const advisoryProgram = new Command();
+    createDumpCommand(dependencies).register(advisoryProgram);
+    await advisoryProgram.parseAsync([
+      'node',
+      'outfitter',
+      'dump',
+      '--agent',
+      'engineer',
+      '--out',
+      join(root, 'advisory-dump'),
+    ]);
+    expect(process.exitCode).toBeUndefined();
+    expect(lines.some((message) => message.includes("Ambiguous agent slug 'engineer'"))).toBe(true);
+    expect(lines.some((message) => message.startsWith("Dumped 'engineer'"))).toBe(true);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.7.4, OFTR-004.7.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('keeps ambiguity advisory outside strict mode', async () => {
+    const root = createTemporaryRoot();
+    runnableAgent(root);
+    write(join(root, 'home', '.agents', 'settings.yml'), 'sources:\n  - github: acme/user-catalog\n');
+    write(join(root, 'project', '.agents', 'settings.yml'), 'sources: []\n');
+
+    const result = await run(root, false);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.messages.some((message) => message.includes("source 'github:acme/user-catalog'"))).toBe(true);
+    expect(result.messages).not.toContain('Strict mode: ambiguous resolution is fatal.');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.7.1, OFTR-004.7.2, OFTR-004.7.3, OFTR-004.7.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('reports every ambiguity before strict mode fails', async () => {
+    const root = createTemporaryRoot();
+    const first = join(root, 'first');
+    const second = join(root, 'second');
+    runnableAgent(root);
+    resource(first, 'skills', 'shared');
+    resource(second, 'skills', 'shared');
+    write(join(root, 'home', '.agents', 'settings.yml'), 'sources:\n  - github: acme/dropped\n');
+    write(
+      join(root, 'project', '.agents', 'settings.yml'),
+      `sources:\n  - github: acme/catalog\n    ref: v1\n  - github: acme/catalog\n    ref: v2\n  - path: ${first}\n  - path: ${second}\n`,
+    );
+
+    const result = await run(root, true);
+    const failureIndex = result.messages.indexOf('Strict mode: ambiguous resolution is fatal.');
+    const ambiguityIndexes = [
+      result.messages.findIndex((message) => message.includes("source 'github:acme/dropped'")),
+      result.messages.findIndex((message) => message.includes("Ambiguous source repository 'github:acme/catalog'")),
+      result.messages.findIndex((message) => message.includes("Ambiguous skill slug 'shared'")),
+    ];
+
+    expect(ambiguityIndexes.every((index) => index >= 0 && index < failureIndex)).toBe(true);
+    expect(failureIndex).toBe(result.messages.length - 1);
   });
 });

--- a/docs/requirements/OFTR-004-sync-and-setup.md
+++ b/docs/requirements/OFTR-004-sync-and-setup.md
@@ -179,3 +179,7 @@ disagree about the same thing, the selected declaration must be visible.
 4. These warnings MUST be surfaced by every command that resolves the effective set, including
    `sync`, `validate`, `list agents`, and `run`, not only by a dedicated diagnostic.
 5. Detection MUST NOT change which declaration wins; precedence rules are unchanged.
+6. Under strict mode, every command that resolves the effective set MUST report every detected
+   ambiguity and then fail with a nonzero exit status. All three ambiguity classes above gate
+   uniformly. A deliberate divergence under strict mode MUST be resolved by making the
+   configuration unambiguous, not by suppressing the error.


### PR DESCRIPTION
Follow-up to #287: under strict mode, an ambiguous resolution is an error, not a printed line above the wrong answer.

Adds OFTR-004.7.6 with pinned tests: a command that resolves the effective set must report **every** detected ambiguity and then exit nonzero — report-all-then-fail, not fail-fast. All three ambiguity classes from #287 gate uniformly; a deliberate divergence under strict is resolved by making the configuration unambiguous.

- `run --strict` and `validate --strict` extend their existing strict semantics (OFTR-005.3.4 composition strictness is untouched — verified byte-identical and downstream of the new gate).
- `sync`, `list`, and `dump` gain `--strict` with the same semantic.

Adversarial review (empirical, against the built CLI): the wiki-incident shape — a project pin replacing the org-catalog declaration — exits 1 under `list agents --strict` after naming the dropped catalog, exits 0 with the warning without the flag, and a clean configuration passes strict on every command. The review's one refutation (`dump` resolved the effective set but had no strict path, contradicting the requirement's "every command that resolves") is fixed with its own pinned tests.

This is the negative half of the "one pin per source" milestone demo: a deliberately conflicting pin now fails instead of resolving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)