### PR TITLE
feat: enforce common .agents validation before harness selection

### DIFF
--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -27,6 +27,7 @@ import type { AgentLaunchPlan } from '../../projection/Projection.js';
 import { strictAmbiguityFailureMessage } from '../../resolver/AmbiguityWarnings.js';
 import { findResource } from '../../resolver/Resource.js';
 import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
+import type { ValidationFinding } from '../../resolver/ResolverValidation.js';
 import type { Harness } from '../../settings/Settings.js';
 import { HARNESSES } from '../../settings/Settings.js';
 import { setupNextStepMessage } from '../../setup/Setup.js';
@@ -38,6 +39,7 @@ import type { CommandObject } from './CommandObject.js';
 import { attachPiRuntimeExtension } from './PiRuntimeLaunch.js';
 import { resolveHomeDirectory, resolveProjectDirectory } from './ProcessDefaults.js';
 import { runSetup } from './SetupCommand.js';
+import { collectCommonValidationFindings, formatValidationFindings } from './ValidateCommand.js';
 
 export type AgentProcessLauncher = (plan: AgentLaunchPlan) => Promise<number>;
 export type RunLogLevel = 'info' | 'debug';
@@ -77,6 +79,8 @@ export interface RunAgentInput {
 
 export interface RunAgentResult {
   readonly launchPlan?: AgentLaunchPlan;
+  /** Shared harness-neutral findings evaluated before harness selection in strict mode. */
+  readonly commonFindings?: readonly ValidationFinding[];
   readonly exitCode: number;
   readonly messages: readonly string[];
 }
@@ -267,42 +271,73 @@ const failedCompositionMessages = (
   ];
 };
 
