### PR TITLE
feat(models): project canonical registry across harnesses

### DIFF
--- a/code/cli/src/agents/PiCredentialPersistence.ts
+++ b/code/cli/src/agents/PiCredentialPersistence.ts
@@ -21,16 +21,23 @@ const copyIfPresent = (sourcePath: string, destinationPath: string): void => {
   copyFileSync(sourcePath, destinationPath);
 };
 
-/** Seeds the projection root with the user's existing pi credentials so pi sees them at startup. */
+/** Seeds durable state without replacing a models.json already projected from the canonical registry. */
 export const seedPiCredentials = (projectionRoot: string, piUserAgentDirectory: string): void => {
   for (const file of persistentPiStateFiles) {
-    copyIfPresent(join(piUserAgentDirectory, file), join(projectionRoot, file));
+    const destination = join(projectionRoot, file);
+    if (file === 'models.json' && existsSync(destination)) continue;
+    copyIfPresent(join(piUserAgentDirectory, file), destination);
   }
 };
 
-/** Copies credentials created or changed during the pi session back to the durable agent dir. */
-export const persistPiCredentials = (projectionRoot: string, piUserAgentDirectory: string): void => {
+/** Copies session state back; a catalog-projected models.json is declared config, not user state. */
+export const persistPiCredentials = (
+  projectionRoot: string,
+  piUserAgentDirectory: string,
+  persistModels = true,
+): void => {
   for (const file of persistentPiStateFiles) {
+    if (file === 'models.json' && !persistModels) continue;
     copyIfPresent(join(projectionRoot, file), join(piUserAgentDirectory, file));
   }
 };

--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -20,6 +20,7 @@ import {
   seedPiCredentials,
 } from '../../agents/PiCredentialPersistence.js';
 import { resolvePiSessionDirectory } from '../../agents/PiSessionDirectory.js';
+import type { CompositionPlan } from '../../composer/Composition.js';
 import { compose } from '../../composer/Composer.js';
 import { ensurePiExtensions } from '../../extensions/PiExtensionCache.js';
 import type { PiInstallSpawner } from '../../extensions/PiExtensionCache.js';
@@ -156,6 +157,8 @@ const assertNoSettingsIssues = (issues: readonly { readonly message: string }[])
 // ephemeral projection root. Seed the durable state before launch and persist changes in a finally
 // block so login and session changes survive both a normal exit and a failed launcher. An inherited
 // Claude run reads and writes the real ~/.claude directly, so it needs neither seed nor copy-back.
+const persistUserPiModels = (plan: CompositionPlan): boolean => plan.models?.configured !== true;
+
 const launchWithStatePersistence = async (
   input: RunAgentInput,
   harness: Harness,
@@ -163,6 +166,7 @@ const launchWithStatePersistence = async (
   rootDirectory: string,
   launch: AgentLaunchPlan,
   lateMessages: string[],
+  persistPiModels: boolean,
 ): Promise<number> => {
   // Persist warnings surface after launch, and writeLine alone can be a dropped sink (setup's
   // auto-launch passes none), so they also go into lateMessages to reach the returned result.
@@ -199,7 +203,9 @@ const launchWithStatePersistence = async (
     return await input.launcher(launch);
   } finally {
     if (piUserAgentDirectory !== undefined) {
-      attempt('persist Pi credentials', () => persistPiCredentials(rootDirectory, piUserAgentDirectory));
+      attempt('persist Pi credentials', () =>
+        persistPiCredentials(rootDirectory, piUserAgentDirectory, persistPiModels),
+      );
     }
     if (bridgesClaudeState) {
       attempt('persist Claude credentials', () => {
@@ -362,6 +368,7 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
       harness,
       rootDirectory,
       homeDirectory: input.homeDirectory,
+      processEnvironment: process.env,
       isolation: claudeConfig.isolation,
       profileSlug: agentSlug,
       sessionDirectory: resolveSessionDirectory(input, harness),
@@ -414,6 +421,7 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
       rootDirectory,
       systemHooks.launch,
       messages,
+      persistUserPiModels(composed.plan),
     );
 
     return { launchPlan: systemHooks.launch, exitCode, messages };

--- a/code/cli/src/composer/Composer.ts
+++ b/code/cli/src/composer/Composer.ts
@@ -8,6 +8,7 @@ import type { AgentDefinition } from '../resolver/AgentDefinition.js';
 import type { EffectiveResourceSet, Loadout, ResolvedResource } from '../resolver/Resource.js';
 import { findLoadoutResource, findResource } from '../resolver/Resource.js';
 import type { ComposedLoadout, ComposedSubagent, ComposedSubagentIdentity, CompositionPlan } from './Composition.js';
+import { resolveModelRegistry } from './Models.js';
 import type { PromptFragment, PromptSourceReference } from './PromptSource.js';
 import { agentBodyFragment, promptSourceKey, resolvePromptSource, rootPromptFragment } from './PromptSource.js';
 
@@ -535,6 +536,7 @@ export const compose = (set: EffectiveResourceSet, agentSlug: string, options: C
   const controls = composeEffectiveControls(chain);
   const identity = composeIdentity(set, chain, controls, options, warnings, errors);
   const loadout = composeLoadout(set, controls, warnings);
+  const models = resolveModelRegistry(set, loadout.model, warnings, errors);
   const composedSubagents = composeSubagents(set, loadout.subagents, options, warnings, errors);
   const uniqueWarnings = uniqueStrings(warnings);
   if (errors.length > 0) return { errors, warnings: uniqueWarnings };
@@ -543,6 +545,7 @@ export const compose = (set: EffectiveResourceSet, agentSlug: string, options: C
     plan: {
       agent: agentSlug,
       identity,
+      ...(models.configured ? { models } : {}),
       loadout: { ...loadout, composedSubagents },
       contributingAgents: chain.map((entry) => entry.resource),
       inheritanceChain: chain.map((entry) => entry.resource.slug),

--- a/code/cli/src/composer/Composition.ts
+++ b/code/cli/src/composer/Composition.ts
@@ -1,5 +1,6 @@
 // Harness-neutral composition types produced from the effective resource set for a selected agent.
 import type { Loadout, ResolvedResource } from '../resolver/Resource.js';
+import type { EffectiveModelRegistry } from './Models.js';
 import type { PromptFragment } from './PromptSource.js';
 
 /** The composed identity: base prompt, shared context, prompt fragments, and agent bodies. */
@@ -66,6 +67,8 @@ export interface ComposedLoadout {
 export interface CompositionPlan {
   readonly agent: string;
   readonly identity: ComposedIdentity;
+  /** Layered provider registry and normalized selected model target, when models.json exists. */
+  readonly models?: EffectiveModelRegistry;
   readonly loadout: ComposedLoadout;
   /** Parent-first agent resources that contributed identity, loadout, or native overlays. */
   readonly contributingAgents?: readonly ResolvedResource[];

--- a/code/cli/src/composer/Models.ts
+++ b/code/cli/src/composer/Models.ts
@@ -1,0 +1,213 @@
+// Resolves the layered Pi models.json registry into a harness-neutral selected model target.
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { escapesRoots } from '../dump/Containment.js';
+import type { EffectiveResourceSet, Layer } from '../resolver/Resource.js';
+
+export interface ModelTarget {
+  readonly providerId: string;
+  readonly modelId: string;
+  readonly providerName?: string;
+  readonly api: string;
+  readonly baseUrl: string;
+  readonly credentialVariable?: string;
+  readonly requiredHeaders: Readonly<Record<string, string>>;
+  readonly capabilities: Readonly<Record<string, unknown>>;
+  readonly source: string;
+}
+
+export interface EffectiveModelRegistry {
+  readonly document: Readonly<Record<string, unknown>>;
+  /** Winning layer label for every effective provider definition. */
+  readonly providerSources?: Readonly<Record<string, string>>;
+  readonly target?: ModelTarget;
+  readonly configured: boolean;
+}
+
+type JsonRecord = Record<string, unknown>;
+interface ProviderEntry {
+  readonly definition: JsonRecord;
+  readonly layer: Layer;
+}
+
+const asRecord = (value: unknown): JsonRecord | undefined =>
+  value !== null && typeof value === 'object' && !Array.isArray(value) ? (value as JsonRecord) : undefined;
+
+const modelsById = (value: unknown): Map<string, JsonRecord> => {
+  const models = new Map<string, JsonRecord>();
+  if (!Array.isArray(value)) return models;
+  for (const item of value) {
+    const model = asRecord(item);
+    if (model !== undefined && typeof model.id === 'string') models.set(model.id, model);
+  }
+  return models;
+};
+
+const mergeProvider = (lower: JsonRecord | undefined, higher: JsonRecord): JsonRecord => {
+  if (lower === undefined) return higher;
+  const models = modelsById(lower.models);
+  for (const [id, model] of modelsById(higher.models)) {
+    models.set(id, { ...models.get(id), ...model });
+  }
+  return {
+    ...lower,
+    ...higher,
+    ...(models.size === 0 ? {} : { models: [...models.values()] }),
+  };
+};
+
+const readProviders = (path: string, warnings: string[]): JsonRecord => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown;
+  } catch (error) {
+    warnings.push(`Model registry '${path}' is not readable JSON: ${String(error)}`);
+    return {};
+  }
+  const providers = asRecord(asRecord(parsed)?.providers);
+  if (providers === undefined) {
+    warnings.push(`Model registry '${path}' must contain an object-valued 'providers' map.`);
+    return {};
+  }
+  return providers;
+};
+
+const credentialReference = (
+  providerId: string,
+  provider: JsonRecord,
+  source: string,
+  errors: string[],
+): string | undefined => {
+  for (const key of ['apiKeyCommand', 'credentialCommand', 'authCommand']) {
+    if (key in provider)
+      errors.push(`Model provider '${providerId}' from '${source}' declares forbidden credential command '${key}'.`);
+  }
+  if (provider.apiKey === undefined) return undefined;
+  if (typeof provider.apiKey !== 'string') {
+    errors.push(`Model provider '${providerId}' from '${source}' has a non-string apiKey; use '$ENV_VARIABLE'.`);
+    return undefined;
+  }
+  const match = /^\$([A-Za-z_][A-Za-z0-9_]*)$/u.exec(provider.apiKey);
+  if (match === null) {
+    errors.push(`Model provider '${providerId}' from '${source}' contains a literal credential; use '$ENV_VARIABLE'.`);
+    return undefined;
+  }
+  return match[1];
+};
+
+const headersFrom = (
+  providerId: string,
+  provider: JsonRecord,
+  source: string,
+  errors: string[],
+): Readonly<Record<string, string>> => {
+  if (provider.headers === undefined) return {};
+  const headers = asRecord(provider.headers);
+  if (headers === undefined) {
+    errors.push(`Model provider '${providerId}' from '${source}' has non-object headers.`);
+    return {};
+  }
+  const selected: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    if (typeof value !== 'string') {
+      errors.push(`Model provider '${providerId}' from '${source}' header '${name}' must be a string.`);
+      continue;
+    }
+    if (name.toLowerCase() === 'authorization' && !/^\$[A-Za-z_][A-Za-z0-9_]*$/u.test(value)) {
+      errors.push(
+        `Model provider '${providerId}' from '${source}' contains a literal Authorization header; use '$ENV_VARIABLE'.`,
+      );
+      continue;
+    }
+    selected[name] = value;
+  }
+  return selected;
+};
+
+const normalizeTarget = (
+  selectedModel: string | undefined,
+  providers: ReadonlyMap<string, ProviderEntry>,
+  configured: boolean,
+  errors: string[],
+): ModelTarget | undefined => {
+  if (selectedModel === undefined || !configured) return undefined;
+  const separator = selectedModel.indexOf('/');
+  if (separator < 1 || separator === selectedModel.length - 1) {
+    errors.push(`Selected model '${selectedModel}' must use the provider/model form when models.json is configured.`);
+    return undefined;
+  }
+  const providerId = selectedModel.slice(0, separator);
+  const modelId = selectedModel.slice(separator + 1);
+  const entry = providers.get(providerId);
+  if (entry === undefined) {
+    errors.push(`Selected model '${selectedModel}' references unknown provider '${providerId}'.`);
+    return undefined;
+  }
+  const model = modelsById(entry.definition.models).get(modelId);
+  if (model === undefined) {
+    errors.push(`Selected model '${selectedModel}' is not declared by provider '${providerId}'.`);
+    return undefined;
+  }
+  const api = entry.definition.api;
+  const baseUrl = entry.definition.baseUrl;
+  if (typeof api !== 'string' || typeof baseUrl !== 'string') {
+    errors.push(
+      `Model provider '${providerId}' from '${entry.layer.label}' must declare string api and baseUrl values.`,
+    );
+    return undefined;
+  }
+  return {
+    providerId,
+    modelId,
+    providerName: typeof entry.definition.name === 'string' ? entry.definition.name : undefined,
+    api,
+    baseUrl,
+    credentialVariable: credentialReference(providerId, entry.definition, entry.layer.label, []),
+    requiredHeaders: headersFrom(providerId, entry.definition, entry.layer.label, []),
+    capabilities: Object.fromEntries(Object.entries(model).filter(([key]) => !['id', 'name'].includes(key))),
+    source: entry.layer.label,
+  };
+};
+
+export const resolveModelRegistry = (
+  set: EffectiveResourceSet,
+  selectedModel: string | undefined,
+  warnings: string[],
+  errors: string[],
+): EffectiveModelRegistry => {
+  const providers = new Map<string, ProviderEntry>();
+  let configured = false;
+  for (const layer of [...set.layers].reverse()) {
+    const path = join(layer.root, 'models.json');
+    if (!existsSync(path)) continue;
+    configured = true;
+    if (escapesRoots(path, [layer.root])) {
+      warnings.push(`Model registry '${path}' resolves outside its resource layer and was skipped.`);
+      continue;
+    }
+    for (const [providerId, value] of Object.entries(readProviders(path, warnings))) {
+      const provider = asRecord(value);
+      if (provider === undefined) {
+        warnings.push(`Model provider '${providerId}' from '${layer.label}' must be an object.`);
+        continue;
+      }
+      // Validate every declaration before precedence merging: a shadowed catalog entry still must
+      // not contain a literal secret or executable credential source.
+      credentialReference(providerId, provider, layer.label, errors);
+      headersFrom(providerId, provider, layer.label, errors);
+      providers.set(providerId, {
+        definition: mergeProvider(providers.get(providerId)?.definition, provider),
+        layer,
+      });
+    }
+  }
+
+  const document = { providers: Object.fromEntries([...providers].map(([id, entry]) => [id, entry.definition])) };
+  return {
+    document,
+    providerSources: Object.fromEntries([...providers].map(([id, entry]) => [id, entry.layer.label])),
+    target: normalizeTarget(selectedModel, providers, configured, errors),
+    configured,
+  };
+};

--- a/code/cli/src/projection/Materialize.ts
+++ b/code/cli/src/projection/Materialize.ts
@@ -323,6 +323,9 @@ export const materializeComposition = (
   if (harness === 'claude' || (harness === 'pi' && composition.loadout.mcp.length > 0)) {
     writeMcpConfig(join(rootDirectory, 'mcp.json'), composition.loadout.mcpServers);
   }
+  if (harness === 'pi' && composition.models?.configured) {
+    writeGeneratedFile(join(rootDirectory, 'models.json'), `${JSON.stringify(composition.models.document, null, 2)}\n`);
+  }
   return {
     rootDirectory,
     systemPromptPath,

--- a/code/cli/src/projection/ModelProjection.ts
+++ b/code/cli/src/projection/ModelProjection.ts
@@ -1,0 +1,148 @@
+// Projects one normalized models.json target without changing its provider endpoint or identity.
+import type { CompositionPlan } from '../composer/Composition.js';
+import type { ModelTarget } from '../composer/Models.js';
+import type { Harness } from '../settings/Settings.js';
+import type { ProjectionInput } from './Projection.js';
+
+export interface ProjectedModel {
+  readonly args: readonly string[];
+  readonly env: Readonly<Record<string, string>>;
+  readonly warnings: readonly string[];
+}
+
+const tomlString = (value: string): string => JSON.stringify(value);
+const tomlInlineTable = (value: Readonly<Record<string, string>>): string =>
+  `{ ${Object.entries(value)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, item]) => `${tomlString(key)} = ${tomlString(item)}`)
+    .join(', ')} }`;
+const override = (key: string, value: string): readonly string[] => ['-c', `${key}=${value}`];
+const environmentReference = (value: string): string | undefined => /^\$([A-Za-z_][A-Za-z0-9_]*)$/u.exec(value)?.[1];
+
+const legacyModel = (composition: CompositionPlan, harness: Harness): ProjectedModel => ({
+  args:
+    composition.loadout.model === undefined ? [] : [harness === 'codex' ? '-m' : '--model', composition.loadout.model],
+  env: {},
+  warnings: [],
+});
+
+const projectPi = (target: ModelTarget): ProjectedModel => ({
+  args: ['--provider', target.providerId, '--model', target.modelId],
+  env: {},
+  warnings: [],
+});
+
+const resolveClaudeHeader = (
+  name: string,
+  value: string,
+  environment: Readonly<Record<string, string | undefined>>,
+  warnings: string[],
+): string | undefined => {
+  const reference = environmentReference(value);
+  if (reference === undefined) return `${name}: ${value}`;
+  const resolved = environment[reference];
+  if (resolved === undefined) {
+    warnings.push(`claude model header '${name}' requires environment variable '${reference}', but it is not set.`);
+    return undefined;
+  }
+  return `${name}: ${resolved}`;
+};
+
+const projectClaude = (target: ModelTarget, input: ProjectionInput): ProjectedModel => {
+  if (target.api !== 'anthropic-messages') {
+    return {
+      args: [],
+      env: {},
+      warnings: [
+        `claude adapter cannot project model '${target.providerId}/${target.modelId}' from '${target.source}' with API dialect '${target.api}'.`,
+      ],
+    };
+  }
+  const environment = input.processEnvironment ?? {};
+  const warnings: string[] = [];
+  const env: Record<string, string> = { ANTHROPIC_BASE_URL: target.baseUrl };
+  if (target.credentialVariable !== undefined) {
+    const credential = environment[target.credentialVariable];
+    if (credential === undefined) {
+      warnings.push(
+        `claude model '${target.providerId}/${target.modelId}' requires environment variable '${target.credentialVariable}', but it is not set.`,
+      );
+    } else env.ANTHROPIC_AUTH_TOKEN = credential;
+  }
+  const headers = Object.entries(target.requiredHeaders)
+    .map(([name, value]) => resolveClaudeHeader(name, value, environment, warnings))
+    .filter((header): header is string => header !== undefined);
+  if (headers.length > 0) env.ANTHROPIC_CUSTOM_HEADERS = headers.join('\n');
+  return { args: ['--model', target.modelId], env, warnings };
+};
+
+const codexWireApi = (api: string): string | undefined => {
+  if (api === 'openai-responses') return 'responses';
+  if (api === 'openai-completions') return 'chat';
+  return undefined;
+};
+
+const codexHeaderArgs = (target: ModelTarget, prefix: string): readonly string[] => {
+  const literalHeaders: Record<string, string> = {};
+  const environmentHeaders: Record<string, string> = {};
+  for (const [name, value] of Object.entries(target.requiredHeaders)) {
+    const reference = environmentReference(value);
+    if (reference === undefined) literalHeaders[name] = value;
+    else environmentHeaders[name] = reference;
+  }
+  return [
+    ...(Object.keys(literalHeaders).length === 0
+      ? []
+      : override(`${prefix}.http_headers`, tomlInlineTable(literalHeaders))),
+    ...(Object.keys(environmentHeaders).length === 0
+      ? []
+      : override(`${prefix}.env_http_headers`, tomlInlineTable(environmentHeaders))),
+  ];
+};
+
+const projectCodex = (target: ModelTarget): ProjectedModel => {
+  const wireApi = codexWireApi(target.api);
+  if (wireApi === undefined) {
+    return {
+      args: [],
+      env: {},
+      warnings: [
+        `codex adapter cannot project model '${target.providerId}/${target.modelId}' from '${target.source}' with API dialect '${target.api}'.`,
+      ],
+    };
+  }
+  if (!/^[A-Za-z0-9_-]+$/u.test(target.providerId)) {
+    return {
+      args: [],
+      env: {},
+      warnings: [
+        `codex adapter cannot project provider id '${target.providerId}' from '${target.source}'; use letters, numbers, '_' or '-'.`,
+      ],
+    };
+  }
+  const prefix = `model_providers.${target.providerId}`;
+  const args = [
+    ...override('model_provider', tomlString(target.providerId)),
+    ...override(`${prefix}.name`, tomlString(target.providerName ?? target.providerId)),
+    ...override(`${prefix}.base_url`, tomlString(target.baseUrl)),
+    ...override(`${prefix}.wire_api`, tomlString(wireApi)),
+  ];
+  if (target.credentialVariable !== undefined) {
+    args.push(...override(`${prefix}.env_key`, tomlString(target.credentialVariable)));
+  }
+  args.push(...codexHeaderArgs(target, prefix), '-m', target.modelId);
+  return { args, env: {}, warnings: [] };
+};
+
+export const projectModel = (composition: CompositionPlan, input: ProjectionInput): ProjectedModel => {
+  const target = composition.models?.target;
+  if (target === undefined) return legacyModel(composition, input.harness);
+  switch (input.harness) {
+    case 'pi':
+      return projectPi(target);
+    case 'claude':
+      return projectClaude(target, input);
+    case 'codex':
+      return projectCodex(target);
+  }
+};

--- a/code/cli/src/projection/ProjectHarness.ts
+++ b/code/cli/src/projection/ProjectHarness.ts
@@ -6,6 +6,8 @@ import type { CompositionPlan } from '../composer/Composition.js';
 import type { Harness, Isolation } from '../settings/Settings.js';
 import { projectCodexMcpServers } from './CodexMcp.js';
 import type { MaterializedComposition } from './Materialize.js';
+import type { ProjectedModel } from './ModelProjection.js';
+import { projectModel } from './ModelProjection.js';
 import {
   applyPiRuntimeDefaults,
   materializeComposition,
@@ -118,11 +120,6 @@ const promptArgs = (
     : []),
 ];
 
-// Split from the thinking flag so each builder states positively what it emits: codex reports
-// `thinking` unsupported, and reporting an element unsupported does not by itself suppress it.
-const modelArg = (composition: CompositionPlan, flag: '-m' | '--model'): readonly string[] =>
-  composition.loadout.model === undefined ? [] : [flag, composition.loadout.model];
-
 const thinkingArg = (composition: CompositionPlan, harness: Harness): readonly string[] =>
   composition.loadout.thinking === undefined
     ? []
@@ -131,14 +128,14 @@ const thinkingArg = (composition: CompositionPlan, harness: Harness): readonly s
 // MCP overrides lead and pass-through args trail so a pass-through positional (`exec "<prompt>"`)
 // stays last, where codex expects its subcommand and prompt.
 const buildCodexLaunchPlan = (
-  composition: CompositionPlan,
   input: ProjectionInput,
   codexMcpArgs: readonly string[],
+  model: ProjectedModel,
 ): AgentLaunchPlan => ({
   command: 'codex',
   // Root `-m` propagation through `exec` was verified empirically on codex-cli 0.145.0.
-  args: [...codexMcpArgs, ...modelArg(composition, '-m'), ...(input.passThroughArgs ?? [])],
-  env: {},
+  args: [...codexMcpArgs, ...model.args, ...(input.passThroughArgs ?? [])],
+  env: model.env,
 });
 
 /**
@@ -188,6 +185,7 @@ const buildPiOrClaudeLaunchPlan = (
   input: ProjectionInput,
   materialized: MaterializedComposition,
   appendPromptPaths: readonly string[],
+  model: ProjectedModel,
 ): AgentLaunchPlan => {
   const isPi = input.harness === 'pi';
   const isolation = resolveProjectionIsolation(input);
@@ -204,7 +202,7 @@ const buildPiOrClaudeLaunchPlan = (
       ...promptArgs(composition, input, materialized.systemPromptPath, appendPromptPaths),
       ...skillArgs,
       ...extensionArgs,
-      ...modelArg(composition, '--model'),
+      ...model.args,
       ...thinkingArg(composition, input.harness),
       ...(isPi ? [] : claudeArgs(input.rootDirectory, isolation)),
       ...(input.passThroughArgs ?? []),
@@ -216,8 +214,9 @@ const buildPiOrClaudeLaunchPlan = (
       ? {
           PI_CODING_AGENT_DIR: input.rootDirectory,
           ...(input.sessionDirectory === undefined ? {} : { [PI_SESSION_DIRECTORY_ENV]: input.sessionDirectory }),
+          ...model.env,
         }
-      : claudeEnv(input.rootDirectory, isolation),
+      : { ...claudeEnv(input.rootDirectory, isolation), ...model.env },
   };
 };
 
@@ -233,6 +232,7 @@ export const projectComposition = (composition: CompositionPlan, input: Projecti
   const materialized = materializeComposition(composition, input.rootDirectory, input.harness);
 
   declareClaudePlugin(composition, input);
+  const projectedModel = projectModel(composition, input);
 
   const unsupported = [
     ...unsupportedElements(composition, input),
@@ -242,21 +242,25 @@ export const projectComposition = (composition: CompositionPlan, input: Projecti
 
   if (input.harness === 'codex') {
     const codexMcp = projectCodexMcpServers(composition.loadout.mcp, composition.loadout.mcpServers);
-    const launch = buildCodexLaunchPlan(composition, input, codexMcp.args);
+    const launch = buildCodexLaunchPlan(input, codexMcp.args, projectedModel);
     const warnings = [
       ...(input.appendPromptPaths?.length
         ? ['codex adapter does not project supplied append-prompt documents; they will be dropped.']
         : []),
       ...codexMcp.warnings,
+      ...projectedModel.warnings,
     ];
     return { rootDirectory: input.rootDirectory, launch, unsupported, warnings };
   }
 
   // Caller documents follow the composition's own, so a persona is read against the agent it adopts.
-  const launch = buildPiOrClaudeLaunchPlan(composition, input, materialized, [
-    ...materialized.appendPromptPaths,
-    ...(input.appendPromptPaths ?? []),
-  ]);
+  const launch = buildPiOrClaudeLaunchPlan(
+    composition,
+    input,
+    materialized,
+    [...materialized.appendPromptPaths, ...(input.appendPromptPaths ?? [])],
+    projectedModel,
+  );
 
-  return { rootDirectory: input.rootDirectory, launch, unsupported, warnings: [] };
+  return { rootDirectory: input.rootDirectory, launch, unsupported, warnings: projectedModel.warnings };
 };

--- a/code/cli/src/projection/Projection.ts
+++ b/code/cli/src/projection/Projection.ts
@@ -21,6 +21,8 @@ export interface ProjectionInput {
   readonly harness: Harness;
   readonly rootDirectory: string;
   readonly homeDirectory: string;
+  /** Runtime credential values used only when a harness requires an environment-variable alias. */
+  readonly processEnvironment?: Readonly<Record<string, string | undefined>>;
   /**
    * Whether the launch stands on the machine's native harness configuration (claude only; pi and
    * codex have no inherit path yet). Defaults to `inherit`, so a profile layers over the user's own

--- a/code/cli/tests/unit/model-registry-projection.test.ts
+++ b/code/cli/tests/unit/model-registry-projection.test.ts
@@ -1,0 +1,312 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { CompositionPlan } from '../../src/composer/Composition.js';
+import { resolveModelRegistry } from '../../src/composer/Models.js';
+import { projectComposition } from '../../src/projection/ProjectHarness.js';
+import type { EffectiveResourceSet, Layer } from '../../src/resolver/Resource.js';
+
+const temporary: string[] = [];
+const root = (): string => {
+  const path = mkdtempSync(join(tmpdir(), 'outfitter-models-'));
+  temporary.push(path);
+  return path;
+};
+afterEach(() => {
+  for (const path of temporary.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+const layer = (path: string, label: string, origin: Layer['origin']): Layer => ({ root: path, label, origin });
+const writeModels = (path: string, document: unknown): void => {
+  mkdirSync(path, { recursive: true });
+  writeFileSync(join(path, 'models.json'), JSON.stringify(document));
+};
+const resourceSet = (layers: readonly Layer[]): EffectiveResourceSet => ({
+  layers,
+  resources: new Map(),
+  agentResources: new Map(),
+});
+
+const composition = (models: NonNullable<CompositionPlan['models']>): CompositionPlan => ({
+  agent: 'luce',
+  identity: { agentBody: 'Review the change.' },
+  models,
+  loadout: {
+    skills: [],
+    delegateSkills: [],
+    subagents: [],
+    mcp: [],
+    mcpServers: {},
+    extensions: [],
+    plugins: [],
+    model: 'gateway/luna',
+  },
+  warnings: [],
+});
+
+describe('canonical models.json resolution and projection', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.9.1, OFTR-006.9.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('merges layered providers and normalizes the selected provider/model target', () => {
+    const catalog = root();
+    const workspace = root();
+    writeModels(catalog, {
+      providers: {
+        gateway: {
+          name: 'Company gateway',
+          api: 'anthropic-messages',
+          baseUrl: 'https://models.example.test',
+          apiKey: '$COMPANY_MODELS_TOKEN',
+          models: [{ id: 'luna', reasoning: true }, { id: 'sol' }],
+        },
+      },
+    });
+    writeModels(workspace, {
+      providers: {
+        gateway: {
+          headers: { 'X-Tenant': 'engineering' },
+          models: [{ id: 'luna', reasoning: false, input: ['text', 'image'] }],
+        },
+      },
+    });
+    const warnings: string[] = [];
+    const errors: string[] = [];
+    const models = resolveModelRegistry(
+      resourceSet([layer(workspace, 'workspace', 'workspace'), layer(catalog, 'catalog', 'source')]),
+      'gateway/luna',
+      warnings,
+      errors,
+    );
+
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([]);
+    expect(models.providerSources).toEqual({ gateway: 'workspace' });
+    expect(models.target).toEqual({
+      providerId: 'gateway',
+      modelId: 'luna',
+      providerName: 'Company gateway',
+      api: 'anthropic-messages',
+      baseUrl: 'https://models.example.test',
+      credentialVariable: 'COMPANY_MODELS_TOKEN',
+      requiredHeaders: { 'X-Tenant': 'engineering' },
+      capabilities: { reasoning: false, input: ['text', 'image'] },
+      source: 'workspace',
+    });
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.9.3, OFTR-006.9.4, OFTR-006.9.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('projects one canonical target to Pi, Claude, and Codex native controls', () => {
+    const catalog = root();
+    writeModels(catalog, {
+      providers: {
+        gateway: {
+          name: 'Company gateway',
+          api: 'anthropic-messages',
+          baseUrl: 'https://models.example.test',
+          apiKey: '$COMPANY_MODELS_TOKEN',
+          headers: { 'X-Tenant': 'engineering', 'X-Request-Key': '$REQUEST_KEY' },
+          models: [{ id: 'luna', reasoning: true }],
+        },
+      },
+    });
+    const errors: string[] = [];
+    const models = resolveModelRegistry(resourceSet([layer(catalog, 'catalog', 'source')]), 'gateway/luna', [], errors);
+    expect(errors).toEqual([]);
+    const plan = composition(models);
+
+    const piRoot = root();
+    const pi = projectComposition(plan, { harness: 'pi', rootDirectory: piRoot, homeDirectory: piRoot });
+    expect(pi.launch.args).toEqual(expect.arrayContaining(['--provider', 'gateway', '--model', 'luna']));
+    expect(JSON.parse(readFileSync(join(piRoot, 'models.json'), 'utf8'))).toEqual(models.document);
+
+    const claudeRoot = root();
+    const claude = projectComposition(plan, {
+      harness: 'claude',
+      rootDirectory: claudeRoot,
+      homeDirectory: claudeRoot,
+      processEnvironment: { COMPANY_MODELS_TOKEN: 'secret-at-runtime', REQUEST_KEY: 'request-at-runtime' },
+    });
+    expect(claude.launch.args).toEqual(expect.arrayContaining(['--model', 'luna']));
+    expect(claude.launch.env).toMatchObject({
+      ANTHROPIC_BASE_URL: 'https://models.example.test',
+      ANTHROPIC_AUTH_TOKEN: 'secret-at-runtime',
+      ANTHROPIC_CUSTOM_HEADERS: 'X-Tenant: engineering\nX-Request-Key: request-at-runtime',
+    });
+
+    const codexModels = {
+      ...models,
+      target: { ...models.target!, api: 'openai-responses' },
+    };
+    const codexRoot = root();
+    const codex = projectComposition(composition(codexModels), {
+      harness: 'codex',
+      rootDirectory: codexRoot,
+      homeDirectory: codexRoot,
+    });
+    expect(codex.launch.args).toEqual(expect.arrayContaining(['-m', 'luna']));
+    expect(codex.launch.args.join(' ')).toContain('model_providers.gateway.base_url="https://models.example.test"');
+    expect(codex.launch.args.join(' ')).toContain('model_providers.gateway.env_key="COMPANY_MODELS_TOKEN"');
+    expect(codex.launch.args.join(' ')).toContain('model_providers.gateway.wire_api="responses"');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.9.6, OFTR-006.9.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('warns and suppresses model identity when an adapter cannot preserve the endpoint', () => {
+    const target = {
+      providerId: 'gateway',
+      modelId: 'luna',
+      api: 'anthropic-messages',
+      baseUrl: 'https://models.example.test',
+      requiredHeaders: {},
+      capabilities: {},
+      source: 'catalog',
+    };
+    const plan = composition({ configured: true, document: { providers: {} }, target });
+    const codexRoot = root();
+    const codex = projectComposition(plan, { harness: 'codex', rootDirectory: codexRoot, homeDirectory: codexRoot });
+
+    expect(codex.warnings).toContainEqual(expect.stringContaining("cannot project model 'gateway/luna'"));
+    expect(codex.launch.args).not.toContain('luna');
+    expect(codex.launch.args.join(' ')).not.toContain('models.example.test');
+  });
+
+  it('reports malformed registries and unresolved selections without throwing', () => {
+    const invalidJson = root();
+    writeFileSync(join(invalidJson, 'models.json'), '{');
+    const invalidShape = root();
+    writeModels(invalidShape, { notProviders: true });
+    const malformed = root();
+    writeModels(malformed, {
+      providers: {
+        scalar: true,
+        noCredential: { api: 'openai-responses', baseUrl: 'https://example.test', models: 'not-an-array' },
+        nonStringCredential: { apiKey: 42, headers: [] },
+        invalidHeaders: {
+          apiKey: '$VALID',
+          headers: { count: 3, Authorization: 'literal-secret', 'X-Safe': '$SAFE_HEADER' },
+          models: [{ id: 'known' }],
+        },
+      },
+    });
+    const warnings: string[] = [];
+    const errors: string[] = [];
+    const set = resourceSet([
+      layer(invalidJson, 'invalid-json', 'workspace'),
+      layer(invalidShape, 'invalid-shape', 'global'),
+      layer(malformed, 'malformed', 'source'),
+    ]);
+    resolveModelRegistry(set, 'invalidHeaders/known', warnings, errors);
+
+    expect(warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('not readable JSON'),
+        expect.stringContaining("must contain an object-valued 'providers' map"),
+        expect.stringContaining("provider 'scalar'"),
+      ]),
+    );
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('non-string apiKey'),
+        expect.stringContaining('non-object headers'),
+        expect.stringContaining("header 'count' must be a string"),
+        expect.stringContaining('literal Authorization header'),
+        expect.stringContaining('must declare string api and baseUrl'),
+      ]),
+    );
+
+    for (const selected of ['not-qualified', 'missing/model', 'invalidHeaders/missing', 'noCredential/model']) {
+      const selectionErrors: string[] = [];
+      resolveModelRegistry(resourceSet([layer(malformed, 'malformed', 'source')]), selected, [], selectionErrors);
+      expect(selectionErrors.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('skips a models.json symlink that escapes its layer', () => {
+    const catalog = root();
+    const outside = join(root(), 'outside-models.json');
+    writeFileSync(outside, JSON.stringify({ providers: {} }));
+    symlinkSync(outside, join(catalog, 'models.json'));
+    const warnings: string[] = [];
+    resolveModelRegistry(resourceSet([layer(catalog, 'catalog', 'source')]), undefined, warnings, []);
+    expect(warnings).toEqual([expect.stringContaining('resolves outside its resource layer')]);
+  });
+
+  it('covers adapter diagnostics for missing runtime values and unsupported native forms', () => {
+    const baseTarget = {
+      providerId: 'gateway',
+      modelId: 'luna',
+      api: 'anthropic-messages',
+      baseUrl: 'https://models.example.test',
+      credentialVariable: 'MISSING_TOKEN',
+      requiredHeaders: { 'X-First': 'one', 'X-Second': 'two', 'X-Missing': '$MISSING_HEADER' },
+      capabilities: {},
+      source: 'catalog',
+    };
+    const claudeRoot = root();
+    const claude = projectComposition(composition({ configured: true, document: {}, target: baseTarget }), {
+      harness: 'claude',
+      rootDirectory: claudeRoot,
+      homeDirectory: claudeRoot,
+    });
+    expect(claude.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("environment variable 'MISSING_TOKEN'"),
+        expect.stringContaining("environment variable 'MISSING_HEADER'"),
+      ]),
+    );
+
+    const unsupportedClaude = projectComposition(
+      composition({ configured: true, document: {}, target: { ...baseTarget, api: 'openai-responses' } }),
+      { harness: 'claude', rootDirectory: root(), homeDirectory: root() },
+    );
+    expect(unsupportedClaude.warnings).toContainEqual(expect.stringContaining('cannot project model'));
+
+    const codex = projectComposition(
+      composition({
+        configured: true,
+        document: {},
+        target: {
+          ...baseTarget,
+          providerName: undefined,
+          api: 'openai-completions',
+          credentialVariable: undefined,
+          requiredHeaders: {},
+        },
+      }),
+      { harness: 'codex', rootDirectory: root(), homeDirectory: root() },
+    );
+    expect(codex.launch.args.join(' ')).toContain('wire_api="chat"');
+
+    const invalidProvider = projectComposition(
+      composition({
+        configured: true,
+        document: {},
+        target: { ...baseTarget, providerId: 'not.valid', api: 'openai-responses' },
+      }),
+      { harness: 'codex', rootDirectory: root(), homeDirectory: root() },
+    );
+    expect(invalidProvider.warnings).toContainEqual(expect.stringContaining("provider id 'not.valid'"));
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.9.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('rejects literal and command-sourced catalog credentials', () => {
+    const catalog = root();
+    writeModels(catalog, {
+      providers: {
+        literal: { apiKey: 'do-not-commit-me', models: [] },
+        command: { apiKey: '$SAFE_REFERENCE', credentialCommand: 'print-token', models: [] },
+      },
+    });
+    const errors: string[] = [];
+    resolveModelRegistry(resourceSet([layer(catalog, 'catalog', 'source')]), undefined, [], errors);
+    expect(errors).toEqual([
+      expect.stringContaining("provider 'literal'"),
+      expect.stringContaining("forbidden credential command 'credentialCommand'"),
+    ]);
+  });
+});

--- a/code/cli/tests/unit/pi-credential-persistence.test.ts
+++ b/code/cli/tests/unit/pi-credential-persistence.test.ts
@@ -47,6 +47,21 @@ describe('pi credential persistence', () => {
     expect(existsSync(join(projection, 'models.json'))).toBe(false);
   });
 
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.9.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('does not replace or persist catalog-projected model definitions', () => {
+    const base = root();
+    const userDir = join(base, 'user');
+    const projection = join(base, 'projection');
+    write(join(userDir, 'models.json'), '{"providers":{"personal":{}}}');
+    write(join(projection, 'models.json'), '{"providers":{"catalog":{}}}');
+
+    seedPiCredentials(projection, userDir);
+    expect(readFileSync(join(projection, 'models.json'), 'utf8')).toContain('catalog');
+    persistPiCredentials(projection, userDir, false);
+    expect(readFileSync(join(userDir, 'models.json'), 'utf8')).toContain('personal');
+  });
+
   it('writes credentials created during the session back to the durable dir', () => {
     const base = root();
     const userDir = join(base, 'user');

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -168,7 +168,7 @@ For a selected agent, the composer builds the run's effective configuration from
 3. **Subagents**: agents named in the selected agent's `subagents` loadout are marked for projection into the harness's delegation surface; their own selected skills are resolved and materialized separately from the leader's active skills.
 4. **Skills**: skills named in the loadout are materialized (frontmatter `references`/`scripts`/`assets` resolved from their two-root model, validated for escapes and collisions) into generated skill directories.
 5. **Harness elements**: extensions and plugins named in the loadout are marked for the adapter (first-class for pi).
-6. **Structured configuration**: `models.json`, `mcp.json`, and per-agent `config.json` merge per protocol JSON semantics; the loadout's `model`, `thinking`, and `tools` select and constrain within them.
+6. **Structured configuration**: `models.json`, `mcp.json`, and per-agent `config.json` merge per protocol JSON semantics; the loadout's `model`, `thinking`, and `tools` select and constrain within them. A `provider/model` selection resolves once into a harness-neutral model target (dialect, endpoint, credential-variable reference, headers, capabilities, and provenance); adapters translate that target to native controls without changing its endpoint.
 
 The composed result is a harness-neutral **composition plan** — the input to dump and adapter projection.
 

--- a/docs/documentation/agents.md
+++ b/docs/documentation/agents.md
@@ -76,6 +76,42 @@ See [Skills](./skills.md#agent-local-skills).
 `subagents` are always catalog-wide (a delegate is a shared agent).
 `extensions`/`plugins` are harness-native passthroughs with no on-disk namespace, and `model`/`thinking`/`tools` are per-agent already via `config.json` merge.
 
+### Provider and model registry
+
+A selected model uses `provider/model`. Outfitter resolves it against the effective layered `models.json`; workspace definitions override home and catalog definitions by provider ID, while model entries merge by model ID. The resulting provider endpoint is canonical for the run — adapters do not silently reuse the model ID against a harness default endpoint.
+
+```json
+{
+  "providers": {
+    "company-claude": {
+      "name": "Company Anthropic gateway",
+      "baseUrl": "https://models.example.com/anthropic",
+      "api": "anthropic-messages",
+      "apiKey": "$COMPANY_MODELS_TOKEN",
+      "headers": { "X-Tenant": "engineering" },
+      "models": [{ "id": "luna", "reasoning": true }]
+    },
+    "company-codex": {
+      "name": "Company OpenAI gateway",
+      "baseUrl": "https://models.example.com/openai/v1",
+      "api": "openai-responses",
+      "apiKey": "$COMPANY_MODELS_TOKEN",
+      "models": [{ "id": "sol", "reasoning": true }]
+    },
+    "ollama": {
+      "name": "Local Ollama",
+      "baseUrl": "http://127.0.0.1:11434/v1",
+      "api": "openai-completions",
+      "models": [{ "id": "qwen3-coder" }]
+    }
+  }
+}
+```
+
+An agent can select `company-claude/luna`, `company-codex/sol`, or `ollama/qwen3-coder` without carrying endpoint configuration of its own. Pi receives the merged registry plus native provider/model flags. Claude Code projects `anthropic-messages` targets through its native gateway environment, and Codex projects `openai-completions` and `openai-responses` targets through native provider overrides. An unsupported dialect warns and fails under `--strict`; it never falls back to the same model name at another endpoint.
+
+Credentials are references, not catalog content: use a single environment-variable reference such as `"$COMPANY_MODELS_TOKEN"`. Literal API keys, command-based credential sources, and literal `Authorization` headers are rejected. Supply the named variable in the launch environment.
+
 ## Inheritance and prompt fragments
 
 An agent may specialize one or more base agents with `inherits`.

--- a/docs/documentation/support-matrix.md
+++ b/docs/documentation/support-matrix.md
@@ -12,33 +12,35 @@ When a composition requests something an adapter cannot project, Outfitter warns
 
 Tasks and bake are not in this matrix — they are the subject of a [separate upcoming RFC](./tasks.md).
 
-| What Outfitter projects                                                  | Pi        | Claude Code | Codex CLI |
-| ------------------------------------------------------------------------ | --------- | ----------- | --------- |
-| Agent config directory                                                   | Supported | Supported   | Roadmap   |
-| Session directory                                                        | Supported | Supported   | Roadmap   |
-| Agent identity (`system-prompt.md`, `agents.md`, `agents/<id>/agent.md`) | Supported | Supported   | Roadmap   |
-| Subagents (`agents/<id>` as harness delegates)                           | Supported | Supported   | Roadmap   |
-| Skills (`skills/<id>`)                                                   | Supported | Partial     | Roadmap   |
-| Commands (`commands/`)                                                   | Supported | Partial     | Roadmap   |
-| Knowledge (`knowledge/`)                                                 | Supported | Partial     | Roadmap   |
-| Model selection (`models.json`)                                          | Supported | Partial     | Partial   |
-| MCP servers (`mcp.json`)                                                 | Supported | Supported   | Partial   |
-| Extensions (agent `extensions:` loadout)                                 | Supported | Pi only     | Pi only   |
-| Plugins (agent `plugins:` loadout)                                       | Supported | Roadmap     | Roadmap   |
-| Credentials and environment                                              | Supported | Supported   | Roadmap   |
-| DeepWork job selection                                                   | Supported | Roadmap     | Roadmap   |
-| Hooks                                                                    | Partial   | Partial     | Roadmap   |
-| Tool availability (agent `tools:` loadout)                               | Supported | Supported   | Roadmap   |
-| Theme / UI presentation                                                  | Roadmap   | Roadmap     | Roadmap   |
-| Working directory                                                        | Roadmap   | Roadmap     | Roadmap   |
-| Pass-through arguments                                                   | Supported | Supported   | Supported |
-| Bootstrap hook                                                           | Supported | Roadmap     | Roadmap   |
+| What Outfitter projects                                                  | Pi        | Claude Code | Codex CLI  |
+| ------------------------------------------------------------------------ | --------- | ----------- | ---------- |
+| Agent config directory                                                   | Supported | Supported   | Roadmap    |
+| Session directory                                                        | Supported | Supported   | Roadmap    |
+| Agent identity (`system-prompt.md`, `agents.md`, `agents/<id>/agent.md`) | Supported | Supported   | Roadmap    |
+| Subagents (`agents/<id>` as harness delegates)                           | Supported | Supported   | Roadmap    |
+| Skills (`skills/<id>`)                                                   | Supported | Partial     | Roadmap    |
+| Commands (`commands/`)                                                   | Supported | Partial     | Roadmap    |
+| Knowledge (`knowledge/`)                                                 | Supported | Partial     | Roadmap    |
+| Model selection (`models.json`)                                          | Supported | Supported¹  | Supported² |
+| MCP servers (`mcp.json`)                                                 | Supported | Supported   | Partial    |
+| Extensions (agent `extensions:` loadout)                                 | Supported | Pi only     | Pi only    |
+| Plugins (agent `plugins:` loadout)                                       | Supported | Roadmap     | Roadmap    |
+| Credentials and environment                                              | Supported | Supported   | Roadmap    |
+| DeepWork job selection                                                   | Supported | Roadmap     | Roadmap    |
+| Hooks                                                                    | Partial   | Partial     | Roadmap    |
+| Tool availability (agent `tools:` loadout)                               | Supported | Supported   | Roadmap    |
+| Theme / UI presentation                                                  | Roadmap   | Roadmap     | Roadmap    |
+| Working directory                                                        | Roadmap   | Roadmap     | Roadmap    |
+| Pass-through arguments                                                   | Supported | Supported   | Supported  |
+| Bootstrap hook                                                           | Supported | Roadmap     | Roadmap    |
+
+¹ Canonical `anthropic-messages` providers. ² Canonical `openai-completions` and `openai-responses` providers. Other dialects warn and fail under `--strict` rather than changing endpoints.
 
 ## Codex CLI notes
 
 - **Launch mode** — Outfitter launches `codex` directly. Pass-through arguments choose the native mode: no subcommand keeps the interactive CLI shape, while `-- exec ...` selects non-interactive `codex exec`.
 - **Agent identity and appended prompts** — Codex has no native identity projection yet: launches drop the composed identity/system prompt and any `--append-prompt` documents, supplied documents produce a separate warning, and `--strict` aborts before execution.
-- **Model selection (Partial)** — an agent's model maps to `-m`. Provider maps have no projection element and produce no warning. Thinking, tools, skills, subagents, plugins, and prompt templates remain unsupported and warn when selected.
+- **Model selection** — an agent's `provider/model` selection resolves from layered `models.json`. OpenAI completions and responses providers map to native `model_provider`, `base_url`, `env_key`, header, wire API, and `-m` overrides. Unsupported dialects warn and omit the target instead of reusing its model ID against Codex's default endpoint. Thinking, tools, skills, subagents, plugins, and prompt templates remain unsupported and warn when selected.
 - **Extensions (Pi only)** — `extensions:` names pi extension packages, so a Codex or Claude Code launch installs none of them. This is a property of the element, not a gap a user can close, so it produces no warning and does not fail under `--strict`.
 - **MCP servers (Partial)** — selected stdio fields (`command`, `args`, `env`, `cwd`) and streamable HTTP fields (`url`, `headers`) become repeated TOML-valued `-c mcp_servers.<id>.<key>=...` overrides. Server ids must contain only letters, digits, `_`, or `-`; other ids cannot be expressed by Codex `-c` key paths and are skipped with a warning. Legacy SSE and other HTTP transport types are also skipped with a warning. User and project `config.toml` servers remain active because Codex has no strict MCP isolation mode, so every launch warns that projection is additive, even when no servers are selected.
 - **Stdio environment safety** — `${ENV_NAME}` becomes an `env_vars` reference only when the stdio `env` key is also `ENV_NAME`; a reference that would rename the variable is dropped with a warning. Literal values pass through `env` and are visible in process arguments.
@@ -52,7 +54,7 @@ Tasks and bake are not in this matrix — they are the subject of a [separate up
 - **MCP servers** — every Claude launch passes the generated `mcp.json` through `--mcp-config`. An inherited run stops there, so the composition's servers merge with the ones already configured on the machine: selecting a server says what the profile needs, not what the user may not have. An isolated run adds `--strict-mcp-config`, which excludes MCP servers from user or project configuration, `.claude.json`, and plugins so only the composition's servers are active.
 - **Subagents** — selected `agents/<id>` definitions are materialized into the composition's agents directory. An inherited run loads them under the plugin's name (`<profile>:<subagent>`); an isolated run finds them natively under `CLAUDE_CONFIG_DIR`.
 - **Skills (Partial)** — selected skills are materialized into the config directory's skills surface; remaining gaps are tracked per release. The bundled Outfitter skill ships through the plugin channel.
-- **Model selection (Partial)** — model maps to `--model` and thinking level to `--effort`; provider selection is not projected for Claude and warns if requested.
+- **Model selection** — an agent's `provider/model` selection resolves from layered `models.json`. Anthropic Messages providers map to native `--model`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, and custom-header controls. Unsupported dialects warn and omit the target instead of reusing its model ID against Claude's default endpoint. Thinking level maps to `--effort`.
 - **Hooks** — Outfitter does not project hook configuration for Claude, and there is no portable protocol hooks resource yet. An inherited run keeps the hooks in your own `~/.claude/settings.json`; an isolated run has none. See [Hooks](./hooks.md).
 - **Tool availability** — `tools.allow` (after `tools.deny` removes entries) maps to both `--tools` (_availability_: an unlisted builtin is not in the session) and `--allowedTools` (_permission_: the granted tools are pre-approved, so a headless session is not stopped by a prompt); `tools.deny` always maps to `--disallowedTools`, including when both are declared, and a bare denied name removes the tool from context per Claude's docs. An allowlist that `tools.deny` empties maps to `--tools ""`, Claude's documented "disable all tools" form. Caveat: per the CLI reference, `--tools` governs the built-in set only — MCP tools (`mcp__server__*`) are unaffected and are governed by which MCP servers the loadout selects, so `--tools ""` is not exactly pi's zero-tool session when MCP servers are present. Claude's behavior here comes from `claude --help` and the CLI reference, not local measurement.
 - **DeepWork jobs** — job selection is Pi-only today and warns on Claude.

--- a/docs/requirements/OFTR-006-agent-adapters.md
+++ b/docs/requirements/OFTR-006-agent-adapters.md
@@ -119,3 +119,14 @@ Amended (2026-07-17, RFC #165): adapters project a harness-neutral composition, 
 6. Plan mode MUST restrict active tools to read-only inspection tools, exclude Bash from the active tool set, and block Bash tool calls while plan mode is active.
 7. Interactive Pi launches SHOULD register a native `/outfitter` command for Outfitter-specific setup and profile management that can run without an agent turn.
 8. Non-interactive Pi launches MUST NOT inject the Outfitter bootstrap extension.
+
+### OFTR-006.9: Canonical Cross-Harness Model Projection
+
+1. When an agent selects `provider/model` and one or more effective layers contain `models.json`, Outfitter MUST merge provider definitions by ID according to layer precedence and resolve the selection to one harness-neutral target containing provider ID, model ID, API dialect, base URL, credential-variable reference, required headers, projection-relevant model capabilities, and winning source layer.
+2. A selected provider and model MUST exist in the effective registry, and a selected provider MUST declare string `api` and `baseUrl` values; otherwise composition MUST fail before launch.
+3. The Pi adapter MUST materialize the effective canonical `models.json`, pass the normalized provider and model IDs through native flags, and MUST NOT replace or persist that declared registry through Pi's user-state bridge.
+4. For the `anthropic-messages` dialect, the Claude adapter MUST project the canonical model ID, base URL, runtime credential, and headers through Claude's native model and gateway controls.
+5. For the `openai-completions` and `openai-responses` dialects, the Codex adapter MUST configure the canonical provider, endpoint, credential environment key, headers, wire API, and model through native command-line configuration overrides.
+6. An adapter that cannot preserve a target's API dialect or provider ID MUST warn and MUST omit both the selected model identity and endpoint rather than silently using the same model ID against another endpoint; the existing `--strict` warning policy MUST make that warning fatal before launch.
+7. Runtime credential values MUST come from the environment. Effective registries MUST reject literal `apiKey` values, executable credential-source fields, non-string headers, and literal `Authorization` headers.
+8. When no `models.json` is configured, adapters MAY preserve legacy native model-name projection for compatibility.


### PR DESCRIPTION
Closes #321

## Summary
- resolve layered `.agents/models.json` providers into a provenance-carrying model target
- project native provider, endpoint, credential reference, headers, and model controls for Pi, Claude Code, and Codex
- reject unsafe credential forms and suppress unsupported targets instead of changing endpoints
- preserve catalog-projected Pi registries across the credential state bridge
- document canonical company gateway and Ollama configurations

## Validation
- `npm run check-ci` (584 tests; branch coverage 98.05%)
- `npm run build`
