### PR TITLE
fix(validate): diagnose missing Pi MCP adapter

### DIFF
--- a/code/cli/src/cli/commands/ValidateCommand.ts
+++ b/code/cli/src/cli/commands/ValidateCommand.ts
@@ -1,11 +1,15 @@
 // Provides `outfitter validate [--strict] [--json]` over the effective resource set.
 
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 
+import { compose } from '../../composer/Composer.js';
+import { listResources } from '../../resolver/Resource.js';
 import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
 import type { ValidationFinding } from '../../resolver/ResolverValidation.js';
 import { validateEffectiveSet } from '../../resolver/ResolverValidation.js';
 import { formatSettingsIssue } from '../../settings/SettingsLoader.js';
+import type { Harness } from '../../settings/Settings.js';
+import { HARNESSES } from '../../settings/Settings.js';
 import type { CommandObject } from './CommandObject.js';
 import { resolveHomeDirectory, resolveProjectDirectory } from './ProcessDefaults.js';
 
@@ -14,6 +18,7 @@ export interface ValidateInput {
   readonly projectDirectory: string;
   readonly strict?: boolean;
   readonly json?: boolean;
+  readonly harness?: Harness;
 }
 
 export interface ValidateResult {
@@ -31,12 +36,33 @@ export interface ValidateCommandDependencies {
 const settingsFindings = (messages: readonly string[]): readonly ValidationFinding[] =>
   messages.map((message) => ({ severity: 'error' as const, resource: 'settings', message }));
 
+const PI_MCP_ADAPTER = 'npm:pi-mcp-adapter';
+const isPiMcpAdapter = (extension: string): boolean =>
+  extension === PI_MCP_ADAPTER || extension.startsWith(`${PI_MCP_ADAPTER}@`);
+
+const piMcpAdapterFindings = (set: ReturnType<typeof resolveEffectiveSet>['set']): readonly ValidationFinding[] =>
+  listResources(set, 'agent').flatMap((agent) => {
+    const composition = compose(set, agent.slug);
+    if (composition.plan === undefined) return [];
+    if (composition.plan.loadout.mcp.length === 0) return [];
+    if (composition.plan.loadout.extensions.some(isPiMcpAdapter)) return [];
+    return [
+      {
+        severity: 'warning' as const,
+        resource: `agent:${agent.slug}`,
+        message: `MCP servers are selected for Pi, but no MCP-capable extension is configured; add '${PI_MCP_ADAPTER}' to extensions.`,
+      },
+    ];
+  });
+
 export const executeValidateCommand = (input: ValidateInput): ValidateResult => {
-  const { set, settingsIssues, warnings } = resolveEffectiveSet(input);
+  const { set, settings, settingsIssues, warnings } = resolveEffectiveSet(input);
+  const harness = input.harness ?? settings.defaultHarness ?? 'pi';
   const findings = [
     ...settingsFindings(settingsIssues.map(formatSettingsIssue)),
     ...warnings.map((message) => ({ severity: 'warning' as const, resource: 'settings', message })),
     ...validateEffectiveSet(set, input.projectDirectory),
+    ...(harness === 'pi' ? piMcpAdapterFindings(set) : []),
   ];
 
   const hasErrors = findings.some((finding) => finding.severity === 'error');
@@ -69,7 +95,8 @@ export const createValidateCommand = (dependencies: ValidateCommandDependencies 
         .description('Validate the resolved .agents tree: schemas, loadout slugs, and shadowing.')
         .option('--strict', 'Treat warnings, including ambiguous source resolution, as failures.')
         .option('--json', 'Emit findings as JSON.')
-        .action((options: { strict?: boolean; json?: boolean }) => {
+        .addOption(new Option('--harness <harness>', 'Target harness for adapter checks.').choices(HARNESSES))
+        .action((options: { strict?: boolean; json?: boolean; harness?: Harness }) => {
           /* v8 ignore next 2 -- process defaults are exercised by the CLI entrypoint, not unit tests. */
           const homeDirectory = resolveHomeDirectory(dependencies.homeDirectory);
           const projectDirectory = resolveProjectDirectory(dependencies.projectDirectory);
@@ -78,6 +105,7 @@ export const createValidateCommand = (dependencies: ValidateCommandDependencies 
             projectDirectory,
             strict: options.strict,
             json: options.json,
+            harness: options.harness,
           });
 
           for (const message of result.messages) {

--- a/code/cli/tests/unit/validate-mcp-extension.test.ts
+++ b/code/cli/tests/unit/validate-mcp-extension.test.ts
@@ -72,12 +72,15 @@ describe('Pi MCP adapter validation', () => {
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('wires the --harness target through the validate command', async () => {
     const input = fixture('mcp: [github]\n');
-    const lines: string[] = [];
-    const program = new Command();
-    createValidateCommand({ ...input, writeLine: (line) => lines.push(line) }).register(program);
+    const runForHarness = async (harness: 'pi' | 'claude'): Promise<string> => {
+      const lines: string[] = [];
+      const program = new Command();
+      createValidateCommand({ ...input, writeLine: (line) => lines.push(line) }).register(program);
+      await program.parseAsync(['node', 'outfitter', 'validate', '--harness', harness]);
+      return lines.join('\n');
+    };
 
-    await program.parseAsync(['node', 'outfitter', 'validate', '--harness', 'pi']);
-
-    expect(lines.join('\n')).toContain("add 'npm:pi-mcp-adapter' to extensions");
+    expect(await runForHarness('pi')).toContain("add 'npm:pi-mcp-adapter' to extensions");
+    expect(await runForHarness('claude')).not.toContain("add 'npm:pi-mcp-adapter' to extensions");
   });
 });

--- a/code/cli/tests/unit/validate-mcp-extension.test.ts
+++ b/code/cli/tests/unit/validate-mcp-extension.test.ts
@@ -1,0 +1,83 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { Command } from 'commander';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createValidateCommand, executeValidateCommand } from '../../src/cli/commands/ValidateCommand.js';
+
+const roots: string[] = [];
+const write = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+const fixture = (loadout: string): { homeDirectory: string; projectDirectory: string } => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-validate-mcp-'));
+  roots.push(root);
+  const projectDirectory = join(root, 'project');
+  write(
+    join(projectDirectory, '.agents', 'agents', 'resident', 'agent.md'),
+    `---\nname: resident\n${loadout}---\n\nResident.\n`,
+  );
+  write(
+    join(projectDirectory, '.agents', 'mcp.json'),
+    `${JSON.stringify({ mcpServers: { github: { command: 'github-mcp-server' } } }, null, 2)}\n`,
+  );
+  return { homeDirectory: join(root, 'home'), projectDirectory };
+};
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('Pi MCP adapter validation', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('warns for selected MCP servers without pi-mcp-adapter and fails under strict mode', () => {
+    const input = fixture('mcp: [github]\n');
+    const result = executeValidateCommand({ ...input, harness: 'pi' });
+
+    expect(result.ok).toBe(true);
+    expect(result.findings).toContainEqual({
+      severity: 'warning',
+      resource: 'agent:resident',
+      message:
+        "MCP servers are selected for Pi, but no MCP-capable extension is configured; add 'npm:pi-mcp-adapter' to extensions.",
+    });
+    expect(executeValidateCommand({ ...input, harness: 'pi', strict: true }).ok).toBe(false);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('accepts the canonical MCP adapter, including a versioned package specifier', () => {
+    const unversioned = fixture('mcp: [github]\nextensions: [npm:pi-mcp-adapter]\n');
+    const versioned = fixture('mcp: [github]\nextensions: [npm:pi-mcp-adapter@1.2.3]\n');
+
+    expect(executeValidateCommand({ ...unversioned, harness: 'pi', strict: true }).ok).toBe(true);
+    expect(executeValidateCommand({ ...versioned, harness: 'pi', strict: true }).ok).toBe(true);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('does not warn without an MCP selection or when targeting another harness', () => {
+    const noMcp = fixture('');
+    const claude = fixture('mcp: [github]\n');
+
+    expect(executeValidateCommand({ ...noMcp, harness: 'pi', strict: true }).ok).toBe(true);
+    expect(executeValidateCommand({ ...claude, harness: 'claude', strict: true }).ok).toBe(true);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('wires the --harness target through the validate command', async () => {
+    const input = fixture('mcp: [github]\n');
+    const lines: string[] = [];
+    const program = new Command();
+    createValidateCommand({ ...input, writeLine: (line) => lines.push(line) }).register(program);
+
+    await program.parseAsync(['node', 'outfitter', 'validate', '--harness', 'pi']);
+
+    expect(lines.join('\n')).toContain("add 'npm:pi-mcp-adapter' to extensions");
+  });
+});

--- a/docs/documentation/cli.md
+++ b/docs/documentation/cli.md
@@ -75,12 +75,13 @@ List resolvable resources across all layers, with the winning source for each sl
 
 ## `outfitter validate`
 
-Validate the effective resource set: protocol layout, frontmatter, unresolved slugs in agent loadouts, broken or escaping skill references, and settings schema.
+Validate the effective resource set: protocol layout, frontmatter, unresolved slugs in agent loadouts, broken or escaping skill references, and settings schema. Adapter checks use `--harness` (or `default_harness`, falling back to Pi); for Pi, an agent that selects MCP servers must include `npm:pi-mcp-adapter` in its composed extensions.
 
-| Option     | Description                              |
-| ---------- | ---------------------------------------- |
-| `--strict` | Exit non-zero when warnings are present. |
-| `--json`   | Print diagnostics as JSON.               |
+| Option                | Description                                                     |
+| --------------------- | --------------------------------------------------------------- |
+| `--strict`            | Exit non-zero when warnings are present.                        |
+| `--json`              | Print diagnostics as JSON.                                      |
+| `--harness <harness>` | Target harness for adapter checks (`pi`, `claude`, or `codex`). |
 
 ## `outfitter dump`
 

--- a/docs/requirements/OFTR-003-profiles.md
+++ b/docs/requirements/OFTR-003-profiles.md
@@ -6,6 +6,8 @@
 > Section IDs are preserved for pinned-test traceability.
 > Target design: [docs/documentation/agents.md](../documentation/agents.md) and [docs/architecture/README.md](../architecture/README.md).
 
+> **Amendment (2026-08-19, issue [#315](https://github.com/ai-outfitter/outfitter/issues/315)):** Validation now diagnoses Pi agents that select MCP servers without the MCP adapter extension, preventing a healthy-looking launch with no projected MCP tools.
+
 ## Overview
 
 An agent is the protocol's identity resource and the thing Outfitter runs.
@@ -63,6 +65,7 @@ Outfitter resolves agents and other resources from layered `.agents` trees into 
 2. Outfitter MUST report a warning when a resource shadows a lower-precedence definition of the same slug.
 3. `outfitter validate --strict` MUST treat warnings as failures.
 4. Validation MUST parse every discovered agent-local skill and report malformed definitions, name/directory mismatches, and local resources without a resolvable owning agent.
+5. When targeting Pi, `outfitter validate` MUST warn for every composed agent that selects one or more MCP servers without the `npm:pi-mcp-adapter` extension; `--strict` MUST make the warning fatal. Agents with no MCP selection and validation targeting another harness MUST remain unaffected.
 
 ### OFTR-003.8: Listing Resources
 


### PR DESCRIPTION
## Summary
- add a harness-aware validation check for composed Pi MCP selections
- warn with actionable `npm:pi-mcp-adapter` guidance and preserve strict-mode failure semantics
- document the validation behavior and cover adapter, empty-MCP, non-Pi, and CLI-option cases

## Validation
- `npm run check-ci`
- `npm run build`

Fixes #315