### PR TITLE
chore(container): retire the Outfitter Nix image variant

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       publish:
-        description: Push the validated images to GHCR
+        description: Push the validated image to GHCR
         required: false
         default: false
         type: boolean
@@ -25,7 +25,7 @@ on:
         default: v1.0.1
         type: string
       publish:
-        description: Push the validated images to GHCR
+        description: Push the validated image to GHCR
         required: false
         default: false
         type: boolean
@@ -40,9 +40,8 @@ permissions:
   packages: write
 
 jobs:
-  # The primary published image. Debian-based so end users can extend it with
-  # an ordinary Dockerfile (FROM + apt-get install / COPY); the Nix closure
-  # image below could not be extended that way and is now the -nix variant.
+  # The published image. Debian-based so end users can extend it with an
+  # ordinary Dockerfile (FROM + apt-get install / COPY).
   debian:
     name: Build and smoke test Debian image
     runs-on: ubuntu-latest
@@ -101,11 +100,8 @@ jobs:
             test -f /etc/ssl/certs/ca-certificates.crt
           '
 
-      # Extension is the workflow this image exists for. Prove the real
-      # end-user story: FROM the published image, apt-get install a tool,
-      # drop back to uid 1000, and the entrypoint still works. This is what
-      # the Nix closure image could not do — a downstream needed a 104-line
-      # repair Dockerfile to get here.
+      # Prove the extension workflow: install a tool, return to uid 1000, and
+      # confirm that the entrypoint still works.
       - name: Smoke test derivative image
         run: |
           set -euo pipefail
@@ -139,117 +135,3 @@ jobs:
         run: |
           docker tag "$IMAGE:$VERSION" "$IMAGE:latest"
           docker push "$IMAGE:latest"
-
-  # The former primary image: the Nix closure built by flake.nix mkContainer,
-  # kept for lib.mkContainer consumers and published under the -nix suffix.
-  nix:
-    name: Build and smoke test Nix image
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: '.node-version'
-
-      - name: Sync release version
-        run: node scripts/sync-release-version.mjs "${{ inputs.version }}"
-
-      - name: Install Nix
-        uses: DeterminateSystems/determinate-nix-action@v3
-
-      - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v7
-        with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock', 'flake.nix', 'package-lock.json', 'code/cli/package.json') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-
-          gc-max-store-size-linux: 2G
-
-      - name: Resolve image name
-        run: |
-          echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/outfitter" >> "$GITHUB_ENV"
-          echo "VERSION=${VERSION_INPUT#v}" >> "$GITHUB_ENV"
-        env:
-          VERSION_INPUT: ${{ inputs.version }}
-
-      - name: Build and load image
-        run: |
-          nix build .#container
-          docker load < result
-          docker tag outfitter:latest "$IMAGE:$VERSION-nix"
-
-      - name: Smoke test image
-        run: |
-          output="$(docker run --rm "$IMAGE:$VERSION-nix" --version)"
-          if [ "$output" != "$VERSION" ]; then
-            echo "Expected outfitter --version to print '$VERSION' but got '$output'." >&2
-            exit 1
-          fi
-          docker run --rm --entrypoint /bin/sh "$IMAGE:$VERSION-nix" -c \
-            'nix --version && node --version && npm --version && test -x /bin/bash && test -x /usr/bin/env && test -r "$SSL_CERT_FILE"'
-          docker run --rm --entrypoint /bin/sh "$IMAGE:$VERSION-nix" -c \
-            'git ls-remote --exit-code https://github.com/ai-outfitter/default-profiles.git HEAD'
-
-      - name: Smoke test quiet extension loading
-        run: |
-          workdir="$(mktemp -d)"
-          mkdir -p "$workdir/.agents/agents/smoke"
-          printf '%s\n' \
-            '---' \
-            'name: smoke' \
-            'extensions: ["npm:pi-nolo"]' \
-            '---' \
-            '' \
-            'Container extension smoke test.' \
-            > "$workdir/.agents/agents/smoke/agent.md"
-
-          output="$(docker run --rm -v "$workdir:/workspace:ro" "$IMAGE:$VERSION-nix" run smoke -- --help 2>&1)"
-          grep -q 'pi - AI coding assistant' <<< "$output"
-          if grep -Eq 'Installing npm:|spawn npm ENOENT' <<< "$output"; then
-            echo 'Normal startup exposed extension installer output.' >&2
-            printf '%s\n' "$output" >&2
-            exit 1
-          fi
-
-          debug_output="$(docker run --rm -v "$workdir:/workspace:ro" "$IMAGE:$VERSION-nix" run smoke --log-level debug -- --help 2>&1)"
-          grep -q 'Installing npm:pi-nolo' <<< "$debug_output"
-
-      # Process residency is covered at the CLI level instead — signal forwarding lives in
-      # spawnLauncher, so tests/unit/agent-launch.test.ts asserts it directly
-      # rather than inferring it from container exit codes.
-      - name: Smoke test derivative image
-        run: |
-          set -euo pipefail
-          # A consumer extends the base with its own entrypoint. This failed
-          # before /etc/passwd carried root: the builder resolves USER against
-          # the base image's passwd file, so `USER root` aborted the build with
-          # "unknown user error looking up user root".
-          workdir="$(mktemp -d)"
-          printf '#!/bin/bash\nexec outfitter "$@"\n' > "$workdir/entrypoint"
-          cat > "$workdir/Dockerfile" <<DOCKERFILE
-          FROM $IMAGE:$VERSION-nix
-          USER root
-          COPY entrypoint /opt/agent/entrypoint
-          RUN chmod 0755 /opt/agent/entrypoint
-          USER 1000:1000
-          ENTRYPOINT ["/opt/agent/entrypoint"]
-          DOCKERFILE
-          docker build -t outfitter-nix-derivative:smoke "$workdir"
-          docker run --rm outfitter-nix-derivative:smoke --version
-
-      - name: Log in to GitHub Container Registry
-        if: inputs.publish
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Push version tag
-        if: inputs.publish
-        run: docker push "$IMAGE:$VERSION-nix"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,12 +143,11 @@ Outfitter assembles a temporary composite profile under the system temp director
 
 ## Docker
 
