### PR TITLE
fix(projection): stop reporting pi extensions as unsupported

### DIFF
--- a/code/cli/src/projection/ProjectHarness.ts
+++ b/code/cli/src/projection/ProjectHarness.ts
@@ -15,8 +15,8 @@ import { toolArgs } from './Tools.js';
 // identity + skills + model + thinking + tools. Both harnesses express an allowlist and a denylist
 // natively, so `tools` is unconditionally supported; a name projection cannot carry is a hard error
 // from `toolArgs`, not an unsupported element. Pi also projects selected subagents and MCP servers
-// into its runtime config directory, and projects `extensions` once the run path has resolved their
-// install dirs (`extensionLoadDirs`). Claude projects selected MCP servers through an explicit,
+// into its runtime config directory, and loads pi extensions from the install dirs the run path
+// resolves (`extensionLoadDirs`). Claude projects selected MCP servers through an explicit,
 // isolated `--mcp-config`; plugins remain unsupported pending incremental parity (#183).
 // Switched rather than chained so a harness added to `Harness` fails to compile here instead of
 // silently inheriting another harness's element set — the exact silent drop this function prevents.
@@ -27,10 +27,8 @@ const supportedElements = (input: ProjectionInput): readonly string[] => {
       return [...baseline, 'mcp'];
     case 'codex':
       return ['model', 'mcp'];
-    case 'pi': {
-      const pi = [...baseline, 'subagents', 'mcp', 'prompt_template'];
-      return input.extensionLoadDirs === undefined ? pi : [...pi, 'extensions'];
-    }
+    case 'pi':
+      return [...baseline, 'subagents', 'mcp', 'prompt_template'];
   }
 };
 
@@ -40,7 +38,12 @@ const loadoutElementsInUse = (composition: CompositionPlan): readonly string[] =
 
   if (loadout.skills.length > 0) present.push('skills');
   if (loadout.subagents.length > 0) present.push('subagents');
-  if (loadout.extensions.length > 0) present.push('extensions');
+  // `extensions` is deliberately absent. It names pi extension packages, so on claude or codex it
+  // can only ever be unsupported — there is no setting a user could change to make it project, and
+  // no launch they would have wanted instead. Reporting it describes Outfitter's internals rather
+  // than a choice the user made, and under `--strict` it would fail every non-pi launch of any
+  // agent that carries extensions at all. Extension resolution and install failures still surface
+  // from the run path, which is where a user can act on them.
   if (loadout.plugins.length > 0) present.push('plugins');
   if (loadout.mcp.length > 0) present.push('mcp');
   if (loadout.model !== undefined) present.push('model');

