### PR TITLE
fix(telemetry): provision the PostHog project key

### DIFF
--- a/code/cli/src/telemetry/TelemetryConstants.ts
+++ b/code/cli/src/telemetry/TelemetryConstants.ts
@@ -1,4 +1,10 @@
-/** PostHog project configuration. An empty key makes telemetry completely inert. */
-export const POSTHOG_API_KEY = '';
+/**
+ * PostHog project configuration. An empty key makes telemetry completely inert.
+ *
+ * This is a PostHog project API key: write-only, safe to ship in client code, and useless for
+ * reading any project data. It belongs to the `ai-outfitter` organization, project 562393, on
+ * PostHog Cloud US — so `POSTHOG_HOST` must stay a US endpoint or events are accepted nowhere.
+ */
+export const POSTHOG_API_KEY = 'phc_v9FGDjtEC7h9UvLxHdJKaHFtFfMN7UZwpJ2weRTFoqvz';
 export const POSTHOG_HOST = 'https://us.i.posthog.com';
 export const TELEMETRY_SHUTDOWN_BUDGET_MS = 1000;

--- a/docs/documentation/telemetry.md
+++ b/docs/documentation/telemetry.md
@@ -1,8 +1,10 @@
 # Telemetry
 
-Outfitter includes opt-outable pseudonymous product analytics to measure command adoption and reliability. The shipped PostHog API key is currently empty, so no build produced from this repository sends telemetry. Provisioning a key is deferred maintainer work. The consent setting still defaults to enabled and can be changed at any time.
+Outfitter includes opt-outable pseudonymous product analytics to measure command adoption and reliability. A PostHog key is provisioned, so builds produced from this repository do send telemetry. The consent setting defaults to enabled and can be changed at any time.
 
-In a future build with a provisioned key, the first command that would send an event prints a one-time notice to stderr. The notice explains what is collected, what is excluded, and how to opt out. With the current empty key, telemetry is inert: it creates no client or state, sends no events, and prints no notice.
+The first command that would send an event prints a one-time notice to stderr. The notice explains what is collected, what is excluded, and how to opt out.
+
+Earlier builds shipped an empty key and were fully inert: they created no client or state, sent no events, and printed no notice.
 
 ## Event contract
 
@@ -45,7 +47,7 @@ In CI, telemetry remains enabled according to the same consent rules and events 
 
 ## Where the data goes
 
-When a maintainer provisions a PostHog key, events go to PostHog Cloud US at `https://us.i.posthog.com`. No retention period is stated here because this repository does not currently configure one.
+Events go to the `ai-outfitter` organization's PostHog project on PostHog Cloud US at `https://us.i.posthog.com`. No retention period is stated here because this repository does not currently configure one.
 
 ## Control telemetry
 


### PR DESCRIPTION
## What this does

Sets the compiled PostHog project API key for the `ai-outfitter` organization (project 562393, PostHog Cloud US). `POSTHOG_HOST` already pointed at the US endpoint and is unchanged.

## Why it matters

Telemetry shipped in #300 / v1.8.0 with an **empty** key, so `TelemetryService` bailed before constructing a client — no events, no consent read, no state file, no first-run notice. The feature was complete and dormant.

This is the commit that turns it on. Consent defaults to enabled (`telemetry.enabled`, docs §Control telemetry), so the release carrying this key begins collecting from every user who has not opted out, and each sees the one-time stderr notice on their next command. Reviewers should weigh this as the privacy-relevant change; v1.8.0 was not.

Unchanged from 1.8.0: the two-event contract, the properties sent, the never-collected list, GeoIP disabled, CI identity handling, and the opt-out path.

## Key handling

The value is a PostHog **project** key — write-only, designed to ship in client code, and unable to read project data. Committing it is the intended deployment model, not a leaked credential.

## Docs

`docs/documentation/telemetry.md` claimed in three places that no build sends telemetry. Corrected, with a note that earlier builds were inert.

`OFTR-011.4` (an empty key MUST keep telemetry inert) is unaffected and still covered by tests — a blank-key build stays dormant.

## Verification

- `npm run coverage` — 547 tests pass across 46 files, thresholds hold.
- `eslint` and `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)