### PR TITLE
fix: quiet successful profile startup

### DIFF
--- a/code/cli/src/cli/commands/PiRuntimeLaunch.ts
+++ b/code/cli/src/cli/commands/PiRuntimeLaunch.ts
@@ -19,7 +19,6 @@ export interface PiRuntimeProfileIdentity {
 }
 
 export interface PiRuntimeExtensionInput {
-  readonly outfitterVersion: string;
   readonly profile?: PiRuntimeProfileIdentity;
   readonly rootDirectory: string;
 }
@@ -38,9 +37,10 @@ export const createPiRuntimeExtensionContent = (input: Omit<PiRuntimeExtensionIn
   /* v8 ignore next -- defensive: the runtime extension ships with the package, so it resolves in practice. */
   if (extensionPath === undefined) throw new Error('Outfitter runtime extension was not found.');
 
-  return readFileSync(extensionPath, 'utf8')
-    .replace(/["']__OUTFITTER_VERSION__["']/gu, JSON.stringify(input.outfitterVersion))
-    .replace(/["']__OUTFITTER_ACTIVE_PROFILE__["']/gu, JSON.stringify(input.profile) ?? 'undefined');
+  return readFileSync(extensionPath, 'utf8').replace(
+    /["']__OUTFITTER_ACTIVE_PROFILE__["']/gu,
+    JSON.stringify(input.profile) ?? 'undefined',
+  );
 };
 
 /**

--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -31,7 +31,6 @@ import type { Harness } from '../../settings/Settings.js';
 import { HARNESSES } from '../../settings/Settings.js';
 import type { SetupResult } from '../../setup/Setup.js';
 import { attachSystemExtensionHooks } from '../../system/SystemExtensionHook.js';
-import { readOutfitterVersion } from '../../version/OutfitterVersion.js';
 import type { CommandObject } from './CommandObject.js';
 import { attachPiRuntimeExtension } from './PiRuntimeLaunch.js';
 import { resolveHomeDirectory, resolveProjectDirectory } from './ProcessDefaults.js';
@@ -221,6 +220,27 @@ const shouldRunSetup = (
 ): input is RunAgentInput & { readonly setup: NonNullable<RunAgentInput['setup']> } =>
   input.agent === undefined && resolved.settings.defaultAgent === undefined && input.setup !== undefined;
 
+const resolutionWarningsForRun = (
+  resolved: ReturnType<typeof resolveEffectiveSet>,
+  strict: boolean | undefined,
+): readonly string[] => (strict === true ? resolved.warnings.map((warning) => `warning: ${warning}`) : []);
+
+const failedCompositionMessages = (
+  resolved: ReturnType<typeof resolveEffectiveSet>,
+  agentSlug: string,
+  composed: ReturnType<typeof compose>,
+): readonly string[] => {
+  const unknownAgent = composed.errors.some((error) => error.includes(`Unknown agent '${agentSlug}'`));
+  const unsynchronizedSource = resolved.warnings.some((warning) => warning.includes('is not synchronized'));
+  if (!unknownAgent || !unsynchronizedSource) return [...composed.warnings, ...composed.errors];
+
+  return [
+    ...composed.warnings,
+    `Agent '${agentSlug}' is not ready. Run 'outfitter sync', then try again.`,
+    ...composed.errors.filter((error) => !error.includes('Unknown agent')),
+  ];
+};
+
 export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunAgentResult> => {
   // Flush messages to the terminal (before launch); they are also returned so callers can inspect them.
   const emit = (messages: readonly string[]): void => {
@@ -232,7 +252,6 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
   assertReadableAppendPrompts(input.appendPromptPaths);
 
   // First run: nothing selected and no default configured — onboard, then resolve again.
-  const setupMessages: string[] = [];
   if (shouldRunSetup(input, resolved)) {
     const setupResult = await input.setup({
       homeDirectory: input.homeDirectory,
@@ -240,20 +259,18 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
     });
 
     if (setupResult !== undefined) {
-      setupMessages.push(...setupResult.messages);
+      // Keep the transition quiet so the real profile UI is the first persistent output.
       resolved = resolveEffectiveSet(input);
       assertNoSettingsIssues(resolved.settingsIssues);
     }
   }
 
-  // Warnings from the FINAL resolved state (after any onboarding), folded into every returned message
-  // array after the setup notices — so a dependency that best-effort bootstrap could not fetch
-  // surfaces its actionable `outfitter sync` guidance to both the terminal and programmatic callers,
-  // not just a generic unknown-skill warning at composition (OFTR-004.6.10).
-  const resolutionWarnings = resolved.warnings.map((warning) => `warning: ${warning}`);
+  // Strict mode exposes the complete final resolution state. Normal startup uses these diagnostics
+  // only to turn an unavailable selected agent into a concise synchronization action.
+  const resolutionWarnings = resolutionWarningsForRun(resolved, input.strict);
 
   if (input.strict === true && resolved.ambiguityWarnings.length > 0) {
-    const messages = [...setupMessages, ...resolutionWarnings, strictAmbiguityFailureMessage];
+    const messages = [...resolutionWarnings, strictAmbiguityFailureMessage];
     emit(messages);
     return { exitCode: 1, messages };
   }
@@ -264,7 +281,7 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
   const composed = compose(set, agentSlug, { projectDirectory: input.projectDirectory });
 
   if (composed.plan === undefined) {
-    const messages = [...setupMessages, ...resolutionWarnings, ...composed.warnings, ...composed.errors];
+    const messages = [...resolutionWarnings, ...failedCompositionMessages(resolved, agentSlug, composed)];
     emit(messages);
     return { exitCode: 1, messages };
   }
@@ -300,7 +317,6 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
 
     if (input.strict === true && warnings.length > 0) {
       const messages = [
-        ...setupMessages,
         ...resolutionWarnings,
         ...warnings,
         'Strict mode: composition warnings and unsupported elements are fatal.',
@@ -309,14 +325,13 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
       return { exitCode: 1, messages };
     }
 
-    // Emit setup notices, resolution warnings, and composition warnings before launch so they precede
-    // the pi session on the terminal (and are returned to programmatic callers).
-    const messages = [...setupMessages, ...resolutionWarnings, ...warnings];
+    // Normal startup stays quiet. Strict mode retains the complete resolution diagnostics, while
+    // composition/projection warnings stay visible because they describe a degraded launch.
+    const messages = [...resolutionWarnings, ...warnings];
     emit(messages);
 
     // Attach the Outfitter runtime UI and sign-in extension to interactive pi sessions.
     const launch = attachPiRuntimeExtension(projection.launch, {
-      outfitterVersion: readOutfitterVersion(),
       profile: { id: agentSlug, label: composed.plan.identity.label },
       rootDirectory,
     });

--- a/code/cli/src/cli/commands/SetupCommand.ts
+++ b/code/cli/src/cli/commands/SetupCommand.ts
@@ -237,7 +237,6 @@ const autoLaunchSelectedProfile = async (
 ): Promise<void> => {
   if (result.defaultAgent === undefined) return;
 
-  writeLine(`Starting '${result.defaultAgent}' in ${result.defaultHarness}…`);
   const runResult = await executeRunAgentCommand({
     homeDirectory: resolveHomeDirectory(dependencies.homeDirectory),
     projectDirectory: resolve(resolveProjectDirectory(dependencies.projectDirectory)),
@@ -265,7 +264,11 @@ export const createSetupCommand = (dependencies: SetupCommandDependencies = {}):
             writeLine('Outfitter setup made no changes. Run it from an interactive terminal to configure .agents.');
             return;
           }
-          for (const message of result.messages) writeLine(message);
+          // Concrete profile selections launch immediately, so their profile UI is the success
+          // confirmation. Setups that still need sync retain their actionable filesystem notices.
+          if (result.defaultAgent === undefined) {
+            for (const message of result.messages) writeLine(message);
+          }
           await autoLaunchSelectedProfile(dependencies, result, writeLine);
         }),
     );

--- a/code/cli/src/projection/Materialize.ts
+++ b/code/cli/src/projection/Materialize.ts
@@ -1,5 +1,14 @@
 // Materializes a CompositionPlan into a runtime configuration directory the harness launches from.
-import { copyFileSync, lstatSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { dirname, join } from 'node:path';
 
 import type { ComposedSubagent, CompositionPlan } from '../composer/Composition.js';
@@ -73,6 +82,27 @@ export const materializeConfigurationOverlays = (sourceDirectories: readonly str
     if (lstatSync(sourceDirectory).isSymbolicLink()) continue;
     copyDirectory(sourceDirectory, rootDirectory);
   }
+};
+
+/** Adds Outfitter's quiet Pi startup default without overriding an explicit profile choice. */
+export const applyPiRuntimeDefaults = (rootDirectory: string): void => {
+  const settingsPath = join(rootDirectory, 'settings.json');
+  if (!existsSync(settingsPath)) {
+    writeGeneratedFile(settingsPath, `${JSON.stringify({ quietStartup: true }, null, 2)}\n`);
+    return;
+  }
+
+  let settings: unknown;
+  try {
+    settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as unknown;
+  } catch {
+    // Preserve invalid native configuration so Pi can report it through its normal diagnostics.
+    return;
+  }
+  if (typeof settings !== 'object' || settings === null || Array.isArray(settings)) return;
+  if ('quietStartup' in settings) return;
+
+  writeGeneratedFile(settingsPath, `${JSON.stringify({ ...settings, quietStartup: true }, null, 2)}\n`);
 };
 
 const materializeSkill = (skill: ResolvedResource, rootDirectory: string): string | undefined => {

--- a/code/cli/src/projection/ProjectHarness.ts
+++ b/code/cli/src/projection/ProjectHarness.ts
@@ -6,7 +6,7 @@ import type { CompositionPlan } from '../composer/Composition.js';
 import type { Harness } from '../settings/Settings.js';
 import { projectCodexMcpServers } from './CodexMcp.js';
 import type { MaterializedComposition } from './Materialize.js';
-import { materializeComposition, materializeConfigurationOverlays } from './Materialize.js';
+import { applyPiRuntimeDefaults, materializeComposition, materializeConfigurationOverlays } from './Materialize.js';
 import type { AgentLaunchPlan, AgentProjectionPlan, ProjectionInput } from './Projection.js';
 import { toolArgs } from './Tools.js';
 
@@ -173,6 +173,7 @@ const buildPiOrClaudeLaunchPlan = (
 export const projectComposition = (composition: CompositionPlan, input: ProjectionInput): AgentProjectionPlan => {
   if (input.harness === 'pi') {
     materializeConfigurationOverlays(input.configurationOverlayDirectories ?? [], input.rootDirectory);
+    applyPiRuntimeDefaults(input.rootDirectory);
   }
   // Materialization runs for every harness so containment and definition diagnostics are reported
   // uniformly. Codex reads none of the generated files — it takes its MCP config in argv and has no

--- a/code/cli/tests/unit/ambiguity-warnings.test.ts
+++ b/code/cli/tests/unit/ambiguity-warnings.test.ts
@@ -134,7 +134,7 @@ describe('ambiguous source resolution warnings', () => {
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.7.4).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('surfaces ambiguity warnings from sync, validate, list agents, and run', async () => {
+  it('surfaces ambiguity warnings in diagnostic commands and keeps normal run quiet', async () => {
     const root = createTemporaryRoot();
     const winner = join(root, 'catalog-one');
     const shadowed = join(root, 'catalog-two');
@@ -152,7 +152,7 @@ describe('ambiguous source resolution warnings', () => {
       agent: 'actions-agent',
       launcher: () => Promise.resolve(0),
     });
-    expect(run.messages.some(isAmbiguityWarning)).toBe(true);
+    expect(run.messages.some(isAmbiguityWarning)).toBe(false);
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.7.1, OFTR-004.7.3).
@@ -357,7 +357,7 @@ describe('ambiguous source resolution warnings', () => {
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.7.4, OFTR-004.7.6).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('keeps ambiguity advisory outside strict mode', async () => {
+  it('suppresses ambiguity diagnostics outside strict mode', async () => {
     const root = createTemporaryRoot();
     runnableAgent(root);
     write(join(root, 'home', '.agents', 'settings.yml'), 'sources:\n  - github: acme/user-catalog\n');
@@ -366,7 +366,7 @@ describe('ambiguous source resolution warnings', () => {
     const result = await run(root, false);
 
     expect(result.exitCode).toBe(0);
-    expect(result.messages.some((message) => message.includes("source 'github:acme/user-catalog'"))).toBe(true);
+    expect(result.messages.some((message) => message.includes("source 'github:acme/user-catalog'"))).toBe(false);
     expect(result.messages).not.toContain('Strict mode: ambiguous resolution is fatal.');
   });
 

--- a/code/cli/tests/unit/pi-runtime-extension.test.ts
+++ b/code/cli/tests/unit/pi-runtime-extension.test.ts
@@ -20,7 +20,6 @@ type Handler = (event: Record<string, unknown>, context: MockContext) => Promise
 type MockContext = ReturnType<typeof createMockContext>;
 
 interface RuntimeFixtureInput {
-  readonly outfitterVersion?: string;
   readonly profile?: PiRuntimeProfileIdentity;
 }
 
@@ -44,13 +43,8 @@ afterEach(() => {
 // Evaluates a stamped runtime extension in a sandbox with Pi's supported imports stubbed out.
 const evaluateRuntimeExtension = (input: RuntimeFixtureInput = {}): ((pi: MockPi) => void) => {
   const executable = createPiRuntimeExtensionContent({
-    outfitterVersion: input.outfitterVersion ?? '1.2.3',
     profile: input.profile,
   })
-    .replace(
-      /import \{ VERSION as PI_VERSION \} from ['"]@earendil-works\/pi-coding-agent['"];/u,
-      "const PI_VERSION = '0.80.3';",
-    )
     .replace(
       /import \{ Key, matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi \} from ['"]@earendil-works\/pi-tui['"];/u,
       [
@@ -149,29 +143,28 @@ const fireSessionStart = async (
 };
 
 describe('Pi runtime extension identity UI', () => {
-  it('shows both runtime versions and the active profile label', async () => {
+  it('shows one compact Outfitter and active profile header', async () => {
     const context = createMockContext({ models: [{ id: 'm' }] });
     await fireSessionStart(
       context,
       { reason: 'startup' },
       {
-        outfitterVersion: '1.2.3',
         profile: { id: 'engineer', label: 'Engineer' },
       },
     );
 
-    expect(context.header?.render(80)).toEqual(['Outfitter v1.2.3 + pi v0.80.3']);
-    expect(context.statuses['outfitter-profile']).toBe('profile: Engineer');
+    expect(context.header?.render(80)).toEqual(['Outfitter · Engineer']);
+    expect(context.statuses).toEqual({});
   });
 
-  it('falls back to the profile id and omits the status when no profile is stamped', async () => {
+  it('falls back to the profile id and shows only Outfitter when no profile is stamped', async () => {
     const fallbackContext = createMockContext({ models: [{ id: 'm' }] });
     await fireSessionStart(fallbackContext, { reason: 'startup' }, { profile: { id: 'engineer' } });
-    expect(fallbackContext.statuses['outfitter-profile']).toBe('profile: engineer');
+    expect(fallbackContext.header?.render(80)).toEqual(['Outfitter · engineer']);
 
     const absentContext = createMockContext({ models: [{ id: 'm' }] });
     await fireSessionStart(absentContext);
-    expect(absentContext.statuses['outfitter-profile']).toBeUndefined();
+    expect(absentContext.header?.render(80)).toEqual(['Outfitter']);
   });
 
   it('keeps the header within the terminal width and re-renders after invalidation', async () => {
@@ -182,7 +175,7 @@ describe('Pi runtime extension identity UI', () => {
     const narrow = header.render(20);
     expect(narrow.every((line) => line.length <= 20)).toBe(true);
     expect(header.render(20)).toBe(narrow);
-    expect(header.render()).toEqual(['Outfitter v1.2.3 + pi v0.80.3']);
+    expect(header.render()).toEqual(['Outfitter']);
     header.invalidate();
     expect(header.render(20)).not.toBe(narrow);
   });
@@ -227,14 +220,13 @@ describe('Pi runtime extension auto sign-in', () => {
     await fireSessionStart(context, { reason: 'reload' }, { profile: { id: 'engineer' } });
     expect(context.editorText).toBe('');
     expect(context.header).toBeDefined();
-    expect(context.statuses['outfitter-profile']).toBe('profile: engineer');
+    expect(context.header?.render(80)).toEqual(['Outfitter · engineer']);
   });
 });
 
 describe('attachPiRuntimeExtension', () => {
   const piPlan = (args: readonly string[] = []): AgentLaunchPlan => ({ command: 'pi', args, env: {} });
   const runtimeInput = (profile?: PiRuntimeProfileIdentity) => ({
-    outfitterVersion: '1.2.3',
     profile,
     rootDirectory: createTemporaryRoot(),
   });
@@ -249,13 +241,11 @@ describe('attachPiRuntimeExtension', () => {
     expect(result.args.slice(2)).toEqual(['--system-prompt', '/x']);
     const extension = readFileSync(result.args[1], 'utf8');
     expect(extension).toContain('const OUTFITTER_ACTIVE_PROFILE = {"id":"engineer","label":"Engineer"};');
-    expect(extension).toContain('const OUTFITTER_VERSION = "1.2.3";');
     expect(extension).not.toContain('__OUTFITTER_');
   });
 
   it('does not reinterpret placeholder-shaped profile metadata while stamping', () => {
     const extension = createPiRuntimeExtensionContent({
-      outfitterVersion: '1.2.3',
       profile: { id: 'engineer', label: '__OUTFITTER_VERSION__' },
     });
 

--- a/code/cli/tests/unit/project-harness.test.ts
+++ b/code/cli/tests/unit/project-harness.test.ts
@@ -397,8 +397,48 @@ describe('projectComposition native configuration overlays', () => {
     });
 
     expect(readFileSync(join(dir, 'keybindings.json'), 'utf8')).toContain('ctrl+shift+y');
-    expect(readFileSync(join(dir, 'settings.json'), 'utf8')).toContain('dark');
+    expect(JSON.parse(readFileSync(join(dir, 'settings.json'), 'utf8'))).toEqual({
+      theme: 'dark',
+      quietStartup: true,
+    });
     expect(readFileSync(join(dir, 'themes', 'shared.json'), 'utf8')).toContain('high');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('defaults Pi to quiet startup while preserving an explicit profile override', () => {
+    const quietDir = root();
+    projectComposition(planWith([]), { harness: 'pi', rootDirectory: quietDir, homeDirectory: quietDir });
+    expect(JSON.parse(readFileSync(join(quietDir, 'settings.json'), 'utf8'))).toEqual({ quietStartup: true });
+
+    const verboseDir = root();
+    const overlay = root();
+    writeFileSync(join(overlay, 'settings.json'), '{"quietStartup":false,"theme":"light"}');
+    projectComposition(planWith([]), {
+      harness: 'pi',
+      rootDirectory: verboseDir,
+      homeDirectory: verboseDir,
+      configurationOverlayDirectories: [overlay],
+    });
+    expect(JSON.parse(readFileSync(join(verboseDir, 'settings.json'), 'utf8'))).toEqual({
+      quietStartup: false,
+      theme: 'light',
+    });
+  });
+
+  it('preserves malformed and non-object native Pi settings for Pi to diagnose', () => {
+    for (const content of ['not json', 'null', '[]', 'true']) {
+      const dir = root();
+      const overlay = root();
+      writeFileSync(join(overlay, 'settings.json'), content);
+      projectComposition(planWith([]), {
+        harness: 'pi',
+        rootDirectory: dir,
+        homeDirectory: dir,
+        configurationOverlayDirectories: [overlay],
+      });
+      expect(readFileSync(join(dir, 'settings.json'), 'utf8')).toBe(content);
+    }
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.3, OFTR-006.3.17).

--- a/code/cli/tests/unit/run-agent-inheritance.test.ts
+++ b/code/cli/tests/unit/run-agent-inheritance.test.ts
@@ -258,7 +258,10 @@ describe('run inherited agent', () => {
       agent: 'engineer',
       harness: 'pi',
       launcher: (plan) => {
-        expect(readFileSync(join(plan.env.PI_CODING_AGENT_DIR, 'settings.json'), 'utf8')).toBe('{"owner":"child"}');
+        expect(JSON.parse(readFileSync(join(plan.env.PI_CODING_AGENT_DIR, 'settings.json'), 'utf8'))).toEqual({
+          owner: 'child',
+          quietStartup: true,
+        });
         return Promise.resolve(0);
       },
     });

--- a/code/cli/tests/unit/run-agent-onboarding-warnings.test.ts
+++ b/code/cli/tests/unit/run-agent-onboarding-warnings.test.ts
@@ -1,7 +1,4 @@
-// Guards OFTR-004.6.10's coherence at the run boundary: first-run onboarding fetches the declared
-// closure best-effort, and a dependency it could not fetch must surface as an actionable
-// `outfitter sync` warning. That warning is only computable after onboarding, so RunAgentCommand
-// must emit it from the post-onboarding re-resolve. Reverting that emit makes this test fail.
+// Guards quiet first-run startup when an unrelated catalog dependency remains unsynchronized.
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -23,9 +20,9 @@ afterEach(() => {
 });
 
 describe('run agent onboarding warnings', () => {
-  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.10).
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.10, OFTR-010.6).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('surfaces a newly-actionable resolution warning produced after onboarding', async () => {
+  it('suppresses an unrelated resolution warning produced after onboarding', async () => {
     const root = mkdtempSync(join(tmpdir(), 'outfitter-onboarding-'));
     temporaryRoots.push(root);
     const home = join(root, 'home');
@@ -62,10 +59,27 @@ describe('run agent onboarding warnings', () => {
       writeLine: (message) => lines.push(message),
     });
 
-    // Surfaced to the terminal (writeLine)...
-    expect(lines.some((line) => line.includes("Run 'outfitter sync'"))).toBe(true);
-    expect(lines.some((line) => line.includes('github:acme/unsynced#v1.0.0'))).toBe(true);
-    // ...and returned to programmatic callers, after the setup notices.
-    expect(result.messages.some((message) => message.includes("Run 'outfitter sync'"))).toBe(true);
+    expect(lines).toEqual([]);
+    expect(result.messages).toEqual([]);
+  });
+
+  it('gives one concise sync action when the selected agent is unavailable', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'outfitter-onboarding-'));
+    temporaryRoots.push(root);
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    write(
+      join(home, '.agents', 'settings.yml'),
+      'default_agent: founder\nsources:\n  - github: acme/unsynced\n    ref: v1.0.0\n',
+    );
+
+    const result = await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      launcher: () => Promise.resolve(0),
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.messages).toEqual(["Agent 'founder' is not ready. Run 'outfitter sync', then try again."]);
   });
 });

--- a/code/cli/tests/unit/run-agent.test.ts
+++ b/code/cli/tests/unit/run-agent.test.ts
@@ -13,7 +13,6 @@ import {
 } from '../../src/cli/commands/RunAgentCommand.js';
 import type { AgentLaunchPlan } from '../../src/projection/Projection.js';
 import type { SetupResult } from '../../src/setup/Setup.js';
-import { readOutfitterVersion } from '../../src/version/OutfitterVersion.js';
 
 const temporaryRoots: string[] = [];
 let previousExitCode: typeof process.exitCode;
@@ -37,6 +36,7 @@ interface CapturedLaunch {
   readonly skillPresent: boolean;
   readonly skillBody?: string;
   readonly runtimeExtension?: string;
+  readonly runtimeSettings?: unknown;
 }
 
 const captured: CapturedLaunch[] = [];
@@ -56,6 +56,9 @@ const launcher = (plan: AgentLaunchPlan): Promise<number> => {
     skillPresent: existsSync(skillPath),
     skillBody: existsSync(skillPath) ? readFileSync(skillPath, 'utf8') : undefined,
     runtimeExtension: runtimeExtensionPath === undefined ? undefined : readFileSync(runtimeExtensionPath, 'utf8'),
+    runtimeSettings: existsSync(join(runtimeDir, 'settings.json'))
+      ? (JSON.parse(readFileSync(join(runtimeDir, 'settings.json'), 'utf8')) as unknown)
+      : undefined,
   });
   return Promise.resolve(0);
 };
@@ -122,7 +125,7 @@ describe('run agent', () => {
     expect(launch.skillPresent).toBe(true); // skill content copied, not an empty dir
   });
 
-  it('stamps the selected profile label and installed Outfitter version into the Pi runtime', async () => {
+  it('stamps the selected profile label and enables quiet Pi startup', async () => {
     const { home, project } = tree();
     write(
       join(project, '.agents', 'agents', 'engineer', 'agent.md'),
@@ -140,9 +143,7 @@ describe('run agent', () => {
     expect(captured[0].runtimeExtension).toContain(
       'const OUTFITTER_ACTIVE_PROFILE = {"id":"engineer","label":"Engineering Lead"};',
     );
-    expect(captured[0].runtimeExtension).toContain(
-      `const OUTFITTER_VERSION = ${JSON.stringify(readOutfitterVersion())};`,
-    );
+    expect(captured[0].runtimeSettings).toMatchObject({ quietStartup: true });
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.1, OFTR-005.3).
@@ -526,7 +527,7 @@ describe('run agent', () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.launchPlan!.command).toBe('pi'); // launched the just-created default agent
-    expect(result.messages).toContain('[setup] created a profile.');
+    expect(result.messages).not.toContain('[setup] created a profile.');
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.1.2).

--- a/code/cli/tests/unit/setup.test.ts
+++ b/code/cli/tests/unit/setup.test.ts
@@ -680,7 +680,7 @@ describe('Pi setup launch', () => {
       writeLine: (message) => lines.push(message),
     }).register(program);
     await program.parseAsync(['node', 'outfitter', 'setup']);
-    expect(lines.join('\n')).toContain("Default agent 'founder'");
+    expect(lines).toEqual([]);
     expect(readFileSync(join(home, '.agents', 'settings.yml'), 'utf8')).toContain(
       `github: ${defaultCatalogSource.github}\n    ref: ${defaultCatalogSource.ref}`,
     );
@@ -718,7 +718,7 @@ describe('Pi setup launch', () => {
       writeLine: (message) => lines.push(message),
     }).register(program);
     await program.parseAsync(['node', 'outfitter', 'setup']);
-    expect(lines.join('\n')).toContain("Starting 'myagent' in pi");
+    expect(lines).toEqual([]);
     expect(runLaunches).toEqual(['pi']); // setup auto-started the selected profile
   });
 

--- a/code/pi-extension/README.md
+++ b/code/pi-extension/README.md
@@ -10,9 +10,9 @@ It brands the startup header and owns the Outfitter interactive shortcuts
 `/login`, so this file is deliberately free of any credential prompt.
 
 `src/outfitter-runtime-extension.js` is the **real-session runtime** extension.
-The CLI loads it into the selected profile's Pi session. It renders the combined
-Outfitter and Pi version header, shows the active profile in Pi's status line,
-and, when Pi starts with no models available, restores Outfitter's original
+The CLI loads it into the selected profile's Pi session. It renders one compact
+`Outfitter · <profile>` header and, when Pi starts with no models available,
+restores Outfitter's original
 "Pi does not have a model provider connected yet — Connect a model provider"
 confirmation before delegating to Pi's native `/login`. It never runs for
 non-interactive Pi launches (`--print`, `--export`, `--mode json|print|rpc`).
@@ -28,11 +28,9 @@ Pi never imports these files from the repository or the npm package directly.
   launch-specific value, then writes the stamped file into the isolated Pi agent
   directory and passes it to pi via `--extension`.
 - The runtime extension is stamped by
-  `code/cli/src/cli/commands/PiRuntimeLaunch.ts` with the active profile and
-  installed Outfitter version, then written inside the ephemeral runtime tree
-  and passed to interactive pi launches via `--extension`. The Pi version is
-  imported through Pi's supported `@earendil-works/pi-coding-agent` extension
-  alias, so it describes the Pi process that is actually running.
+  `code/cli/src/cli/commands/PiRuntimeLaunch.ts` with the active profile, then
+  written inside the ephemeral runtime tree and passed to interactive pi
+  launches via `--extension`.
 
 The `@ai-outfitter/outfitter` package ships this workspace's `src/` folder under
 `code/pi-extension/` (staged by `code/cli/scripts/sync-package-assets.mjs`) so
@@ -41,7 +39,7 @@ the packaged CLI can resolve the same sources after install.
 ## Editing notes
 
 - Keep both files dependency-free apart from Pi's supported runtime imports
-  (`@earendil-works/pi-tui` and `@earendil-works/pi-coding-agent`) and, for the
+  (`@earendil-works/pi-tui`) and, for the
   setup extension, the enterprise support modules copied next to the written
   extension (`./pi-extension/privateCatalogOnboarding.js`).
 - `src/outfitter-extension.js` (setup) is intentionally excluded from Prettier so

--- a/code/pi-extension/src/outfitter-runtime-extension.js
+++ b/code/pi-extension/src/outfitter-runtime-extension.js
@@ -1,19 +1,17 @@
-import { VERSION as PI_VERSION } from '@earendil-works/pi-coding-agent';
 import { Key, matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi } from '@earendil-works/pi-tui';
 
 const OUTFITTER_ACTIVE_PROFILE = '__OUTFITTER_ACTIVE_PROFILE__';
-const OUTFITTER_VERSION = '__OUTFITTER_VERSION__';
 
 // Outfitter runtime extension. Unlike the setup walkthrough extension
 // (outfitter-extension.js), this file is loaded into the real profile pi session. It restores the
-// Outfitter + pi header and active-profile status, plus the original "no provider connected yet"
+// compact Outfitter + profile header, plus the original "no provider connected yet"
 // sign-in prompt: when pi starts with no models available, it offers to connect one and delegates
 // to pi's native /login command, which persists credentials in pi's own agent directory and selects
 // a default model in-session.
 //
 // The setup pi stays deliberately model-free and MUST NOT open /login (OFTR-010.1.4); that is why
-// the auto-login lives here instead. The CLI stamps profile and Outfitter-version metadata into a
-// per-run copy before loading it via --extension. PI_VERSION comes from the running pi package.
+// the auto-login lives here instead. The CLI stamps profile metadata into a per-run copy before
+// loading it via --extension.
 
 export default function outfitterRuntime(pi) {
   let loginSubmitted = false;
@@ -78,7 +76,6 @@ export default function outfitterRuntime(pi) {
   pi.on('session_start', async (event, ctx) => {
     if (ctx.mode !== 'tui') return;
     setRuntimeHeader(ctx);
-    updateProfileStatus(ctx);
     if (event.reason === 'startup') await openLoginIfNoModels(ctx);
   });
 }
@@ -91,8 +88,11 @@ const setRuntimeHeader = (ctx) => {
       render: (width) => {
         const maxWidth = typeof width === 'number' && width > 0 ? width : 120;
         if (cachedLines === undefined || cachedWidth !== maxWidth) {
-          const line =
-            theme.bold(theme.fg('accent', 'Outfitter')) + theme.fg('dim', ` v${OUTFITTER_VERSION} + pi v${PI_VERSION}`);
+          const profile =
+            typeof OUTFITTER_ACTIVE_PROFILE === 'object' && OUTFITTER_ACTIVE_PROFILE !== null
+              ? (OUTFITTER_ACTIVE_PROFILE.label ?? OUTFITTER_ACTIVE_PROFILE.id)
+              : undefined;
+          const line = theme.bold(theme.fg('accent', 'Outfitter')) + (profile ? theme.fg('dim', ` · ${profile}`) : '');
           cachedLines = [visibleWidth(line) > maxWidth ? truncateToWidth(line, maxWidth) : line];
           cachedWidth = maxWidth;
         }
@@ -104,15 +104,6 @@ const setRuntimeHeader = (ctx) => {
       },
     };
   });
-};
-
-const updateProfileStatus = (ctx) => {
-  // Stays a string when the source asset is loaded without Outfitter stamping and is undefined
-  // when a caller intentionally attaches the extension without a resolved profile.
-  if (typeof OUTFITTER_ACTIVE_PROFILE !== 'object' || OUTFITTER_ACTIVE_PROFILE === null) return;
-  const name = OUTFITTER_ACTIVE_PROFILE.label ?? OUTFITTER_ACTIVE_PROFILE.id;
-  if (!name) return;
-  ctx.ui.setStatus('outfitter-profile', ctx.ui.theme.fg('muted', 'profile: ' + name));
 };
 
 // Renders a described-option picker identical to the setup walkthrough's, so the runtime sign-in

--- a/docs/requirements/OFTR-004-sync-and-setup.md
+++ b/docs/requirements/OFTR-004-sync-and-setup.md
@@ -176,8 +176,9 @@ disagree about the same thing, the selected declaration must be visible.
    MUST report a warning naming each supplying source, and MUST name the definition that won. A slug
    intentionally overridden by a higher-precedence layer is still reported; visibility, not
    prohibition, is the requirement.
-4. These warnings MUST be surfaced by every command that resolves the effective set, including
-   `sync`, `validate`, `list agents`, and `run`, not only by a dedicated diagnostic.
+4. These warnings MUST be surfaced by diagnostic commands that resolve the effective set, including
+   `sync`, `validate`, and `list agents`. `run --strict` MUST also surface them before it fails.
+   A successful non-strict `run` MUST suppress them so routine startup stays quiet.
 5. Detection MUST NOT change which declaration wins; precedence rules are unchanged.
 6. Under strict mode, every command that resolves the effective set MUST report every detected
    ambiguity and then fail with a nonzero exit status. All three ambiguity classes above gate

--- a/docs/requirements/OFTR-010-onboarding-welcome.md
+++ b/docs/requirements/OFTR-010-onboarding-welcome.md
@@ -33,6 +33,19 @@
    first-run setup → relaunch → `/login`, later launches start with an active model and do not
    re-prompt.
 
+## OFTR-010.6: Quiet runtime startup
+
+1. An Outfitter-managed interactive Pi session MUST default `quietStartup` to `true` when the
+   selected profile does not set it explicitly.
+2. A profile's explicit `quietStartup` value MUST take precedence over the Outfitter default.
+3. Normal startup MUST render one identity header in the form `Outfitter · <profile label>` and
+   MUST NOT render a duplicate profile status or runtime version text.
+4. A successful setup that immediately launches a concrete profile MUST NOT print file-write or
+   transition notices before the profile UI.
+5. A successful non-strict run MUST suppress resolver hygiene diagnostics. It MUST continue to
+   report blocking errors and warnings that describe a degraded launch. Diagnostic commands and
+   strict mode MUST retain complete resolution diagnostics.
+
 ## OFTR-010.2: Exact walkthrough
 
 1. The first prompt MUST be `How would you like to set up Outfitter?` with, in order:


### PR DESCRIPTION
## Summary

- default Outfitter-managed Pi sessions to quiet startup without overriding an explicit profile setting
- replace the version and status UI with one `Outfitter · <profile>` header
- suppress successful setup notices and non-strict resolver hygiene during routine startup
- keep degraded-launch warnings, strict diagnostics, and diagnostic command output visible

## Verification

- `nix develop --command npm run check-ci`
- 42 test files passed
- 508 tests passed
- branch coverage: 98.08%
- documentation production build passed
