### PR TITLE
feat(profiles): allow dot-namespaced agent slugs

### DIFF
--- a/code/cli/src/schemas/agent.schema.json
+++ b/code/cli/src/schemas/agent.schema.json
@@ -5,16 +5,16 @@
   "type": "object",
   "required": ["name"],
   "properties": {
-    "name": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$", "maxLength": 64 },
+    "name": { "$ref": "#/$defs/agentSlug" },
     "label": { "type": "string", "minLength": 1 },
     "description": { "type": "string" },
     "inherits": {
       "oneOf": [
-        { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$", "maxLength": 64 },
+        { "$ref": "#/$defs/agentSlug" },
         {
           "type": "array",
           "minItems": 1,
-          "items": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$", "maxLength": 64 }
+          "items": { "$ref": "#/$defs/agentSlug" }
         }
       ],
       "description": "Parent agent slug or ordered parent slug list composed parent-first before this agent."
@@ -36,7 +36,7 @@
       "description": "Skill slugs resolved from agents/<name>/skills first, then catalog-wide skills."
     },
     "subagents": {
-      "$ref": "#/$defs/slugList",
+      "$ref": "#/$defs/agentSlugList",
       "description": "Agent slugs delegated to. Resolved catalog-wide (a delegate is a shared agent, not nested under agents/<name>)."
     },
     "mcp": {
@@ -64,6 +64,15 @@
   },
   "additionalProperties": true,
   "$defs": {
+    "agentSlug": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*(?:\\.[a-z0-9]+(?:-[a-z0-9]+)*)*$",
+      "maxLength": 64
+    },
+    "agentSlugList": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/agentSlug" }
+    },
     "toolName": {
       "type": "string",
       "minLength": 1,

--- a/code/cli/src/setup/Setup.ts
+++ b/code/cli/src/setup/Setup.ts
@@ -51,16 +51,19 @@ export const setupNextStepMessage = "Run 'outfitter sync', then run 'outfitter' 
 
 const defaultAgentSlug = 'assistant';
 const maxSlugLength = 64;
-const agentSlugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const agentSlugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*(?:\.[a-z0-9]+(?:-[a-z0-9]+)*)*$/;
 
 export const sanitizeAgentSlug = (raw: string): string => {
   const slug = raw
     .trim()
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
+    .replace(/[^a-z0-9.-]+/g, '-')
+    .split('.')
+    .map((segment) => segment.replace(/-+/g, '-').replace(/^-+|-+$/g, ''))
+    .filter((segment) => segment.length > 0)
+    .join('.')
     .slice(0, maxSlugLength)
-    .replace(/-+$/g, '');
+    .replace(/[.-]+$/g, '');
 
   return agentSlugPattern.test(slug) ? slug : defaultAgentSlug;
 };

--- a/code/cli/tests/fixtures/catalogs/namespaced-agent-slugs/agents/environment.sample/agent.md
+++ b/code/cli/tests/fixtures/catalogs/namespaced-agent-slugs/agents/environment.sample/agent.md
@@ -1,0 +1,8 @@
+---
+name: environment.sample
+description: Namespaced environment profile.
+---
+
+# Environment Sample
+
+Configure the sample environment.

--- a/code/cli/tests/fixtures/catalogs/namespaced-agent-slugs/agents/plain-agent/agent.md
+++ b/code/cli/tests/fixtures/catalogs/namespaced-agent-slugs/agents/plain-agent/agent.md
@@ -1,0 +1,9 @@
+---
+name: plain-agent
+inherits: environment.sample
+subagents: [environment.sample]
+---
+
+# Plain Agent
+
+Run the plain agent.

--- a/code/cli/tests/unit/namespaced-agent-slugs.test.ts
+++ b/code/cli/tests/unit/namespaced-agent-slugs.test.ts
@@ -1,0 +1,107 @@
+// Tests dotted agent-slug validation, inheritance, resolution, and Pi delegate materialization.
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { executeValidateCommand } from '../../src/cli/commands/ValidateCommand.js';
+import { compose } from '../../src/composer/Composer.js';
+import { projectComposition } from '../../src/projection/ProjectHarness.js';
+import { isAgentDefinitionIssue, parseAgentDefinition } from '../../src/resolver/AgentDefinition.js';
+import { discoverLayers } from '../../src/resolver/Layer.js';
+import { findResource } from '../../src/resolver/Resource.js';
+import { resolveResources } from '../../src/resolver/Resolver.js';
+
+const fixtureCatalog = fileURLToPath(new URL('../fixtures/catalogs/namespaced-agent-slugs', import.meta.url));
+const temporaryRoots: string[] = [];
+
+const temporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-namespaced-agent-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const write = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('dot-namespaced agent slugs', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.2, OFTR-003.5, OFTR-003.9, OFTR-006.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('composes and strictly validates a dotted parent, then round-trips its Pi delegate filename', () => {
+    const root = temporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    write(join(project, '.agents', 'settings.yml'), `sources:\n  - path: ${JSON.stringify(fixtureCatalog)}\n`);
+
+    const set = resolveResources(
+      discoverLayers({
+        homeDirectory: home,
+        projectDirectory: project,
+        settings: { sources: [{ path: fixtureCatalog }] },
+      }).layers,
+    );
+    expect(findResource(set, 'agent', 'environment.sample')?.winner.path).toBe(
+      join(fixtureCatalog, 'agents', 'environment.sample', 'agent.md'),
+    );
+
+    const composed = compose(set, 'plain-agent', { projectDirectory: project });
+    expect(composed.errors).toEqual([]);
+    expect(composed.warnings).toEqual([]);
+    expect(composed.plan?.inheritanceChain).toEqual(['environment.sample', 'plain-agent']);
+    expect(composed.plan?.identity.agentBodies?.map((body) => body.declaringAgent)).toEqual([
+      'environment.sample',
+      'plain-agent',
+    ]);
+    expect(executeValidateCommand({ homeDirectory: home, projectDirectory: project, strict: true })).toMatchObject({
+      ok: true,
+      findings: [],
+    });
+
+    const runtimeRoot = join(root, 'runtime');
+    const projection = projectComposition(composed.plan!, {
+      harness: 'pi',
+      rootDirectory: runtimeRoot,
+      homeDirectory: home,
+    });
+    expect(projection.unsupported).toEqual([]);
+
+    const delegateNames = readdirSync(join(runtimeRoot, 'agents'))
+      .filter((fileName) => fileName.endsWith('.md'))
+      .map((fileName) => fileName.replace(/\.md$/u, ''));
+    expect(delegateNames).toEqual(['environment.sample']);
+    const delegatePath = join(runtimeRoot, 'agents', 'environment.sample.md');
+    const roundTripped = parseAgentDefinition(readFileSync(delegatePath, 'utf8'), [], delegatePath);
+    expect(isAgentDefinitionIssue(roundTripped)).toBe(false);
+    if (isAgentDefinitionIssue(roundTripped)) return;
+    expect(roundTripped.name).toBe('environment.sample');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it.each(['.leading', 'double..dot', 'trailing.'])('rejects invalid dotted name %s', (name) => {
+    const parsed = parseAgentDefinition(`---\nname: ${name}\n---\n`, [], '/catalog/agents/invalid/agent.md');
+    expect(isAgentDefinitionIssue(parsed)).toBe(true);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.2, OFTR-003.9).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it.each(['inherits: environment.sample', 'inherits: [environment.sample]'])(
+    'accepts a dotted inheritance reference as %s',
+    (inherits) => {
+      const parsed = parseAgentDefinition(
+        `---\nname: plain-agent\n${inherits}\n---\n`,
+        [],
+        '/catalog/agents/plain-agent/agent.md',
+      );
+      expect(isAgentDefinitionIssue(parsed)).toBe(false);
+    },
+  );
+});

--- a/code/cli/tests/unit/setup.test.ts
+++ b/code/cli/tests/unit/setup.test.ts
@@ -69,6 +69,29 @@ describe('setup state machine', () => {
     expect(discoverSetupAgentChoices({})).toEqual([]);
   });
 
+  it('discovers and selects a dot-namespaced catalog agent', () => {
+    const { catalog, home, project } = createTree();
+    write(
+      join(catalog, 'agents', 'environment.sample', 'agent.md'),
+      '---\nname: environment.sample\ndescription: Sample environment.\n---\n\n# Environment Sample\n',
+    );
+    const availableAgents = discoverSetupAgentChoices({ defaultCatalogRoot: catalog });
+    expect(availableAgents).toContainEqual({
+      id: 'environment.sample',
+      label: 'Environment Sample',
+      description: 'Sample environment.',
+    });
+
+    applySetupSelection({
+      homeDirectory: home,
+      projectDirectory: project,
+      defaultCatalogRoot: catalog,
+      availableAgents,
+      selection: { setupMode: 'default', agentId: 'environment.sample', harness: 'pi', target: 'home' },
+    });
+    expect(readFileSync(join(home, '.agents', 'settings.yml'), 'utf8')).toContain('default_agent: environment.sample');
+  });
+
   it('keeps a non-comment # in frontmatter metadata (e.g. C#) but strips a real inline comment', () => {
     const { catalog } = createTree();
     write(
@@ -399,9 +422,9 @@ describe('setup state machine', () => {
         selection: { setupMode: 'create', agentId: 'bad id', harness: 'pi', target: 'home' },
       }),
     ).toThrow(/invalid agent id/);
-    // Validation runs on the exact id that gets written, so schema-invalid slugs (underscores, dots)
+    // Validation runs on the exact id that gets written, so schema-invalid slugs
     // are rejected up front rather than written as an unresolvable agent.
-    for (const agentId of ['bad_id', 'my.profile', 'my--profile']) {
+    for (const agentId of ['bad_id', '.my-profile', 'my..profile', 'my-profile.', 'my--profile']) {
       expect(() =>
         applySetupSelection({ ...base, selection: { setupMode: 'create', agentId, harness: 'pi', target: 'home' } }),
       ).toThrow(/invalid agent id/);
@@ -457,6 +480,7 @@ describe('setup state machine', () => {
   it('normalizes setup names into schema-valid slugs', () => {
     expect(sanitizeAgentSlug('  My Profile  ')).toBe('my-profile');
     expect(sanitizeAgentSlug('foo--bar__baz')).toBe('foo-bar-baz');
+    expect(sanitizeAgentSlug(' Environment.Sample ')).toBe('environment.sample');
     expect(sanitizeAgentSlug('!!!')).toBe('assistant');
   });
 });

--- a/docs/requirements/OFTR-003-profiles.md
+++ b/docs/requirements/OFTR-003-profiles.md
@@ -24,7 +24,7 @@ Outfitter resolves agents and other resources from layered `.agents` trees into 
 
 ### OFTR-003.2: Agent Identity
 
-1. Agent IDs MUST be filesystem-safe slugs matching `^[a-z0-9]+(?:-[a-z0-9]+)*$`, at most 64 characters.
+1. Agent IDs MUST be filesystem-safe slugs matching `^[a-z0-9]+(?:-[a-z0-9]+)*(?:\.[a-z0-9]+(?:-[a-z0-9]+)*)*$`, at most 64 characters. Dots MAY group profiles by namespace convention (for example, `environment.agent-operator-pod` or `environment.sample`), while plain hyphenated slugs remain valid. A dot has naming significance only: it MUST NOT imply hierarchy, wildcard matching, or inheritance.
 2. The agent's frontmatter `name` MUST match its directory ID; a mismatch MUST be a validation error.
 3. Agents MAY include a `description` used by discovery surfaces.
 


### PR DESCRIPTION
Allows 'prefix.profile' agent slugs — e.g. environment.agent-operator-pod — so catalogs can group profiles (the environment.* family on community-profiles PR #41) while plain hyphenated slugs remain valid. The dot is naming only: no resolution semantics, no hierarchy, no wildcards (stated in OFTR-003). Pattern relaxed in agent.schema.json (name/inherits) and Setup.ts; slug-to-filename paths audited so agents/<slug>.md materialization and discovery handle dots without extension confusion; fixture tests cover a dotted parent inherited by a plain-slug agent, reject cases for leading/trailing/double dots, and the materialize round-trip.

Sequencing: community-profiles PR #41's environment.* rename depends on this merging and releasing — older outfitters reject the pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EySj3woPAA9pDXDNWGNi9r