+const strictCommonValidationFailure = (
+  input: RunAgentInput,
+  resolved: ReturnType<typeof resolveEffectiveSet>,
+): RunAgentResult | undefined => {
+  if (input.strict !== true) return undefined;
+
+  const commonFindings = collectCommonValidationFindings(resolved, input.projectDirectory);
+  if (commonFindings.length === 0) return undefined;
+
+  return {
+    commonFindings,
+    exitCode: 1,
+    messages: [
+      ...formatValidationFindings(commonFindings, false),
+      'Strict mode stops the run when common .agents validation finds an error or warning.',
+      ...(resolved.ambiguityWarnings.length > 0 ? [strictAmbiguityFailureMessage] : []),
+    ],
+  };
+};
+
+const prepareResolvedRun = async (
+  input: RunAgentInput,
+): Promise<{ readonly resolved: ReturnType<typeof resolveEffectiveSet> } | { readonly result: RunAgentResult }> => {
+  let resolved = resolveEffectiveSet(input);
+  let strictFailure = strictCommonValidationFailure(input, resolved);
+  if (strictFailure !== undefined) return { result: strictFailure };
+  assertNoSettingsIssues(resolved.settingsIssues);
+  assertReadableAppendPrompts(input.appendPromptPaths);
+
+  if (!shouldRunSetup(input, resolved)) return { resolved };
+  const setupResult = await input.setup({
+    homeDirectory: input.homeDirectory,
+    projectDirectory: input.projectDirectory,
+  });
+
+  if (setupDidNotSelectAgent(setupResult) && input.strict !== true) {
+    return { result: { exitCode: 0, messages: [setupNextStepMessage] } };
+  }
+
+  // Setup can change the effective tree. Strict mode validates that new state before any result
+  // or launch; normal mode keeps its existing quiet transition to the selected profile.
+  resolved = resolveEffectiveSet(input);
+  strictFailure = strictCommonValidationFailure(input, resolved);
+  if (strictFailure !== undefined) return { result: strictFailure };
+  assertNoSettingsIssues(resolved.settingsIssues);
+
+  return setupDidNotSelectAgent(setupResult)
+    ? { result: { exitCode: 0, messages: [setupNextStepMessage] } }
+    : { resolved };
+};
+
 export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunAgentResult> => {
   // Flush messages to the terminal (before launch); they are also returned so callers can inspect them.
   const emit = (messages: readonly string[]): void => {
     for (const message of messages) input.writeLine?.(message);
   };
 
-  let resolved = resolveEffectiveSet(input);
-  assertNoSettingsIssues(resolved.settingsIssues);
-  assertReadableAppendPrompts(input.appendPromptPaths);
-
-  // First run: nothing selected and no default configured — onboard, then resolve again.
-  if (shouldRunSetup(input, resolved)) {
-    const setupResult = await input.setup({
-      homeDirectory: input.homeDirectory,
-      projectDirectory: input.projectDirectory,
-    });
-
-    if (setupDidNotSelectAgent(setupResult)) {
-      const messages = [setupNextStepMessage];
-      emit(messages);
-      return { exitCode: 0, messages };
-    }
-    // Keep the transition quiet so the real profile UI is the first persistent output.
-    resolved = resolveEffectiveSet(input);
-    assertNoSettingsIssues(resolved.settingsIssues);
+  const prepared = await prepareResolvedRun(input);
+  if ('result' in prepared) {
+    emit(prepared.result.messages);
+    return prepared.result;
   }
+  const { resolved } = prepared;
 
   // Strict mode exposes the complete final resolution state. Normal startup uses these diagnostics
   // only to turn an unavailable selected agent into a concise synchronization action.
   const resolutionWarnings = resolutionWarningsForRun(resolved, input.strict);
-
-  if (input.strict === true && resolved.ambiguityWarnings.length > 0) {
-    const messages = [...resolutionWarnings, strictAmbiguityFailureMessage];
-    emit(messages);
-    return { exitCode: 1, messages };
-  }
 
   const { set, settings } = resolved;
   const agentSlug = resolveAgentSlug(settings.defaultAgent, input.agent);

--- a/code/cli/src/cli/commands/ValidateCommand.ts
+++ b/code/cli/src/cli/commands/ValidateCommand.ts
@@ -4,8 +4,10 @@ import { Command } from 'commander';
 
 import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
 import type { ValidationFinding } from '../../resolver/ResolverValidation.js';
-import { validateEffectiveSet } from '../../resolver/ResolverValidation.js';
+import { validateEffectiveSet, validationFinding } from '../../resolver/ResolverValidation.js';
 import { formatSettingsIssue } from '../../settings/SettingsLoader.js';
+import type { SettingsLoadIssue } from '../../settings/SettingsLoader.js';
+import type { ResolutionWarningDetail } from '../../validation/ResolutionWarning.js';
 import type { CommandObject } from './CommandObject.js';
 import { resolveHomeDirectory, resolveProjectDirectory } from './ProcessDefaults.js';
 
@@ -28,33 +30,63 @@ export interface ValidateCommandDependencies {
   readonly writeLine?: (message: string) => void;
 }
 
-const settingsFindings = (messages: readonly string[]): readonly ValidationFinding[] =>
-  messages.map((message) => ({ severity: 'error' as const, resource: 'settings', message }));
+const settingsFindings = (issues: readonly SettingsLoadIssue[]): readonly ValidationFinding[] =>
+  issues.map((issue) =>
+    validationFinding({
+      phase: 'parse',
+      code: 'settings-invalid',
+      severity: 'error',
+      resource: 'settings',
+      sourcePath: issue.filePath,
+      message: formatSettingsIssue(issue),
+      remediation: 'Correct the settings file, then run validation again.',
+    }),
+  );
+
+const settingsWarningFindings = (warnings: readonly ResolutionWarningDetail[]): readonly ValidationFinding[] =>
+  warnings.map((warning) =>
+    validationFinding({
+      phase: 'resolve',
+      code: 'settings-warning',
+      severity: 'warning',
+      resource: warning.resource,
+      sourcePath: warning.sourcePath,
+      message: warning.message,
+      remediation: 'Run outfitter sync to update remote sources. Correct any invalid source configuration.',
+    }),
+  );
+
+export const collectCommonValidationFindings = (
+  resolved: ReturnType<typeof resolveEffectiveSet>,
+  projectDirectory: string,
+): readonly ValidationFinding[] => [
+  ...settingsFindings(resolved.settingsIssues),
+  ...settingsWarningFindings(resolved.warningDetails),
+  ...validateEffectiveSet(resolved.set, projectDirectory),
+];
 
 export const executeValidateCommand = (input: ValidateInput): ValidateResult => {
-  const { set, settingsIssues, warnings } = resolveEffectiveSet(input);
-  const findings = [
-    ...settingsFindings(settingsIssues.map(formatSettingsIssue)),
-    ...warnings.map((message) => ({ severity: 'warning' as const, resource: 'settings', message })),
-    ...validateEffectiveSet(set, input.projectDirectory),
-  ];
+  const findings = collectCommonValidationFindings(resolveEffectiveSet(input), input.projectDirectory);
 
   const hasErrors = findings.some((finding) => finding.severity === 'error');
   const hasWarnings = findings.some((finding) => finding.severity === 'warning');
   const ok = !hasErrors && !(input.strict === true && hasWarnings);
 
-  const messages = input.json === true ? [JSON.stringify({ ok, findings }, null, 2)] : formatFindings(findings, ok);
+  const messages =
+    input.json === true ? [JSON.stringify({ ok, findings }, null, 2)] : formatValidationFindings(findings, ok);
 
   return { findings, ok, messages };
 };
 
-const formatFindings = (findings: readonly ValidationFinding[], ok: boolean): readonly string[] => {
+export const formatValidationFindings = (findings: readonly ValidationFinding[], ok: boolean): readonly string[] => {
   if (findings.length === 0) {
     return ['✓ No issues found.'];
   }
 
   const lines = findings.map(
-    (finding) => `${finding.severity === 'error' ? '✗' : '⚠'} ${finding.resource}: ${finding.message}`,
+    (finding) =>
+      `${finding.severity === 'error' ? '✗' : '⚠'} [${finding.code}] ${finding.resource}: ${finding.message} ` +
+      `Source: ${finding.sourcePath}. Remediation: ${finding.remediation}`,
   );
 
   return [...lines, ok ? '✓ Passed (warnings only).' : '✗ Validation failed.'];

--- a/code/cli/src/composer/Composer.ts
+++ b/code/cli/src/composer/Composer.ts
@@ -1,15 +1,18 @@
-// Composes a harness-neutral CompositionPlan from the effective resource set and a selected agent.
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { escapesRoots } from '../dump/Containment.js';
-import { isAgentDefinitionIssue, readAgentDefinition } from '../resolver/AgentDefinition.js';
 import type { AgentDefinition } from '../resolver/AgentDefinition.js';
 import type { EffectiveResourceSet, Loadout, ResolvedResource } from '../resolver/Resource.js';
 import { findLoadoutResource, findResource } from '../resolver/Resource.js';
 import type { ComposedLoadout, ComposedSubagent, ComposedSubagentIdentity, CompositionPlan } from './Composition.js';
+import { asRecord, stablePush, union, uniqueStrings } from './CompositionCollections.js';
+import { addDiagnostic, diagnosticList, uniqueDiagnostics } from './CompositionDiagnostic.js';
+import type { CompositionDiagnostic, DiagnosticList } from './CompositionDiagnostic.js';
+import { resolveInheritanceChain } from './InheritanceChain.js';
+import type { ChainEntry } from './InheritanceChain.js';
 import type { PromptFragment, PromptSourceReference } from './PromptSource.js';
-import { agentBodyFragment, promptSourceKey, resolvePromptSource, rootPromptFragment } from './PromptSource.js';
+import { agentBodyFragment, promptSourceKey, readRootPromptFile, resolvePromptSource } from './PromptSource.js';
 
 export interface ComposeOptions {
   /** Active repository root for `repo_file` prompt references. */
@@ -20,16 +23,14 @@ export interface ComposeResult {
   readonly plan?: CompositionPlan;
   readonly errors: readonly string[];
   readonly warnings: readonly string[];
-}
-
-interface ChainEntry {
-  readonly resource: ResolvedResource;
-  readonly definition: AgentDefinition;
+  /** Typed diagnostics with stable codes and declaration provenance. */
+  readonly diagnostics: readonly CompositionDiagnostic[];
 }
 
 interface DeclaredSlug {
   readonly slug: string;
   readonly owner: string;
+  readonly sourcePath: string;
 }
 
 interface EffectiveControls {
@@ -41,114 +42,56 @@ interface EffectiveControls {
     readonly source: PromptSourceReference;
     readonly owner: string;
     readonly index: number;
+    readonly sourcePath: string;
   }[];
-  readonly systemPrompt?: { readonly source: PromptSourceReference; readonly owner: string };
-  readonly promptTemplate?: { readonly source: PromptSourceReference; readonly owner: string };
+  readonly systemPrompt?: {
+    readonly source: PromptSourceReference;
+    readonly owner: string;
+    readonly sourcePath: string;
+  };
+  readonly promptTemplate?: {
+    readonly source: PromptSourceReference;
+    readonly owner: string;
+    readonly sourcePath: string;
+  };
   readonly label?: string;
   readonly description?: string;
 }
 
-/** Reads the highest-precedence tree-root file (e.g. system-prompt.md) across layers, or undefined. */
-const readRootFile = (set: EffectiveResourceSet, fileName: string): PromptFragment | undefined => {
-  for (const layer of set.layers) {
-    const candidate = join(layer.root, fileName);
-
-    if (existsSync(candidate)) {
-      return rootPromptFragment({ fileName, layer, content: readFileSync(candidate, 'utf8') });
-    }
-  }
-
-  return undefined;
-};
-
-const readValidAgent = (agent: ResolvedResource): AgentDefinition | string => {
-  const definition = readAgentDefinition(agent.winner.path, agent.configPaths);
-  if (isAgentDefinitionIssue(definition)) return definition.message;
-  if (definition.name !== agent.slug) return `agent.md name '${definition.name}' must match its directory.`;
-  return definition;
-};
-
-const resolveInheritanceChain = (
-  set: EffectiveResourceSet,
-  agentSlug: string,
-): { entries?: readonly ChainEntry[]; errors: readonly string[] } => {
-  const entries: ChainEntry[] = [];
-  const composed = new Set<string>();
-  const visiting: string[] = [];
-  const errors: string[] = [];
-
-  const visit = (slug: string): void => {
-    if (composed.has(slug)) return;
-    const cycleIndex = visiting.indexOf(slug);
-    if (cycleIndex !== -1) {
-      errors.push(`Agent inheritance cycle detected: ${[...visiting.slice(cycleIndex), slug].join(' -> ')}.`);
-      return;
-    }
-
-    const resource = findResource(set, 'agent', slug);
-    if (resource === undefined) {
-      errors.push(
-        `Agent inheritance references unknown parent '${slug}' in chain ${[...visiting, slug].join(' -> ')}.`,
-      );
-      return;
-    }
-
-    const definition = readValidAgent(resource);
-    if (typeof definition === 'string') {
-      errors.push(`Agent '${slug}' is invalid: ${definition}`);
-      return;
-    }
-
-    visiting.push(slug);
-    for (const parent of definition.inherits) visit(parent);
-    visiting.pop();
-
-    if (!composed.has(slug)) {
-      composed.add(slug);
-      entries.push({ resource, definition });
-    }
-  };
-
-  visit(agentSlug);
-  return errors.length > 0 ? { errors } : { entries, errors: [] };
-};
-
-const stablePush = <T>(items: T[], keySet: Set<string>, key: string, value: T): void => {
-  if (!keySet.has(key)) {
-    keySet.add(key);
-    items.push(value);
-  }
-};
-
-const union = (values: readonly string[] = [], next: readonly string[] = []): readonly string[] | undefined => {
-  const merged: string[] = [];
-  const seen = new Set<string>();
-  for (const value of [...values, ...next]) stablePush(merged, seen, value, value);
-  return merged.length > 0 ? merged : undefined;
-};
-
-const uniqueStrings = (values: readonly string[]): readonly string[] => [...new Set(values)];
-
 const declaredSelections = (
   chain: readonly ChainEntry[],
-  select: (definition: AgentDefinition) => readonly string[],
+  key: 'skills' | 'subagents' | 'mcp',
 ): readonly DeclaredSlug[] => {
   const selections: DeclaredSlug[] = [];
   const seen = new Set<string>();
   for (const entry of chain) {
-    for (const slug of select(entry.definition)) {
-      stablePush(selections, seen, slug, { slug, owner: entry.resource.slug });
+    for (const slug of entry.definition.loadout[key]) {
+      stablePush(selections, seen, slug, {
+        slug,
+        owner: entry.resource.slug,
+        sourcePath: entry.definition.loadoutSourcePaths[key],
+      });
     }
   }
   return selections;
 };
 
 const appendPromptSelections = (chain: readonly ChainEntry[]): EffectiveControls['appendPromptSelections'] => {
-  const selections: { readonly source: PromptSourceReference; readonly owner: string; readonly index: number }[] = [];
+  const selections: {
+    readonly source: PromptSourceReference;
+    readonly owner: string;
+    readonly index: number;
+    readonly sourcePath: string;
+  }[] = [];
   const seen = new Set<string>();
   for (const entry of chain) {
     entry.definition.promptControls.appendSystemPrompt.forEach((source, index) => {
-      stablePush(selections, seen, promptSourceKey(source), { source, owner: entry.resource.slug, index });
+      stablePush(selections, seen, promptSourceKey(source), {
+        source,
+        owner: entry.resource.slug,
+        index,
+        sourcePath: entry.definition.sourcePath,
+      });
     });
   }
   return selections;
@@ -183,15 +126,15 @@ const nearestPrompt = (
 ): EffectiveControls['systemPrompt'] => {
   for (const entry of [...chain].reverse()) {
     const source = select(entry.definition);
-    if (source !== undefined) return { source, owner: entry.resource.slug };
+    if (source !== undefined) return { source, owner: entry.resource.slug, sourcePath: entry.definition.sourcePath };
   }
   return undefined;
 };
 
 const composeEffectiveControls = (chain: readonly ChainEntry[]): EffectiveControls => {
-  const skills = declaredSelections(chain, (definition) => definition.loadout.skills);
-  const subagents = declaredSelections(chain, (definition) => definition.loadout.subagents);
-  const mcp = declaredSelections(chain, (definition) => definition.loadout.mcp);
+  const skills = declaredSelections(chain, 'skills');
+  const subagents = declaredSelections(chain, 'subagents');
+  const mcp = declaredSelections(chain, 'mcp');
   const model = nearest(chain, (definition) => definition.loadout.model);
   const thinking = nearest(chain, (definition) => definition.loadout.thinking);
 
@@ -222,7 +165,7 @@ const resolveDeclaredSlugs = (
   kind: 'skill' | 'agent',
   reference: string,
   selections: readonly DeclaredSlug[],
-  warnings: string[],
+  warnings: DiagnosticList,
 ): readonly ResolvedResource[] => {
   const resolved: ResolvedResource[] = [];
 
@@ -230,7 +173,13 @@ const resolveDeclaredSlugs = (
     const resource = findLoadoutResource(set, selection.owner, kind, selection.slug);
 
     if (resource === undefined) {
-      warnings.push(`${reference} references unknown ${kind} '${selection.slug}'.`);
+      addDiagnostic(warnings, {
+        severity: 'warning',
+        code: 'resource-unresolved',
+        sourcePath: selection.sourcePath,
+        deferInIsolatedSource: true,
+        message: `${reference} references unknown ${kind} '${selection.slug}'.`,
+      });
     } else {
       resolved.push(resource);
     }
@@ -239,16 +188,18 @@ const resolveDeclaredSlugs = (
   return resolved;
 };
 
-const asRecord = (value: unknown): Record<string, unknown> | undefined =>
-  value !== null && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
-
-const readMcpServers = (path: string, warnings: string[]): Readonly<Record<string, unknown>> => {
+const readMcpServers = (path: string, warnings: DiagnosticList): Readonly<Record<string, unknown>> => {
   let parsed: unknown;
 
   try {
     parsed = JSON.parse(readFileSync(path, 'utf8'));
   } catch (error) {
-    warnings.push(`MCP configuration '${path}' is not readable JSON: ${String(error)}`);
+    addDiagnostic(warnings, {
+      severity: 'warning',
+      code: 'resource-invalid',
+      sourcePath: path,
+      message: `MCP configuration '${path}' is not readable JSON: ${String(error)}`,
+    });
     return {};
   }
 
@@ -256,7 +207,12 @@ const readMcpServers = (path: string, warnings: string[]): Readonly<Record<strin
   const servers = document === undefined ? undefined : asRecord(document.mcpServers);
 
   if (servers === undefined) {
-    warnings.push(`MCP configuration '${path}' must contain an object-valued 'mcpServers' map.`);
+    addDiagnostic(warnings, {
+      severity: 'warning',
+      code: 'resource-invalid',
+      sourcePath: path,
+      message: `MCP configuration '${path}' must contain an object-valued 'mcpServers' map.`,
+    });
     return {};
   }
 
@@ -266,7 +222,7 @@ const readMcpServers = (path: string, warnings: string[]): Readonly<Record<strin
 const composeMcpServers = (
   set: EffectiveResourceSet,
   selections: readonly DeclaredSlug[],
-  warnings: string[],
+  warnings: DiagnosticList,
 ): Readonly<Record<string, unknown>> => {
   if (selections.length === 0) return {};
 
@@ -278,7 +234,12 @@ const composeMcpServers = (
     if (cached !== undefined) return cached;
     let servers: Readonly<Record<string, unknown>>;
     if (escapesRoots(path, roots)) {
-      warnings.push(`MCP configuration '${path}' resolves outside the resource layers and was skipped.`);
+      addDiagnostic(warnings, {
+        severity: 'warning',
+        code: 'reference-escaped',
+        sourcePath: path,
+        message: `MCP configuration '${path}' resolves outside the resource layers and was skipped.`,
+      });
       servers = {};
     } else {
       servers = readMcpServers(path, warnings);
@@ -306,7 +267,14 @@ const composeMcpServers = (
     }
 
     if (found) selected[selection.slug] = definition;
-    else warnings.push(`loadout mcp references unknown server '${selection.slug}'.`);
+    else {
+      addDiagnostic(warnings, {
+        severity: 'warning',
+        code: 'resource-unresolved',
+        sourcePath: selection.sourcePath,
+        message: `loadout mcp references unknown server '${selection.slug}'.`,
+      });
+    }
   }
 
   return selected;
@@ -316,7 +284,7 @@ const resolveDelegateSkills = (
   set: EffectiveResourceSet,
   subagents: readonly ResolvedResource[],
   leaderSkills: readonly ResolvedResource[],
-  warnings: string[],
+  warnings: DiagnosticList,
 ): readonly ResolvedResource[] => {
   const skills = new Map(leaderSkills.map((skill) => [skill.slug, skill]));
   const delegateSkills: ResolvedResource[] = [];
@@ -344,9 +312,12 @@ const resolveDelegateSkills = (
         skills.set(skill.slug, skill);
         delegateSkills.push(skill);
       } else if (selected.winner.path !== skill.winner.path) {
-        warnings.push(
-          `delegate skill '${skill.slug}' resolves to conflicting definitions; using '${selected.winner.path}'.`,
-        );
+        addDiagnostic(warnings, {
+          severity: 'warning',
+          code: 'resource-invalid',
+          sourcePath: skill.winner.path,
+          message: `delegate skill '${skill.slug}' resolves to conflicting definitions; using '${selected.winner.path}'.`,
+        });
       }
     }
   }
@@ -357,7 +328,7 @@ const resolveDelegateSkills = (
 const composeLoadout = (
   set: EffectiveResourceSet,
   controls: EffectiveControls,
-  warnings: string[],
+  warnings: DiagnosticList,
 ): ComposedLoadout => {
   const subagents = resolveDeclaredSlugs(set, 'agent', 'loadout subagents', controls.subagentSelections, warnings);
   const skills = resolveDeclaredSlugs(set, 'skill', 'loadout skills', controls.skillSelections, warnings);
@@ -378,11 +349,11 @@ const composeLoadout = (
 
 const resolvePromptSelection = (
   set: EffectiveResourceSet,
-  selection: { readonly source: PromptSourceReference; readonly owner: string },
+  selection: { readonly source: PromptSourceReference; readonly owner: string; readonly sourcePath: string },
   options: ComposeOptions,
   label: string,
-  warnings: string[],
-  errors: string[],
+  warnings: DiagnosticList,
+  errors: DiagnosticList,
 ): PromptFragment | undefined => {
   // Prompt selections are created only from entries in the resolved inheritance chain.
   const owner = findResource(set, 'agent', selection.owner)!;
@@ -394,8 +365,22 @@ const resolvePromptSelection = (
     optionalRepoFile: true,
     label,
   });
-  if (resolved.warning !== undefined) warnings.push(resolved.warning);
-  if (resolved.error !== undefined) errors.push(resolved.error);
+  if (resolved.warning !== undefined) {
+    addDiagnostic(warnings, {
+      severity: 'warning',
+      code: resolved.code,
+      sourcePath: selection.sourcePath,
+      message: resolved.warning,
+    });
+  }
+  if (resolved.error !== undefined) {
+    addDiagnostic(errors, {
+      severity: 'error',
+      code: resolved.code,
+      sourcePath: selection.sourcePath,
+      message: resolved.error,
+    });
+  }
   return resolved.fragment;
 };
 
@@ -404,8 +389,8 @@ const resolveOptionalPrompt = (
   selection: EffectiveControls['systemPrompt'],
   options: ComposeOptions,
   label: string,
-  warnings: string[],
-  errors: string[],
+  warnings: DiagnosticList,
+  errors: DiagnosticList,
 ): PromptFragment | undefined =>
   selection === undefined ? undefined : resolvePromptSelection(set, selection, options, label, warnings, errors);
 
@@ -414,8 +399,8 @@ const composeIdentity = (
   chain: readonly ChainEntry[],
   controls: EffectiveControls,
   options: ComposeOptions,
-  warnings: string[],
-  errors: string[],
+  warnings: DiagnosticList,
+  errors: DiagnosticList,
 ): ComposedSubagentIdentity => {
   const declaredSystemPrompt = resolveOptionalPrompt(
     set,
@@ -426,12 +411,15 @@ const composeIdentity = (
     errors,
   );
   if (declaredSystemPrompt?.kind === 'repo_file') {
-    warnings.push(
-      `agent '${controls.systemPrompt!.owner}' uses untrusted repo_file '${declaredSystemPrompt.reference}' as system_prompt.`,
-    );
+    addDiagnostic(warnings, {
+      severity: 'warning',
+      code: 'resource-invalid',
+      sourcePath: controls.systemPrompt!.sourcePath,
+      message: `agent '${controls.systemPrompt!.owner}' uses untrusted repo_file '${declaredSystemPrompt.reference}' as system_prompt.`,
+    });
   }
-  const systemPrompt = declaredSystemPrompt ?? readRootFile(set, 'system-prompt.md');
-  const sharedContext = readRootFile(set, 'agents.md');
+  const systemPrompt = declaredSystemPrompt ?? readRootPromptFile(set, 'system-prompt.md');
+  const sharedContext = readRootPromptFile(set, 'agents.md');
   const appendSystemPrompts = controls.appendPromptSelections
     .map((selection) =>
       resolvePromptSelection(
@@ -479,8 +467,8 @@ const composeSubagents = (
   set: EffectiveResourceSet,
   subagents: readonly ResolvedResource[],
   options: ComposeOptions,
-  warnings: string[],
-  errors: string[],
+  warnings: DiagnosticList,
+  errors: DiagnosticList,
 ): readonly ComposedSubagent[] => {
   const composed: ComposedSubagent[] = [];
 
@@ -491,7 +479,9 @@ const composeSubagents = (
 
     const chainResult = resolveInheritanceChain(set, resource.slug);
     if (chainResult.entries === undefined) {
-      errors.push(...chainResult.errors.map((error) => `Subagent '${resource.slug}' is invalid: ${error}`));
+      for (const detail of chainResult.errors.details) {
+        addDiagnostic(errors, { ...detail, message: `Subagent '${resource.slug}' is invalid: ${detail.message}` });
+      }
       continue;
     }
 
@@ -521,23 +511,30 @@ const composeSubagents = (
 /** Composes one selected agent from the shared effective resource set. */
 export const compose = (set: EffectiveResourceSet, agentSlug: string, options: ComposeOptions = {}): ComposeResult => {
   if (findResource(set, 'agent', agentSlug) === undefined) {
+    const message = `Unknown agent '${agentSlug}'. Run 'outfitter list agents' to see resolvable agents.`;
     return {
-      errors: [`Unknown agent '${agentSlug}'. Run 'outfitter list agents' to see resolvable agents.`],
+      errors: [message],
       warnings: [],
+      diagnostics: [{ severity: 'error', code: 'resource-unresolved', message }],
     };
   }
 
   const chainResult = resolveInheritanceChain(set, agentSlug);
-  if (chainResult.entries === undefined) return { errors: chainResult.errors, warnings: [] };
+  if (chainResult.entries === undefined) {
+    return { errors: [...chainResult.errors], warnings: [], diagnostics: chainResult.errors.details };
+  }
   const chain = chainResult.entries;
-  const warnings: string[] = [];
-  const errors: string[] = [];
+  const warnings = diagnosticList();
+  const errors = diagnosticList();
   const controls = composeEffectiveControls(chain);
   const identity = composeIdentity(set, chain, controls, options, warnings, errors);
   const loadout = composeLoadout(set, controls, warnings);
   const composedSubagents = composeSubagents(set, loadout.subagents, options, warnings, errors);
-  const uniqueWarnings = uniqueStrings(warnings);
-  if (errors.length > 0) return { errors, warnings: uniqueWarnings };
+  const uniqueWarningDetails = uniqueDiagnostics(warnings.details);
+  const uniqueWarnings = uniqueWarningDetails.map(({ message }) => message);
+  if (errors.length > 0) {
+    return { errors: [...errors], warnings: uniqueWarnings, diagnostics: [...errors.details, ...uniqueWarningDetails] };
+  }
 
   return {
     plan: {
@@ -550,5 +547,6 @@ export const compose = (set: EffectiveResourceSet, agentSlug: string, options: C
     },
     errors: [],
     warnings: uniqueWarnings,
+    diagnostics: uniqueWarningDetails,
   };
 };

--- a/code/cli/src/composer/CompositionCollections.ts
+++ b/code/cli/src/composer/CompositionCollections.ts
@@ -1,0 +1,18 @@
+export const stablePush = <T>(items: T[], keySet: Set<string>, key: string, value: T): void => {
+  if (!keySet.has(key)) {
+    keySet.add(key);
+    items.push(value);
+  }
+};
+
+export const union = (values: readonly string[] = [], next: readonly string[] = []): readonly string[] | undefined => {
+  const merged: string[] = [];
+  const seen = new Set<string>();
+  for (const value of [...values, ...next]) stablePush(merged, seen, value, value);
+  return merged.length > 0 ? merged : undefined;
+};
+
+export const uniqueStrings = (values: readonly string[]): readonly string[] => [...new Set(values)];
+
+export const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  value !== null && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;

--- a/code/cli/src/composer/CompositionDiagnostic.ts
+++ b/code/cli/src/composer/CompositionDiagnostic.ts
@@ -1,0 +1,29 @@
+export type CompositionDiagnosticCode =
+  'inheritance-cycle' | 'resource-invalid' | 'resource-unresolved' | 'reference-escaped';
+
+export interface CompositionDiagnostic {
+  readonly severity: 'error' | 'warning';
+  readonly code: CompositionDiagnosticCode;
+  readonly message: string;
+  readonly sourcePath?: string;
+  /** An isolated catalog can defer this check until the complete effective set is available. */
+  readonly deferInIsolatedSource?: boolean;
+}
+
+export interface DiagnosticList extends Array<string> {
+  readonly details: CompositionDiagnostic[];
+}
+
+export const diagnosticList = (): DiagnosticList => {
+  const list: string[] = [];
+  Object.defineProperty(list, 'details', { value: [] as CompositionDiagnostic[], enumerable: false });
+  return list as DiagnosticList;
+};
+
+export const addDiagnostic = (list: DiagnosticList, detail: CompositionDiagnostic): void => {
+  list.push(detail.message);
+  list.details.push(detail);
+};
+
+export const uniqueDiagnostics = (details: readonly CompositionDiagnostic[]): readonly CompositionDiagnostic[] =>
+  details.filter((detail, index, all) => all.findIndex((candidate) => candidate.message === detail.message) === index);

--- a/code/cli/src/composer/InheritanceChain.ts
+++ b/code/cli/src/composer/InheritanceChain.ts
@@ -1,0 +1,96 @@
+import { isAgentDefinitionIssue, readAgentDefinition } from '../resolver/AgentDefinition.js';
+import type { AgentDefinition } from '../resolver/AgentDefinition.js';
+import type { EffectiveResourceSet, ResolvedResource } from '../resolver/Resource.js';
+import { findResource } from '../resolver/Resource.js';
+import { addDiagnostic, diagnosticList } from './CompositionDiagnostic.js';
+import type { DiagnosticList } from './CompositionDiagnostic.js';
+
+export interface ChainEntry {
+  readonly resource: ResolvedResource;
+  readonly definition: AgentDefinition;
+}
+
+export interface InheritanceChainResult {
+  readonly entries?: readonly ChainEntry[];
+  readonly errors: DiagnosticList;
+}
+
+const reportCycle = (
+  set: EffectiveResourceSet,
+  slug: string,
+  visiting: readonly string[],
+  errors: DiagnosticList,
+): boolean => {
+  const cycleIndex = visiting.indexOf(slug);
+  if (cycleIndex === -1) return false;
+  const declaringSlug = visiting.at(-1)!;
+  addDiagnostic(errors, {
+    severity: 'error',
+    code: 'inheritance-cycle',
+    sourcePath: findResource(set, 'agent', declaringSlug)?.winner.path,
+    message: `Agent inheritance cycle detected: ${[...visiting.slice(cycleIndex), slug].join(' -> ')}.`,
+  });
+  return true;
+};
+
+const readChainEntry = (resource: ResolvedResource, errors: DiagnosticList): ChainEntry | undefined => {
+  const definition = readAgentDefinition(resource.winner.path, resource.configPaths);
+  if (isAgentDefinitionIssue(definition)) {
+    addDiagnostic(errors, {
+      severity: 'error',
+      code: 'resource-invalid',
+      sourcePath: definition.path,
+      message: `Agent '${resource.slug}' is invalid: ${definition.message}`,
+    });
+    return undefined;
+  }
+  if (definition.name !== resource.slug) {
+    addDiagnostic(errors, {
+      severity: 'error',
+      code: 'resource-invalid',
+      sourcePath: definition.sourcePath,
+      message: `Agent '${resource.slug}' is invalid: agent.md name '${definition.name}' must match its directory.`,
+    });
+    return undefined;
+  }
+  return { resource, definition };
+};
+
+export const resolveInheritanceChain = (set: EffectiveResourceSet, agentSlug: string): InheritanceChainResult => {
+  const entries: ChainEntry[] = [];
+  const composed = new Set<string>();
+  const visiting: string[] = [];
+  const errors = diagnosticList();
+
+  const visit = (slug: string): void => {
+    if (composed.has(slug)) return;
+    if (reportCycle(set, slug, visiting, errors)) return;
+
+    const resource = findResource(set, 'agent', slug);
+    if (resource === undefined) {
+      addDiagnostic(errors, {
+        severity: 'error',
+        code: 'resource-unresolved',
+        sourcePath: findResource(set, 'agent', visiting.at(-1)!)?.winner.path,
+        message: `Agent inheritance references unknown parent '${slug}' in chain ${[...visiting, slug].join(' -> ')}.`,
+      });
+      return;
+    }
+
+    const entry = readChainEntry(resource, errors);
+    if (entry === undefined) return;
+    const { definition } = entry;
+
+    visiting.push(slug);
+    for (const parent of definition.inherits) visit(parent);
+    visiting.pop();
+
+    if (!composed.has(slug)) {
+      composed.add(slug);
+      entries.push(entry);
+    }
+  };
+
+  visit(agentSlug);
+  return errors.length > 0 ? { errors } : { entries, errors };
+};

--- a/code/cli/src/composer/PromptSource.ts
+++ b/code/cli/src/composer/PromptSource.ts
@@ -3,7 +3,7 @@ import { existsSync, realpathSync, statSync, readFileSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
 
 import { escapesRoots } from '../dump/Containment.js';
-import type { Layer } from '../resolver/Resource.js';
+import type { EffectiveResourceSet, Layer } from '../resolver/Resource.js';
 
 export type PromptSourceKind = 'root' | 'file' | 'repo_file' | 'agent_body';
 
@@ -25,11 +25,17 @@ export interface PromptFragment {
   readonly trust: 'catalog' | 'repository' | 'generated';
 }
 
-export interface PromptResolution {
-  readonly fragment?: PromptFragment;
-  readonly warning?: string;
-  readonly error?: string;
-}
+type PromptDiagnosticCode = 'reference-escaped' | 'resource-invalid' | 'resource-unresolved';
+
+export type PromptResolution =
+  | { readonly fragment: PromptFragment; readonly warning?: never; readonly error?: never; readonly code?: never }
+  | { readonly warning: string; readonly code: PromptDiagnosticCode; readonly fragment?: never; readonly error?: never }
+  | {
+      readonly error: string;
+      readonly code: PromptDiagnosticCode;
+      readonly fragment?: never;
+      readonly warning?: never;
+    };
 
 export const isPromptSourceReference = (value: unknown): value is PromptSourceReference =>
   value !== null &&
@@ -43,24 +49,31 @@ export const isPromptSourceReference = (value: unknown): value is PromptSourceRe
 const safeRelative = (value: string): boolean =>
   value.length > 0 && !value.startsWith('/') && !value.split(/[\\/]+/).includes('..');
 
-const containedFile = (path: string, root: string): true | string => {
-  if (!existsSync(path)) return `missing file '${path}'.`;
+interface ContainedFileIssue {
+  readonly code: 'reference-escaped' | 'resource-invalid';
+  readonly message: string;
+}
+
+const containedFile = (path: string, root: string): true | ContainedFileIssue => {
+  if (!existsSync(path)) return { code: 'resource-invalid', message: `missing file '${path}'.` };
 
   let real: string;
   try {
     real = realpathSync(path);
     /* v8 ignore next 2 -- existsSync succeeded; this only covers a concurrent filesystem race. */
   } catch (error) {
-    return `cannot resolve '${path}': ${String(error)}`;
+    return { code: 'resource-invalid', message: `cannot resolve '${path}': ${String(error)}` };
   }
 
-  if (escapesRoots(real, [root])) return `'${path}' resolves outside '${root}'.`;
+  if (escapesRoots(real, [root])) {
+    return { code: 'reference-escaped', message: `'${path}' resolves outside '${root}'.` };
+  }
 
   try {
-    if (!statSync(real).isFile()) return `'${path}' is not a file.`;
+    if (!statSync(real).isFile()) return { code: 'resource-invalid', message: `'${path}' is not a file.` };
     /* v8 ignore next 2 -- realpathSync succeeded; this only covers a concurrent filesystem race. */
   } catch (error) {
-    return `cannot stat '${path}': ${String(error)}`;
+    return { code: 'resource-invalid', message: `cannot stat '${path}': ${String(error)}` };
   }
 
   return true;
@@ -83,11 +96,17 @@ export const resolvePromptSource = (input: {
     if (!safeRelative(source.file)) {
       return {
         error: `agent '${declaringAgent}' prompt source file '${source.file}' must be a contained relative path.`,
+        code: 'reference-escaped',
       };
     }
     const path = join(layer.root, source.file);
     const contained = containedFile(path, layer.root);
-    if (contained !== true) return { error: `agent '${declaringAgent}' prompt source file ${contained}` };
+    if (contained !== true) {
+      return {
+        error: `agent '${declaringAgent}' prompt source file ${contained.message}`,
+        code: contained.code,
+      };
+    }
     return {
       fragment: {
         kind: 'file',
@@ -106,6 +125,7 @@ export const resolvePromptSource = (input: {
   if (!safeRelative(repoFile)) {
     return {
       error: `agent '${declaringAgent}' repo_file prompt source '${repoFile}' must be a contained relative path.`,
+      code: 'reference-escaped',
     };
   }
 
@@ -113,15 +133,24 @@ export const resolvePromptSource = (input: {
   if (projectDirectory === undefined) {
     return {
       warning: `agent '${declaringAgent}' repo_file prompt source '${repoFile}' cannot be resolved without a project root.`,
+      code: 'resource-unresolved',
     };
   }
 
   const path = join(projectDirectory, repoFile);
   if (!existsSync(path) && input.optionalRepoFile === true) {
-    return { warning: `agent '${declaringAgent}' optional repo_file prompt source '${repoFile}' was not found.` };
+    return {
+      warning: `agent '${declaringAgent}' optional repo_file prompt source '${repoFile}' was not found.`,
+      code: 'resource-unresolved',
+    };
   }
   const contained = containedFile(path, projectDirectory);
-  if (contained !== true) return { error: `agent '${declaringAgent}' repo_file prompt source ${contained}` };
+  if (contained !== true) {
+    return {
+      error: `agent '${declaringAgent}' repo_file prompt source ${contained.message}`,
+      code: contained.code,
+    };
+  }
 
   return {
     fragment: {
@@ -150,6 +179,17 @@ export const rootPromptFragment = (input: {
   label: input.fileName.replace(/\.md$/, ''),
   trust: 'catalog',
 });
+
+/** Reads the highest-precedence tree-root prompt file across resource layers. */
+export const readRootPromptFile = (set: EffectiveResourceSet, fileName: string): PromptFragment | undefined => {
+  for (const layer of set.layers) {
+    const candidate = join(layer.root, fileName);
+    if (existsSync(candidate)) {
+      return rootPromptFragment({ fileName, layer, content: readFileSync(candidate, 'utf8') });
+    }
+  }
+  return undefined;
+};
 
 export const agentBodyFragment = (input: {
   readonly agent: string;

--- a/code/cli/src/dump/Containment.ts
+++ b/code/cli/src/dump/Containment.ts
@@ -1,6 +1,9 @@
 // Realpath containment helpers so a dump can never read or overwrite content outside the tree.
 import { realpathSync } from 'node:fs';
-import { isAbsolute, relative, resolve } from 'node:path';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
+
+const isContainedRelativePath = (path: string): boolean =>
+  path === '' || (path !== '..' && !path.startsWith(`..${sep}`) && !isAbsolute(path));
 
 /** Resolves symlinks to a real path; falls back to a normalized absolute path when it does not exist. */
 export const realpathOrResolve = (path: string): string => {
@@ -11,10 +14,16 @@ export const realpathOrResolve = (path: string): string => {
   }
 };
 
+/** True when a normalized child path is lexically contained without following symlinks. */
+export const isLexicallyInside = (child: string, parent: string): boolean => {
+  const relativePath = relative(parent, child);
+  return isContainedRelativePath(relativePath);
+};
+
 /** True when `child` resolves to `parent` or somewhere inside it (symlinks followed on both sides). */
 export const isInside = (child: string, parent: string): boolean => {
   const relativePath = relative(realpathOrResolve(parent), realpathOrResolve(child));
-  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath));
+  return isContainedRelativePath(relativePath);
 };
 
 /** True when `path` resolves outside every provided root — i.e. it escapes the tree. */

--- a/code/cli/src/resolver/AgentDefinition.ts
+++ b/code/cli/src/resolver/AgentDefinition.ts
@@ -10,6 +10,8 @@ import type { Loadout } from './Resource.js';
 import { emptyLoadout } from './Resource.js';
 
 export interface AgentDefinition {
+  /** The agent.md file that declares identity, inheritance, and prompt controls. */
+  readonly sourcePath: string;
   readonly name: string;
   /** Human-readable profile name shown in interactive harness UI. */
   readonly label?: string;
@@ -17,6 +19,8 @@ export interface AgentDefinition {
   /** Markdown body after the frontmatter — the agent's identity prose. */
   readonly body: string;
   readonly loadout: Loadout;
+  /** The effective declaration file for each loadout key after config.json overrides. */
+  readonly loadoutSourcePaths: Readonly<Record<LoadoutKey, string>>;
   /** Ordered parent agent slugs declared by `inherits`. */
   readonly inherits: readonly string[];
   readonly promptControls: PromptControls;
@@ -29,6 +33,7 @@ export interface PromptControls {
 }
 
 export interface AgentDefinitionIssue {
+  readonly kind: 'frontmatter' | 'invalid-name' | 'config' | 'invalid-tools' | 'read';
   readonly path: string;
   readonly message: string;
 }
@@ -48,6 +53,8 @@ export const loadoutKeys = [
   'thinking',
   'tools',
 ] as const;
+
+export type LoadoutKey = (typeof loadoutKeys)[number];
 
 /** Restricts an arbitrary record to the loadout keys config.json is allowed to supply. */
 export const pickLoadoutKeys = (record: Readonly<Record<string, unknown>>): Record<string, unknown> =>
@@ -189,7 +196,11 @@ const toolsIssue = (record: Readonly<Record<string, unknown>>, path: string): Ag
 
   return offending === undefined
     ? undefined
-    : { path, message: `declares an unusable tool name ${JSON.stringify(offending)}: ${TOOL_NAME_RULE}` };
+    : {
+        kind: 'invalid-tools',
+        path,
+        message: `declares an unusable tool name ${JSON.stringify(offending)}: ${TOOL_NAME_RULE}`,
+      };
 };
 
 /** Reads one config.json, restricting it to loadout keys; parse/read/non-object failures are issues. */
@@ -199,11 +210,11 @@ const readConfigLoadout = (configPath: string): Readonly<Record<string, unknown>
   try {
     parsed = JSON.parse(readFileSync(configPath, 'utf8'));
   } catch (error) {
-    return { path: configPath, message: `config.json is not readable JSON: ${String(error)}` };
+    return { kind: 'config', path: configPath, message: `config.json is not readable JSON: ${String(error)}` };
   }
 
   if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    return { path: configPath, message: 'config.json must be a JSON object of loadout overrides.' };
+    return { kind: 'config', path: configPath, message: 'config.json must be a JSON object of loadout overrides.' };
   }
 
   const picked = pickLoadoutKeys(parsed as Record<string, unknown>);
@@ -214,7 +225,11 @@ const readConfigLoadout = (configPath: string): Readonly<Record<string, unknown>
     const defect = toolsShapeDefect(picked.tools);
 
     if (defect !== undefined) {
-      return { path: configPath, message: `config.json declares a malformed tool selection: ${defect}` };
+      return {
+        kind: 'invalid-tools',
+        path: configPath,
+        message: `config.json declares a malformed tool selection: ${defect}`,
+      };
     }
   }
 
@@ -228,17 +243,25 @@ const parseFrontmatterRecord = (
   const split = splitFrontmatter(content);
 
   if (split === undefined) {
-    return { path: agentPath, message: 'agent.md must start with a `---` YAML frontmatter block.' };
+    return {
+      kind: 'frontmatter',
+      path: agentPath,
+      message: 'agent.md must start with a `---` YAML frontmatter block.',
+    };
   }
 
   const parsed = parseYamlDocument(split.frontmatter, agentPath);
 
   if (!parsed.ok) {
-    return { path: agentPath, message: `agent.md frontmatter is not valid YAML: ${parsed.issue.message}` };
+    return {
+      kind: 'frontmatter',
+      path: agentPath,
+      message: `agent.md frontmatter is not valid YAML: ${parsed.issue.message}`,
+    };
   }
 
   if (parsed.document === null || typeof parsed.document !== 'object' || Array.isArray(parsed.document)) {
-    return { path: agentPath, message: 'agent.md frontmatter must be a YAML mapping.' };
+    return { kind: 'frontmatter', path: agentPath, message: 'agent.md frontmatter must be a YAML mapping.' };
   }
 
   // Validate the frontmatter on its own so config.json cannot supply required identity fields.
@@ -246,10 +269,39 @@ const parseFrontmatterRecord = (
 
   if (!validation.valid) {
     // An invalid document always yields at least one issue.
-    return { path: agentPath, message: `agent.md is invalid: ${validation.issues[0].message}` };
+    return {
+      kind: validation.issues[0].path === '/name' ? 'invalid-name' : 'frontmatter',
+      path: agentPath,
+      message: `agent.md is invalid: ${validation.issues[0].message}`,
+    };
   }
 
   return { record: parsed.document as Record<string, unknown>, body: split.body };
+};
+
+interface MergedLoadout {
+  readonly record: Record<string, unknown>;
+  readonly sourcePaths: Readonly<Record<LoadoutKey, string>>;
+}
+
+const mergeLoadoutOverrides = (
+  frontmatter: Readonly<Record<string, unknown>>,
+  configPaths: readonly string[],
+  agentPath: string,
+): MergedLoadout | AgentDefinitionIssue => {
+  let record = { ...frontmatter };
+  const sourcePaths = Object.fromEntries(loadoutKeys.map((key) => [key, agentPath])) as Record<LoadoutKey, string>;
+
+  for (const configPath of [...configPaths].reverse()) {
+    const config = readConfigLoadout(configPath);
+    if (isAgentDefinitionIssue(config)) return config;
+    record = { ...record, ...config };
+    for (const key of loadoutKeys) {
+      if (key in config) sourcePaths[key] = configPath;
+    }
+  }
+
+  return { record, sourcePaths };
 };
 
 /**
@@ -267,34 +319,26 @@ export const parseAgentDefinition = (
     return frontmatter;
   }
 
-  let merged: Record<string, unknown> = { ...frontmatter.record };
-
-  // Apply lowest precedence first so higher layers win per key.
-  for (const configPath of [...configPaths].reverse()) {
-    const config = readConfigLoadout(configPath);
-
-    if (isAgentDefinitionIssue(config)) {
-      return config;
-    }
-
-    merged = { ...merged, ...config };
-  }
+  const merged = mergeLoadoutOverrides(frontmatter.record, configPaths, agentPath);
+  if (isAgentDefinitionIssue(merged)) return merged;
 
   // The JSON Schema only sees the frontmatter, and a config.json overlay can replace `tools`
   // wholesale after that check. Validate the merged loadout so an unprojectable tool name is an
   // error from `outfitter validate`, not a surprise at launch.
-  const toolIssue = toolsIssue(merged, configPaths[0] ?? agentPath);
+  const toolIssue = toolsIssue(merged.record, merged.sourcePaths.tools ?? agentPath);
 
   if (toolIssue !== undefined) {
     return toolIssue;
   }
 
   return {
+    sourcePath: agentPath,
     name: frontmatter.record.name as string,
     label: asString(frontmatter.record.label)?.trim() || readMarkdownHeading(frontmatter.body),
     description: asString(frontmatter.record.description),
     body: frontmatter.body,
-    loadout: loadoutFromRecord(merged),
+    loadout: loadoutFromRecord(merged.record),
+    loadoutSourcePaths: merged.sourcePaths,
     inherits: asSlugListOrScalar(frontmatter.record.inherits),
     promptControls: promptControlsFromRecord(frontmatter.record),
   };
@@ -309,7 +353,7 @@ export const readAgentDefinition = (
   try {
     content = readFileSync(agentPath, 'utf8');
   } catch (error) {
-    return { path: agentPath, message: `Could not read agent.md: ${String(error)}` };
+    return { kind: 'read', path: agentPath, message: `Could not read agent.md: ${String(error)}` };
   }
 
   return parseAgentDefinition(content, configPaths, agentPath);

--- a/code/cli/src/resolver/AmbiguityWarnings.ts
+++ b/code/cli/src/resolver/AmbiguityWarnings.ts
@@ -9,12 +9,14 @@ import {
   redactSourceUriCredentials,
 } from '../sources/SourceCache.js';
 import type { RemoteSourceReference } from '../sources/SourceCache.js';
-import type { DeclaredRemoteSource } from '../sources/TransitiveSources.js';
+import type { AttributedRemoteSource } from '../sources/TransitiveSources.js';
+import type { ResolutionWarningDetail } from '../validation/ResolutionWarning.js';
 import type { EffectiveResourceSet, ResolvedResource, ResourceKind } from './Resource.js';
 
 interface SourceDeclaration {
   readonly source: RemoteSourceReference;
   readonly declaredBy: string;
+  readonly sourcePath: string;
 }
 
 export const strictAmbiguityFailureMessage = 'Strict mode: ambiguous resolution is fatal.';
@@ -35,29 +37,31 @@ const directDeclarations = (files: readonly LoadedSettingsFile[]): readonly Sour
     .flatMap((file) =>
       (file.settings.sources ?? [])
         .filter(isRemoteSource)
-        .map((source) => ({ source, declaredBy: file.location.path })),
+        .map((source) => ({ source, declaredBy: file.location.path, sourcePath: file.location.path })),
     );
 
-const replacedSourceListWarnings = (
+const replacedSourceListWarningDetails = (
   files: readonly LoadedSettingsFile[],
   effectiveSources: readonly SourceReference[],
-): readonly string[] => {
+): readonly ResolutionWarningDetail[] => {
   const replacingIndex = files.findLastIndex((file) => file.settings.sources !== undefined);
   if (replacingIndex < 1) return [];
 
   const replacingFile = files[replacingIndex];
   const effectiveRepositories = new Set(effectiveSources.filter(isRemoteSource).map(repositoryKey));
   const reportedRepositories = new Set<string>();
-  const warnings: string[] = [];
+  const warnings: ResolutionWarningDetail[] = [];
 
   for (const file of files.slice(0, replacingIndex).reverse()) {
     for (const source of (file.settings.sources ?? []).filter(isRemoteSource)) {
       const key = repositoryKey(source);
       if (effectiveRepositories.has(key) || reportedRepositories.has(key)) continue;
       reportedRepositories.add(key);
-      warnings.push(
-        `source '${repositoryDisplay(source)}' declared by '${file.location.path}' was replaced by '${replacingFile.location.path}' and is not in the effective configuration`,
-      );
+      warnings.push({
+        resource: `source:${repositoryDisplay(source)}`,
+        sourcePath: replacingFile.location.path,
+        message: `source '${repositoryDisplay(source)}' declared by '${file.location.path}' was replaced by '${replacingFile.location.path}' and is not in the effective configuration`,
+      });
     }
   }
 
@@ -67,7 +71,7 @@ const replacedSourceListWarnings = (
 const selectedDeclarations = (
   effectiveSources: readonly SourceReference[],
   direct: readonly SourceDeclaration[],
-  transitive: readonly DeclaredRemoteSource[],
+  transitive: readonly AttributedRemoteSource[],
 ): readonly SourceDeclaration[] => {
   const selectedDirect = effectiveSources.filter(isRemoteSource).map((source) => {
     const selection = encodeRemoteSourceSelection(source);
@@ -77,11 +81,11 @@ const selectedDeclarations = (
   return [...selectedDirect, ...transitive];
 };
 
-export const sourceRefAmbiguityWarnings = (
+export const sourceRefAmbiguityWarningDetails = (
   files: readonly LoadedSettingsFile[],
   effectiveSources: readonly SourceReference[],
-  transitiveDeclarations: readonly DeclaredRemoteSource[],
-): readonly string[] => {
+  transitiveDeclarations: readonly AttributedRemoteSource[],
+): readonly ResolutionWarningDetail[] => {
   const direct = directDeclarations(files);
   const declarations: readonly SourceDeclaration[] = [...direct, ...transitiveDeclarations];
   const selected = selectedDeclarations(effectiveSources, direct, transitiveDeclarations);
@@ -94,7 +98,7 @@ export const sourceRefAmbiguityWarnings = (
     byRepository.set(key, entries);
   }
 
-  const warnings: string[] = [...replacedSourceListWarnings(files, effectiveSources)];
+  const warnings: ResolutionWarningDetail[] = [...replacedSourceListWarningDetails(files, effectiveSources)];
   for (const entries of byRepository.values()) {
     if (new Set(entries.map((entry) => entry.source.ref)).size < 2) continue;
     const key = repositoryKey(entries[0].source);
@@ -103,26 +107,40 @@ export const sourceRefAmbiguityWarnings = (
     const declarationsText = entries
       .map((entry) => `'${entry.declaredBy}' declares ref '${refDisplay(entry.source)}'`)
       .join('; ');
-    warnings.push(
-      `Ambiguous source repository '${repositoryDisplay(entries[0].source)}': ${declarationsText}; declaration from '${winner.declaredBy}' at ref '${refDisplay(winner.source)}' won.`,
-    );
+    warnings.push({
+      resource: `source:${repositoryDisplay(entries[0].source)}`,
+      sourcePath: winner.sourcePath,
+      message: `Ambiguous source repository '${repositoryDisplay(entries[0].source)}': ${declarationsText}; declaration from '${winner.declaredBy}' at ref '${refDisplay(winner.source)}' won.`,
+    });
   }
 
   return warnings;
 };
 
-const slugWarning = (kind: ResourceKind, resource: ResolvedResource, context?: string): string | undefined => {
+const slugWarning = (
+  kind: ResourceKind,
+  resource: ResolvedResource,
+  context?: string,
+): ResolutionWarningDetail | undefined => {
   const definitions = [resource.winner, ...resource.shadowed];
   const labels = [...new Set(definitions.map((definition) => definition.layer.label))];
   if (labels.length < 2) return undefined;
-  return `Ambiguous ${kind} slug '${resource.slug}'${context ?? ''} is supplied by ${labels.map((label) => `'${label}'`).join(', ')}; '${resource.winner.layer.label}' won.`;
+  const resourceIdentity =
+    resource.winner.ownerAgent === undefined
+      ? `${kind}:${resource.slug}`
+      : `agent:${resource.winner.ownerAgent}/${kind}:${resource.slug}`;
+  return {
+    resource: resourceIdentity,
+    sourcePath: resource.winner.path,
+    message: `Ambiguous ${kind} slug '${resource.slug}'${context ?? ''} is supplied by ${labels.map((label) => `'${label}'`).join(', ')}; '${resource.winner.layer.label}' won.`,
+  };
 };
 
 const resourceWarnings = (
   kind: ResourceKind,
   resources: Iterable<ResolvedResource> | undefined,
   context?: string,
-): readonly string[] =>
+): readonly ResolutionWarningDetail[] =>
   resources === undefined
     ? []
     : [...resources].flatMap((resource) => {
@@ -130,7 +148,7 @@ const resourceWarnings = (
         return warning === undefined ? [] : [warning];
       });
 
-export const slugAmbiguityWarnings = (set: EffectiveResourceSet): readonly string[] => [
+export const slugAmbiguityWarningDetails = (set: EffectiveResourceSet): readonly ResolutionWarningDetail[] => [
   ...resourceWarnings('agent', set.resources.get('agent')?.values()),
   ...resourceWarnings('skill', set.resources.get('skill')?.values()),
   ...[...set.agentResources].flatMap(([agent, kinds]) =>

--- a/code/cli/src/resolver/Layer.ts
+++ b/code/cli/src/resolver/Layer.ts
@@ -11,14 +11,17 @@ import {
 } from '../sources/SourceCache.js';
 import type { RemoteSourceReference } from '../sources/SourceCache.js';
 import { expandTransitiveSources } from '../sources/TransitiveSources.js';
-import type { DeclaredRemoteSource } from '../sources/TransitiveSources.js';
+import type { AttributedRemoteSource } from '../sources/TransitiveSources.js';
 import type { Settings, SourceReference } from '../settings/Settings.js';
+import type { ResolutionWarningDetail } from '../validation/ResolutionWarning.js';
 import type { Layer } from './Resource.js';
 
 export interface LayerDiscoveryInput {
   readonly homeDirectory: string;
   readonly projectDirectory: string;
   readonly settings: Settings;
+  /** The effective settings file that declares direct sources. */
+  readonly settingsSourcePath?: string;
 }
 
 const agentsRoot = (directory: string): string => join(directory, '.agents');
@@ -44,7 +47,7 @@ const sourceLayer = (input: LayerDiscoveryInput, source: SourceReference): Layer
 export interface LayerDiscoveryResult {
   readonly layers: readonly Layer[];
   /** Accepted transitive declarations, including duplicates, retained for ambiguity diagnostics. */
-  readonly transitiveDeclarations: readonly DeclaredRemoteSource[];
+  readonly transitiveDeclarations: readonly AttributedRemoteSource[];
   /**
    * Configured remote sources whose cache is absent, reported with `outfitter sync` guidance rather
    * than silently dropped (OFTR-004.2.18). Reported, never fatal: a private catalog the enterprise
@@ -52,8 +55,10 @@ export interface LayerDiscoveryResult {
    * would deadlock every other command behind advice the user cannot act on (OFTR-004.2.15).
    */
   readonly unsynchronized: readonly string[];
+  readonly unsynchronizedDetails: readonly ResolutionWarningDetail[];
   /** Non-fatal transitive-source skip warnings (unpinned refs, path sources, invalid settings). */
   readonly warnings: readonly string[];
+  readonly warningDetails: readonly ResolutionWarningDetail[];
 }
 
 /**
@@ -66,25 +71,32 @@ export const discoverLayers = (input: LayerDiscoveryInput): LayerDiscoveryResult
     { root: agentsRoot(input.projectDirectory), origin: 'workspace', label: 'workspace' },
     { root: agentsRoot(input.homeDirectory), origin: 'global', label: 'global' },
   ];
-  const unsynchronized: string[] = [];
-  const invalid: string[] = [];
+  const unsynchronizedDetails: ResolutionWarningDetail[] = [];
+  const invalidDetails: ResolutionWarningDetail[] = [];
+  const directSourcePath = input.settingsSourcePath ?? join(input.projectDirectory, '.agents', 'settings.yml');
 
-  const appendSourceLayer = (source: SourceReference): void => {
+  const appendSourceLayer = (source: SourceReference, declarationPath: string): void => {
+    const display = isRemoteSource(source) ? formatRemoteSourceDisplay(source) : source.path;
+    const resource = `source:${display}`;
     // An absolute or escaping `path:` makes payload-root resolution throw; skip the source with a
     // warning rather than crash every resolve command (list/validate/run/dump).
     let layer: Layer;
     try {
       layer = sourceLayer(input, source);
     } catch {
-      invalid.push(
-        `Configured source '${isRemoteSource(source) ? formatRemoteSourceDisplay(source) : source.path}' has an invalid path and was skipped.`,
-      );
+      invalidDetails.push({
+        message: `Configured source '${display}' has an invalid path and was skipped.`,
+        resource,
+        sourcePath: declarationPath,
+      });
       return;
     }
     if (isRemoteSource(source) && !existsSync(layer.root)) {
-      unsynchronized.push(
-        `Configured remote source '${layer.label}' is not synchronized at '${layer.root}'. Run 'outfitter sync' to fetch it.`,
-      );
+      unsynchronizedDetails.push({
+        message: `Configured remote source '${layer.label}' is not synchronized at '${layer.root}'. Run 'outfitter sync' to fetch it.`,
+        resource,
+        sourcePath: declarationPath,
+      });
       return;
     }
     candidates.push(layer);
@@ -100,7 +112,7 @@ export const discoverLayers = (input: LayerDiscoveryInput): LayerDiscoveryResult
     return true;
   });
   for (const source of directSources) {
-    appendSourceLayer(source);
+    appendSourceLayer(source, directSourcePath);
   }
 
   const expansion = expandTransitiveSources({
@@ -110,14 +122,18 @@ export const discoverLayers = (input: LayerDiscoveryInput): LayerDiscoveryResult
       return existsSync(checkoutRoot) ? checkoutRoot : undefined;
     },
   });
-  for (const transitive of expansion.sources) {
-    appendSourceLayer(transitive.source);
+  for (const transitive of expansion.attributedSources) {
+    appendSourceLayer(transitive.source, transitive.sourcePath);
   }
+
+  const warningDetails = [...invalidDetails, ...expansion.warningDetails];
 
   return {
     layers: candidates.filter((layer) => existsSync(layer.root)),
-    transitiveDeclarations: expansion.declarations,
-    unsynchronized,
-    warnings: [...invalid, ...expansion.warnings],
+    transitiveDeclarations: expansion.attributedDeclarations,
+    unsynchronized: unsynchronizedDetails.map(({ message }) => message),
+    unsynchronizedDetails,
+    warnings: warningDetails.map(({ message }) => message),
+    warningDetails,
   };
 };

--- a/code/cli/src/resolver/ReferenceTreeInspection.ts
+++ b/code/cli/src/resolver/ReferenceTreeInspection.ts
@@ -1,0 +1,68 @@
+// Inspects materialization inputs without copying them or crossing their declared root.
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { isInside, realpathOrResolve } from '../dump/Containment.js';
+
+export type ReferenceTreeIssueKind = 'escaped' | 'missing' | 'unreadable' | 'special' | 'directory-unreadable';
+
+export interface ReferenceTreeIssue {
+  readonly kind: ReferenceTreeIssueKind;
+  readonly path: string;
+}
+
+type InspectedEntry =
+  | { readonly kind: 'file' }
+  | { readonly kind: 'directory'; readonly identity: string }
+  | { readonly kind: 'issue'; readonly issue: ReferenceTreeIssue };
+
+const inspectEntry = (path: string, root: string): InspectedEntry => {
+  // A missing target has no real path. Let statSync classify it instead of comparing a lexical
+  // macOS `/var` path with the canonical `/private/var` root and misreporting an escape.
+  if (existsSync(path) && !isInside(path, root)) return { kind: 'issue', issue: { kind: 'escaped', path } };
+
+  try {
+    const stats = statSync(path);
+    if (stats.isDirectory()) return { kind: 'directory', identity: realpathOrResolve(path) };
+    if (stats.isFile()) return { kind: 'file' };
+    return { kind: 'issue', issue: { kind: 'special', path } };
+  } catch (error) {
+    const kind = (error as NodeJS.ErrnoException).code === 'ENOENT' ? 'missing' : 'unreadable';
+    return { kind: 'issue', issue: { kind, path } };
+  }
+};
+
+export const inspectReferenceTree = (
+  target: string,
+  root: string,
+  visitedDirectories: Set<string>,
+): readonly ReferenceTreeIssue[] => {
+  const pending = [target];
+  const issues: ReferenceTreeIssue[] = [];
+  const rootIdentity = realpathOrResolve(root);
+
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    const inspected = inspectEntry(current, root);
+    if (inspected.kind === 'issue') {
+      issues.push(inspected.issue);
+      continue;
+    }
+    if (inspected.kind === 'file') continue;
+
+    const visitKey = `${rootIdentity}\0${inspected.identity}`;
+    if (visitedDirectories.has(visitKey)) continue;
+    visitedDirectories.add(visitKey);
+
+    try {
+      const children = readdirSync(current)
+        .sort()
+        .map((name) => join(current, name));
+      pending.push(...children.reverse());
+    } catch {
+      issues.push({ kind: 'directory-unreadable', path: current });
+    }
+  }
+
+  return issues;
+};

--- a/code/cli/src/resolver/ResolverContext.ts
+++ b/code/cli/src/resolver/ResolverContext.ts
@@ -1,8 +1,11 @@
 // Shared entry point that turns a home/project location into one effective resource set.
+import { join } from 'node:path';
+
 import { loadSettingsWithCachedRemoteSettings } from '../settings/SettingsLoader.js';
 import type { SettingsLoadIssue } from '../settings/SettingsLoader.js';
 import type { Settings } from '../settings/Settings.js';
-import { slugAmbiguityWarnings, sourceRefAmbiguityWarnings } from './AmbiguityWarnings.js';
+import type { ResolutionWarningDetail } from '../validation/ResolutionWarning.js';
+import { slugAmbiguityWarningDetails, sourceRefAmbiguityWarningDetails } from './AmbiguityWarnings.js';
 import { discoverLayers } from './Layer.js';
 import type { EffectiveResourceSet } from './Resource.js';
 import { resolveResources } from './Resolver.js';
@@ -19,6 +22,8 @@ export interface ResolveResult {
   readonly settingsIssues: readonly SettingsLoadIssue[];
   /** Non-fatal guidance: uncached remote sources plus transitive-source skip warnings. */
   readonly warnings: readonly string[];
+  /** Structured provenance for each entry in `warnings`, in the same order. */
+  readonly warningDetails: readonly ResolutionWarningDetail[];
   /** Configured remote sources whose cache is absent. */
   readonly unsynchronizedWarnings: readonly string[];
   /** Ambiguity-only subset, exposed so sync can report shared resolution diagnostics after fetching. */
@@ -28,23 +33,35 @@ export interface ResolveResult {
 /** The single shared resolution path used by list, validate, run, and dump. */
 export const resolveEffectiveSet = (input: ResolveInput): ResolveResult => {
   const loadedSettings = loadSettingsWithCachedRemoteSettings(input);
-  const discovered = discoverLayers({ ...input, settings: loadedSettings.settings });
+  const settingsSourcePath =
+    [...loadedSettings.files].reverse().find((file) => file.settings.sources !== undefined)?.location.path ??
+    loadedSettings.files.at(-1)?.location.path ??
+    join(input.projectDirectory, '.agents', 'settings.yml');
+  const discovered = discoverLayers({
+    ...input,
+    settings: loadedSettings.settings,
+    settingsSourcePath,
+  });
   const set = resolveResources(discovered.layers);
-  const ambiguityWarnings = [
-    ...sourceRefAmbiguityWarnings(
+  const ambiguityWarningDetails = [
+    ...sourceRefAmbiguityWarningDetails(
       loadedSettings.files,
       // Settings merging always materializes the default empty source list.
       loadedSettings.settings.sources!,
       discovered.transitiveDeclarations,
     ),
-    ...slugAmbiguityWarnings(set),
+    ...slugAmbiguityWarningDetails(set),
   ];
+  const discoveryWarningDetails = [...discovered.unsynchronizedDetails, ...discovered.warningDetails];
+  const warningDetails = [...discoveryWarningDetails, ...ambiguityWarningDetails];
+  const ambiguityWarnings = ambiguityWarningDetails.map(({ message }) => message);
 
   return {
     set,
     settings: loadedSettings.settings,
     settingsIssues: loadedSettings.issues,
-    warnings: [...discovered.unsynchronized, ...discovered.warnings, ...ambiguityWarnings],
+    warnings: warningDetails.map(({ message }) => message),
+    warningDetails,
     unsynchronizedWarnings: discovered.unsynchronized,
     ambiguityWarnings,
   };

--- a/code/cli/src/resolver/ResolverValidation.ts
+++ b/code/cli/src/resolver/ResolverValidation.ts
@@ -1,15 +1,55 @@
 // Validates an effective resource set: agent + skill definitions, unresolved loadout slugs, shadowing.
+import { existsSync, globSync } from 'node:fs';
+import { basename, dirname, isAbsolute, resolve } from 'node:path';
+
 import { compose } from '../composer/Composer.js';
+import { isInside, isLexicallyInside, realpathOrResolve } from '../dump/Containment.js';
 import { isSkillDocumentIssue, readSkillDocument } from '../skills/SkillDocument.js';
+import type {
+  SkillDocument,
+  SkillDocumentIssue,
+  SkillMaterializationSection,
+  SkillReference,
+} from '../skills/SkillDocument.js';
+import { skillMaterializationSections } from '../skills/SkillDocument.js';
 import { isAgentDefinitionIssue, readAgentDefinition } from './AgentDefinition.js';
+import type { AgentDefinitionIssue } from './AgentDefinition.js';
+import { inspectReferenceTree } from './ReferenceTreeInspection.js';
+import type { ReferenceTreeIssue } from './ReferenceTreeInspection.js';
 import type { EffectiveResourceSet, ResolvedResource } from './Resource.js';
 import { agentLocalKinds, findResource, listAgentResources, listResources } from './Resource.js';
 
 export interface ValidationFinding {
+  readonly scope: 'agents';
+  readonly phase: 'parse' | 'resolve' | 'author' | 'materialize';
+  readonly code: ValidationFindingCode;
   readonly severity: 'error' | 'warning';
   readonly resource: string;
+  readonly sourcePath: string;
   readonly message: string;
+  readonly remediation: string;
 }
+
+export type ValidationFindingCode =
+  | 'invalid-frontmatter'
+  | 'invalid-name'
+  | 'missing-description'
+  | 'description-too-long'
+  | 'description-not-actionable'
+  | 'resource-invalid'
+  | 'resource-unresolved'
+  | 'inheritance-cycle'
+  | 'reference-escaped'
+  | 'reference-missing'
+  | 'path-collision'
+  | 'resource-shadowed'
+  | 'namespace-reserved'
+  | 'settings-invalid'
+  | 'settings-warning';
+
+type FindingInput = Omit<ValidationFinding, 'scope'>;
+
+export const validationFinding = (input: FindingInput): ValidationFinding => ({ scope: 'agents', ...input });
 
 /**
  * Options for {@link validateEffectiveSet}. `deferLoadoutResolution` downgrades an unresolved
@@ -23,14 +63,28 @@ export interface ValidationOptions {
   readonly deferLoadoutResolution?: boolean;
 }
 
-// Matches the composer's top-level unresolved-loadout warning wording (see `compose` in Composer.ts).
-// It is deliberately coupled to that message; `resolver-validation.test.ts` drives the real composer,
-// so a wording drift fails that test rather than silently disabling deferral.
-const isUnresolvedLoadoutReference = (message: string): boolean =>
-  /^loadout (?:skills|subagents) references unknown (?:skill|agent) '/.test(message);
+const agentDefinitionIssueCode = (issue: AgentDefinitionIssue): ValidationFindingCode =>
+  issue.kind === 'invalid-name'
+    ? 'invalid-name'
+    : issue.kind === 'frontmatter'
+      ? 'invalid-frontmatter'
+      : 'resource-invalid';
 
-const compositionWarningSeverity = (message: string, options: ValidationOptions): ValidationFinding['severity'] =>
-  isUnresolvedLoadoutReference(message) && !options.deferLoadoutResolution ? 'error' : 'warning';
+const skillDocumentIssueCode = (issue: SkillDocumentIssue): ValidationFindingCode =>
+  issue.kind === 'invalid-name'
+    ? 'invalid-name'
+    : issue.kind === 'frontmatter'
+      ? 'invalid-frontmatter'
+      : 'resource-invalid';
+
+const skillDocumentIssueRemediation = (issue: SkillDocumentIssue): string =>
+  issue.kind === 'read'
+    ? 'Make SKILL.md readable, then run validation again.'
+    : issue.kind === 'invalid-name'
+      ? 'Correct the SKILL.md name, then run validation again.'
+      : issue.kind === 'invalid-references'
+        ? 'Correct the SKILL.md references, then run validation again.'
+        : 'Correct the SKILL.md frontmatter, then run validation again.';
 
 const validateAgent = (
   set: EffectiveResourceSet,
@@ -41,28 +95,53 @@ const validateAgent = (
   const definition = readAgentDefinition(agent.winner.path, agent.configPaths);
 
   if (isAgentDefinitionIssue(definition)) {
-    return [{ severity: 'error', resource: `agent:${agent.slug}`, message: definition.message }];
+    return [
+      validationFinding({
+        phase: 'parse',
+        code: agentDefinitionIssueCode(definition),
+        severity: 'error',
+        resource: `agent:${agent.slug}`,
+        sourcePath: definition.path,
+        message: definition.message,
+        remediation: 'Correct the agent frontmatter and configuration, then run validation again.',
+      }),
+    ];
   }
 
   if (definition.name !== agent.slug) {
     return [
-      {
+      validationFinding({
+        phase: 'parse',
+        code: 'invalid-name',
         severity: 'error',
         resource: `agent:${agent.slug}`,
+        sourcePath: agent.winner.path,
         message: `agent.md name '${definition.name}' must match its directory '${agent.slug}'.`,
-      },
+        remediation: `Set the agent name to '${agent.slug}' or rename its directory.`,
+      }),
     ];
   }
 
   const composed = compose(set, agent.slug, { projectDirectory });
-  const compositionFindings: ValidationFinding[] = [
-    ...composed.errors.map((message) => ({ severity: 'error' as const, resource: `agent:${agent.slug}`, message })),
-    ...composed.warnings.map((message) => ({
-      severity: compositionWarningSeverity(message, options),
+  const compositionFindings: ValidationFinding[] = composed.diagnostics.map((diagnostic) =>
+    validationFinding({
+      phase: 'resolve',
+      code: diagnostic.code,
+      severity:
+        diagnostic.severity === 'warning' &&
+        diagnostic.deferInIsolatedSource === true &&
+        !options.deferLoadoutResolution
+          ? 'error'
+          : diagnostic.severity,
       resource: `agent:${agent.slug}`,
-      message,
-    })),
-  ];
+      sourcePath: diagnostic.sourcePath ?? agent.winner.path,
+      message: diagnostic.message,
+      remediation:
+        diagnostic.severity === 'error'
+          ? 'Correct the referenced resource or inheritance declaration, then run validation again.'
+          : 'Correct the referenced resource or remove the unresolved selection.',
+    }),
+  );
 
   return compositionFindings;
 };
@@ -72,45 +151,327 @@ const resourceLabel = (resource: ResolvedResource): string =>
     ? `${resource.kind}:${resource.slug}`
     : `agent:${resource.winner.ownerAgent}/${resource.kind}:${resource.slug}`;
 
-const validateSkill = (skill: ResolvedResource): readonly ValidationFinding[] => {
-  const document = readSkillDocument(skill.winner.path);
-  const label = resourceLabel(skill);
+const skillDescriptionFindings = (
+  skill: ResolvedResource,
+  label: string,
+  document: SkillDocument,
+): readonly ValidationFinding[] => {
+  const description = document.description;
 
-  if (isSkillDocumentIssue(document)) {
-    return [{ severity: 'error', resource: label, message: document.message }];
-  }
-
-  if (document.name !== skill.slug) {
+  if (description === undefined || description.trim().length === 0) {
     return [
-      {
+      validationFinding({
+        phase: 'parse',
+        code: 'missing-description',
         severity: 'error',
         resource: label,
-        message: `SKILL.md name '${document.name}' must match its directory '${skill.slug}'.`,
-      },
+        sourcePath: skill.winner.path,
+        message: 'SKILL.md description must contain 1–1,024 characters.',
+        remediation: 'Add a concise description that states what the skill does and when to use it.',
+      }),
+    ];
+  }
+
+  if ([...description].length > 1024) {
+    return [
+      validationFinding({
+        phase: 'parse',
+        code: 'description-too-long',
+        severity: 'error',
+        resource: label,
+        sourcePath: skill.winner.path,
+        message: `SKILL.md description contains ${[...description].length} characters; the maximum is 1,024.`,
+        remediation: 'Shorten the description to 1,024 characters or fewer.',
+      }),
+    ];
+  }
+
+  // Keep this authoring check deliberately narrow. A short tautology is objectively unable to
+  // provide both capability and selection guidance; broader natural-language judgments belong in
+  // an advisory reviewer, not a strict deterministic gate.
+  const words = description.trim().split(/\s+/u);
+  if (words.length <= 3) {
+    return [
+      validationFinding({
+        phase: 'author',
+        code: 'description-not-actionable',
+        severity: 'warning',
+        resource: label,
+        sourcePath: skill.winner.path,
+        message: 'SKILL.md description is too short to identify when it applies.',
+        remediation: 'Describe what the skill does and when to use it.',
+      }),
     ];
   }
 
   return [];
 };
 
+const referenceValue = (reference: SkillReference): string =>
+  'file' in reference ? reference.file : reference.repo_file;
+
+const referenceRoot = (
+  skill: ResolvedResource,
+  reference: SkillReference,
+  projectDirectory: string | undefined,
+): string | undefined => ('file' in reference ? skill.winner.layer.root : projectDirectory);
+
+const hasGlobSyntax = (value: string): boolean => /[*?[]/u.test(value);
+
+interface SkillReferenceContext {
+  readonly skill: ResolvedResource;
+  readonly label: string;
+  readonly section: SkillMaterializationSection;
+  readonly projectDirectory?: string;
+  readonly targets: Map<string, { readonly sourceLabel: string; readonly realPath: string }>;
+  readonly visitedDirectories: Set<string>;
+}
+
+const materializationFinding = (
+  context: SkillReferenceContext,
+  code: Extract<
+    ValidationFindingCode,
+    'reference-escaped' | 'reference-missing' | 'path-collision' | 'resource-invalid'
+  >,
+  message: string,
+  remediation: string,
+): ValidationFinding =>
+  validationFinding({
+    phase: 'materialize',
+    code,
+    severity: 'error',
+    resource: context.label,
+    sourcePath: context.skill.winner.path,
+    message,
+    remediation,
+  });
+
+const pathCollisionFinding = (
+  context: SkillReferenceContext,
+  value: string,
+  destinationName: string,
+  existingSource: string | undefined,
+): ValidationFinding =>
+  materializationFinding(
+    context,
+    'path-collision',
+    existingSource === undefined
+      ? `SKILL.md '${context.section}' reference '${value}' collides with packaged path '${context.section}/${destinationName}'.`
+      : `SKILL.md '${context.section}' references '${existingSource}' and '${value}' have the same destination '${context.section}/${destinationName}'.`,
+    'Rename one source so every materialized target has a unique basename.',
+  );
+
+const referenceTreeIssueFinding = (
+  context: SkillReferenceContext,
+  declaredValue: string,
+  issue: ReferenceTreeIssue,
+): ValidationFinding => {
+  if (issue.kind === 'escaped')
+    return materializationFinding(
+      context,
+      'reference-escaped',
+      `SKILL.md '${context.section}' reference '${declaredValue}' resolves outside its allowed root at '${issue.path}'.`,
+      'Use a relative path inside the allowed root. Remove symlinks that resolve outside the root.',
+    );
+  if (issue.kind === 'special')
+    return materializationFinding(
+      context,
+      'resource-invalid',
+      `SKILL.md '${context.section}' reference '${declaredValue}' path '${issue.path}' is not a regular file or directory.`,
+      'Use a regular file or directory, or remove the reference.',
+    );
+  if (issue.kind === 'directory-unreadable')
+    return materializationFinding(
+      context,
+      'resource-invalid',
+      `SKILL.md '${context.section}' reference '${declaredValue}' cannot read directory '${issue.path}'.`,
+      'Make the directory readable or remove the reference.',
+    );
+  return materializationFinding(
+    context,
+    issue.kind === 'missing' ? 'reference-missing' : 'resource-invalid',
+    `SKILL.md '${context.section}' reference '${declaredValue}' cannot access path '${issue.path}'.`,
+    'Make the path readable or remove the reference.',
+  );
+};
+
+const materializeReferenceTarget = (
+  context: SkillReferenceContext,
+  root: string,
+  declaredValue: string,
+  sourceLabel: string,
+  target: string,
+): readonly ValidationFinding[] => {
+  const destinationName = basename(target);
+  const realTarget = realpathOrResolve(target);
+  const existing = context.targets.get(destinationName);
+  if (existing?.realPath === realTarget) return [];
+
+  const inspectionFindings = inspectReferenceTree(target, root, context.visitedDirectories).map((issue) =>
+    referenceTreeIssueFinding(context, declaredValue, issue),
+  );
+  if (inspectionFindings.length > 0) return inspectionFindings;
+
+  const shippedDestination = resolve(dirname(context.skill.winner.path), context.section, destinationName);
+  const collidesWithShipped = existsSync(shippedDestination) && realpathOrResolve(shippedDestination) !== realTarget;
+  if (existing !== undefined || collidesWithShipped) {
+    return [pathCollisionFinding(context, sourceLabel, destinationName, existing?.sourceLabel)];
+  }
+
+  context.targets.set(destinationName, { sourceLabel, realPath: realTarget });
+  return [];
+};
+
+const emptyReferenceFinding = (context: SkillReferenceContext): ValidationFinding =>
+  materializationFinding(
+    context,
+    'resource-invalid',
+    `SKILL.md '${context.section}' reference must not be empty.`,
+    'Set the reference to a file or directory inside its allowed root.',
+  );
+
+const referenceLocation = (
+  context: SkillReferenceContext,
+  reference: SkillReference,
+): { readonly value: string; readonly root: string } | { readonly findings: readonly ValidationFinding[] } => {
+  const value = referenceValue(reference);
+  if (value.length === 0) return { findings: [emptyReferenceFinding(context)] };
+  const root = referenceRoot(context.skill, reference, context.projectDirectory);
+  return root === undefined ? { findings: [] } : { value, root };
+};
+
+const validateSkillReference = (
+  context: SkillReferenceContext,
+  reference: SkillReference,
+): readonly ValidationFinding[] => {
+  const location = referenceLocation(context, reference);
+  if ('findings' in location) return location.findings;
+  const { value, root } = location;
+
+  const target = resolve(root, value);
+  if (isAbsolute(value) || !isLexicallyInside(target, root) || (existsSync(target) && !isInside(target, root))) {
+    return [
+      materializationFinding(
+        context,
+        'reference-escaped',
+        `SKILL.md '${context.section}' reference '${value}' resolves outside its allowed root.`,
+        'Use a relative path inside the allowed root. Remove symlinks that resolve outside the root.',
+      ),
+    ];
+  }
+
+  const hasGlob = hasGlobSyntax(value);
+  const matches = hasGlob
+    ? globSync(value, { cwd: root })
+        .map((match) => resolve(root, match))
+        .sort()
+    : existsSync(target)
+      ? [target]
+      : [];
+  if (matches.length === 0) {
+    return 'repo_file' in reference
+      ? []
+      : [
+          materializationFinding(
+            context,
+            'reference-missing',
+            `SKILL.md '${context.section}' file reference '${value}' does not exist.`,
+            'Create the referenced path or remove the reference.',
+          ),
+        ];
+  }
+
+  return matches.flatMap((match) => materializeReferenceTarget(context, root, value, hasGlob ? match : value, match));
+};
+
+const validateSkillReferences = (
+  skill: ResolvedResource,
+  label: string,
+  document: SkillDocument,
+  projectDirectory?: string,
+): readonly ValidationFinding[] =>
+  skillMaterializationSections.flatMap((section) => {
+    const context: SkillReferenceContext = {
+      skill,
+      label,
+      section,
+      projectDirectory,
+      targets: new Map(),
+      visitedDirectories: new Set(),
+    };
+    return document[section].flatMap((reference) => validateSkillReference(context, reference));
+  });
+
+const validateSkill = (skill: ResolvedResource, projectDirectory?: string): readonly ValidationFinding[] => {
+  const document = readSkillDocument(skill.winner.path);
+  const label = resourceLabel(skill);
+
+  if (isSkillDocumentIssue(document)) {
+    return [
+      validationFinding({
+        phase: 'parse',
+        code: skillDocumentIssueCode(document),
+        severity: 'error',
+        resource: label,
+        sourcePath: document.path,
+        message: document.message,
+        remediation: skillDocumentIssueRemediation(document),
+      }),
+    ];
+  }
+
+  const nameFindings =
+    document.name === skill.slug
+      ? []
+      : [
+          validationFinding({
+            phase: 'parse',
+            code: 'invalid-name',
+            severity: 'error',
+            resource: label,
+            sourcePath: skill.winner.path,
+            message: `SKILL.md name '${document.name}' must match its directory '${skill.slug}'.`,
+            remediation: `Set the skill name to '${skill.slug}' or rename its directory.`,
+          }),
+        ];
+
+  return [
+    ...nameFindings,
+    ...skillDescriptionFindings(skill, label, document),
+    ...validateSkillReferences(skill, label, document, projectDirectory),
+  ];
+};
+
 const shadowFindings = (resource: ResolvedResource): readonly ValidationFinding[] =>
-  resource.shadowed.map((definition) => ({
-    severity: 'warning' as const,
-    resource: resourceLabel(resource),
-    message: `shadowed definition in ${definition.layer.label} is overridden by ${resource.winner.layer.label}.`,
-  }));
+  resource.shadowed.map((definition) =>
+    validationFinding({
+      phase: 'resolve',
+      code: 'resource-shadowed',
+      severity: 'warning',
+      resource: resourceLabel(resource),
+      sourcePath: definition.path,
+      message: `shadowed definition in ${definition.layer.label} is overridden by ${resource.winner.layer.label}.`,
+      remediation: 'Remove the duplicate. If the override is intentional, run validation without --strict.',
+    }),
+  );
 
 // Reserved agent-local resource shapes that resolver discovers but does not yet project into a run.
 // Surfaced as warnings (fatal only under --strict) so content placed here is never silently dropped.
 const reservedNamespaceFindings = (agent: ResolvedResource): readonly ValidationFinding[] => {
   const findings: ValidationFinding[] = [];
 
-  if ((agent.hookPaths ?? []).length > 0) {
-    findings.push({
-      severity: 'warning',
-      resource: `agent:${agent.slug}`,
-      message: "agent-local 'hooks/' is a reserved namespace and is not yet resolved.",
-    });
+  if (agent.hookPaths !== undefined && agent.hookPaths.length > 0) {
+    findings.push(
+      validationFinding({
+        phase: 'resolve',
+        code: 'namespace-reserved',
+        severity: 'warning',
+        resource: `agent:${agent.slug}`,
+        sourcePath: agent.hookPaths[0],
+        message: "agent-local 'hooks/' is a reserved namespace and is not yet resolved.",
+        remediation: "Remove the reserved 'hooks/' content until the namespace is supported.",
+      }),
+    );
   }
 
   return findings;
@@ -119,7 +480,7 @@ const reservedNamespaceFindings = (agent: ResolvedResource): readonly Validation
 const deduplicateFindings = (findings: readonly ValidationFinding[]): readonly ValidationFinding[] => {
   const deduplicated = new Map<string, ValidationFinding>();
   for (const finding of findings) {
-    const key = `${finding.resource}\u0000${finding.message}`;
+    const key = `${finding.code}\u0000${finding.resource}\u0000${finding.sourcePath}\u0000${finding.message}`;
     if (!deduplicated.has(key)) deduplicated.set(key, finding);
   }
   return [...deduplicated.values()];
@@ -127,21 +488,32 @@ const deduplicateFindings = (findings: readonly ValidationFinding[]): readonly V
 
 // Validates one agent's local resources: the owning agent must resolve, and each local skill is
 // document-checked; knowledge/commands are opaque file trees today, so only shadowing is surfaced.
-const validateAgentLocalResources = (set: EffectiveResourceSet, agentSlug: string): readonly ValidationFinding[] => {
+const validateAgentLocalResources = (
+  set: EffectiveResourceSet,
+  agentSlug: string,
+  projectDirectory?: string,
+): readonly ValidationFinding[] => {
   const findings: ValidationFinding[] = [];
 
   if (findResource(set, 'agent', agentSlug) === undefined) {
-    findings.push({
-      severity: 'error',
-      resource: `agent:${agentSlug}`,
-      message: 'agent-local resources require a resolvable owning agent.',
-    });
+    const localResource = [...agentLocalKinds].flatMap((kind) => listAgentResources(set, agentSlug, kind)).at(0);
+    findings.push(
+      validationFinding({
+        phase: 'resolve',
+        code: 'resource-unresolved',
+        severity: 'error',
+        resource: `agent:${agentSlug}`,
+        sourcePath: localResource?.winner.path ?? `agents/${agentSlug}`,
+        message: 'agent-local resources require a resolvable owning agent.',
+        remediation: `Add a valid agents/${agentSlug}/agent.md or remove the orphaned local resources.`,
+      }),
+    );
   }
 
   for (const kind of agentLocalKinds) {
     for (const resource of listAgentResources(set, agentSlug, kind)) {
       findings.push(...shadowFindings(resource));
-      if (kind === 'skill') findings.push(...validateSkill(resource));
+      if (kind === 'skill') findings.push(...validateSkill(resource, projectDirectory));
     }
   }
 
@@ -164,11 +536,11 @@ export const validateEffectiveSet = (
   }
 
   for (const skill of listResources(set, 'skill')) {
-    findings.push(...validateSkill(skill));
+    findings.push(...validateSkill(skill, projectDirectory));
   }
 
   for (const [agentSlug] of set.agentResources) {
-    findings.push(...validateAgentLocalResources(set, agentSlug));
+    findings.push(...validateAgentLocalResources(set, agentSlug, projectDirectory));
   }
 
   for (const kind of ['agent', 'skill', 'knowledge', 'command'] as const) {

--- a/code/cli/src/skills/SkillDocument.ts
+++ b/code/cli/src/skills/SkillDocument.ts
@@ -30,6 +30,7 @@ export interface SkillDocument {
 }
 
 export interface SkillDocumentIssue {
+  readonly kind: 'frontmatter' | 'invalid-name' | 'invalid-references' | 'read';
   readonly path: string;
   readonly message: string;
 }
@@ -52,6 +53,7 @@ export const parseSkillDocument = (content: string, skillPath: string): SkillDoc
 
   if (typeof name !== 'string' || !isValidSkillId(name)) {
     return {
+      kind: 'invalid-name',
       path: skillPath,
       message:
         `SKILL.md 'name' must use lowercase letters, numbers, and single hyphens ` +
@@ -66,6 +68,7 @@ export const parseSkillDocument = (content: string, skillPath: string): SkillDoc
 
     if (entries !== undefined && (!Array.isArray(entries) || !entries.every(isSkillReference))) {
       return {
+        kind: 'invalid-references',
         path: skillPath,
         message: `SKILL.md '${section}' entries must each contain exactly one 'file' or 'repo_file' source.`,
       };
@@ -90,19 +93,27 @@ const parseSkillFrontmatter = (
   const frontmatter = extractFrontmatter(content);
 
   if (frontmatter === undefined) {
-    return { path: skillPath, message: 'SKILL.md must start with a `---` YAML frontmatter block.' };
+    return {
+      kind: 'frontmatter',
+      path: skillPath,
+      message: 'SKILL.md must start with a `---` YAML frontmatter block.',
+    };
   }
 
   const parsed = parseYamlDocument(frontmatter, skillPath);
 
   if (!parsed.ok) {
-    return { path: skillPath, message: `SKILL.md frontmatter is not valid YAML: ${parsed.issue.message}` };
+    return {
+      kind: 'frontmatter',
+      path: skillPath,
+      message: `SKILL.md frontmatter is not valid YAML: ${parsed.issue.message}`,
+    };
   }
 
   const record = parsed.document;
 
   if (record === null || typeof record !== 'object' || Array.isArray(record)) {
-    return { path: skillPath, message: 'SKILL.md frontmatter must be a YAML mapping.' };
+    return { kind: 'frontmatter', path: skillPath, message: 'SKILL.md frontmatter must be a YAML mapping.' };
   }
 
   return { record: record as Readonly<Record<string, unknown>> };
@@ -114,7 +125,7 @@ export const readSkillDocument = (skillPath: string): SkillDocument | SkillDocum
   try {
     content = readFileSync(skillPath, 'utf8');
   } catch (error) {
-    return { path: skillPath, message: `Could not read SKILL.md: ${String(error)}` };
+    return { kind: 'read', path: skillPath, message: `Could not read SKILL.md: ${String(error)}` };
   }
 
   return parseSkillDocument(content, skillPath);

--- a/code/cli/src/sources/TransitiveSources.ts
+++ b/code/cli/src/sources/TransitiveSources.ts
@@ -12,12 +12,18 @@ import {
   resolveSourcePayloadRoot,
 } from './SourceCache.js';
 import type { RemoteSourceReference } from './SourceCache.js';
+import type { ResolutionWarningDetail } from '../validation/ResolutionWarning.js';
 
 /** A `github:` catalog dependency, pinned to an immutable ref, attributed to its declaring catalog. */
 export interface DeclaredRemoteSource {
   readonly source: { readonly github: string; readonly ref: string };
   /** Display name of the declaring catalog, for warnings and provenance. */
   readonly declaredBy: string;
+}
+
+/** A catalog declaration with the settings file that contains it. */
+export interface AttributedRemoteSource extends DeclaredRemoteSource {
+  readonly sourcePath: string;
 }
 
 export interface DeclaredSourcesResult {
@@ -84,7 +90,9 @@ const loadCatalogSourceList = (
   payloadRoot: string,
   checkoutRoot: string,
   declaredBy: string,
-): { readonly sources: readonly SourceReference[] } | { readonly warning: string } => {
+):
+  | { readonly sources: readonly SourceReference[]; readonly sourcePath?: string }
+  | { readonly warning: ResolutionWarningDetail } => {
   const settingsPath = resolveCatalogSettingsPath(payloadRoot);
   if (settingsPath === undefined) return { sources: [] };
 
@@ -105,15 +113,55 @@ const loadCatalogSourceList = (
     const loaded = loadSettingsFiles(createSettingsLoadPlan([{ scope: 'remote', path: settingsPath }]));
     if (loaded.issues.length > 0) {
       return {
-        warning: `Catalog '${declaredBy}' declares invalid settings at '${settingsPath}'; its sources were skipped.`,
+        warning: {
+          message: `Catalog '${declaredBy}' declares invalid settings at '${settingsPath}'; its sources were skipped.`,
+          resource: `source:${declaredBy}`,
+          sourcePath: settingsPath,
+        },
       };
     }
-    return { sources: loaded.files[0].settings.sources ?? [] };
+    return { sources: loaded.files[0].settings.sources ?? [], sourcePath: settingsPath };
   } catch {
     return {
-      warning: `Catalog '${declaredBy}' has an unreadable settings.yml (not a regular file inside the checkout); its sources were skipped.`,
+      warning: {
+        message: `Catalog '${declaredBy}' has an unreadable settings.yml (not a regular file inside the checkout); its sources were skipped.`,
+        resource: `source:${declaredBy}`,
+        sourcePath: settingsPath,
+      },
     };
   }
+};
+
+interface AttributedDeclaredSourcesResult {
+  readonly sources: readonly AttributedRemoteSource[];
+  readonly warningDetails: readonly ResolutionWarningDetail[];
+}
+
+const readAttributedRemoteSources = (
+  payloadRoot: string,
+  checkoutRoot: string,
+  declaredBy: string,
+): AttributedDeclaredSourcesResult => {
+  const loaded = loadCatalogSourceList(payloadRoot, checkoutRoot, declaredBy);
+  if ('warning' in loaded) return { sources: [], warningDetails: [loaded.warning] };
+  if (loaded.sourcePath === undefined) return { sources: [], warningDetails: [] };
+
+  const sources: AttributedRemoteSource[] = [];
+  const warningDetails: ResolutionWarningDetail[] = [];
+  for (const declared of loaded.sources) {
+    const classified = classifyDeclaredSource(declared, declaredBy);
+    if ('skip' in classified) {
+      warningDetails.push({
+        message: classified.skip,
+        resource: `source:${declaredBy}`,
+        sourcePath: loaded.sourcePath,
+      });
+    } else {
+      sources.push({ source: classified.source, declaredBy, sourcePath: loaded.sourcePath });
+    }
+  }
+
+  return { sources, warningDetails };
 };
 
 /**
@@ -134,18 +182,11 @@ export const readDeclaredRemoteSources = (
   checkoutRoot: string,
   declaredBy: string,
 ): DeclaredSourcesResult => {
-  const loaded = loadCatalogSourceList(payloadRoot, checkoutRoot, declaredBy);
-  if ('warning' in loaded) return { sources: [], warnings: [loaded.warning] };
-
-  const sources: DeclaredRemoteSource[] = [];
-  const warnings: string[] = [];
-  for (const declared of loaded.sources) {
-    const classified = classifyDeclaredSource(declared, declaredBy);
-    if ('skip' in classified) warnings.push(classified.skip);
-    else sources.push({ source: classified.source, declaredBy });
-  }
-
-  return { sources, warnings };
+  const attributed = readAttributedRemoteSources(payloadRoot, checkoutRoot, declaredBy);
+  return {
+    sources: attributed.sources.map(({ source, declaredBy: owner }) => ({ source, declaredBy: owner })),
+    warnings: attributed.warningDetails.map(({ message }) => message),
+  };
 };
 
 export interface TransitiveExpansionInput {
@@ -160,7 +201,12 @@ export interface TransitiveExpansionResult {
   readonly sources: readonly DeclaredRemoteSource[];
   /** Every accepted declaration, including duplicates suppressed from the resolved source graph. */
   readonly declarations: readonly DeclaredRemoteSource[];
+  /** Source declarations with their exact catalog settings file. */
+  readonly attributedSources: readonly AttributedRemoteSource[];
+  /** Every attributed declaration, including duplicates suppressed from the source graph. */
+  readonly attributedDeclarations: readonly AttributedRemoteSource[];
   readonly warnings: readonly string[];
+  readonly warningDetails: readonly ResolutionWarningDetail[];
 }
 
 /**
@@ -175,7 +221,7 @@ export interface TransitiveExpansionResult {
 const declarationsFromParent = (
   parent: RemoteSourceReference,
   resolveCachedCheckoutRoot: TransitiveExpansionInput['resolveCachedCheckoutRoot'],
-): DeclaredSourcesResult | undefined => {
+): AttributedDeclaredSourcesResult | undefined => {
   const checkoutRoot = resolveCachedCheckoutRoot(parent);
   if (checkoutRoot === undefined) return undefined;
 
@@ -187,13 +233,15 @@ const declarationsFromParent = (
   }
   if (!existsSync(payloadRoot)) return undefined;
 
-  return readDeclaredRemoteSources(payloadRoot, checkoutRoot, formatRemoteSourceDisplay(parent));
+  return readAttributedRemoteSources(payloadRoot, checkoutRoot, formatRemoteSourceDisplay(parent));
 };
 
 export const expandTransitiveSources = (input: TransitiveExpansionInput): TransitiveExpansionResult => {
   const sources: DeclaredRemoteSource[] = [];
   const declarations: DeclaredRemoteSource[] = [];
-  const warnings: string[] = [];
+  const attributedSources: AttributedRemoteSource[] = [];
+  const attributedDeclarations: AttributedRemoteSource[] = [];
+  const warningDetails: ResolutionWarningDetail[] = [];
   const visited = new Set<string>();
 
   // Seed the visited set with each direct source's path-aware identity so a directly configured
@@ -214,14 +262,17 @@ export const expandTransitiveSources = (input: TransitiveExpansionInput): Transi
     for (const parent of frontier) {
       const declared = declarationsFromParent(parent, input.resolveCachedCheckoutRoot);
       if (declared === undefined) continue;
-      warnings.push(...declared.warnings);
+      warningDetails.push(...declared.warningDetails);
 
       for (const entry of declared.sources) {
-        declarations.push(entry);
+        const legacy = { source: entry.source, declaredBy: entry.declaredBy };
+        declarations.push(legacy);
+        attributedDeclarations.push(entry);
         const key = encodeRemoteSourceSelection(entry.source);
         if (visited.has(key)) continue;
         visited.add(key);
-        sources.push(entry);
+        sources.push(legacy);
+        attributedSources.push(entry);
         next.push(entry.source);
       }
     }
@@ -229,5 +280,12 @@ export const expandTransitiveSources = (input: TransitiveExpansionInput): Transi
     frontier = next;
   }
 
-  return { sources, declarations, warnings };
+  return {
+    sources,
+    declarations,
+    attributedSources,
+    attributedDeclarations,
+    warnings: warningDetails.map(({ message }) => message),
+    warningDetails,
+  };
 };

--- a/code/cli/src/validation/ResolutionWarning.ts
+++ b/code/cli/src/validation/ResolutionWarning.ts
@@ -1,0 +1,6 @@
+/** A non-fatal resolution warning with the resource and declaration file that caused it. */
+export interface ResolutionWarningDetail {
+  readonly message: string;
+  readonly resource: string;
+  readonly sourcePath: string;
+}

--- a/code/cli/tests/unit/common-agents-validation.test.ts
+++ b/code/cli/tests/unit/common-agents-validation.test.ts
@@ -1,0 +1,595 @@
+// Tests the harness-neutral `.agents` validation gate shared by validate and run --strict.
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { executeRunAgentCommand } from '../../src/cli/commands/RunAgentCommand.js';
+import { executeValidateCommand } from '../../src/cli/commands/ValidateCommand.js';
+import { discoverLayers } from '../../src/resolver/Layer.js';
+import { resolveResources } from '../../src/resolver/Resolver.js';
+import { validateEffectiveSet } from '../../src/resolver/ResolverValidation.js';
+import { setupNextStepMessage } from '../../src/setup/Setup.js';
+
+const temporaryRoots: string[] = [];
+
+const temporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-common-validation-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const write = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+
+const skill = (name: string, description: string): string =>
+  `---\nname: ${name}\ndescription: ${JSON.stringify(description)}\n---\n\n# ${name}\n`;
+
+const agent = (name: string): string => `---\nname: ${name}\n---\n\n# ${name}\n`;
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('common .agents validation', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.12.1-003.12.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('checks every global and agent-local skill, including unused skills', () => {
+    const root = temporaryRoot();
+    const project = join(root, 'project');
+    write(join(project, '.agents', 'agents', 'engineer', 'agent.md'), agent('engineer'));
+    write(join(project, '.agents', 'skills', 'missing', 'SKILL.md'), '---\nname: missing\n---\n');
+    write(join(project, '.agents', 'skills', 'empty', 'SKILL.md'), skill('empty', ''));
+    write(join(project, '.agents', 'skills', 'long', 'SKILL.md'), skill('long', 'x'.repeat(1025)));
+    write(join(project, '.agents', 'agents', 'engineer', 'skills', 'private', 'SKILL.md'), 'not frontmatter');
+
+    const result = executeValidateCommand({ homeDirectory: join(root, 'home'), projectDirectory: project });
+    const byResource = new Map(result.findings.map((finding) => [finding.resource, finding]));
+
+    expect(byResource.get('skill:missing')?.code).toBe('missing-description');
+    expect(byResource.get('skill:empty')?.code).toBe('missing-description');
+    expect(byResource.get('skill:long')?.code).toBe('description-too-long');
+    expect(byResource.get('agent:engineer/skill:private')?.code).toBe('invalid-frontmatter');
+    expect(result.ok).toBe(false);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.12.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('warns only for a clearly non-actionable description', () => {
+    const root = temporaryRoot();
+    const project = join(root, 'project');
+    write(join(project, '.agents', 'skills', 'generic', 'SKILL.md'), skill('generic', 'A generic skill.'));
+    write(
+      join(project, '.agents', 'skills', 'actionable', 'SKILL.md'),
+      skill('actionable', 'Review pull requests. Use when a change needs correctness and safety checks.'),
+    );
+
+    const findings = executeValidateCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+    }).findings;
+
+    expect(findings.filter((finding) => finding.code === 'description-not-actionable')).toEqual([
+      expect.objectContaining({ resource: 'skill:generic', severity: 'warning' }),
+    ]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.12.7-003.12.9).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('returns stable JSON fields and gives run --strict the same findings before harness selection', async () => {
+    const root = temporaryRoot();
+    const project = join(root, 'project');
+    write(join(project, '.agents', 'agents', 'engineer', 'agent.md'), agent('engineer'));
+    write(join(project, '.agents', 'skills', 'unused', 'SKILL.md'), '---\nname: unused\n---\n');
+    let launched = false;
+
+    const validation = executeValidateCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+      json: true,
+    });
+    const run = await executeRunAgentCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+      agent: 'engineer',
+      harness: 'not-a-harness',
+      strict: true,
+      appendPromptPaths: [join(root, 'absent.md')],
+      launcher: () => {
+        launched = true;
+        return Promise.resolve(0);
+      },
+    });
+
+    expect(run.commonFindings).toEqual(validation.findings);
+    expect(run.exitCode).toBe(1);
+    expect(launched).toBe(false);
+    const json = JSON.parse(validation.messages[0]) as { readonly ok: boolean; readonly findings: readonly unknown[] };
+    expect(json.ok).toBe(false);
+    expect(json.findings).toEqual(validation.findings);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.12.9).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('does not apply the complete common gate to a normal run', async () => {
+    const root = temporaryRoot();
+    const project = join(root, 'project');
+    write(join(project, '.agents', 'agents', 'engineer', 'agent.md'), agent('engineer'));
+    write(join(project, '.agents', 'skills', 'unused', 'SKILL.md'), 'not frontmatter');
+    let launched = false;
+
+    const result = await executeRunAgentCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+      agent: 'engineer',
+      harness: 'pi',
+      launcher: () => {
+        launched = true;
+        return Promise.resolve(0);
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(launched).toBe(true);
+    expect(result.commonFindings).toBeUndefined();
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.12.2-003.12.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('stops an invalid initial tree before first-run setup or launch', async () => {
+    const root = temporaryRoot();
+    const project = join(root, 'project');
+    write(join(project, '.agents', 'skills', 'unused', 'SKILL.md'), '---\nname: unused\n---\n');
+    let setupCalls = 0;
+    let launchCalls = 0;
+
+    const result = await executeRunAgentCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+      strict: true,
+      setup: () => {
+        setupCalls += 1;
+        return Promise.resolve({
+          created: [],
+          updated: [],
+          settingsPath: join(project, '.agents', 'settings.yml'),
+          defaultAgent: 'engineer',
+          defaultHarness: 'pi',
+          messages: [],
+        });
+      },
+      launcher: () => {
+        launchCalls += 1;
+        return Promise.resolve(0);
+      },
+    });
+
+    expect(result.commonFindings?.map((finding) => finding.code)).toContain('missing-description');
+    expect(setupCalls).toBe(0);
+    expect(launchCalls).toBe(0);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.12.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('revalidates a clean strict tree after setup does not select an agent', async () => {
+    const root = temporaryRoot();
+    const project = join(root, 'project');
+    let setupCalls = 0;
+
+    const result = await executeRunAgentCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+      strict: true,
+      setup: () => {
+        setupCalls += 1;
+        return Promise.resolve({
+          created: [],
+          updated: [],
+          settingsPath: join(project, '.agents', 'settings.yml'),
+          defaultHarness: 'pi',
+          messages: [],
+        });
+      },
+      launcher: () => Promise.reject(new Error('launcher must not run')),
+    });
+
+    expect(setupCalls).toBe(1);
+    expect(result.exitCode).toBe(0);
+    expect(result.messages).toContain(setupNextStepMessage);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.12.1-003.12.3, OFTR-003.12.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('collects ambiguity and invalid unused skills identically for validate and strict run', async () => {
+    const root = temporaryRoot();
+    const project = join(root, 'project');
+    const first = join(root, 'first');
+    const second = join(root, 'second');
+    write(join(project, '.agents', 'agents', 'engineer', 'agent.md'), agent('engineer'));
+    write(join(first, 'skills', 'shared', 'SKILL.md'), '---\nname: shared\n---\n');
+    write(
+      join(first, 'agents', 'engineer', 'skills', 'private', 'SKILL.md'),
+      skill('private', 'Check private resources. Use when validating local source precedence.'),
+    );
+    write(
+      join(second, 'skills', 'shared', 'SKILL.md'),
+      skill('shared', 'Review shared resources. Use when checking source precedence.'),
+    );
+    write(
+      join(second, 'agents', 'engineer', 'skills', 'private', 'SKILL.md'),
+      skill('private', 'Check private resources. Use when validating local source precedence.'),
+    );
+    write(join(project, '.agents', 'settings.yml'), `sources:\n  - path: ${first}\n  - path: ${second}\n`);
+    const input = { homeDirectory: join(root, 'home'), projectDirectory: project };
+
+    const validation = executeValidateCommand(input);
+    const run = await executeRunAgentCommand({
+      ...input,
+      agent: 'engineer',
+      strict: true,
+      launcher: () => Promise.resolve(0),
+    });
+
+    expect(run.commonFindings).toEqual(validation.findings);
+    expect(run.commonFindings?.map((finding) => finding.code)).toEqual(
+      expect.arrayContaining(['settings-warning', 'missing-description', 'resource-shadowed']),
+    );
+    expect(run.commonFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'settings-warning',
+          resource: 'skill:shared',
+          sourcePath: join(first, 'skills', 'shared', 'SKILL.md'),
+        }),
+        expect.objectContaining({
+          code: 'settings-warning',
+          resource: 'agent:engineer/skill:private',
+          sourcePath: join(first, 'agents', 'engineer', 'skills', 'private', 'SKILL.md'),
+        }),
+      ]),
+    );
+    expect(run.messages.at(-1)).toContain('ambiguous resolution is fatal');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.12.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('reports escaped references, destination collisions, and shadowed skills with stable codes', () => {
+    const root = temporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    write(
+      join(home, '.agents', 'skills', 'shadowed', 'SKILL.md'),
+      skill('shadowed', 'Review code. Use when checking changes.'),
+    );
+    write(
+      join(project, '.agents', 'skills', 'shadowed', 'SKILL.md'),
+      skill('shadowed', 'Review code. Use when checking changes.'),
+    );
+    write(join(project, '.agents', 'docs', 'one', 'guide.md'), '# one\n');
+    write(join(project, '.agents', 'docs', 'two', 'guide.md'), '# two\n');
+    write(
+      join(project, '.agents', 'skills', 'references', 'SKILL.md'),
+      `---\nname: references\ndescription: Check references. Use when validating skill packages.\nreferences:\n  - file: ../outside.md\n  - file: docs/one/guide.md\n  - file: docs/two/guide.md\n---\n`,
+    );
+
+    const findings = executeValidateCommand({ homeDirectory: home, projectDirectory: project }).findings;
+    expect(findings.map((finding) => finding.code)).toEqual(
+      expect.arrayContaining(['reference-escaped', 'path-collision', 'resource-shadowed']),
+    );
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.12.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('checks required, optional, glob, and packaged reference targets without harness policy', () => {
+    const root = temporaryRoot();
+    const project = join(root, 'project');
+    const agentsRoot = join(project, '.agents');
+    write(join(agentsRoot, 'docs', 'guide.md'), '# guide\n');
+    write(join(agentsRoot, 'docs', 'glob-one', 'shared.md'), '# one\n');
+    write(join(agentsRoot, 'docs', 'glob-two', 'shared.md'), '# two\n');
+    write(join(project, 'docs', 'repo.md'), '# repository guide\n');
+    const outside = join(root, 'outside.md');
+    write(outside, '# outside\n');
+    symlinkSync(outside, join(agentsRoot, 'docs', 'escape.md'));
+    write(join(agentsRoot, 'skills', 'references', 'references', 'guide.md'), '# packaged guide\n');
+    write(
+      join(agentsRoot, 'skills', 'references', 'SKILL.md'),
+      `---
+name: references
+description: Check skill references. Use when validating portable package inputs.
+references:
+  - file: docs/missing.md
+  - file: docs/none/*.md
+  - file: docs/*.md
+  - file: docs/glob-*/shared.md
+  - file: docs/escape*.md
+  - file: docs/guide.md
+  - repo_file: docs/repo.md
+  - repo_file: docs/optional.md
+---
+`,
+    );
+    write(
+      join(agentsRoot, 'skills', 'malformed-reference', 'SKILL.md'),
+      `---
+name: malformed-reference
+description: Check invalid inputs. Use when testing parser diagnostics.
+references: wrong
+---
+`,
+    );
+
+    const findings = executeValidateCommand({ homeDirectory: join(root, 'home'), projectDirectory: project }).findings;
+    expect(findings.map((finding) => finding.code)).toEqual(
+      expect.arrayContaining(['reference-missing', 'reference-escaped', 'path-collision', 'resource-invalid']),
+    );
+    expect(findings.some((finding) => finding.message.includes('docs/optional.md'))).toBe(false);
+
+    const set = resolveResources(
+      discoverLayers({ homeDirectory: join(root, 'home'), projectDirectory: project, settings: {} }).layers,
+    );
+    expect(() => validateEffectiveSet(set)).not.toThrow();
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.12.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('classifies a missing reference below an aliased layer root as missing', () => {
+    const root = temporaryRoot();
+    const project = join(root, 'project');
+    const realAgentsRoot = join(root, 'real-agents');
+    mkdirSync(project, { recursive: true });
+    symlinkSync(realAgentsRoot, join(project, '.agents'), 'dir');
+    write(
+      join(realAgentsRoot, 'skills', 'aliased-root', 'SKILL.md'),
+      `---
+name: aliased-root
+description: Check missing references. Use when a catalog root has a filesystem alias.
+references:
+  - file: docs/missing.md
+---
+`,
+    );
+
+    const findings = executeValidateCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+    }).findings;
+
+    expect(findings).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: 'reference-missing', resource: 'skill:aliased-root' })]),
+    );
+    expect(
+      findings.some((finding) => finding.code === 'reference-escaped' && finding.resource === 'skill:aliased-root'),
+    ).toBe(false);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.12.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('accepts an in-tree reference whose first segment starts with two dots', () => {
+    const root = temporaryRoot();
+    const project = join(root, 'project');
+    write(join(project, '.agents', '..catalog', 'guide.md'), '# guide\n');
+    write(
+      join(project, '.agents', 'skills', 'dot-prefix', 'SKILL.md'),
+      `---
+name: dot-prefix
+description: Check dot-prefixed directories. Use when validating reference containment.
+references:
+  - file: ..catalog/guide.md
+---
+`,
+    );
+
+    const findings = executeValidateCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+    }).findings;
+
+    expect(
+      findings.some((finding) => finding.resource === 'skill:dot-prefix' && finding.code.startsWith('reference-')),
+    ).toBe(false);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.12.5, OFTR-003.12.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('uses structured invalid-name codes and the actual malformed config path', () => {
+    const root = temporaryRoot();
+    const project = join(root, 'project');
+    const configPath = join(project, '.agents', 'agents', 'configured', 'config.json');
+    write(join(project, '.agents', 'agents', 'bad-agent', 'agent.md'), agent('Bad Agent'));
+    write(join(project, '.agents', 'agents', 'configured', 'agent.md'), agent('configured'));
+    write(configPath, '{ invalid json');
+    write(
+      join(project, '.agents', 'skills', 'bad-skill', 'SKILL.md'),
+      skill('Bad Skill', 'Review names. Use when validating resource identifiers.'),
+    );
+
+    const findings = executeValidateCommand({ homeDirectory: join(root, 'home'), projectDirectory: project }).findings;
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'invalid-name', resource: 'agent:bad-agent' }),
+        expect.objectContaining({ code: 'invalid-name', resource: 'skill:bad-skill' }),
+        expect.objectContaining({ resource: 'agent:configured', sourcePath: configPath }),
+      ]),
+    );
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.12.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('rejects a referenced directory with a nested symlink that escapes its root', () => {
+    const root = temporaryRoot();
+    const project = join(root, 'project');
+    const agentsRoot = join(project, '.agents');
+    const referenceDirectory = join(agentsRoot, 'docs', 'tree');
+    write(join(referenceDirectory, 'safe.md'), '# safe\n');
+    const outside = join(root, 'outside.md');
+    write(outside, '# outside\n');
+    symlinkSync(outside, join(referenceDirectory, 'nested-link.md'));
+    write(
+      join(agentsRoot, 'skills', 'directory-reference', 'SKILL.md'),
+      `---
+name: directory-reference
+description: Inspect documentation trees. Use when validating recursive reference containment.
+references:
+  - file: docs/tree
+---
+`,
+    );
+
+    const findings = executeValidateCommand({ homeDirectory: join(root, 'home'), projectDirectory: project }).findings;
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'reference-escaped', resource: 'skill:directory-reference' }),
+      ]),
+    );
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.12.5, OFTR-003.12.7-003.12.9).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('reports a dangling nested symlink without throwing and keeps strict findings equal', async () => {
+    const root = temporaryRoot();
+    const project = join(root, 'project');
+    const agentsRoot = join(project, '.agents');
+    const referenceDirectory = join(agentsRoot, 'docs', 'tree');
+    const danglingLink = join(referenceDirectory, 'dangling.md');
+    write(join(referenceDirectory, 'safe.md'), '# safe\n');
+    symlinkSync(join(referenceDirectory, 'missing.md'), danglingLink);
+    write(join(agentsRoot, 'agents', 'engineer', 'agent.md'), agent('engineer'));
+    write(
+      join(agentsRoot, 'skills', 'directory-reference', 'SKILL.md'),
+      `---
+name: directory-reference
+description: Inspect documentation trees. Use when validating recursive reference failures.
+references:
+  - file: docs/tree
+---
+`,
+    );
+
+    const validation = executeValidateCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+    });
+    const run = await executeRunAgentCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+      agent: 'engineer',
+      harness: 'pi',
+      strict: true,
+      launcher: () => Promise.resolve(0),
+    });
+
+    const danglingFinding = validation.findings.find(
+      (finding) => finding.code === 'reference-missing' && finding.resource === 'skill:directory-reference',
+    );
+    expect(danglingFinding?.message).toContain(danglingLink);
+    expect(run.commonFindings).toEqual(validation.findings);
+    expect(run.exitCode).toBe(1);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.12.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('deduplicates one target selected by a literal and an overlapping glob', () => {
+    const root = temporaryRoot();
+    const project = join(root, 'project');
+    const agentsRoot = join(project, '.agents');
+    write(join(agentsRoot, 'dedupe', 'unique.md'), '# unique\n');
+    write(
+      join(agentsRoot, 'skills', 'deduplicated-reference', 'SKILL.md'),
+      `---
+name: deduplicated-reference
+description: Select reference files. Use when literal paths and globs can overlap.
+references:
+  - file: dedupe/unique.md
+  - file: dedupe/*.md
+---
+`,
+    );
+
+    const findings = executeValidateCommand({ homeDirectory: join(root, 'home'), projectDirectory: project }).findings;
+    expect(
+      findings.some(
+        (finding) => finding.resource === 'skill:deduplicated-reference' && finding.code === 'path-collision',
+      ),
+    ).toBe(false);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.12.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('validates overlapping directory matches without duplicate failures', () => {
+    const root = temporaryRoot();
+    const project = join(root, 'project');
+    const agentsRoot = join(project, '.agents');
+    write(join(agentsRoot, 'docs', 'tree', 'nested', 'guide.md'), '# guide\n');
+    write(
+      join(agentsRoot, 'skills', 'overlapping-directories', 'SKILL.md'),
+      `---
+name: overlapping-directories
+description: Inspect documentation trees. Use when directory reference patterns overlap.
+references:
+  - file: docs/tree
+  - file: docs/tree/*
+---
+`,
+    );
+
+    const findings = executeValidateCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+    }).findings;
+
+    expect(findings.filter((finding) => finding.resource === 'skill:overlapping-directories')).toEqual([]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.12.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('reports a typed finding when a referenced descendant cannot be inspected', () => {
+    const root = temporaryRoot();
+    const project = join(root, 'project');
+    const agentsRoot = join(project, '.agents');
+    write(join(agentsRoot, 'docs', 'tree', 'guide.md'), '# guide\n');
+    symlinkSync('loop', join(agentsRoot, 'docs', 'tree', 'loop'));
+    write(
+      join(agentsRoot, 'skills', 'uninspectable', 'SKILL.md'),
+      skill('uninspectable', 'Inspect references. Use when reference trees contain invalid entries.').replace(
+        '---\n\n#',
+        'references:\n  - file: docs/tree\n---\n\n#',
+      ),
+    );
+
+    const findings = executeValidateCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+    }).findings;
+
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'resource-invalid',
+          resource: 'skill:uninspectable',
+        }),
+      ]),
+    );
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.12.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('preserves the malformed settings.local.yml path in JSON findings', () => {
+    const root = temporaryRoot();
+    const project = join(root, 'project');
+    const settingsPath = join(project, '.agents', 'settings.local.yml');
+    write(settingsPath, 'default_harness: invalid\n');
+
+    const result = executeValidateCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: project,
+      json: true,
+    });
+    const parsed = JSON.parse(result.messages[0]) as { readonly findings: readonly { readonly sourcePath: string }[] };
+
+    expect(parsed.findings).toEqual(expect.arrayContaining([expect.objectContaining({ sourcePath: settingsPath })]));
+  });
+});

--- a/code/cli/tests/unit/reference-tree-validation.test.ts
+++ b/code/cli/tests/unit/reference-tree-validation.test.ts
@@ -1,0 +1,108 @@
+// Tests reference-tree entry types that require platform filesystem primitives.
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { executeValidateCommand } from '../../src/cli/commands/ValidateCommand.js';
+
+let temporaryRoot: string | undefined;
+
+afterEach(() => {
+  if (temporaryRoot !== undefined) rmSync(temporaryRoot, { recursive: true, force: true });
+  temporaryRoot = undefined;
+});
+
+describe('reference tree validation', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.12.2, OFTR-003.12.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('keeps validating a parseable skill after its name does not match its directory', () => {
+    temporaryRoot = mkdtempSync(join(tmpdir(), 'outfitter-reference-tree-'));
+    const project = join(temporaryRoot, 'project');
+    const skillPath = join(project, '.agents', 'skills', 'directory-name', 'SKILL.md');
+    mkdirSync(dirname(skillPath), { recursive: true });
+    writeFileSync(
+      skillPath,
+      `---
+name: different-name
+references:
+  - file: docs/missing.md
+---
+`,
+    );
+
+    const findings = executeValidateCommand({
+      homeDirectory: join(temporaryRoot, 'home'),
+      projectDirectory: project,
+    }).findings.filter((finding) => finding.resource === 'skill:directory-name');
+
+    expect(findings.map(({ code }) => code)).toEqual(
+      expect.arrayContaining(['invalid-name', 'missing-description', 'reference-missing']),
+    );
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.12.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('rejects an empty reference instead of scanning its complete root', () => {
+    temporaryRoot = mkdtempSync(join(tmpdir(), 'outfitter-reference-tree-'));
+    const project = join(temporaryRoot, 'project');
+    const skillPath = join(project, '.agents', 'skills', 'empty-reference', 'SKILL.md');
+    mkdirSync(dirname(skillPath), { recursive: true });
+    writeFileSync(
+      skillPath,
+      `---
+name: empty-reference
+description: Validate references. Use when a skill declares materialization inputs.
+references:
+  - file: ""
+---
+`,
+    );
+
+    const findings = executeValidateCommand({
+      homeDirectory: join(temporaryRoot, 'home'),
+      projectDirectory: project,
+    }).findings;
+
+    const finding = findings.find(
+      (candidate) => candidate.code === 'resource-invalid' && candidate.resource === 'skill:empty-reference',
+    );
+    expect(finding?.message).toContain('must not be empty');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.12.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('rejects a reference target that is not a regular file or directory', () => {
+    if (process.platform === 'win32') return;
+
+    temporaryRoot = mkdtempSync(join(tmpdir(), 'outfitter-reference-tree-'));
+    const project = join(temporaryRoot, 'project');
+    const agentsRoot = join(project, '.agents');
+    const fifoPath = join(agentsRoot, 'docs', 'events.fifo');
+    mkdirSync(dirname(fifoPath), { recursive: true });
+    execFileSync('mkfifo', [fifoPath]);
+    const skillPath = join(agentsRoot, 'skills', 'special-file', 'SKILL.md');
+    mkdirSync(dirname(skillPath), { recursive: true });
+    writeFileSync(
+      skillPath,
+      `---
+name: special-file
+description: Validate reference types. Use when a catalog contains special filesystem entries.
+references:
+  - file: docs/events.fifo
+---
+`,
+    );
+
+    const findings = executeValidateCommand({
+      homeDirectory: join(temporaryRoot, 'home'),
+      projectDirectory: project,
+    }).findings;
+
+    expect(findings).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: 'resource-invalid', resource: 'skill:special-file' })]),
+    );
+  });
+});

--- a/code/cli/tests/unit/resolver-validation.test.ts
+++ b/code/cli/tests/unit/resolver-validation.test.ts
@@ -64,4 +64,63 @@ describe('loadout resolution deferral', () => {
       ),
     ).toBe(true);
   });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.12.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('preserves typed codes and exact declaration paths for composition findings', () => {
+    const root = mkdtempSync(join(tmpdir(), 'outfitter-resolver-outside-'));
+    temporaryRoots.push(root);
+    const project = join(root, 'project');
+    const parentPath = join(project, '.agents', 'agents', 'parent', 'agent.md');
+    const childPath = join(project, '.agents', 'agents', 'child', 'agent.md');
+    const configPath = join(project, '.agents', 'agents', 'configured', 'config.json');
+    const mcpPath = join(project, '.agents', 'agents', 'outside', 'mcp.json');
+    write(parentPath, agentMd('parent', 'skills: [from-parent]\nsystem_prompt:\n  file: ../secret.md\n'));
+    write(childPath, agentMd('child', 'inherits: [parent]\n'));
+    write(join(project, '.agents', 'agents', 'configured', 'agent.md'), agentMd('configured'));
+    write(configPath, '{"skills":["from-config"]}\n');
+    write(join(project, '.agents', 'agents', 'outside', 'agent.md'), agentMd('outside', 'mcp: [server]\n'));
+    write(mcpPath, '{ invalid json');
+    const set = resolveResources(
+      discoverLayers({ homeDirectory: join(root, 'home'), projectDirectory: project, settings: {} }).layers,
+    );
+
+    const findings = validateEffectiveSet(set);
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ resource: 'agent:child', code: 'resource-unresolved', sourcePath: parentPath }),
+        expect.objectContaining({ resource: 'agent:child', code: 'reference-escaped', sourcePath: parentPath }),
+        expect.objectContaining({ resource: 'agent:configured', code: 'resource-unresolved', sourcePath: configPath }),
+        expect.objectContaining({ resource: 'agent:outside', code: 'resource-invalid', sourcePath: mcpPath }),
+      ]),
+    );
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.12.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('attributes unknown parents and cycles to the agent that declares the failing edge', () => {
+    const root = mkdtempSync(join(tmpdir(), 'outfitter-resolver-inheritance-'));
+    temporaryRoots.push(root);
+    const project = join(root, 'project');
+    const unknownPath = join(project, '.agents', 'agents', 'unknown-child', 'agent.md');
+    const cycleBPath = join(project, '.agents', 'agents', 'cycle-b', 'agent.md');
+    write(unknownPath, agentMd('unknown-child', 'inherits: [ghost]\n'));
+    write(join(project, '.agents', 'agents', 'cycle-a', 'agent.md'), agentMd('cycle-a', 'inherits: [cycle-b]\n'));
+    write(cycleBPath, agentMd('cycle-b', 'inherits: [cycle-a]\n'));
+    const set = resolveResources(
+      discoverLayers({ homeDirectory: join(root, 'home'), projectDirectory: project, settings: {} }).layers,
+    );
+
+    const findings = validateEffectiveSet(set);
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          resource: 'agent:unknown-child',
+          code: 'resource-unresolved',
+          sourcePath: unknownPath,
+        }),
+        expect.objectContaining({ resource: 'agent:cycle-a', code: 'inheritance-cycle', sourcePath: cycleBPath }),
+      ]),
+    );
+  });
 });

--- a/code/cli/tests/unit/resolver.test.ts
+++ b/code/cli/tests/unit/resolver.test.ts
@@ -305,7 +305,10 @@ describe('resource resolution', () => {
     const home = join(root, 'home');
     const project = join(root, 'project');
     write(join(home, '.agents', 'agents', 'engineer', 'agent.md'), agentMd('engineer', 'skills: [wiki]\n'));
-    write(join(home, '.agents', 'skills', 'wiki', 'SKILL.md'), '---\nname: wiki\n---\n');
+    write(
+      join(home, '.agents', 'skills', 'wiki', 'SKILL.md'),
+      '---\nname: wiki\ndescription: Maintain project knowledge. Use when reading or updating the wiki.\n---\n',
+    );
     write(join(project, '.agents', 'agents', 'engineer', 'agent.md'), agentMd('engineer', 'skills: [wiki]\n'));
     write(join(project, '.agents', 'knowledge', 'arch', 'overview.md'), '# overview\n');
     write(join(project, '.agents', 'commands', 'ship.md'), '# ship\n');

--- a/code/cli/tests/unit/run-agent-append-prompt.test.ts
+++ b/code/cli/tests/unit/run-agent-append-prompt.test.ts
@@ -118,6 +118,25 @@ describe('append-prompt projection', () => {
     }
   });
 
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.12.9).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('preserves normal-run settings error precedence over an unreadable append prompt', async () => {
+    const { home, project, root } = tree();
+    const missing = join(root, 'absent.md');
+    write(join(project, '.agents', 'settings.local.yml'), 'default_harness: invalid\n');
+
+    await expect(
+      executeRunAgentCommand({
+        homeDirectory: home,
+        projectDirectory: project,
+        agent: 'engineer',
+        harness: 'pi',
+        appendPromptPaths: [missing],
+        launcher: () => Promise.resolve(0),
+      }),
+    ).rejects.toThrow(/invalid settings/u);
+  });
+
   it('gives Claude one --append-system-prompt-file over a concatenation, never a repeated flag', async () => {
     const { home, project } = tree();
 

--- a/code/cli/tests/unit/run-agent.test.ts
+++ b/code/cli/tests/unit/run-agent.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- shared run integration fixtures remain together to preserve launch-path coverage. */
 // Tests run: resolve → compose → project → launch, launch mapping, cleanup, and strict/validation.
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -81,7 +82,10 @@ const tree = (): { home: string; project: string } => {
   const project = join(root, 'project');
   write(join(project, '.agents', 'system-prompt.md'), 'BASE PROMPT');
   write(join(project, '.agents', 'agents.md'), 'SHARED');
-  write(join(project, '.agents', 'skills', 'wiki', 'SKILL.md'), '---\nname: wiki\n---\n\nWiki skill body.\n');
+  write(
+    join(project, '.agents', 'skills', 'wiki', 'SKILL.md'),
+    '---\nname: wiki\ndescription: Maintain project knowledge. Use when reading or updating the wiki.\n---\n\nWiki skill body.\n',
+  );
   write(join(project, '.agents', 'skills', 'wiki', 'scripts', 'go.sh'), 'echo hi'); // nested dir under the skill
   symlinkSync('/etc/hosts', join(project, '.agents', 'skills', 'wiki', 'inner-link')); // inner symlink skipped on materialize
   write(
@@ -151,7 +155,10 @@ describe('run agent', () => {
   it('projects the selected agent-local skill and its packaged files into the harness runtime', async () => {
     const { home, project } = tree();
     const localSkill = join(project, '.agents', 'agents', 'engineer', 'skills', 'wiki');
-    write(join(localSkill, 'SKILL.md'), '---\nname: wiki\n---\n\nAgent-local body.\n');
+    write(
+      join(localSkill, 'SKILL.md'),
+      '---\nname: wiki\ndescription: Maintain project knowledge. Use when reading or updating the wiki.\n---\n\nAgent-local body.\n',
+    );
     write(join(localSkill, 'references', 'on-failure.md'), '# Diagnose the failure\n');
     write(join(localSkill, 'scripts', 'collect.sh'), 'echo collect\n');
     write(join(localSkill, 'assets', 'comment.md'), 'Failure report\n');

--- a/code/cli/tests/unit/sync-loadout-deferral.test.ts
+++ b/code/cli/tests/unit/sync-loadout-deferral.test.ts
@@ -61,7 +61,10 @@ describe('sync loadout-resolution deferral', () => {
     const home = join(root, 'home');
     // The dependency supplies `dep-skill`; `top`'s agent references it but does not define it.
     const dependency = createRepository(
-      { 'skills/dep-skill/SKILL.md': '---\nname: dep-skill\n---\n\n# dep-skill\n' },
+      {
+        'skills/dep-skill/SKILL.md':
+          '---\nname: dep-skill\ndescription: Provide dependency guidance. Use when the parent catalog selects this skill.\n---\n\n# dep-skill\n',
+      },
       'v1.0.0',
     );
     const top = createRepository({

--- a/code/cli/tests/unit/transitive-sources.test.ts
+++ b/code/cli/tests/unit/transitive-sources.test.ts
@@ -603,6 +603,12 @@ describe('transitive layers', () => {
     expect(discovered.unsynchronized).toHaveLength(1);
     expect(discovered.unsynchronized[0]).toContain('github:example/never-synced#v1.0.0');
     expect(discovered.unsynchronized[0]).toMatch(/Run 'outfitter sync'/u);
+    expect(discovered.unsynchronizedDetails).toEqual([
+      expect.objectContaining({
+        resource: 'source:github:example/never-synced#v1.0.0',
+        sourcePath: join(directRoot, 'settings.yml'),
+      }),
+    ]);
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.4).
@@ -624,6 +630,12 @@ describe('transitive layers', () => {
     expect(resolved.warnings).toHaveLength(1);
     expect(resolved.warnings[0]).toContain("Catalog 'github:example/direct#v1.0.0'");
     expect(resolved.warnings[0]).toContain('immutable');
+    expect(resolved.warningDetails).toEqual([
+      expect.objectContaining({
+        resource: 'source:github:example/direct#v1.0.0',
+        sourcePath: join(directRoot, 'settings.yml'),
+      }),
+    ]);
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.15).
@@ -644,6 +656,12 @@ describe('transitive layers', () => {
     });
 
     expect(discovered.warnings.some((warning) => warning.includes('invalid path'))).toBe(true);
+    expect(discovered.warningDetails).toEqual([
+      expect.objectContaining({
+        resource: 'source:github:example/evil#v1.0.0',
+        sourcePath: join(root, 'project', '.agents', 'settings.yml'),
+      }),
+    ]);
     expect(findResource(resolveResources(discovered.layers), 'agent', 'ok')).toBeDefined();
   });
 });

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -258,6 +258,7 @@ Outfitter launches `codex`, maps model selection to `-m`, and injects selected M
 
 - **`outfitter run [agent]`** (default command): resolve → compose → project → launch.
   A positional agent slug selects what to run (default from settings `default_agent`); `--harness <pi|claude|codex>` selects the harness (default from settings `default_harness`, then `pi`); unknown args pass through to the child CLI; `--strict` makes warnings fatal.
+  Strict mode first validates the complete effective `.agents` resource set and stops on any common finding before it selects the harness. Normal mode skips this full validation and uses the existing launch checks.
   Interactive clean-home launches start Pi-native onboarding; non-interactive clean-home launches require `outfitter setup` first.
 - **`outfitter setup [source]`**: launch the bundled, model-free Pi walkthrough with the original three setup modes (default catalog, create a profile, or another catalog), original profile/target wording, and optional direct-source path; append only the default CLI-agent choice (Pi/Outfitter preselected); then atomically apply the result through the CLI state machine.
 - **`outfitter sync`**: validate local settings; atomically fetch configured remote settings; reload the merged settings; then atomically fetch every resulting remote source into `<cache_directory>/repos/<encoded-uri-and-ref>/`.
@@ -265,7 +266,7 @@ Outfitter launches `codex`, maps model selection to `-m`, and injects selected M
   Required-source failures exit nonzero.
   Network synchronization never runs implicitly during `outfitter run`.
 - **`outfitter list [kind]`**: report the effective resource set — slugs, winning sources, shadowed definitions — deterministically.
-- **`outfitter validate [--strict] [--json]`**: protocol layout, frontmatter and JSON schemas, unresolved loadout slugs, skill reference escapes/collisions, settings schema.
+- **`outfitter validate [--strict] [--json]`**: protocol layout, frontmatter and JSON schemas, all effective global and agent-local skill descriptions, unresolved loadout slugs, skill reference escapes/collisions, settings schema. Findings use stable codes and include severity, resource identity, source path, message, and remediation.
 - **`outfitter dump [--agent <id>] [--out]`**: write the deterministic tree, optionally restricted to one agent's transitive closure.
 
 > `outfitter task bake` is deferred to the [tasks RFC](../documentation/tasks.md).

--- a/docs/documentation/skills.md
+++ b/docs/documentation/skills.md
@@ -64,7 +64,11 @@ description: Design concise GitHub automation using stable agent identities and 
 Describe when and how to perform this capability.
 ```
 
-Skill directory names use lowercase letters, numbers, and hyphens — at most 64 characters, with no leading, trailing, or consecutive hyphens. Keep the description precise enough for an agent to decide when the skill applies.
+Skill directory names use lowercase letters, numbers, and hyphens — at most 64 characters, with no leading, trailing, or consecutive hyphens. A description is required and must contain 1–1,024 Unicode characters. Keep it precise enough for an agent to decide when the skill applies.
+
+The description length is an Agent Skills conformance rule. Outfitter reports a portable-authoring warning for every description of three words or fewer. This objective rule avoids subjective prose judgments in strict mode.
+
+The Agent Skills specification does not set a total description-length limit for a catalog. The common validator does not use a limit from a harness or model. A future total limit must be an Outfitter policy based on tests across harnesses. Each adapter still reports harness-specific capability or projection loss.
 
 ## Where context and instructions live
 

--- a/docs/requirements/OFTR-003-profiles.md
+++ b/docs/requirements/OFTR-003-profiles.md
@@ -97,3 +97,18 @@ Outfitter resolves agents and other resources from layered `.agents` trees into 
 4. Missing optional `repo_file` prompt fragments SHOULD produce observable composition warnings instead of making reusable catalog agents fail across repositories.
 5. Prompt fragments MUST retain source kind, path or reference, declaring agent, owning layer, content, order, and trust provenance in the composition plan.
 6. Named prompt slug shorthand MUST NOT be accepted until its namespace, layer semantics, protocol compatibility, and dump behavior are specified in these requirements.
+
+### OFTR-003.12: Common `.agents` Validation
+
+> **Amendment (2026-08-15, Issue [#301](https://github.com/ai-outfitter/outfitter/issues/301)):** The complete effective resource set now has one harness-neutral validation gate.
+
+1. `outfitter validate` and `outfitter run --strict` MUST use the same common validation findings.
+2. `run --strict` MUST execute the common validator before first-run setup or harness selection, MUST revalidate after setup changes the effective tree, and MUST stop before process spawn when the validator returns an error or warning.
+3. The validator MUST check every effective global and agent-local skill, including a skill that the selected agent does not use.
+4. A skill description MUST contain 1–1,024 Unicode characters. A missing, empty, or longer description MUST produce an error.
+5. Common findings MUST cover invalid frontmatter, invalid or mismatched names, unresolved resources, inheritance cycles, escaping references, materialized destination collisions, and shadowed resources.
+6. A description of three words or fewer MUST produce the `description-not-actionable` portable-authoring warning. Broader semantic judgments MUST NOT block strict mode.
+7. Every common finding MUST include a stable code, severity, resource identity, source path, message, and remediation. JSON output MUST preserve these fields.
+8. Common findings MUST NOT name a harness. An adapter MAY report only later harness capability or projection loss.
+9. Normal `outfitter run` MUST NOT execute the complete common gate. Existing composition errors and degraded-launch warnings continue to use their current behavior.
+10. The Agent Skills description limit is a conformance rule. An aggregate description budget would be an Outfitter portable policy, not an Agent Skills requirement. Outfitter MUST NOT enforce or claim an aggregate numeric threshold until cross-harness evaluation establishes one.


### PR DESCRIPTION
Closes #301

## What changed

- Add stable typed findings for common `.agents` validation.
- Validate every effective global and agent-local skill, including unused skills.
- Enforce skill description bounds and conservative authoring warnings.
- Validate references, globs, containment, nested symlinks, missing paths, and materialization collisions.
- Make `outfitter validate` and `outfitter run --strict` use the same common finding collector.
- Stop strict runs before setup, harness selection, projection, or process spawn.
- Preserve normal-run behavior and keep adapter-specific checks at the later projection boundary.
- Document that an aggregate catalog-description budget is an Outfitter policy, not an Agent Skills standard.

## Why

Common portable defects belong at the complete effective-resource-set boundary. Adapter checks report only harness-specific capability or projection loss.

## Validation

- `npm run check-ci`
- 48 test files and 571 tests passed.
- Branch coverage is 98.01%.
- Formatting, ESLint, documentation lint, and documentation build passed.
- GitHub Actions passed on macOS, Ubuntu, and Windows. The packaged E2E smoke test also passed.
- Adversarial correctness review found no remaining P1 or P2 issues.
- Copilot reviewed all 28 changed files on final commit `e98bd7d` and found no new visible or suppressed issues.