-Each published release builds the `container` output from `flake.nix` and pushes a `linux/amd64` image to GitHub Container Registry as `ghcr.io/ai-outfitter/outfitter:<version>` and `ghcr.io/ai-outfitter/outfitter:latest` (see the `publish-docker` job in `.github/workflows/release.yml`).
-The image uses the Nix-built Outfitter package directly as its entrypoint and
-includes the Nix CLI, Bash, core utilities, Git, SSH, and CA certificates. See
-[Container images](docs/documentation/containers.md) for the persistent runtime
-contract and the reusable Nix image builder.
-Use the manually dispatched `Container` workflow to reproduce and smoke test a release image without publishing it. Its Nix store paths are cached between GitHub Actions runs; the normal pull-request and push CI workflow does not build the image.
+Each published release builds a `linux/amd64` image from `container/Dockerfile` and pushes it to GitHub Container Registry as `ghcr.io/ai-outfitter/outfitter:<version>` and `ghcr.io/ai-outfitter/outfitter:latest` (see the `publish-docker` job in `.github/workflows/release.yml`).
+The image installs the built CLI package and includes Node.js, npm, Git, SSH,
+and CA certificates. See [Container images](docs/documentation/containers.md)
+for the persistent runtime contract.
+Use the manually dispatched `Container` workflow to reproduce and smoke test a release image without publishing it. The normal pull-request and push CI workflow does not build the image.
 
 Run the published image:
 
@@ -159,14 +158,14 @@ docker run --rm -it ghcr.io/ai-outfitter/outfitter
 ## Test profiles with a local container
 
 The release workflow publishes the npm package from the `code/cli` workspace and the container image to GHCR.
-The flake container output is also useful for local smoke testing on Linux.
+The flake keeps a development image for local smoke tests on Linux.
 
 Build a local image from the repository root:
 
 ```sh
-nix build .#container
+nix build .#container-dev
 docker load < result
-docker tag outfitter:latest outfitter:dev
+docker tag outfitter-dev:latest outfitter:dev
 ```
 
 Run setup from a remote setup source:

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,7 +1,6 @@
 # Outfitter primary published image (ghcr.io/ai-outfitter/outfitter).
 #
-# Debian-based on purpose. The previous primary image was a Nix closure
-# (flake.nix mkContainer, still published as the `-nix` variant): end users
+# Debian-based on purpose. The previous image was a Nix closure. End users
 # could not extend it conventionally — no apt, no /lib64 ELF interpreter for
 # foreign dynamic binaries, node/npm not on PATH (extension installs died with
 # `spawn npm ENOENT`), and the CA bundle at a non-default path. This image

--- a/docs/architecture/file_structure.md
+++ b/docs/architecture/file_structure.md
@@ -29,7 +29,7 @@ Outfitter is organized around a private npm workspace root, clear TypeScript pac
 ├── .snapperrc.toml                    # Snapper Markdown formatting configuration
 ├── CONTRIBUTING.md                    # local install and contributor workflow guide
 ├── container/                         # Dockerfile for the primary Debian-based published image
