### PR TITLE
fix: harden quiet profile startup

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -191,10 +191,35 @@ jobs:
             exit 1
           fi
           docker run --rm --entrypoint /bin/sh "$IMAGE:$VERSION-nix" -c \
-            'nix --version && test -x /bin/bash && test -x /usr/bin/env'
+            'nix --version && node --version && npm --version && test -x /bin/bash && test -x /usr/bin/env && test -r "$SSL_CERT_FILE"'
+          docker run --rm --entrypoint /bin/sh "$IMAGE:$VERSION-nix" -c \
+            'git ls-remote --exit-code https://github.com/ai-outfitter/default-profiles.git HEAD'
 
-      # The checks above only prove tools are present in the base. Residency is
-      # covered at the CLI level instead — signal forwarding lives in
+      - name: Smoke test quiet extension loading
+        run: |
+          workdir="$(mktemp -d)"
+          mkdir -p "$workdir/.agents/agents/smoke"
+          printf '%s\n' \
+            '---' \
+            'name: smoke' \
+            'extensions: ["npm:pi-nolo"]' \
+            '---' \
+            '' \
+            'Container extension smoke test.' \
+            > "$workdir/.agents/agents/smoke/agent.md"
+
+          output="$(docker run --rm -v "$workdir:/workspace:ro" "$IMAGE:$VERSION-nix" run smoke -- --help 2>&1)"
+          grep -q 'pi - AI coding assistant' <<< "$output"
+          if grep -Eq 'Installing npm:|spawn npm ENOENT' <<< "$output"; then
+            echo 'Normal startup exposed extension installer output.' >&2
+            printf '%s\n' "$output" >&2
+            exit 1
+          fi
+
+          debug_output="$(docker run --rm -v "$workdir:/workspace:ro" "$IMAGE:$VERSION-nix" run smoke --log-level debug -- --help 2>&1)"
+          grep -q 'Installing npm:pi-nolo' <<< "$debug_output"
+
+      # Process residency is covered at the CLI level instead — signal forwarding lives in
       # spawnLauncher, so tests/unit/agent-launch.test.ts asserts it directly
       # rather than inferring it from container exit codes.
       - name: Smoke test derivative image

--- a/code/cli/src/agents/AgentLaunch.ts
+++ b/code/cli/src/agents/AgentLaunch.ts
@@ -104,11 +104,11 @@ export const attachSignalForwarding = (
 };
 
 /* v8 ignore start -- real process spawn is covered by end-to-end smoke usage, not unit tests. */