--- a/code/cli/tests/unit/project-harness-codex.test.ts
+++ b/code/cli/tests/unit/project-harness-codex.test.ts
@@ -337,11 +337,12 @@ describe('projectComposition Codex MCP projection', () => {
     );
 
     expect(projection.launch.args).toEqual(['-m', 'gpt-5']);
+    // `extensions` is absent by design: it names pi extension packages, so codex could never load
+    // them and the user has no setting that would change that. See OFTR-006.6.7.
     expect(projection.unsupported).toEqual([
       'identity',
       'skills',
       'subagents',
-      'extensions',
       'plugins',
       'thinking',
       'tools',

--- a/code/cli/tests/unit/project-harness.test.ts
+++ b/code/cli/tests/unit/project-harness.test.ts
@@ -69,7 +69,7 @@ describe('projectComposition prompt templates', () => {
 });
 
 describe('projectComposition extensions', () => {
-  it('loads pi extension dirs with --extension and drops extensions from unsupported', () => {
+  it('loads pi extension dirs with --extension', () => {
     const dir = root();
     const projection = projectComposition(planWith(['git:github.com/o/r']), {
       harness: 'pi',
@@ -82,7 +82,7 @@ describe('projectComposition extensions', () => {
     expect(projection.unsupported).not.toContain('extensions');
   });
 
-  it('reports extensions unsupported for pi when no load dirs are provided (adds no --extension)', () => {
+  it('adds no --extension for pi when no load dirs are provided', () => {
     const dir = root();
     const projection = projectComposition(planWith(['git:github.com/o/r']), {
       harness: 'pi',
@@ -90,19 +90,24 @@ describe('projectComposition extensions', () => {
       homeDirectory: dir,
     });
     expect(projection.launch.args).not.toContain('--extension');
-    expect(projection.unsupported).toContain('extensions');
+    expect(projection.unsupported).not.toContain('extensions');
   });
 
-  it('never adds --extension for claude and keeps extensions unsupported', () => {
+  // `extensions` names pi extension packages, so a claude or codex launch can never project it and
+  // the user has no setting that would change that. Reporting it would fail every non-pi `--strict`
+  // run of an agent that carries extensions, for a mismatch the user did not create.
+  it('never adds --extension for claude and never reports extensions unsupported', () => {
     const dir = root();
-    const projection = projectComposition(planWith(['git:github.com/o/r']), {
-      harness: 'claude',
-      rootDirectory: dir,
-      homeDirectory: dir,
-      extensionLoadDirs: ['/cache/git/github.com/o/r'],
-    });
-    expect(projection.launch.args).not.toContain('--extension');
-    expect(projection.unsupported).toContain('extensions');
+    for (const harness of ['claude', 'codex'] as const) {
+      const projection = projectComposition(planWith(['git:github.com/o/r']), {
+        harness,
+        rootDirectory: dir,
+        homeDirectory: dir,
+        extensionLoadDirs: ['/cache/git/github.com/o/r'],
+      });
+      expect(projection.launch.args).not.toContain('--extension');
+      expect(projection.unsupported).not.toContain('extensions');
+    }
   });
 });
 

--- a/code/cli/tests/unit/run-agent.test.ts
+++ b/code/cli/tests/unit/run-agent.test.ts
@@ -226,7 +226,7 @@ describe('run agent', () => {
     expect(existsSync(captured[0].runtimeDir)).toBe(false); // removed afterwards
   });
 
-  it('maps model/thinking to claude flags and reports pi-only elements as unsupported', async () => {
+  it('maps model/thinking to claude flags and stays silent about the agent pi extensions', async () => {
     const { home, project } = tree();
     const result = await executeRunAgentCommand({
       homeDirectory: home,
@@ -241,22 +241,25 @@ describe('run agent', () => {
     expect(plan.env.CLAUDE_CONFIG_DIR).toBeDefined();
     expect(plan.args).toEqual(expect.arrayContaining(['--effort', 'high']));
     expect(plan.args).not.toContain('--skill'); // claude skills are materialized, not flagged
-    expect(result.messages.join(' ')).toContain("cannot project loadout element 'extensions'");
+    // The engineer's `extensions: [ext-a]` is pi-only, a mismatch a claude user cannot act on.
+    expect(result.messages.join(' ')).not.toContain('extensions');
   });
 
-  it('fails under --strict on an unsupported element and never launches', async () => {
+  it('fails under --strict on an unsupported element, but not on pi extensions alone', async () => {
     const { home, project } = tree();
-    const result = await executeRunAgentCommand({
-      homeDirectory: home,
-      projectDirectory: project,
-      agent: 'engineer',
-      harness: 'claude',
-      strict: true,
-      launcher,
-    });
-    expect(result.exitCode).toBe(1);
+    // `plugins` is claude-native and still unprojected (#183), so it is a genuine capability gap a
+    // strict run must catch — unlike the engineer's `extensions`, which claude could never load.
+    write(join(project, '.agents', 'agents', 'plugged', 'agent.md'), '---\nname: plugged\nplugins: [p]\n---\n\nP.\n');
+    const strict = { homeDirectory: home, projectDirectory: project, harness: 'claude' as const, strict: true, launcher }; // prettier-ignore
+
+    const failed = await executeRunAgentCommand({ ...strict, agent: 'plugged' });
+    expect(failed.exitCode).toBe(1);
     expect(captured).toHaveLength(0);
-    expect(result.messages.join(' ')).toContain('Strict mode');
+    expect(failed.messages.join(' ')).toContain("cannot project loadout element 'plugins'");
+    expect(failed.messages.join(' ')).toContain('Strict mode');
+
+    expect((await executeRunAgentCommand({ ...strict, agent: 'engineer' })).exitCode).toBe(0);
+    expect(captured).toHaveLength(1);
   });
 
   it('fails under --strict on a composition warning (unresolved skill)', async () => {

--- a/docs/architecture/controllable-elements.md
+++ b/docs/architecture/controllable-elements.md
@@ -98,6 +98,9 @@ An agent can select any number of extensions; the adapter registers them alongsi
 
 - Pi name: extensions loaded via `--extension` / `-e`
 - Claude name: no direct equivalent; roadmap adapter mapping
+- Exempt from the unsupported-element warning. The element names pi extension packages, so a claude
+  or codex launch could never load them and the user has no setting that would change that. A non-pi
+  launch installs none of them, says nothing about them, and does not fail under `--strict`.
 
 ### Plugins
 
@@ -215,7 +218,7 @@ An early-startup customization used to register providers, tools, hooks, or addi
 | Knowledge                   | Supported | Partial   | Roadmap   |
 | Model Selection             | Supported | Partial   | Partial   |
 | MCP Servers                 | Supported | Supported | Partial   |
-| Extensions                  | Supported | Roadmap   | Roadmap   |
+| Extensions                  | Supported | Pi only   | Pi only   |
 | Plugins                     | Supported | Roadmap   | Roadmap   |
 | Credentials and Environment | Supported | Supported | Roadmap   |
 | Tasks                       | Future    | Future    | Future    |

--- a/docs/documentation/support-matrix.md
+++ b/docs/documentation/support-matrix.md
@@ -23,7 +23,7 @@ Tasks and bake are not in this matrix — they are the subject of a [separate up
 | Knowledge (`knowledge/`)                                                 | Supported | Partial     | Roadmap   |
 | Model selection (`models.json`)                                          | Supported | Partial     | Partial   |
 | MCP servers (`mcp.json`)                                                 | Supported | Supported   | Partial   |
-| Extensions (agent `extensions:` loadout)                                 | Supported | Roadmap     | Roadmap   |
+| Extensions (agent `extensions:` loadout)                                 | Supported | Pi only     | Pi only   |
 | Plugins (agent `plugins:` loadout)                                       | Supported | Roadmap     | Roadmap   |
 | Credentials and environment                                              | Supported | Supported   | Roadmap   |
 | DeepWork job selection                                                   | Supported | Roadmap     | Roadmap   |
@@ -38,7 +38,8 @@ Tasks and bake are not in this matrix — they are the subject of a [separate up
 
 - **Launch mode** — Outfitter launches `codex` directly. Pass-through arguments choose the native mode: no subcommand keeps the interactive CLI shape, while `-- exec ...` selects non-interactive `codex exec`.
 - **Agent identity and appended prompts** — Codex has no native identity projection yet: launches drop the composed identity/system prompt and any `--append-prompt` documents, supplied documents produce a separate warning, and `--strict` aborts before execution.
-- **Model selection (Partial)** — an agent's model maps to `-m`. Provider maps have no projection element and produce no warning. Thinking, tools, skills, subagents, extensions, plugins, and prompt templates remain unsupported and warn when selected.
+- **Model selection (Partial)** — an agent's model maps to `-m`. Provider maps have no projection element and produce no warning. Thinking, tools, skills, subagents, plugins, and prompt templates remain unsupported and warn when selected.
+- **Extensions (Pi only)** — `extensions:` names pi extension packages, so a Codex or Claude Code launch installs none of them. This is a property of the element, not a gap a user can close, so it produces no warning and does not fail under `--strict`.
 - **MCP servers (Partial)** — selected stdio fields (`command`, `args`, `env`, `cwd`) and streamable HTTP fields (`url`, `headers`) become repeated TOML-valued `-c mcp_servers.<id>.<key>=...` overrides. Server ids must contain only letters, digits, `_`, or `-`; other ids cannot be expressed by Codex `-c` key paths and are skipped with a warning. Legacy SSE and other HTTP transport types are also skipped with a warning. User and project `config.toml` servers remain active because Codex has no strict MCP isolation mode, so every launch warns that projection is additive, even when no servers are selected.
 - **Stdio environment safety** — `${ENV_NAME}` becomes an `env_vars` reference only when the stdio `env` key is also `ENV_NAME`; a reference that would rename the variable is dropped with a warning. Literal values pass through `env` and are visible in process arguments.
 - **HTTP header safety** — `${ENV_NAME}` becomes an `env_http_headers` reference, while `Authorization: Bearer ${ENV_NAME}` becomes `bearer_token_env_var`. Other header values pass through `http_headers` and are visible in process arguments. Outfitter warns for every literal stdio environment or HTTP header entry exposed in argv, so use environment references for secrets.

--- a/docs/requirements/OFTR-006-agent-adapters.md
+++ b/docs/requirements/OFTR-006-agent-adapters.md
@@ -91,7 +91,8 @@ Amended (2026-07-17, RFC #165): adapters project a harness-neutral composition, 
 3. For server ids containing only ASCII letters, digits, `_`, or `-`, the Codex adapter MUST project selected stdio MCP server `command`, `args`, `env`, and `cwd` fields through repeated `-c mcp_servers.<id>.<key>=<toml-value>` overrides. An `env` entry `${ENV_NAME}` MUST become an `env_vars` reference only when its key is also `ENV_NAME`; the adapter MUST warn and omit a reference that would rename the variable. Literal `env` entries MUST be projected and MUST warn that their values are exposed in process arguments. The adapter MUST warn and skip a server whose id contains other characters because Codex `-c` key paths cannot express it.
 4. The Codex adapter MUST project selected HTTP MCP server fields through repeated `-c` overrides using `url` and `http_headers`, with `env_http_headers` for `${ENV_NAME}` values and `bearer_token_env_var` for `Authorization: Bearer ${ENV_NAME}`.
 5. The Codex adapter MUST warn that MCP projection is additive because Codex has no strict MCP isolation mode; this adapter warning follows the normal `--strict` warning policy.
-6. The Codex adapter MUST report every selected loadout element other than `model` and `mcp` as unsupported until a native projection is implemented and tested.
+6. The Codex adapter MUST report every selected loadout element other than `model`, `mcp`, and `extensions` as unsupported until a native projection is implemented and tested.
+7. No adapter MAY report `extensions` as an unsupported loadout element. `extensions` names pi extension packages, so only the pi adapter can load them, and no user setting can make another harness load them. A non-pi launch MUST stay silent about the selected extensions and MUST NOT fail under `--strict` because of them.
 
 ### OFTR-006.7: Pi Settings Reconciliation
 


### PR DESCRIPTION
## Problem

Launching any agent that declares `extensions:` on a non-pi harness printed a warning about a mismatch the user did not create and cannot fix:

```
$ outfitter run --harness claude
harness 'claude' cannot project loadout element 'extensions'.
```

The default `founder` profile carries eight pi extensions, so this fired on every Claude Code launch. Worse, `--strict` promoted it to a hard failure — a strict claude run of an ordinary profile could not succeed at all.

## Why this one is different

The unsupported-element report earns its keep when a harness silently drops something the user chose and could have chosen differently: codex dropping the system prompt, claude not yet projecting plugins (#183). Those describe a gap worth knowing about.

`extensions:` names pi extension packages. No harness other than pi can ever load them and no setting changes that, so the message describes Outfitter's internals rather than a decision the user made. It is dropped from the report entirely instead of moved to a quieter log level, because there is no mode in which a user wants it — including `--strict`.

Non-pi launches already install no extensions and emit no extension warnings (`resolvePiExtensions` returns early), so they now stay silent end to end.

## Changes

- `extensions` is no longer collected as a loadout element in use, so no harness reports it unsupported. The pi branch of `supportedElements` no longer needs its `extensionLoadDirs` conditional.
- Requirements: OFTR-006.6.6 amended, OFTR-006.6.7 added to record the carve-out.
- Docs: support matrix and controllable-elements now read `Pi only` rather than `Roadmap` for extensions, since "roadmap" implied a projection that will never exist.
- Tests: claude/codex projections assert extensions are never reported; a strict run fails on `plugins` but launches when pi extensions are the only unprojectable element.

## Verification

- `npm run coverage` — 547 tests pass, 46 files, thresholds hold.
- `npx eslint .`, `prettier --check` clean.
- Built and ran the original reproduction: `outfitter run --harness claude` now goes straight to Claude Code with no preamble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)