### PR TITLE
chore(deps): bump the default catalog to default-profiles v1.1.1

### DIFF
--- a/code/cli/src/setup/DefaultCatalog.ts
+++ b/code/cli/src/setup/DefaultCatalog.ts
@@ -21,7 +21,7 @@ export const defaultCatalogSource = {
   github: 'ai-outfitter/default-profiles',
   // TODO(release-automation): when default-profiles publishes a new Release Please tag, open a
   // conventional dependency-bump commit in Outfitter so its next Release Please release ships it.
-  ref: 'v1.1.0',
+  ref: 'v1.1.1',
 } as const satisfies RemoteSourceReference;
 
 export interface PinnedCatalogBootstrapInput {

--- a/code/cli/tests/unit/default-catalog.test.ts
+++ b/code/cli/tests/unit/default-catalog.test.ts
@@ -45,7 +45,7 @@ describe('default catalog bootstrap', () => {
   it('ships the canonical catalog at one immutable Release Please tag', () => {
     expect(defaultCatalogSource).toEqual({
       github: 'ai-outfitter/default-profiles',
-      ref: 'v1.1.0',
+      ref: 'v1.1.1',
     });
   });
 


### PR DESCRIPTION
default-profiles v1.1.1 dropped the `actions-agent`/`platform` agents that duplicated community-profiles' slugs and re-pinned its cp source to v1.2.1. Per DefaultCatalog.ts's own TODO, this moves the first-run bootstrap pin so new users fetch the deduplicated catalog. OFTR-004.6.10 pinned tests untouched (they pin the repo name; fixtures carry their own refs) — 501 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)