-export const spawnLauncher: AgentProcessLauncher = {
+export const createSpawnLauncher = (stdio: 'inherit' | 'ignore'): AgentProcessLauncher => ({
   async launch(plan: AgentLaunchPlan): Promise<number> {
     const { default: spawn } = await import('cross-spawn');
     return await new Promise<number>((resolve, reject) => {
-      const child = spawn(plan.command, [...plan.args], { stdio: 'inherit', env: { ...process.env, ...plan.env } });
+      const child = spawn(plan.command, [...plan.args], { stdio, env: { ...process.env, ...plan.env } });
       const detach = attachSignalForwarding(child);
       child.on('error', (error) => {
         detach();
@@ -122,7 +122,9 @@ export const spawnLauncher: AgentProcessLauncher = {
       });
     });
   },
-};
+});
+
+export const spawnLauncher: AgentProcessLauncher = createSpawnLauncher('inherit');
 /* v8 ignore stop */
 
 /**

--- a/code/cli/src/cli/TerminalLoading.ts
+++ b/code/cli/src/cli/TerminalLoading.ts
@@ -1,0 +1,30 @@
+// One delayed terminal status for startup work. Fast cached runs write nothing; long work replaces
+// profile-extension subprocess chatter with a stable loading indicator.
+export type LoadingStarter = (label: string) => () => void;
+
+/* v8 ignore start -- real terminal animation; command tests inject a loading boundary. */
+export const startTerminalLoading: LoadingStarter = (label) => {
+  if (process.stderr.isTTY !== true) return () => undefined;
+
+  const frames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+  let frame = 0;
+  let rendered = false;
+  let interval: NodeJS.Timeout | undefined;
+  const render = (): void => {
+    rendered = true;
+    process.stderr.write(`\r${frames[frame++ % frames.length]} ${label}`);
+  };
+  const delay = setTimeout(() => {
+    render();
+    interval = setInterval(render, 80);
+    interval.unref();
+  }, 120);
+  delay.unref();
+
+  return () => {
+    clearTimeout(delay);
+    if (interval !== undefined) clearInterval(interval);
+    if (rendered) process.stderr.write('\r\u001b[2K');
+  };
+};
+/* v8 ignore stop */

--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -29,14 +29,18 @@ import { findResource } from '../../resolver/Resource.js';
 import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
 import type { Harness } from '../../settings/Settings.js';
 import { HARNESSES } from '../../settings/Settings.js';
+import { setupNextStepMessage } from '../../setup/Setup.js';
 import type { SetupResult } from '../../setup/Setup.js';
 import { attachSystemExtensionHooks } from '../../system/SystemExtensionHook.js';
+import { startTerminalLoading } from '../TerminalLoading.js';
+import type { LoadingStarter } from '../TerminalLoading.js';
 import type { CommandObject } from './CommandObject.js';
 import { attachPiRuntimeExtension } from './PiRuntimeLaunch.js';
 import { resolveHomeDirectory, resolveProjectDirectory } from './ProcessDefaults.js';
 import { runSetup } from './SetupCommand.js';
 
 export type AgentProcessLauncher = (plan: AgentLaunchPlan) => Promise<number>;
+export type RunLogLevel = 'info' | 'debug';
 
 /**
  * Runs first-run onboarding when `run` finds nothing configured. Returns the setup result, or
@@ -54,6 +58,7 @@ export interface RunAgentInput {
   readonly agent?: string;
   readonly harness?: string;
   readonly strict?: boolean;
+  readonly logLevel?: RunLogLevel;
   readonly passThroughArgs?: readonly string[];
   /** `--append-prompt` documents appended to the system prompt after the agent's own, in order. */
   readonly appendPromptPaths?: readonly string[];
@@ -66,6 +71,8 @@ export interface RunAgentInput {
   readonly writeLine?: (message: string) => void;
   /** Test seam for the `pi install` boundary used to cache pi extensions. */
   readonly extensionInstallSpawner?: PiInstallSpawner;
+  /** Optional loading UI. The command wires a terminal spinner; tests can observe this boundary. */
+  readonly startLoading?: LoadingStarter;
 }
 
 export interface RunAgentResult {
@@ -80,6 +87,7 @@ export interface RunAgentDependencies {
   readonly launcher?: AgentProcessLauncher;
   readonly setup?: SetupRunner;
   readonly writeLine?: (message: string) => void;
+  readonly startLoading?: LoadingStarter;
 }
 
 /* v8 ignore start -- real-TTY onboarding wiring; the setup state machine is tested via an injected runner. */
@@ -193,8 +201,26 @@ const resolvePiExtensions = async (
   return ensurePiExtensions(extensionSpecs, {
     cacheAgentDir: join(resolveOutfitterCacheDir(process.env, input.homeDirectory), 'pi-extensions'),
     offline: process.env.PI_OFFLINE === '1' || process.env.PI_OFFLINE === 'true',
+    debug: input.logLevel === 'debug',
     spawn: input.extensionInstallSpawner,
   });
+};
+
+const loadPiExtensions = async (
+  input: RunAgentInput,
+  harness: Harness,
+  agentSlug: string,
+  extensionSpecs: readonly string[],
+): ReturnType<typeof resolvePiExtensions> => {
+  const showLoading = harness === 'pi' && input.logLevel !== 'debug' && extensionSpecs.length > 0;
+  const stopLoading = showLoading
+    ? (input.startLoading?.(`Loading ${agentSlug} profile…`) ?? (() => undefined))
+    : () => undefined;
+  try {
+    return await resolvePiExtensions(input, harness, extensionSpecs);
+  } finally {
+    stopLoading();
+  }
 };
 
 const piConfigurationOverlays = (
@@ -220,6 +246,9 @@ const shouldRunSetup = (
 ): input is RunAgentInput & { readonly setup: NonNullable<RunAgentInput['setup']> } =>
   input.agent === undefined && resolved.settings.defaultAgent === undefined && input.setup !== undefined;
 
+const setupDidNotSelectAgent = (result: SetupResult | undefined): result is SetupResult =>
+  result !== undefined && result.defaultAgent === undefined;
+
 const resolutionWarningsForRun = (
   resolved: ReturnType<typeof resolveEffectiveSet>,
   strict: boolean | undefined,
@@ -227,17 +256,14 @@ const resolutionWarningsForRun = (
 
 const failedCompositionMessages = (
   resolved: ReturnType<typeof resolveEffectiveSet>,
-  agentSlug: string,
   composed: ReturnType<typeof compose>,
 ): readonly string[] => {
-  const unknownAgent = composed.errors.some((error) => error.includes(`Unknown agent '${agentSlug}'`));
-  const unsynchronizedSource = resolved.warnings.some((warning) => warning.includes('is not synchronized'));
-  if (!unknownAgent || !unsynchronizedSource) return [...composed.warnings, ...composed.errors];
-
   return [
     ...composed.warnings,
-    `Agent '${agentSlug}' is not ready. Run 'outfitter sync', then try again.`,
-    ...composed.errors.filter((error) => !error.includes('Unknown agent')),
+    ...composed.errors,
+    ...(resolved.unsynchronizedWarnings.length === 0
+      ? []
+      : ["Some configured sources are not synchronized. Run 'outfitter sync', then try again."]),
   ];
 };
 
@@ -258,11 +284,14 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
       projectDirectory: input.projectDirectory,
     });
 
-    if (setupResult !== undefined) {
-      // Keep the transition quiet so the real profile UI is the first persistent output.
-      resolved = resolveEffectiveSet(input);
-      assertNoSettingsIssues(resolved.settingsIssues);
+    if (setupDidNotSelectAgent(setupResult)) {
+      const messages = [setupNextStepMessage];
+      emit(messages);
+      return { exitCode: 0, messages };
     }
+    // Keep the transition quiet so the real profile UI is the first persistent output.
+    resolved = resolveEffectiveSet(input);
+    assertNoSettingsIssues(resolved.settingsIssues);
   }
 
   // Strict mode exposes the complete final resolution state. Normal startup uses these diagnostics
@@ -281,13 +310,14 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
   const composed = compose(set, agentSlug, { projectDirectory: input.projectDirectory });
 
   if (composed.plan === undefined) {
-    const messages = [...resolutionWarnings, ...failedCompositionMessages(resolved, agentSlug, composed)];
+    const messages = [...resolutionWarnings, ...failedCompositionMessages(resolved, composed)];
     emit(messages);
     return { exitCode: 1, messages };
   }
 
   // Install/cache the pi extensions into a shared XDG cache and load them at launch (pi only).
-  const extensions = await resolvePiExtensions(input, harness, composed.plan.loadout.extensions);
+  // Normal startup keeps installer chatter behind one loading state. Debug mode exposes it.
+  const extensions = await loadPiExtensions(input, harness, agentSlug, composed.plan.loadout.extensions);
   const selectedAgent = findResource(set, 'agent', agentSlug)!;
   const configurationOverlays = piConfigurationOverlays(composed.plan, selectedAgent);
 
@@ -367,6 +397,12 @@ export const createRunAgentCommand = (dependencies: RunAgentDependencies = {}): 
       .argument('[agent]', 'Agent slug to run (default: settings default_agent).')
       .argument('[args...]', 'Arguments passed through to the harness after --.')
       .addOption(new Option('--harness <harness>', 'Harness to launch.').choices([...HARNESSES]))
+      .addOption(
+        new Option('--log-level <level>', 'Set startup log detail.')
+          .choices(['info', 'debug'])
+          .default('info')
+          .env('OUTFITTER_LOG_LEVEL'),
+      )
       .option('--strict', 'Treat ambiguity, composition warnings, and unsupported loadout elements as fatal.')
       .option(
         '--append-prompt <path>',
@@ -378,7 +414,12 @@ export const createRunAgentCommand = (dependencies: RunAgentDependencies = {}): 
         async (
           agent: string | undefined,
           passThroughArgs: readonly string[],
-          options: { harness?: string; strict?: boolean; appendPrompt?: readonly string[] },
+          options: {
+            harness?: string;
+            logLevel: RunLogLevel;
+            strict?: boolean;
+            appendPrompt?: readonly string[];
+          },
         ) => {
           /* v8 ignore next 3 -- process/launcher defaults are exercised by the CLI entrypoint, not unit tests. */
           const homeDirectory = resolveHomeDirectory(dependencies.homeDirectory);
@@ -389,6 +430,7 @@ export const createRunAgentCommand = (dependencies: RunAgentDependencies = {}): 
             projectDirectory,
             agent,
             harness: options.harness,
+            logLevel: options.logLevel,
             strict: options.strict,
             passThroughArgs,
             appendPromptPaths: options.appendPrompt,
@@ -397,6 +439,7 @@ export const createRunAgentCommand = (dependencies: RunAgentDependencies = {}): 
             // executeRunAgentCommand emits messages (before launch) through this sink.
             /* v8 ignore next -- console.error fallback is direct CLI behavior; tests inject a writer. */
             writeLine: dependencies.writeLine ?? console.error,
+            startLoading: dependencies.startLoading ?? startTerminalLoading,
           });
 
           process.exitCode = result.exitCode;

--- a/code/cli/src/cli/commands/SetupCommand.ts
+++ b/code/cli/src/cli/commands/SetupCommand.ts
@@ -4,7 +4,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 
 import { launchThroughSpawn, spawnLauncher } from '../../agents/AgentLaunch.js';
 import { readRepositoryCodeAsset } from '../../paths/RepositoryAssets.js';
@@ -13,11 +13,14 @@ import type { Harness } from '../../settings/Settings.js';
 import { HARNESSES } from '../../settings/Settings.js';
 import { discoverSettingsLoadPlan, loadSettings } from '../../settings/SettingsLoader.js';
 import type { SetupAgentChoice, SetupResult, SetupSelection } from '../../setup/Setup.js';
-import { applySetupSelection, discoverSetupAgentChoices } from '../../setup/Setup.js';
+import { applySetupSelection, discoverSetupAgentChoices, setupNextStepMessage } from '../../setup/Setup.js';
 import { bootstrapDefaultCatalog } from '../../setup/DefaultCatalog.js';
+import { startTerminalLoading } from '../TerminalLoading.js';
+import type { LoadingStarter } from '../TerminalLoading.js';
 import type { CommandObject } from './CommandObject.js';
 import { resolveHomeDirectory, resolveProjectDirectory } from './ProcessDefaults.js';
 import { executeRunAgentCommand } from './RunAgentCommand.js';
+import type { RunLogLevel } from './RunAgentCommand.js';
 
 export type SetupProcessLauncher = (plan: AgentLaunchPlan) => Promise<number>;
 
@@ -31,6 +34,8 @@ export interface SetupCommandDependencies {
   /** Launcher for the profile pi started after setup; defaults to the real spawn boundary. */
   readonly runLauncher?: SetupProcessLauncher;
   readonly writeLine?: (message: string) => void;
+  readonly startLoading?: LoadingStarter;
+  readonly logLevel?: RunLogLevel;
 }
 
 export interface PiSetupLaunch {
@@ -241,7 +246,9 @@ const autoLaunchSelectedProfile = async (
     homeDirectory: resolveHomeDirectory(dependencies.homeDirectory),
     projectDirectory: resolve(resolveProjectDirectory(dependencies.projectDirectory)),
     harness: result.defaultHarness,
+    logLevel: dependencies.logLevel,
     launcher: dependencies.runLauncher ?? defaultRunLauncher,
+    startLoading: dependencies.startLoading ?? startTerminalLoading,
   });
   for (const message of runResult.messages) writeLine(message);
   /* v8 ignore next -- surfaces a nonzero profile-launch exit to the shell; happy path returns 0. */
@@ -256,7 +263,13 @@ export const createSetupCommand = (dependencies: SetupCommandDependencies = {}):
       new Command('setup')
         .description('Configure .agents through the bundled Pi walkthrough.')
         .argument('[source]', 'Optional setup source URI or path.')
-        .action(async (source?: string) => {
+        .addOption(
+          new Option('--log-level <level>', 'Set startup log detail.')
+            .choices(['info', 'debug'])
+            .default('info')
+            .env('OUTFITTER_LOG_LEVEL'),
+        )
+        .action(async (source: string | undefined, options: { logLevel: RunLogLevel }) => {
           const result = await runSetup({ ...dependencies, setupSourceUri: source ?? dependencies.setupSourceUri });
           /* v8 ignore next -- console fallback is direct CLI behavior. */
           const writeLine = dependencies.writeLine ?? console.log;
@@ -265,11 +278,11 @@ export const createSetupCommand = (dependencies: SetupCommandDependencies = {}):
             return;
           }
           // Concrete profile selections launch immediately, so their profile UI is the success
-          // confirmation. Setups that still need sync retain their actionable filesystem notices.
+          // confirmation. Setups that still need sync receive one concise next action.
           if (result.defaultAgent === undefined) {
-            for (const message of result.messages) writeLine(message);
+            writeLine(setupNextStepMessage);
           }
-          await autoLaunchSelectedProfile(dependencies, result, writeLine);
+          await autoLaunchSelectedProfile({ ...dependencies, logLevel: options.logLevel }, result, writeLine);
         }),
     );
   },

--- a/code/cli/src/extensions/PiExtensionCache.ts
+++ b/code/cli/src/extensions/PiExtensionCache.ts
@@ -19,16 +19,22 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve, sep } from 'node:path';
 
-import { launchThroughSpawn, spawnLauncher } from '../agents/AgentLaunch.js';
+import { createSpawnLauncher, launchThroughSpawn, spawnLauncher } from '../agents/AgentLaunch.js';
 import { runGit } from '../sources/GitRepository.js';
 
 /** Spawns `pi install <source>` against the cache agent dir; injectable so tests avoid the network. */
-export type PiInstallSpawner = (input: { readonly source: string; readonly cacheAgentDir: string }) => Promise<number>;
+export type PiInstallSpawner = (input: {
+  readonly source: string;
+  readonly cacheAgentDir: string;
+  readonly debug?: boolean;
+}) => Promise<number>;
 
 export interface EnsurePiExtensionsInput {
   readonly cacheAgentDir: string;
   /** When true, missing extensions are never installed — they warn and are dropped. */
   readonly offline: boolean;
+  /** Show the underlying pi/git/npm installer output. Normal startup keeps it behind loading UI. */
+  readonly debug?: boolean;
   readonly spawn?: PiInstallSpawner;
 }
 
@@ -198,8 +204,9 @@ const evaluateCachedInstall = (installDir: string, mapped: PiExtensionSource, of
 };
 
 /* v8 ignore start -- real `pi install` subprocess; ensurePiExtensions is unit-tested with a fake spawner. */
-const defaultSpawner: PiInstallSpawner = ({ source, cacheAgentDir }) =>
-  launchThroughSpawn(spawnLauncher, {
+const quietSpawnLauncher = createSpawnLauncher('ignore');
+const defaultSpawner: PiInstallSpawner = ({ source, cacheAgentDir, debug }) =>
+  launchThroughSpawn(debug === true ? spawnLauncher : quietSpawnLauncher, {
     command: 'pi',
     args: ['install', source],
     env: { PI_CODING_AGENT_DIR: cacheAgentDir, GIT_TERMINAL_PROMPT: '0' },
@@ -228,7 +235,7 @@ const ensureOneExtension = async (
   removeStaleGitInstall(installDir, mapped);
   mkdirSync(input.cacheAgentDir, { recursive: true });
   try {
-    const exitCode = await spawn({ source: mapped.source, cacheAgentDir: input.cacheAgentDir });
+    const exitCode = await spawn({ source: mapped.source, cacheAgentDir: input.cacheAgentDir, debug: input.debug });
     if (exitCode !== 0 || !existsSync(installDir)) {
       return { warning: `extension '${specifier}' failed to install (pi install exited ${exitCode}).` };
     }

--- a/code/cli/src/projection/Materialize.ts
+++ b/code/cli/src/projection/Materialize.ts
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
+  renameSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
@@ -102,7 +103,13 @@ export const applyPiRuntimeDefaults = (rootDirectory: string): void => {
   if (typeof settings !== 'object' || settings === null || Array.isArray(settings)) return;
   if ('quietStartup' in settings) return;
 
-  writeGeneratedFile(settingsPath, `${JSON.stringify({ ...settings, quietStartup: true }, null, 2)}\n`);
+  const temporaryPath = `${settingsPath}.outfitter-${process.pid}-${Math.random().toString(16).slice(2)}.tmp`;
+  try {
+    writeFileSync(temporaryPath, `${JSON.stringify({ ...settings, quietStartup: true }, null, 2)}\n`, { flag: 'wx' });
+    renameSync(temporaryPath, settingsPath);
+  } finally {
+    rmSync(temporaryPath, { force: true });
+  }
 };
 
 const materializeSkill = (skill: ResolvedResource, rootDirectory: string): string | undefined => {

--- a/code/cli/src/resolver/ResolverContext.ts
+++ b/code/cli/src/resolver/ResolverContext.ts
@@ -19,6 +19,8 @@ export interface ResolveResult {
   readonly settingsIssues: readonly SettingsLoadIssue[];
   /** Non-fatal guidance: uncached remote sources plus transitive-source skip warnings. */
   readonly warnings: readonly string[];
+  /** Configured remote sources whose cache is absent. */
+  readonly unsynchronizedWarnings: readonly string[];
   /** Ambiguity-only subset, exposed so sync can report shared resolution diagnostics after fetching. */
   readonly ambiguityWarnings: readonly string[];
 }
@@ -43,6 +45,7 @@ export const resolveEffectiveSet = (input: ResolveInput): ResolveResult => {
     settings: loadedSettings.settings,
     settingsIssues: loadedSettings.issues,
     warnings: [...discovered.unsynchronized, ...discovered.warnings, ...ambiguityWarnings],
+    unsynchronizedWarnings: discovered.unsynchronized,
     ambiguityWarnings,
   };
 };

--- a/code/cli/src/setup/Setup.ts
+++ b/code/cli/src/setup/Setup.ts
@@ -47,6 +47,8 @@ export interface SetupResult {
   readonly messages: readonly string[];
 }
 
+export const setupNextStepMessage = "Run 'outfitter sync', then run 'outfitter' again.";
+
 const defaultAgentSlug = 'assistant';
 const maxSlugLength = 64;
 const agentSlugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;

--- a/code/cli/tests/unit/pi-extension-cache.test.ts
+++ b/code/cli/tests/unit/pi-extension-cache.test.ts
@@ -167,6 +167,21 @@ describe('ensurePiExtensions', () => {
     ]);
   });
 
+  it('passes debug logging through to the installer', async () => {
+    const dir = cacheDir();
+    let debug: boolean | undefined;
+    await ensurePiExtensions(['npm:pi-nolo'], {
+      cacheAgentDir: dir,
+      offline: false,
+      debug: true,
+      spawn: (input) => {
+        debug = input.debug;
+        return spawnCreating(input);
+      },
+    });
+    expect(debug).toBe(true);
+  });
+
   it('warns and drops a missing extension when offline, without spawning', async () => {
     const dir = cacheDir();
     let spawned = 0;

--- a/code/cli/tests/unit/project-harness.test.ts
+++ b/code/cli/tests/unit/project-harness.test.ts
@@ -1,5 +1,5 @@
 // Tests pi/claude extension projection: --extension args and extension unsupported-set handling.
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -375,6 +375,7 @@ describe('projectComposition Pi delegates', () => {
 
 describe('projectComposition native configuration overlays', () => {
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.3.17).
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.6.7).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('materializes lower-precedence Pi configuration before higher-precedence configuration', () => {
     const dir = root();
@@ -383,7 +384,9 @@ describe('projectComposition native configuration overlays', () => {
     mkdirSync(join(low, 'themes'), { recursive: true });
     mkdirSync(join(high, 'themes'), { recursive: true });
     writeFileSync(join(low, 'keybindings.json'), '{"tui.editor.yank":"alt+y"}');
-    writeFileSync(join(low, 'settings.json'), '{"theme":"dark"}');
+    const settingsPath = join(low, 'settings.json');
+    writeFileSync(settingsPath, '{"theme":"dark"}');
+    chmodSync(settingsPath, 0o444);
     writeFileSync(join(low, 'themes', 'shared.json'), '{"name":"low"}');
     writeFileSync(join(high, 'keybindings.json'), '{"tui.editor.yank":"ctrl+shift+y"}');
     writeFileSync(join(high, 'themes', 'shared.json'), '{"name":"high"}');

--- a/code/cli/tests/unit/run-agent-onboarding-warnings.test.ts
+++ b/code/cli/tests/unit/run-agent-onboarding-warnings.test.ts
@@ -63,7 +63,7 @@ describe('run agent onboarding warnings', () => {
     expect(result.messages).toEqual([]);
   });
 
-  it('gives one concise sync action when the selected agent is unavailable', async () => {
+  it('preserves an unknown-agent error and appends one concise sync action', async () => {
     const root = mkdtempSync(join(tmpdir(), 'outfitter-onboarding-'));
     temporaryRoots.push(root);
     const home = join(root, 'home');
@@ -80,6 +80,83 @@ describe('run agent onboarding warnings', () => {
     });
 
     expect(result.exitCode).toBe(1);
-    expect(result.messages).toEqual(["Agent 'founder' is not ready. Run 'outfitter sync', then try again."]);
+    expect(result.messages[0]).toContain("Unknown agent 'founder'");
+    expect(result.messages.at(-1)).toBe(
+      "Some configured sources are not synchronized. Run 'outfitter sync', then try again.",
+    );
+  });
+
+  it('does not claim that syncing an unrelated source will resolve a mistyped agent', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'outfitter-onboarding-'));
+    temporaryRoots.push(root);
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    write(join(home, '.agents', 'settings.yml'), 'sources:\n  - github: acme/unsynced\n    ref: v1.0.0\n');
+
+    const result = await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      agent: 'typo',
+      launcher: () => Promise.resolve(0),
+    });
+
+    expect(result.messages[0]).toContain("Unknown agent 'typo'");
+    expect(result.messages[0]).toContain('outfitter list agents');
+    expect(result.messages.at(-1)).toContain("Run 'outfitter sync'");
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.10, OFTR-010.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('keeps synchronization guidance when a selected agent has a missing inherited dependency', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'outfitter-onboarding-'));
+    temporaryRoots.push(root);
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    write(
+      join(home, '.agents', 'agents', 'founder', 'agent.md'),
+      '---\nname: founder\ninherits: base\n---\n\nFounder.\n',
+    );
+    write(
+      join(home, '.agents', 'settings.yml'),
+      'default_agent: founder\nsources:\n  - github: acme/unsynced\n    ref: v1.0.0\n',
+    );
+
+    const result = await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      launcher: () => Promise.resolve(0),
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.messages.join('\n')).toContain('base');
+    expect(result.messages.at(-1)).toContain("Run 'outfitter sync'");
+  });
+
+  it('returns one next action when setup configures a source without a launchable agent', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'outfitter-onboarding-'));
+    temporaryRoots.push(root);
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    const lines: string[] = [];
+    const setup = (): Promise<SetupResult> =>
+      Promise.resolve({
+        created: [join(home, '.agents', 'settings.yml')],
+        updated: [],
+        settingsPath: join(home, '.agents', 'settings.yml'),
+        defaultHarness: 'pi',
+        messages: ['Created a settings file.'],
+      });
+
+    const result = await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      launcher: () => Promise.resolve(0),
+      setup,
+      writeLine: (message) => lines.push(message),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.messages).toEqual(["Run 'outfitter sync', then run 'outfitter' again."]);
+    expect(lines).toEqual(result.messages);
   });
 });

--- a/code/cli/tests/unit/run-agent.test.ts
+++ b/code/cli/tests/unit/run-agent.test.ts
@@ -363,6 +363,7 @@ describe('run agent', () => {
       '---\nname: dev\nextensions: ["npm:pi-nolo", "git:github.com/ai-outfitter/deepwork"]\n---\n\nBody.\n',
     );
     const installed: string[] = [];
+    const loading: string[] = [];
     const extensionInstallSpawner = ({ source, cacheAgentDir }: { source: string; cacheAgentDir: string }) => {
       installed.push(source);
       const segments = source.startsWith('npm:')
@@ -382,6 +383,10 @@ describe('run agent', () => {
         harness: 'pi',
         launcher,
         extensionInstallSpawner,
+        startLoading: (label) => {
+          loading.push(label);
+          return () => loading.push('stopped');
+        },
       });
 
       expect(result.exitCode).toBe(0);
@@ -392,6 +397,7 @@ describe('run agent', () => {
       expect(args[args.indexOf(nolo) - 1]).toBe('--extension');
       expect(args[args.indexOf(deepwork) - 1]).toBe('--extension');
       expect(installed).toEqual(['npm:pi-nolo', 'git:github.com/ai-outfitter/deepwork']);
+      expect(loading).toEqual(['Loading dev profile…', 'stopped']);
       expect(result.messages.join(' ')).not.toContain("loadout element 'extensions'");
 
       // Second run reuses the cache: no reinstall.
@@ -402,6 +408,7 @@ describe('run agent', () => {
         projectDirectory: project,
         agent: 'dev',
         harness: 'pi',
+        logLevel: 'debug',
         launcher,
         extensionInstallSpawner,
       });

--- a/code/cli/tests/unit/setup.test.ts
+++ b/code/cli/tests/unit/setup.test.ts
@@ -753,7 +753,7 @@ describe('Pi setup launch', () => {
       writeLine: (message) => lines.push(message),
     }).register(program);
     await program.parseAsync(['node', 'outfitter', 'setup']);
-    expect(lines.join('\n')).not.toContain('Starting');
+    expect(lines).toEqual(["Run 'outfitter sync', then run 'outfitter' again."]);
     expect(runLaunches).toEqual([]); // catalog setup reports next-launch instead of launching
   });
 

--- a/docs/documentation/cli.md
+++ b/docs/documentation/cli.md
@@ -15,7 +15,11 @@ Resolve, compose, and launch an agent. `run` is the default command, so plain `o
 | --------------------- | -------------------------------------------------------------------------------- |
 | `[agent]`             | Agent slug to run. Defaults to the settings `default_agent`.                     |
 | `--harness <harness>` | Harness to launch in: `pi`, `claude`, or `codex`. Defaults to `default_harness`. |
+| `--log-level <level>` | Use `info` for quiet loading or `debug` for installer output.                    |
 | `--strict`            | Fail instead of warning when the adapter cannot project part of the composition. |
+
+Set `OUTFITTER_LOG_LEVEL=debug` to enable debug startup output without passing the option. The
+`setup` command also accepts `--log-level` for its automatic profile launch.
 
 Any other arguments and unrecognized options are passed through to the launched harness:
 

--- a/docs/requirements/OFTR-010-onboarding-welcome.md
+++ b/docs/requirements/OFTR-010-onboarding-welcome.md
@@ -45,6 +45,12 @@
 5. A successful non-strict run MUST suppress resolver hygiene diagnostics. It MUST continue to
    report blocking errors and warnings that describe a degraded launch. Diagnostic commands and
    strict mode MUST retain complete resolution diagnostics.
+6. A setup mode that cannot launch a concrete profile MUST report one concise sync-and-rerun action.
+7. Applying the quiet-startup default MUST work when the selected profile's native settings file is
+   read-only, as it can be when a profile comes from the Nix store.
+8. Normal startup MUST hide profile-extension installer output behind one loading state. Debug log
+   level MUST expose the underlying Pi, Git, and npm output. Installation failures MUST remain
+   visible as concise warnings after the loading state stops.
 
 ## OFTR-010.2: Exact walkthrough
 

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,7 @@
               pkgs.gzip
               pkgs.cacert
               pkgs.gitMinimal
+              pkgs.nodejs_24
               pkgs.openssh
               pkgs.dockerTools.binSh
               pkgs.dockerTools.usrBinEnv
@@ -68,6 +69,8 @@
             Env = [
               "HOME=/tmp"
               "PATH=/bin:/usr/bin"
+              "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+              "NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
               "NIX_CONFIG=experimental-features = nix-command flakes"
             ];
             User = "1000:1000";

--- a/scripts/e2e-smoke.sh
+++ b/scripts/e2e-smoke.sh
@@ -120,4 +120,53 @@ case "$validate_output" in
 esac
 log 'validate OK'
 
+# Replace the bundled Pi entrypoint inside the throwaway install with a process-boundary capture.
+# Outfitter still resolves and launches its bundled dependency through the published CLI path; the
+# capture avoids opening a TUI while preserving the projected environment and arguments for checks.
+pi_manifest="$(find "$install_prefix/lib/node_modules" -path '*/@earendil-works/pi-coding-agent/package.json' -print -quit)"
+[ -n "$pi_manifest" ] || fail 'bundled Pi manifest was not installed'
+pi_package_root="$(dirname "$pi_manifest")"
+pi_bin_relative="$(node -p "require('$pi_manifest').bin.pi")"
+pi_bin="$pi_package_root/$pi_bin_relative"
+capture_dir="$work_dir/run-capture"
+mkdir -p "$capture_dir"
+cat >"$pi_bin" <<'FAKE_PI'
+#!/usr/bin/env node
+import { copyFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const captureDirectory = process.env.OUTFITTER_E2E_CAPTURE_DIR;
+const runtimeDirectory = process.env.PI_CODING_AGENT_DIR;
+if (!captureDirectory || !runtimeDirectory) process.exit(91);
+mkdirSync(captureDirectory, { recursive: true });
+copyFileSync(join(runtimeDirectory, 'settings.json'), join(captureDirectory, 'settings.json'));
+copyFileSync(
+  join(runtimeDirectory, '.outfitter', 'outfitter-runtime-extension.js'),
+  join(captureDirectory, 'outfitter-runtime-extension.js'),
+);
+writeFileSync(join(captureDirectory, 'args.json'), JSON.stringify(process.argv.slice(2)));
+FAKE_PI
+chmod +x "$pi_bin"
+
+log 'Checking installed `outfitter run` quiet-startup projection'
+run_output="$({
+  cd "$project_dir"
+  OUTFITTER_E2E_CAPTURE_DIR="$capture_dir" run_outfitter run
+} 2>&1)" || fail "outfitter run exited non-zero: $run_output"
+[ -z "$run_output" ] || fail "outfitter run printed unexpected startup output: $run_output"
+node -e '
+  const fs = require("node:fs");
+  const path = require("node:path");
+  const capture = process.argv[1];
+  const settings = JSON.parse(fs.readFileSync(path.join(capture, "settings.json"), "utf8"));
+  if (settings.quietStartup !== true) throw new Error("quietStartup was not projected");
+  const extension = fs.readFileSync(path.join(capture, "outfitter-runtime-extension.js"), "utf8");
+  if (!extension.includes(`const OUTFITTER_ACTIVE_PROFILE = {"id":"smoke"`)) {
+    throw new Error("runtime extension was not stamped with the selected profile");
+  }
+  const args = JSON.parse(fs.readFileSync(path.join(capture, "args.json"), "utf8"));
+  if (!args.includes("--extension")) throw new Error("runtime extension was not passed to Pi");
+' "$capture_dir" || fail 'installed run did not project quiet settings and the runtime extension'
+log 'installed run quiet-startup projection OK'
+
 log "All packaged smoke checks passed (cold ${cold_duration}ms, warm ${warm_duration}ms)"


### PR DESCRIPTION
## Summary

- preserve actionable composition errors while replacing stale-source noise with one sync instruction
- keep first-run and profile startup quiet behind one loading state, with raw installer output available at debug log level
- support read-only Pi settings overlays and verify the installed npm package path
- add CA certificates, Node, and npm to the Nix container runtime
- add container smoke coverage for HTTPS catalogs and quiet npm-backed extension loading

## Verification

- `nix develop --command npm run check-ci` (512 tests; lint, coverage, and docs passed)
- `nix develop --command bash scripts/e2e-smoke.sh`
- `nix build .#container --no-link`
- real container install of `npm:pi-nolo` in normal and debug modes