-├── flake.nix                          # Nix package and `-nix` container variant outputs for the Outfitter CLI
+├── flake.nix                          # Nix package and development container outputs for the Outfitter CLI
 ├── flake.lock                         # pinned Nix flake inputs
 ├── code/                              # npm workspace packages and license-separated code areas
 │   ├── cli/                           # @ai-outfitter/outfitter npm package root

--- a/docs/documentation/README.md
+++ b/docs/documentation/README.md
@@ -48,7 +48,7 @@ The same composition runs on every surface; only the trigger changes.
 
 - [Running an agent in GitHub Actions](./actions.md) — headless runs on any workflow trigger.
 - [Channels](./channels.md) — add external event sources that wake a resident agent only when work arrives.
-- [Container images](./containers.md) — run the published Debian-based image persistently, extend it with apt, or use the `-nix` variant.
+- [Container images](./containers.md) — run the published Debian-based image persistently or extend it with apt.
 - [Recurring runs](./recurring-runs.md) — loops three ways: the local loop extension, Actions cron, cluster schedules.
 - [Cost estimation](./cost-estimation.md) — one workload profile and model-cost line across local, Actions, and Kubernetes runs.
 - [In-cluster agents](./in-cluster.md) — resident agents, CronJobs, and subagent Jobs via Link Operator.

--- a/docs/documentation/containers.md
+++ b/docs/documentation/containers.md
@@ -13,9 +13,6 @@ servers, or other use-case behavior. The default runtime user and group are
 both `1000` (named `outfitter`), with `/tmp` as the home directory and
 `/workspace` as the working directory.
 
