### PR TITLE
feat: add all-harness development container

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,11 @@ Because this command writes to the active home or project target, use it only wh
 
 ### Run the local container smoke test
 
-Use `bin/dev-container-setup` to build the local development image and run Outfitter in a container. Pi credentials and settings are stored in the named container volume `outfitter-pi-agent`, not copied from the host:
+Use `bin/dev-container-setup` to build the local development image and run Outfitter in a container. The image includes Pi plus Claude Code and Codex from Numtide's `llm-agents.nix` flake. Named container volumes preserve each harness's credentials and sessions without copying them from the host:
+
+- `outfitter-pi-agent` mounts at `/home/outfitter/.pi/agent`.
+- `outfitter-claude-agent` mounts at `/home/outfitter/.claude`.
+- `outfitter-codex-agent` mounts at `/home/outfitter/.codex`.
 
 ```sh
 bin/dev-container-setup

--- a/bin/dev-container-setup
+++ b/bin/dev-container-setup
@@ -6,6 +6,8 @@ REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 
 IMAGE="outfitter-dev:local"
 PI_VOLUME="outfitter-pi-agent"
+CLAUDE_VOLUME="outfitter-claude-agent"
+CODEX_VOLUME="outfitter-codex-agent"
 SETUP_SOURCE=""
 SKIP_BUILD=0
 
@@ -18,12 +20,12 @@ usage() {
   cat <<'USAGE'
 Usage: bin/dev-container-setup [options] [setup-source] [-- <outfitter setup args>]
 
-Build the local Outfitter Nix image, start in /workspace, and run Outfitter.
+Build the local all-harness Outfitter Nix image, start in /workspace, and run Outfitter.
 With no setup-source, this opens `outfitter`. With setup-source, it opens
 Pi-native setup through `outfitter setup <setup-source>`.
 
-Pi credentials and settings are stored in a named container volume mounted at
-~/.pi/agent. They are not copied from the host.
+Pi, Claude Code, and Codex credentials and sessions are stored in named
+container volumes. They are not copied from the host.
 
 When setup-source is a local directory, it is mounted read-only into the
 container. Remote Git URLs are passed through unchanged.
@@ -68,9 +70,9 @@ command -v docker >/dev/null 2>&1 || die "docker is required"
 command -v nix >/dev/null 2>&1 || die "nix is required"
 
 if [[ "$SKIP_BUILD" -eq 0 ]]; then
-  nix build "$REPO_ROOT#container" --out-link "$REPO_ROOT/result"
+  nix build --accept-flake-config "$REPO_ROOT#container-dev" --out-link "$REPO_ROOT/result"
   docker load < "$REPO_ROOT/result"
-  docker tag outfitter:latest "$IMAGE"
+  docker tag outfitter-dev:latest "$IMAGE"
 fi
 
 RUN_FLAGS=(--rm)
@@ -79,8 +81,11 @@ if [[ -t 0 && -t 1 ]]; then
 fi
 
 RUN_FLAGS+=(
+  -e ANTHROPIC_API_KEY
   -e OPENAI_API_KEY
-  --mount "type=volume,source=$PI_VOLUME,target=/tmp/.pi/agent"
+  --mount "type=volume,source=$PI_VOLUME,target=/home/outfitter/.pi/agent"
+  --mount "type=volume,source=$CLAUDE_VOLUME,target=/home/outfitter/.claude"
+  --mount "type=volume,source=$CODEX_VOLUME,target=/home/outfitter/.codex"
   -w /workspace
 )
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,6 +1,98 @@
 {
   "nodes": {
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": [
+          "llm-agents",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ],
+        "systems": [
+          "llm-agents",
+          "systems"
+        ],
+        "treefmt-nix": [
+          "llm-agents",
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784665499,
+        "narHash": "sha256-9BMxlTxCCDAeoNLtb1a/st7udtTIJep+wpUzquA29VU=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "0f2a1f0b6f42cebe3b149bf62d38754c5e0e9729",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785627969,
+        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "llm-agents": {
+      "inputs": {
+        "bun2nix": "bun2nix",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1786734550,
+        "narHash": "sha256-AO7Byy5VAzJiHV+W0Tf/8ngi4pO73v5g81Vx4SxI8sc=",
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "rev": "c209e10a6ffda35cf5560fce1d45d7c322c4bf1a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1786593342,
+        "narHash": "sha256-smTKQXMLLStzc8zJevMCckbk3My7SvbbLmPYZUJJKW4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6b5e5b7a6631f065bf6908986990b37d845f847f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1784497964,
         "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
@@ -18,7 +110,44 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "llm-agents": "llm-agents",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785945821,
+        "narHash": "sha256-NLSyTCW4K4ofhNBllt3omPasm6QpralXH1DBZOc91Dw=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "ae7910970dddc408fe6ab1c8e4b277bb21d72dc0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,20 @@
 {
   description = "Outfitter — reproducible configuration for agent CLIs";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  nixConfig = {
+    extra-substituters = [ "https://cache.numtide.com" ];
+    extra-trusted-public-keys = [
+      "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
+    ];
+  };
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    llm-agents.url = "github:numtide/llm-agents.nix";
+  };
 
   outputs =
-    { nixpkgs, ... }:
+    { nixpkgs, llm-agents, ... }:
     let
       supportedSystems = [
         "aarch64-darwin"
@@ -17,6 +27,7 @@
           pkgs,
           outfitterPackage,
           extraPackages ? [ ],
+          home ? "/tmp",
           name ? "outfitter",
           tag ? "latest",
         }:
@@ -50,6 +61,7 @@
           contents = [ runtime ];
           extraCommands = ''
             mkdir -p etc tmp workspace
+            ${nixpkgs.lib.optionalString (home != "/tmp") ''mkdir -p ".${home}"''}
             # root must exist even though nothing here runs as root. A derived
             # image does `USER root` to COPY and chmod its own entrypoint, and
             # the builder resolves that name against this passwd file — without
@@ -57,17 +69,20 @@
             # looking up user root" before the layer even executes, which makes
             # the image unusable as the base this exists to be.
             printf 'root:x:0:0:root:/root:/bin/bash\n' > etc/passwd
-            printf 'outfitter:x:1000:1000:Outfitter:/tmp:/bin/bash\n' >> etc/passwd
+            printf 'outfitter:x:1000:1000:Outfitter:${home}:/bin/bash\n' >> etc/passwd
             printf 'nobody:x:65534:65534:nobody:/var/empty:/bin/false\n' >> etc/passwd
             printf 'root:x:0:\n' > etc/group
             printf 'outfitter:x:1000:\n' >> etc/group
             printf 'nogroup:x:65534:\n' >> etc/group
             chmod 1777 tmp workspace
           '';
+          fakeRootCommands = nixpkgs.lib.optionalString (home != "/tmp") ''
+            chown 1000:1000 ".${home}"
+          '';
           config = {
             Entrypoint = [ "${outfitterPackage}/bin/outfitter" ];
             Env = [
-              "HOME=/tmp"
+              "HOME=${home}"
               "PATH=/bin:/usr/bin"
               "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
               "NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
@@ -174,6 +189,19 @@
           container = mkContainer {
             inherit pkgs;
             outfitterPackage = outfitter;
+          };
+
+          # The interactive setup smoke image includes every harness offered by onboarding. Keep
+          # the published generic container lean; Numtide owns the fast-moving CLI packages here.
+          container-dev = mkContainer {
+            inherit pkgs;
+            outfitterPackage = outfitter;
+            home = "/home/outfitter";
+            name = "outfitter-dev";
+            extraPackages = [
+              llm-agents.packages.${system}.claude-code
+              llm-agents.packages.${system}.codex
+            ];
           };
         }
       );


### PR DESCRIPTION
## Summary

- add a development-only container with Claude Code and Codex from Numtide's `llm-agents.nix`
- keep the published Outfitter container unchanged
- persist Pi, Claude Code, and Codex credentials in separate Docker volumes
- use a normal non-root home directory to avoid Codex startup warnings

## Verification

- `nix build --accept-flake-config .#container-dev`
- image runtime: Claude Code 2.1.232, Codex CLI 0.147.0, Outfitter 1.7.1
- `bin/dev-container-setup --skip-build -- --version`
- `bash -n bin/dev-container-setup`
- `prettier --check CONTRIBUTING.md`
- `git diff --check`

The repository-wide `npm run check-ci` stops at four existing Prettier failures in unchanged TypeScript files. The lint step also cannot run in this worktree because its development dependencies are absent.
