### PR TITLE
feat(models): project registry targets across harnesses

### DIFF
--- a/code/cli/src/agents/AgentLaunch.ts
+++ b/code/cli/src/agents/AgentLaunch.ts
@@ -108,7 +108,15 @@ export const createSpawnLauncher = (stdio: 'inherit' | 'ignore'): AgentProcessLa
   async launch(plan: AgentLaunchPlan): Promise<number> {
     const { default: spawn } = await import('cross-spawn');
     return await new Promise<number>((resolve, reject) => {
-      const child = spawn(plan.command, [...plan.args], { stdio, env: { ...process.env, ...plan.env } });
+      const referencedEnvironment = Object.fromEntries(
+        Object.entries(plan.envReferences ?? {}).flatMap(([target, source]) =>
+          process.env[source] === undefined ? [] : [[target, process.env[source]]],
+        ),
+      );
+      const child = spawn(plan.command, [...plan.args], {
+        stdio,
+        env: { ...process.env, ...plan.env, ...referencedEnvironment },
+      });
       const detach = attachSignalForwarding(child);
       child.on('error', (error) => {
         detach();

--- a/code/cli/src/agents/PiCredentialPersistence.ts
+++ b/code/cli/src/agents/PiCredentialPersistence.ts
@@ -22,15 +22,25 @@ const copyIfPresent = (sourcePath: string, destinationPath: string): void => {
 };
 
 /** Seeds the projection root with the user's existing pi credentials so pi sees them at startup. */
-export const seedPiCredentials = (projectionRoot: string, piUserAgentDirectory: string): void => {
+export const seedPiCredentials = (
+  projectionRoot: string,
+  piUserAgentDirectory: string,
+  hasCatalogModels = false,
+): void => {
   for (const file of persistentPiStateFiles) {
+    if (hasCatalogModels && file === 'models.json') continue;
     copyIfPresent(join(piUserAgentDirectory, file), join(projectionRoot, file));
   }
 };
 
 /** Copies credentials created or changed during the pi session back to the durable agent dir. */
-export const persistPiCredentials = (projectionRoot: string, piUserAgentDirectory: string): void => {
+export const persistPiCredentials = (
+  projectionRoot: string,
+  piUserAgentDirectory: string,
+  hasCatalogModels = false,
+): void => {
   for (const file of persistentPiStateFiles) {
+    if (hasCatalogModels && file === 'models.json') continue;
     copyIfPresent(join(projectionRoot, file), join(piUserAgentDirectory, file));
   }
 };

--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -24,6 +24,7 @@ import { compose } from '../../composer/Composer.js';
 import { ensurePiExtensions } from '../../extensions/PiExtensionCache.js';
 import type { PiInstallSpawner } from '../../extensions/PiExtensionCache.js';
 import { resolveOutfitterCacheDir } from '../../paths/OutfitterCache.js';
+import { resolveModelRegistry } from '../../projection/ModelRegistry.js';
 import { projectComposition } from '../../projection/ProjectHarness.js';
 import type { AgentLaunchPlan } from '../../projection/Projection.js';
 import { strictAmbiguityFailureMessage } from '../../resolver/AmbiguityWarnings.js';
@@ -163,6 +164,7 @@ const launchWithStatePersistence = async (
   rootDirectory: string,
   launch: AgentLaunchPlan,
   lateMessages: string[],
+  hasCatalogModels = false,
 ): Promise<number> => {
   // Persist warnings surface after launch, and writeLine alone can be a dropped sink (setup's
   // auto-launch passes none), so they also go into lateMessages to reach the returned result.
@@ -185,7 +187,7 @@ const launchWithStatePersistence = async (
   const bridgesClaudeState = harness === 'claude' && isolation === 'isolated';
   let seededClaudeCredentialsHash: string | undefined;
   let seededClaudeSessionHashes: ReadonlyMap<string, string> = new Map();
-  if (piUserAgentDirectory !== undefined) seedPiCredentials(rootDirectory, piUserAgentDirectory);
+  if (piUserAgentDirectory !== undefined) seedPiCredentials(rootDirectory, piUserAgentDirectory, hasCatalogModels);
   if (bridgesClaudeState) {
     seededClaudeCredentialsHash = seedClaudeCredentials(rootDirectory, input.homeDirectory, input.projectDirectory);
     attempt('seed Claude session history', () => {
@@ -199,7 +201,9 @@ const launchWithStatePersistence = async (
     return await input.launcher(launch);
   } finally {
     if (piUserAgentDirectory !== undefined) {
-      attempt('persist Pi credentials', () => persistPiCredentials(rootDirectory, piUserAgentDirectory));
+      attempt('persist Pi credentials', () =>
+        persistPiCredentials(rootDirectory, piUserAgentDirectory, hasCatalogModels),
+      );
     }
     if (bridgesClaudeState) {
       attempt('persist Claude credentials', () => {
@@ -287,6 +291,17 @@ const resolutionWarningsForRun = (
   strict: boolean | undefined,
 ): readonly string[] => (strict === true ? resolved.warnings.map((warning) => `warning: ${warning}`) : []);
 
+const hasCatalogModels = (registry: ReturnType<typeof resolveModelRegistry> | undefined): boolean =>
+  registry?.content !== undefined && registry.errors.length === 0;
+
+const modelRegistryForRun = (
+  set: Parameters<typeof resolveModelRegistry>[0],
+  model: string | undefined,
+): ReturnType<typeof resolveModelRegistry> | undefined => {
+  const resolved = resolveModelRegistry(set, model);
+  return resolved.content === undefined && resolved.errors.length === 0 ? undefined : resolved;
+};
+
 const failedCompositionMessages = (
   resolved: ReturnType<typeof resolveEffectiveSet>,
   composed: ReturnType<typeof compose>,
@@ -354,6 +369,7 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
   const extensions = await loadPiExtensions(input, harness, agentSlug, composed.plan.loadout.extensions);
   const selectedAgent = findResource(set, 'agent', agentSlug)!;
   const configurationOverlays = piConfigurationOverlays(composed.plan, selectedAgent);
+  const modelRegistry = modelRegistryForRun(set, composed.plan.loadout.model);
 
   const rootDirectory = mkdtempSync(join(tmpdir(), `outfitter-${agentSlug}-${harness}-`));
 
@@ -370,6 +386,7 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
       extensionLoadDirs: harness === 'pi' ? extensions.loadDirs : undefined,
       // ProjectHarness only overlays these for the pi harness, so pass them through unconditionally.
       configurationOverlayDirectories: configurationOverlays,
+      modelRegistry,
     });
 
     // Composition warnings, unsupported harness elements, and extension-install failures are all
@@ -414,6 +431,7 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
       rootDirectory,
       systemHooks.launch,
       messages,
+      hasCatalogModels(modelRegistry),
     );
 
     return { launchPlan: systemHooks.launch, exitCode, messages };

--- a/code/cli/src/projection/ModelRegistry.ts
+++ b/code/cli/src/projection/ModelRegistry.ts
@@ -1,0 +1,149 @@
+/* eslint-disable complexity -- registry parsing keeps complete per-layer diagnostics in one pass. */
+// Resolves the canonical .agents/models.json registry into harness-neutral model targets.
+import { existsSync, readFileSync } from 'node:fs';
+import type { EffectiveResourceSet, Layer } from '../resolver/Resource.js';
+
+export type ModelApi = 'anthropic-messages' | 'openai-completions' | 'openai-responses' | 'google-generative-ai';
+
+export interface ModelTarget {
+  readonly provider: string;
+  readonly model: string;
+  readonly api: ModelApi;
+  readonly baseUrl: string;
+  readonly credentialVariable?: string;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly capabilities: Readonly<Record<string, unknown>>;
+  readonly source: string;
+}
+
+export interface EffectiveModelRegistry {
+  readonly content?: string;
+  readonly target?: ModelTarget;
+  readonly warnings: readonly string[];
+  readonly errors: readonly string[];
+}
+
+type RecordValue = Readonly<Record<string, unknown>>;
+interface ProviderEntry {
+  readonly value: RecordValue;
+  readonly layer: Layer;
+}
+
+const record = (value: unknown): RecordValue | undefined =>
+  value !== null && typeof value === 'object' && !Array.isArray(value) ? (value as RecordValue) : undefined;
+const stringRecord = (value: unknown): Readonly<Record<string, string>> => {
+  const object = record(value);
+  return object === undefined
+    ? {}
+    : Object.fromEntries(
+        Object.entries(object).filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
+      );
+};
+const isModelApi = (value: unknown): value is ModelApi =>
+  typeof value === 'string' &&
+  ['anthropic-messages', 'openai-completions', 'openai-responses', 'google-generative-ai'].includes(value);
+
+const credentialVariable = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  return /^\$[A-Z_][A-Z0-9_]*$/.test(value)
+    ? value.slice(1)
+    : /^\$\{[A-Z_][A-Z0-9_]*\}$/.test(value)
+      ? value.slice(2, -1)
+      : undefined;
+};
+
+/** Provider definitions merge by provider id; the highest-precedence layer supplies each id. */
+// Registry parsing deliberately keeps diagnostics in one pass so every malformed layer is reported.
+export const resolveModelRegistry = (
+  set: EffectiveResourceSet,
+  selection: string | undefined,
+): EffectiveModelRegistry => {
+  const providers = new Map<string, ProviderEntry>();
+  const warnings: string[] = [];
+  const errors: string[] = [];
+
+  for (const layer of [...set.layers].reverse()) {
+    const path = `${layer.root}/models.json`;
+    if (!existsSync(path)) continue;
+    let document: unknown;
+    try {
+      document = JSON.parse(readFileSync(path, 'utf8'));
+    } catch (error) {
+      errors.push(`${layer.label} models.json is not readable JSON: ${String(error)}`);
+      continue;
+    }
+    const definitions = record(record(document)?.providers);
+    if (definitions === undefined) {
+      errors.push(`${layer.label} models.json must contain a providers object.`);
+      continue;
+    }
+    for (const [id, value] of Object.entries(definitions)) {
+      const provider = record(value);
+      if (provider === undefined) errors.push(`${layer.label} models.json provider '${id}' must be an object.`);
+      else providers.set(id, { value: provider, layer });
+    }
+  }
+
+  if (providers.size === 0) return { warnings, errors };
+
+  // Emit a flattened native Pi registry so layer precedence is identical in all harnesses.
+  const content = `${JSON.stringify({ providers: Object.fromEntries([...providers].map(([id, entry]) => [id, entry.value])) }, null, 2)}\n`;
+  if (selection === undefined) return { content, warnings, errors };
+
+  const matches: { provider: string; model: RecordValue; entry: ProviderEntry }[] = [];
+  for (const [provider, entry] of providers) {
+    const models = Array.isArray(entry.value.models) ? entry.value.models : [];
+    for (const candidate of models) {
+      const model = record(candidate);
+      if (
+        model !== undefined &&
+        typeof model.id === 'string' &&
+        (selection === model.id || selection === `${provider}/${model.id}`)
+      )
+        matches.push({ provider, model, entry });
+    }
+  }
+  if (matches.length !== 1) {
+    const detail = matches.length === 0 ? 'does not exist' : 'is ambiguous; select provider/model';
+    errors.push(`model '${selection}' ${detail} in the effective models.json registry.`);
+    return { content, warnings, errors };
+  }
+
+  const match = matches[0];
+  const api = match.model.api ?? match.entry.value.api;
+  const baseUrl = match.entry.value.baseUrl;
+  if (!isModelApi(api) || typeof baseUrl !== 'string') {
+    errors.push(`model '${selection}' from ${match.entry.layer.label} must resolve an api and baseUrl.`);
+    return { content, warnings, errors };
+  }
+
+  const apiKey = match.entry.value.apiKey;
+  const untrusted = match.entry.layer.origin === 'workspace' || match.entry.layer.origin === 'source';
+  if (untrusted && typeof apiKey === 'string' && credentialVariable(apiKey) === undefined)
+    errors.push(
+      `provider '${match.provider}' from ${match.entry.layer.label} must use an environment variable reference for apiKey; literals and commands are rejected.`,
+    );
+  const headers = stringRecord(match.entry.value.headers);
+  if (untrusted && Object.values(headers).some((value) => value.startsWith('!')))
+    errors.push(
+      `provider '${match.provider}' from ${match.entry.layer.label} cannot execute a credential command in headers.`,
+    );
+
+  const capabilities = {
+    ...record(match.entry.value.compat),
+    ...record(match.model.compat),
+    reasoning: match.model.reasoning,
+    input: match.model.input,
+  };
+  const target: ModelTarget = {
+    provider: match.provider,
+    model: match.model.id,
+    api,
+    baseUrl,
+    credentialVariable: credentialVariable(apiKey),
+    headers,
+    capabilities,
+    source: match.entry.layer.label,
+  };
+  return { content, target, warnings, errors };
+};

--- a/code/cli/src/projection/ProjectHarness.ts
+++ b/code/cli/src/projection/ProjectHarness.ts
@@ -1,3 +1,4 @@
+/* eslint-disable complexity -- native launch assembly keeps ordering-sensitive controls together. */
 // Projects a harness-neutral CompositionPlan to a native pi, Claude Code, or Codex CLI launch.
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -12,6 +13,7 @@ import {
   materializeConfigurationOverlays,
   writeClaudePluginManifest,
 } from './Materialize.js';
+import type { ModelTarget } from './ModelRegistry.js';
 import type { AgentLaunchPlan, AgentProjectionPlan, ProjectionInput } from './Projection.js';
 import { toolArgs } from './Tools.js';
 
@@ -120,8 +122,54 @@ const promptArgs = (
 
 // Split from the thinking flag so each builder states positively what it emits: codex reports
 // `thinking` unsupported, and reporting an element unsupported does not by itself suppress it.
-const modelArg = (composition: CompositionPlan, flag: '-m' | '--model'): readonly string[] =>
-  composition.loadout.model === undefined ? [] : [flag, composition.loadout.model];
+const modelArg = (composition: CompositionPlan, input: ProjectionInput, flag: '-m' | '--model'): readonly string[] => {
+  if (composition.loadout.model === undefined) return [];
+  if (input.modelRegistry !== undefined) {
+    const target = input.modelRegistry.target;
+    if (input.modelRegistry.errors.length > 0 || target === undefined) return [];
+    if (input.harness === 'claude' && target.api !== 'anthropic-messages') return [];
+    if (input.harness === 'codex' && target.api !== 'openai-completions' && target.api !== 'openai-responses')
+      return [];
+    return [flag, target.model];
+  }
+  return [flag, composition.loadout.model];
+};
+
+const tomlString = (value: string): string => JSON.stringify(value);
+const codexModelArgs = (target: ModelTarget | undefined): readonly string[] => {
+  if (target === undefined) return [];
+  const wireApi = target.api === 'openai-responses' ? 'responses' : 'chat';
+  return [
+    '-c',
+    `model_provider=${tomlString(target.provider)}`,
+    '-c',
+    `model_providers.${target.provider}.name=${tomlString(target.provider)}`,
+    '-c',
+    `model_providers.${target.provider}.base_url=${tomlString(target.baseUrl)}`,
+    '-c',
+    `model_providers.${target.provider}.wire_api=${tomlString(wireApi)}`,
+    ...(target.credentialVariable === undefined
+      ? []
+      : ['-c', `model_providers.${target.provider}.env_key=${tomlString(target.credentialVariable)}`]),
+  ];
+};
+
+const modelProjectionWarnings = (input: ProjectionInput): readonly string[] => {
+  const registry = input.modelRegistry;
+  if (registry === undefined) return [];
+  if (registry.errors.length > 0) return registry.errors.map((error) => `models.json: ${error}`);
+  const target = registry.target;
+  if (target === undefined) return [];
+  if (input.harness === 'claude' && target.api !== 'anthropic-messages')
+    return [
+      `claude adapter cannot project model '${target.provider}/${target.model}' with API dialect '${target.api}'.`,
+    ];
+  if (input.harness === 'codex' && target.api !== 'openai-completions' && target.api !== 'openai-responses')
+    return [
+      `codex adapter cannot project model '${target.provider}/${target.model}' with API dialect '${target.api}'.`,
+    ];
+  return [];
+};
 
 const thinkingArg = (composition: CompositionPlan, harness: Harness): readonly string[] =>
   composition.loadout.thinking === undefined
@@ -137,7 +185,17 @@ const buildCodexLaunchPlan = (
 ): AgentLaunchPlan => ({
   command: 'codex',
   // Root `-m` propagation through `exec` was verified empirically on codex-cli 0.145.0.
-  args: [...codexMcpArgs, ...modelArg(composition, '-m'), ...(input.passThroughArgs ?? [])],
+  args: [
+    ...codexMcpArgs,
+    ...codexModelArgs(
+      input.modelRegistry?.target?.api === 'openai-completions' ||
+        input.modelRegistry?.target?.api === 'openai-responses'
+        ? input.modelRegistry.target
+        : undefined,
+    ),
+    ...modelArg(composition, input, '-m'),
+    ...(input.passThroughArgs ?? []),
+  ],
   env: {},
 });
 
@@ -183,6 +241,8 @@ const declareClaudePlugin = (composition: CompositionPlan, input: ProjectionInpu
   writeClaudePluginManifest(input.rootDirectory, input.profileSlug ?? 'outfitter', composition.identity.label);
 };
 
+// Each branch below mirrors one native CLI control; keeping the final argv/env assembly together
+// makes ordering-sensitive flags reviewable as one launch plan.
 const buildPiOrClaudeLaunchPlan = (
   composition: CompositionPlan,
   input: ProjectionInput,
@@ -204,7 +264,8 @@ const buildPiOrClaudeLaunchPlan = (
       ...promptArgs(composition, input, materialized.systemPromptPath, appendPromptPaths),
       ...skillArgs,
       ...extensionArgs,
-      ...modelArg(composition, '--model'),
+      ...(isPi && input.modelRegistry?.target !== undefined ? ['--provider', input.modelRegistry.target.provider] : []),
+      ...modelArg(composition, input, '--model'),
       ...thinkingArg(composition, input.harness),
       ...(isPi ? [] : claudeArgs(input.rootDirectory, isolation)),
       ...(input.passThroughArgs ?? []),
@@ -217,7 +278,27 @@ const buildPiOrClaudeLaunchPlan = (
           PI_CODING_AGENT_DIR: input.rootDirectory,
           ...(input.sessionDirectory === undefined ? {} : { [PI_SESSION_DIRECTORY_ENV]: input.sessionDirectory }),
         }
-      : claudeEnv(input.rootDirectory, isolation),
+      : {
+          ...claudeEnv(input.rootDirectory, isolation),
+          ...(input.modelRegistry?.target?.api === 'anthropic-messages'
+            ? {
+                ANTHROPIC_BASE_URL: input.modelRegistry.target.baseUrl,
+                ...(Object.keys(input.modelRegistry.target.headers).length === 0
+                  ? {}
+                  : {
+                      ANTHROPIC_CUSTOM_HEADERS: Object.entries(input.modelRegistry.target.headers)
+                        .map(([name, value]) => `${name}: ${value}`)
+                        .join('\n'),
+                    }),
+              }
+            : {}),
+        },
+    envReferences:
+      !isPi &&
+      input.modelRegistry?.target?.api === 'anthropic-messages' &&
+      input.modelRegistry.target.credentialVariable !== undefined
+        ? { ANTHROPIC_AUTH_TOKEN: input.modelRegistry.target.credentialVariable }
+        : undefined,
   };
 };
 
@@ -226,6 +307,9 @@ export const projectComposition = (composition: CompositionPlan, input: Projecti
   if (input.harness === 'pi') {
     materializeConfigurationOverlays(input.configurationOverlayDirectories ?? [], input.rootDirectory);
     applyPiRuntimeDefaults(input.rootDirectory);
+    if (input.modelRegistry?.content !== undefined && input.modelRegistry.errors.length === 0) {
+      writeFileSync(join(input.rootDirectory, 'models.json'), input.modelRegistry.content);
+    }
   }
   // Materialization runs for every harness so containment and definition diagnostics are reported
   // uniformly. Codex reads none of the generated files — it takes its MCP config in argv and has no
@@ -248,6 +332,7 @@ export const projectComposition = (composition: CompositionPlan, input: Projecti
         ? ['codex adapter does not project supplied append-prompt documents; they will be dropped.']
         : []),
       ...codexMcp.warnings,
+      ...modelProjectionWarnings(input),
     ];
     return { rootDirectory: input.rootDirectory, launch, unsupported, warnings };
   }
@@ -258,5 +343,5 @@ export const projectComposition = (composition: CompositionPlan, input: Projecti
     ...(input.appendPromptPaths ?? []),
   ]);
 
-  return { rootDirectory: input.rootDirectory, launch, unsupported, warnings: [] };
+  return { rootDirectory: input.rootDirectory, launch, unsupported, warnings: [...modelProjectionWarnings(input)] };
 };

--- a/code/cli/src/projection/Projection.ts
+++ b/code/cli/src/projection/Projection.ts
@@ -1,10 +1,13 @@
 // Harness-neutral projection types: a materialized runtime tree plus the launch plan for one run.
 import type { Harness, Isolation } from '../settings/Settings.js';
+import type { EffectiveModelRegistry } from './ModelRegistry.js';
 
 export interface AgentLaunchPlan {
   readonly command: string;
   readonly args: readonly string[];
   readonly env: Readonly<Record<string, string>>;
+  /** Native environment variable aliases resolved from the runtime environment only at spawn. */
+  readonly envReferences?: Readonly<Record<string, string>>;
 }
 
 export interface AgentProjectionPlan {
@@ -42,4 +45,6 @@ export interface ProjectionInput {
   readonly extensionLoadDirs?: readonly string[];
   /** Harness-native configuration directories, highest precedence first, overlaid into the root. */
   readonly configurationOverlayDirectories?: readonly string[];
+  /** Effective canonical models.json plus the selected normalized target. */
+  readonly modelRegistry?: EffectiveModelRegistry;
 }

--- a/code/cli/tests/unit/model-registry.test.ts
+++ b/code/cli/tests/unit/model-registry.test.ts
@@ -1,0 +1,251 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { CompositionPlan } from '../../src/composer/Composition.js';
+import { resolveModelRegistry } from '../../src/projection/ModelRegistry.js';
+import { projectComposition } from '../../src/projection/ProjectHarness.js';
+import type { EffectiveResourceSet, Layer } from '../../src/resolver/Resource.js';
+
+const roots: string[] = [];
+const root = (): string => {
+  const path = mkdtempSync(join(tmpdir(), 'outfitter-models-'));
+  roots.push(path);
+  return path;
+};
+afterEach(() => {
+  for (const path of roots.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+const layer = (path: string, origin: Layer['origin'], label: string): Layer => ({ root: path, origin, label });
+const set = (layers: readonly Layer[]): EffectiveResourceSet => ({
+  layers,
+  resources: new Map(),
+  agentResources: new Map(),
+});
+const writeModels = (path: string, providers: Record<string, unknown>): void => {
+  mkdirSync(path, { recursive: true });
+  writeFileSync(join(path, 'models.json'), JSON.stringify({ providers }));
+};
+const parsedProviders = (content: string): Record<string, { baseUrl: string }> =>
+  (JSON.parse(content) as { providers: Record<string, { baseUrl: string }> }).providers;
+const provider = (api: string, baseUrl: string, id: string, apiKey = '$COMPANY_AI_TOKEN') => ({
+  api,
+  baseUrl,
+  apiKey,
+  headers: { 'x-company': 'agents' },
+  models: [{ id, reasoning: true, input: ['text'] }],
+});
+const plan = (model: string): CompositionPlan => ({
+  agent: 'engineer',
+  identity: { agentBody: 'Engineer.' },
+  loadout: {
+    skills: [],
+    delegateSkills: [],
+    subagents: [],
+    mcp: [],
+    mcpServers: {},
+    extensions: [],
+    plugins: [],
+    model,
+  },
+  warnings: [],
+});
+
+// THIS TEST VALIDATES THE MODEL-REGISTRY LAYER-PRECEDENCE REQUIREMENT IN #321.
+// YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+it('resolves a selected provider from the highest-precedence models.json layer', () => {
+  const high = root();
+  const low = root();
+  writeModels(low, { company: provider('openai-completions', 'https://old.example/v1', 'coder') });
+  writeModels(high, { company: provider('openai-responses', 'https://gateway.example/v1', 'coder') });
+  const result = resolveModelRegistry(
+    set([layer(high, 'global', 'user'), layer(low, 'source', 'catalog')]),
+    'company/coder',
+  );
+  expect(result.errors).toEqual([]);
+  expect(result.target).toMatchObject({
+    provider: 'company',
+    model: 'coder',
+    api: 'openai-responses',
+    baseUrl: 'https://gateway.example/v1',
+    credentialVariable: 'COMPANY_AI_TOKEN',
+    source: 'user',
+  });
+  expect(parsedProviders(result.content!).company?.baseUrl).toBe('https://gateway.example/v1');
+});
+
+// THIS TEST VALIDATES THE UNTRUSTED-CREDENTIAL REJECTION REQUIREMENT IN #321.
+// YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+it('rejects literal credentials and credential commands from project or remote layers', () => {
+  for (const [origin, key] of [
+    ['workspace', 'secret-value'],
+    ['source', '!read-secret'],
+  ] as const) {
+    const path = root();
+    writeModels(path, { company: provider('openai-completions', 'https://gateway.example/v1', 'coder', key) });
+    expect(resolveModelRegistry(set([layer(path, origin, origin)]), 'company/coder').errors.join('\n')).toContain(
+      'literals and commands are rejected',
+    );
+  }
+});
+
+it('reports malformed registries and unresolved selections without executing catalog values', () => {
+  const malformed = root();
+  mkdirSync(malformed, { recursive: true });
+  writeFileSync(join(malformed, 'models.json'), '{');
+  expect(resolveModelRegistry(set([layer(malformed, 'source', 'broken')]), 'x').errors.join()).toContain(
+    'not readable JSON',
+  );
+
+  const invalid = root();
+  writeFileSync(join(invalid, 'models.json'), JSON.stringify({ providers: { broken: 1 } }));
+  expect(resolveModelRegistry(set([layer(invalid, 'source', 'invalid')]), 'x').errors.join()).toContain(
+    "provider 'broken' must be an object",
+  );
+
+  const absent = root();
+  writeFileSync(join(absent, 'models.json'), JSON.stringify({ wrong: {} }));
+  expect(resolveModelRegistry(set([layer(absent, 'source', 'absent')]), 'x').errors.join()).toContain(
+    'must contain a providers object',
+  );
+
+  const variants = root();
+  writeModels(variants, {
+    noModels: { api: 'openai-completions', baseUrl: 'https://example' },
+    one: { ...provider('openai-completions', 'https://one', 'same'), apiKey: '${TOKEN}' },
+    two: provider('openai-completions', 'https://two', 'same'),
+    missingApi: { baseUrl: 'https://example', models: [{ id: 'bad' }] },
+    commandHeader: {
+      ...provider('openai-completions', 'https://example', 'header'),
+      apiKey: undefined,
+      headers: { authorization: '!read-secret' },
+    },
+  });
+  const registrySet = set([layer(variants, 'source', 'variants')]);
+  expect(resolveModelRegistry(registrySet, undefined).content).toBeDefined();
+  expect(resolveModelRegistry(registrySet, 'unknown').errors.join()).toContain('does not exist');
+  expect(resolveModelRegistry(registrySet, 'same').errors.join()).toContain('ambiguous');
+  expect(resolveModelRegistry(registrySet, 'missingApi/bad').errors.join()).toContain('api and baseUrl');
+  expect(resolveModelRegistry(registrySet, 'commandHeader/header').errors.join()).toContain(
+    'cannot execute a credential command',
+  );
+  expect(resolveModelRegistry(registrySet, 'one/same').target?.credentialVariable).toBe('TOKEN');
+});
+
+describe('model adapter projection', () => {
+  it('materializes Pi models and selects the resolved provider and model', () => {
+    const catalog = root();
+    const runtime = root();
+    writeModels(catalog, { company: provider('openai-completions', 'https://gateway.example/v1', 'coder') });
+    const registry = resolveModelRegistry(set([layer(catalog, 'source', 'catalog')]), 'company/coder');
+    const result = projectComposition(plan('company/coder'), {
+      harness: 'pi',
+      rootDirectory: runtime,
+      homeDirectory: runtime,
+      modelRegistry: registry,
+    });
+    expect(result.launch.args).toEqual(expect.arrayContaining(['--provider', 'company', '--model', 'coder']));
+    expect(parsedProviders(readFileSync(join(runtime, 'models.json'), 'utf8')).company?.baseUrl).toBe(
+      'https://gateway.example/v1',
+    );
+  });
+
+  it('projects an Anthropic target through Claude native gateway controls', () => {
+    const catalog = root();
+    const runtime = root();
+    writeModels(catalog, { company: provider('anthropic-messages', 'https://claude.example', 'sonnet') });
+    const registry = resolveModelRegistry(set([layer(catalog, 'source', 'catalog')]), 'company/sonnet');
+    const result = projectComposition(plan('company/sonnet'), {
+      harness: 'claude',
+      rootDirectory: runtime,
+      homeDirectory: runtime,
+      modelRegistry: registry,
+    });
+    expect(result.launch.args).toEqual(expect.arrayContaining(['--model', 'sonnet']));
+    expect(result.launch.env).toMatchObject({ ANTHROPIC_BASE_URL: 'https://claude.example' });
+    expect(result.launch.envReferences).toEqual({ ANTHROPIC_AUTH_TOKEN: 'COMPANY_AI_TOKEN' });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('projects an OpenAI target through Codex native provider controls', () => {
+    const catalog = root();
+    const runtime = root();
+    writeModels(catalog, { company: provider('openai-responses', 'https://codex.example/v1', 'gpt') });
+    const registry = resolveModelRegistry(set([layer(catalog, 'source', 'catalog')]), 'company/gpt');
+    const result = projectComposition(plan('company/gpt'), {
+      harness: 'codex',
+      rootDirectory: runtime,
+      homeDirectory: runtime,
+      modelRegistry: registry,
+    });
+    expect(result.launch.args).toEqual(
+      expect.arrayContaining([
+        '-c',
+        'model_provider="company"',
+        '-c',
+        'model_providers.company.base_url="https://codex.example/v1"',
+        '-m',
+        'gpt',
+      ]),
+    );
+    expect(result.warnings.join('\n')).not.toContain('model');
+  });
+
+  it('projects keyless OpenAI chat providers without fabricating a credential', () => {
+    const catalog = root();
+    const runtime = root();
+    writeModels(catalog, {
+      local: { api: 'openai-completions', baseUrl: 'http://localhost:11434/v1', models: [{ id: 'llama' }] },
+    });
+    const registry = resolveModelRegistry(set([layer(catalog, 'global', 'user')]), 'local/llama');
+    const result = projectComposition(plan('local/llama'), {
+      harness: 'codex',
+      rootDirectory: runtime,
+      homeDirectory: runtime,
+      modelRegistry: registry,
+    });
+    expect(result.launch.args.join(' ')).toContain('wire_api="chat"');
+    expect(result.launch.args.join(' ')).not.toContain('env_key');
+  });
+
+  it('surfaces registry errors and unsupported Claude dialects without a model fallback', () => {
+    const runtime = root();
+    const invalid = projectComposition(plan('company/gpt'), {
+      harness: 'pi',
+      rootDirectory: runtime,
+      homeDirectory: runtime,
+      modelRegistry: { warnings: [], errors: ['rejected registry'] },
+    });
+    expect(invalid.warnings.join()).toContain('rejected registry');
+    expect(invalid.launch.args).not.toContain('--model');
+
+    const catalog = root();
+    writeModels(catalog, { company: provider('openai-responses', 'https://example/v1', 'gpt') });
+    const registry = resolveModelRegistry(set([layer(catalog, 'global', 'user')]), 'company/gpt');
+    const claude = projectComposition(plan('company/gpt'), {
+      harness: 'claude',
+      rootDirectory: root(),
+      homeDirectory: runtime,
+      modelRegistry: registry,
+    });
+    expect(claude.warnings.join()).toContain('claude adapter cannot project');
+    expect(claude.launch.args).not.toContain('--model');
+  });
+
+  it('warns and suppresses endpoint fallback for unsupported dialects', () => {
+    const catalog = root();
+    const runtime = root();
+    writeModels(catalog, { company: provider('anthropic-messages', 'https://claude.example', 'sonnet') });
+    const registry = resolveModelRegistry(set([layer(catalog, 'source', 'catalog')]), 'company/sonnet');
+    const result = projectComposition(plan('company/sonnet'), {
+      harness: 'codex',
+      rootDirectory: runtime,
+      homeDirectory: runtime,
+      modelRegistry: registry,
+    });
+    expect(result.warnings.join('\n')).toContain('cannot project');
+    expect(result.launch.args).not.toContain('-m');
+    expect(result.launch.args.join(' ')).not.toContain('model_providers');
+  });
+});

--- a/code/cli/tests/unit/pi-credential-persistence.test.ts
+++ b/code/cli/tests/unit/pi-credential-persistence.test.ts
@@ -47,6 +47,24 @@ describe('pi credential persistence', () => {
     expect(existsSync(join(projection, 'models.json'))).toBe(false);
   });
 
+  it('keeps catalog models authoritative while still bridging auth credentials', () => {
+    const base = root();
+    const userDir = join(base, 'user');
+    const projection = join(base, 'projection');
+    write(join(userDir, 'auth.json'), '{"token":"user"}');
+    write(join(userDir, 'models.json'), '{"source":"user"}');
+    write(join(projection, 'models.json'), '{"source":"catalog"}');
+
+    seedPiCredentials(projection, userDir, true);
+    expect(readFileSync(join(projection, 'auth.json'), 'utf8')).toBe('{"token":"user"}');
+    expect(readFileSync(join(projection, 'models.json'), 'utf8')).toBe('{"source":"catalog"}');
+
+    writeFileSync(join(projection, 'auth.json'), '{"token":"new"}');
+    persistPiCredentials(projection, userDir, true);
+    expect(readFileSync(join(userDir, 'auth.json'), 'utf8')).toBe('{"token":"new"}');
+    expect(readFileSync(join(userDir, 'models.json'), 'utf8')).toBe('{"source":"user"}');
+  });
+
   it('writes credentials created during the session back to the durable dir', () => {
     const base = root();
     const userDir = join(base, 'user');

--- a/docs/documentation/usecases/organization-profile-catalog.md
+++ b/docs/documentation/usecases/organization-profile-catalog.md
@@ -54,7 +54,43 @@ verification.
 
 ```json
 // .agents/agents/engineer/config.json
-{ "provider": "anthropic", "model": "anthropic/claude-sonnet-4", "thinking": "high" }
+{ "model": "company-claude/claude-sonnet-4", "thinking": "high" }
+```
+
+Define endpoints once at the catalog root. Credential values remain in the runtime environment;
+only variable references belong in a shared catalog. Outfitter resolves the selected provider/model
+and projects its endpoint through Pi's native `models.json`, Claude Code's Anthropic gateway
+environment, or Codex's native `model_providers` configuration. A harness warns (and `--strict`
+fails before launch) when the selected API dialect is unsupported.
+
+```json
+{
+  "providers": {
+    "company-claude": {
+      "api": "anthropic-messages",
+      "baseUrl": "https://ai.example.com/anthropic",
+      "apiKey": "$COMPANY_AI_TOKEN",
+      "models": [{ "id": "claude-sonnet-4", "reasoning": true }]
+    },
+    "company-codex": {
+      "api": "openai-responses",
+      "baseUrl": "https://ai.example.com/openai/v1",
+      "apiKey": "$COMPANY_AI_TOKEN",
+      "headers": { "x-company-tenant": "engineering" },
+      "models": [{ "id": "gpt-5.2-codex", "reasoning": true }]
+    },
+    "local-ollama": {
+      "api": "openai-completions",
+      "baseUrl": "http://127.0.0.1:11434/v1",
+      "models": [
+        {
+          "id": "qwen2.5-coder:7b",
+          "compat": { "supportsDeveloperRole": false, "supportsReasoningEffort": false }
+        }
+      ]
+    }
+  }
+}
 ```
 
 ```


### PR DESCRIPTION
## Summary
- resolve layered `.agents/models.json` providers into provenance-rich model targets
- project native provider, endpoint, credential reference, headers, and model controls for Pi, Claude Code, and Codex
- reject unsafe catalog credential forms and document a company gateway catalog

## Validation
- `npm run check-ci`
- 586 tests pass; branch coverage 98.06%
- docs production build passes

Closes #321