-A Nix closure variant of the image is also published under the `-nix` suffix;
-see [the `-nix` variant](#the--nix-variant) below.
-
 ## Run a resident agent
 
 A resident container is an ordinary `outfitter run` whose harness stays in RPC
@@ -47,7 +44,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: agent
-          # The primary Debian-based image; append -nix for the Nix variant.
+          # The published Debian-based image.
           image: ghcr.io/ai-outfitter/outfitter:<version>
           stdin: true
           workingDir: /workspace
@@ -85,8 +82,8 @@ The image is a normal Debian base: extend it with an ordinary Dockerfile.
 `apt-get` works, and so does `COPY`ing binaries. A dynamically linked binary
 runs when it matches the image — same architecture, glibc-linked, and its
 shared-library dependencies present. The standard ELF interpreter is where
-tools expect it (unlike the `-nix` variant), but the slim base ships a small
-library set: `apt-get install` a binary's runtime libraries when it needs more.
+tools expect it, but the slim base ships a small library set. Use `apt-get
+install` when a binary needs more runtime libraries.
 Switch to `root` for the layers that install, then drop back to `1000`:
 
 ```dockerfile
@@ -111,77 +108,3 @@ docker run --rm --entrypoint /bin/sh example-agent \
 
 The entrypoint stays `outfitter`; override `ENTRYPOINT` only when the derived
 image wraps the launch itself.
-
-## The `-nix` variant
-
-The Nix closure image that was previously the primary tag remains published
-for `lib.mkContainer` consumers:
-
-```text
-ghcr.io/ai-outfitter/outfitter:<version>-nix
-```
-
-It is built by the flake, includes the Nix CLI, Bash, core utilities, Git,
-SSH, and CA certificates, and its entrypoint is an absolute `/nix/store` path.
-It is not conventionally extensible — there is no apt, and foreign dynamic
-binaries do not run — so extend it through Nix instead: the flake exports
-`lib.mkContainer` for reproducible derivative images:
-
-```nix
-{
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    outfitter = {
-      url = "github:ai-outfitter/outfitter/v1.4.0";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-  };
-
-  outputs =
-    { nixpkgs, outfitter, ... }:
-    let
-      system = "x86_64-linux";
-      pkgs = nixpkgs.legacyPackages.${system};
-    in
-    {
-      packages.${system}.default = outfitter.lib.mkContainer {
-        inherit pkgs;
-        outfitterPackage = outfitter.packages.${system}.outfitter;
-        name = "example-agent";
-        extraPackages = [
-          pkgs.jq
-          pkgs.ripgrep
-        ];
-      };
-    };
-}
-```
-
-Build and exercise the exact image:
-
-```sh
-nix build
-docker load < result
-docker run --rm example-agent:latest --version
-docker run --rm --entrypoint /bin/sh example-agent:latest \
-  -c 'nix --version && jq --version && rg --version'
-```
-
-Prefer adding known runtime packages through `extraPackages`. The resulting
-image stays reproducible, and it avoids the trap below.
-
-**Do not mount an empty volume over `/nix` of the `-nix` variant.** That image
-_is_ its Nix store: the entrypoint is an absolute store path and every binary
-in `/bin` is a symlink into `/nix/store`. Mounting a fresh volume there hides
-all of it, so the container cannot start — it fails before it could initialize
-the very store you mounted the volume to populate. (The primary Debian image
-has no `/nix` and is not affected.)
-
-Runtime installation in the `-nix` variant therefore needs one of:
-
-- a volume **pre-populated** with the image's closure, seeded from the image
-  before the agent starts (an init container copying `/nix` into the volume);
-- an **overlay** whose lower layer is the image's `/nix`, so the closure stays
-  visible while writes land in the upper layer; or
-- writable Nix **state** only — `/nix/var` and a per-user profile — leaving the
-  store itself as the image shipped it.

--- a/docs/requirements/OFTR-009-release-publishing.md
+++ b/docs/requirements/OFTR-009-release-publishing.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Outfitter release publishing prepares package metadata from Conventional Commit release PRs and GitHub release tags, then publishes the `@ai-outfitter/outfitter` CLI workspace package through npm trusted publishing / OIDC and the container images — a Debian-based primary image and a flake-built `-nix` variant — through GitHub Container Registry.
+Outfitter release publishing prepares package metadata from Conventional Commit release PRs and GitHub release tags. It publishes the `@ai-outfitter/outfitter` CLI workspace package through npm trusted publishing and OIDC. It publishes a Debian-based container image through GitHub Container Registry.
 
 ## Requirements
 
@@ -40,10 +40,6 @@ Outfitter release publishing prepares package metadata from Conventional Commit 
 2. The primary image MUST install Outfitter from the CLI workspace tarball built in the release workflow, not from the npm registry, so the image is buildable for unreleased versions and in CI before publish.
 3. The primary image MUST include Node.js matching the `.node-version` major, npm, Git, SSH, and CA certificates at their conventional Debian paths, and MUST use `outfitter` as its entrypoint.
 4. The primary image MUST run as UID/GID 1000 with `/workspace` as its working directory and `/tmp` as its default home directory.
-5. The release workflow MUST smoke test each image before publishing it, including `outfitter --version`, the presence of Node.js, npm, Git, and SSH, and the CA bundle at `/etc/ssl/certs/ca-certificates.crt` in the primary image.
-6. The release workflow MUST smoke test a derivative build of the primary image that installs a package with `apt-get` as root and returns to UID 1000.
-7. The Nix closure image MUST remain published under the `-nix` tag suffix for `lib.mkContainer` consumers.
-8. The flake MUST expose the `-nix` container as the `container` package output, and that container MUST use the Nix-built Outfitter package directly as its entrypoint.
-9. The `-nix` container MUST include the Nix CLI, a shell, core utilities, Git, SSH, and CA certificates, and the flake MUST expose a container builder that accepts caller-selected runtime packages without rebuilding Outfitter through another package manager.
-10. The release workflow MUST smoke test Outfitter, Nix, and the conventional shell and environment executable paths in the `-nix` image.
-11. Documentation MUST define the persistent Kubernetes invocation, describe conventional Dockerfile extension of the primary image, scope the writable-`/nix` guidance to the `-nix` variant, and explain that callers own profile configuration, credentials, and channel-specific extensions.
+5. The release workflow MUST smoke test the image before publishing it. The test MUST check `outfitter --version`, Node.js, npm, Git, SSH, and the CA bundle at `/etc/ssl/certs/ca-certificates.crt`.
+6. The release workflow MUST smoke test a derivative build of the image. The build MUST install a package with `apt-get` as root. The build MUST return to UID 1000.
+7. Documentation MUST define the persistent Kubernetes invocation and conventional Dockerfile extension. It MUST explain that callers own profile configuration, credentials, and channel-specific extensions.

--- a/flake.nix
+++ b/flake.nix
@@ -94,8 +94,6 @@
         };
     in
     {
-      lib = { inherit mkContainer; };
-
       packages = forAllSystems (
         system:
         let
@@ -186,13 +184,8 @@
 
           default = outfitter;
 
-          container = mkContainer {
-            inherit pkgs;
-            outfitterPackage = outfitter;
-          };
-
-          # The interactive setup smoke image includes every harness offered by onboarding. Keep
-          # the published generic container lean; Numtide owns the fast-moving CLI packages here.
+          # The interactive development image includes every harness offered by onboarding.
+          # Numtide owns the fast-moving CLI packages here.
           container-dev = mkContainer {
             inherit pkgs;
             outfitterPackage = outfitter;


### PR DESCRIPTION
## Summary

- remove the obsolete Nix runtime image output and publish job
- keep Nix package and development support
- keep the standard Outfitter image and existing published tags

## Verification

- `nix flake show --offline`
- focused Prettier checks
- `git diff --check`
- stale `-nix`, `.#container`, and `lib.mkContainer` reference scan

The full base CI still has unrelated package-lock and formatting failures.
