### PR TITLE
feat(hooks): add workspace stop hooks

### DIFF
--- a/code/cli/src/composer/Composer.ts
+++ b/code/cli/src/composer/Composer.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { escapesRoots } from '../dump/Containment.js';
+import { readWorkspaceHooks } from '../hooks/WorkspaceHook.js';
 import { isAgentDefinitionIssue, readAgentDefinition } from '../resolver/AgentDefinition.js';
 import type { AgentDefinition } from '../resolver/AgentDefinition.js';
 import type { EffectiveResourceSet, Loadout, ResolvedResource } from '../resolver/Resource.js';
@@ -540,6 +541,12 @@ export const compose = (set: EffectiveResourceSet, agentSlug: string, options: C
   const composedSubagents = composeSubagents(set, loadout.subagents, options, warnings, errors);
   const uniqueWarnings = uniqueStrings(warnings);
   if (errors.length > 0) return { errors, warnings: uniqueWarnings };
+  let workspaceHooks;
+  try {
+    workspaceHooks = options.projectDirectory === undefined ? undefined : readWorkspaceHooks(options.projectDirectory);
+  } catch (error) {
+    return { errors: [String(error)], warnings: uniqueWarnings };
+  }
 
   return {
     plan: {
@@ -549,6 +556,7 @@ export const compose = (set: EffectiveResourceSet, agentSlug: string, options: C
       loadout: { ...loadout, composedSubagents },
       contributingAgents: chain.map((entry) => entry.resource),
       inheritanceChain: chain.map((entry) => entry.resource.slug),
+      ...(workspaceHooks === undefined ? {} : { workspaceHooks }),
       warnings: uniqueWarnings,
     },
     errors: [],

--- a/code/cli/src/composer/Composer.ts
+++ b/code/cli/src/composer/Composer.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 
 import { escapesRoots } from '../dump/Containment.js';
 import { readWorkspaceHooks } from '../hooks/WorkspaceHook.js';
+import type { WorkspaceHooksSnapshot } from '../hooks/WorkspaceHook.js';
 import { isAgentDefinitionIssue, readAgentDefinition } from '../resolver/AgentDefinition.js';
 import type { AgentDefinition } from '../resolver/AgentDefinition.js';
 import type { EffectiveResourceSet, Loadout, ResolvedResource } from '../resolver/Resource.js';
@@ -541,9 +542,9 @@ export const compose = (set: EffectiveResourceSet, agentSlug: string, options: C
   const composedSubagents = composeSubagents(set, loadout.subagents, options, warnings, errors);
   const uniqueWarnings = uniqueStrings(warnings);
   if (errors.length > 0) return { errors, warnings: uniqueWarnings };
-  let workspaceHooks;
+  let workspaceHooks: WorkspaceHooksSnapshot | undefined;
   try {
-    workspaceHooks = options.projectDirectory === undefined ? undefined : readWorkspaceHooks(options.projectDirectory);
+    if (options.projectDirectory !== undefined) workspaceHooks = readWorkspaceHooks(options.projectDirectory);
   } catch (error) {
     return { errors: [String(error)], warnings: uniqueWarnings };
   }

--- a/code/cli/src/composer/Composition.ts
+++ b/code/cli/src/composer/Composition.ts
@@ -1,8 +1,8 @@
 // Harness-neutral composition types produced from the effective resource set for a selected agent.
+import type { WorkspaceHooksSnapshot } from '../hooks/WorkspaceHook.js';
 import type { Loadout, ResolvedResource } from '../resolver/Resource.js';
 import type { EffectiveModelRegistry } from './Models.js';
 import type { PromptFragment } from './PromptSource.js';
-import type { WorkspaceHooksSnapshot } from '../hooks/WorkspaceHook.js';
 
 /** The composed identity: base prompt, shared context, prompt fragments, and agent bodies. */
 export interface ComposedIdentity {

--- a/code/cli/src/composer/Composition.ts
+++ b/code/cli/src/composer/Composition.ts
@@ -2,6 +2,7 @@
 import type { Loadout, ResolvedResource } from '../resolver/Resource.js';
 import type { EffectiveModelRegistry } from './Models.js';
 import type { PromptFragment } from './PromptSource.js';
+import type { WorkspaceHooksSnapshot } from '../hooks/WorkspaceHook.js';
 
 /** The composed identity: base prompt, shared context, prompt fragments, and agent bodies. */
 export interface ComposedIdentity {
@@ -74,6 +75,8 @@ export interface CompositionPlan {
   readonly contributingAgents?: readonly ResolvedResource[];
   /** Parent-first chain of agent slugs that contributed to this composition, selected child last. */
   readonly inheritanceChain?: readonly string[];
+  /** Immutable workspace-only portable hook packages captured for this composition. */
+  readonly workspaceHooks?: WorkspaceHooksSnapshot;
   /** Non-fatal issues (e.g. unknown loadout slugs) surfaced during composition. */
   readonly warnings: readonly string[];
 }

--- a/code/cli/src/hooks/HookProjection.ts
+++ b/code/cli/src/hooks/HookProjection.ts
@@ -14,6 +14,8 @@ export interface WorkspaceHookProjection {
 
 const runtimeDirectoryName = '.outfitter/workspace-hooks';
 
+const runtimeRoot = (rootDirectory: string): string => join(rootDirectory, ...runtimeDirectoryName.split('/'));
+
 const dispatcherSource = (snapshot: WorkspaceHooksSnapshot, packageRoot: string): string => {
   const hooks = snapshot.hooks.flatMap((hook) => {
     const command = hook.events.stop;
@@ -93,17 +95,18 @@ if (reasons.length > 0) {
 };
 
 const writeSnapshot = (snapshot: WorkspaceHooksSnapshot, rootDirectory: string): string => {
-  const runtimeRoot = join(rootDirectory, ...runtimeDirectoryName.split('/'));
-  const packageRoot = join(runtimeRoot, 'packages');
+  const packageRoot = join(runtimeRoot(rootDirectory), 'packages');
   for (const hook of snapshot.hooks) {
     for (const file of hook.files) {
       const target = join(packageRoot, hook.slug, ...file.path.split('/'));
       mkdirSync(dirname(target), { recursive: true });
       writeFileSync(target, file.content, { mode: file.mode });
+      // `mode` on create is masked by the process umask, so an executable bit only survives
+      // the explicit chmod. A command that loses it would fail the launch, not the read.
       chmodSync(target, file.mode);
     }
   }
-  const dispatcherPath = join(runtimeRoot, 'dispatcher.mjs');
+  const dispatcherPath = join(runtimeRoot(rootDirectory), 'dispatcher.mjs');
   mkdirSync(dirname(dispatcherPath), { recursive: true });
   writeFileSync(dispatcherPath, dispatcherSource(snapshot, packageRoot), { mode: 0o755 });
   return dispatcherPath;
@@ -112,10 +115,8 @@ const writeSnapshot = (snapshot: WorkspaceHooksSnapshot, rootDirectory: string):
 const stopTimeoutSeconds = (snapshot: WorkspaceHooksSnapshot): number =>
   snapshot.hooks.reduce((sum, hook) => sum + (hook.events.stop?.timeoutSeconds ?? 0), 0) + 5;
 
-const claudeHookDocument = (command: string, timeout: number): Record<string, unknown> => ({
-  hooks: {
-    Stop: [{ hooks: [{ type: 'command', command, timeout }] }],
-  },
+const claudeStopMatcher = (command: string, timeout: number): Record<string, unknown> => ({
+  hooks: [{ type: 'command', command, timeout }],
 });
 
 const objectValue = (value: unknown): Record<string, unknown> =>
@@ -123,7 +124,7 @@ const objectValue = (value: unknown): Record<string, unknown> =>
 
 const arrayValue = (value: unknown): readonly unknown[] => (Array.isArray(value) ? (value as readonly unknown[]) : []);
 
-const mergeClaudeIsolatedSettings = (rootDirectory: string, portable: Record<string, unknown>): void => {
+const mergeClaudeIsolatedSettings = (rootDirectory: string, matcher: Record<string, unknown>): void => {
   const settingsPath = join(rootDirectory, 'settings.json');
   let settings: Record<string, unknown> = {};
   try {
@@ -134,15 +135,12 @@ const mergeClaudeIsolatedSettings = (rootDirectory: string, portable: Record<str
     // The projection owns this file. An absent file starts with an empty object.
   }
   const existingHooks = objectValue(settings.hooks);
-  const portableHooks = objectValue(portable.hooks);
-  const existingStop = arrayValue(existingHooks.Stop);
-  const portableStop = arrayValue(portableHooks.Stop);
   writeFileSync(
     settingsPath,
     `${JSON.stringify(
       {
         ...settings,
-        hooks: { ...existingHooks, ...portableHooks, Stop: [...existingStop, ...portableStop] },
+        hooks: { ...existingHooks, Stop: [...arrayValue(existingHooks.Stop), matcher] },
       },
       null,
       2,
@@ -157,25 +155,36 @@ const projectClaude = (
   launch: AgentLaunchPlan,
 ): WorkspaceHookProjection => {
   const inherited = input.isolation !== 'isolated';
-  const target = inherited ? '$CLAUDE_PLUGIN_ROOT/.outfitter/workspace-hooks/dispatcher.mjs' : dispatcherPath;
+  const target = inherited ? `$CLAUDE_PLUGIN_ROOT/${runtimeDirectoryName}/dispatcher.mjs` : dispatcherPath;
   const command = `node "${target.replaceAll('"', '\\"')}" --harness claude --event stop`;
-  const document = claudeHookDocument(command, stopTimeoutSeconds(snapshot));
+  const matcher = claudeStopMatcher(command, stopTimeoutSeconds(snapshot));
   if (inherited) {
     const hooksPath = join(input.rootDirectory, 'hooks', 'hooks.json');
     mkdirSync(dirname(hooksPath), { recursive: true });
-    writeFileSync(hooksPath, `${JSON.stringify(document, null, 2)}\n`);
+    writeFileSync(hooksPath, `${JSON.stringify({ hooks: { Stop: [matcher] } }, null, 2)}\n`);
   } else {
-    mergeClaudeIsolatedSettings(input.rootDirectory, document);
+    mergeClaudeIsolatedSettings(input.rootDirectory, matcher);
   }
   return { launch, warnings: [] };
 };
 
+// Unlike the Claude adapter, which reads the dispatcher's stderr from a child process, pi loads
+// this extension in-process. A TUI session owns the terminal, so a raw stderr write lands inside
+// the rendered frame; notify() is the delivered channel there but is a no-op without a UI. Hook
+// warnings are required output under OFTR-012.5.4 and OFTR-012.6.2, so route by which one works.
 const piExtensionSource = (dispatcherPath: string): string => `
 const DISPATCHER = ${JSON.stringify(dispatcherPath)};
 let continuationActive = false;
 
+const report = (ctx, message) => {
+  const text = message.trim();
+  if (text === '') return;
+  if (ctx && ctx.hasUI === true) ctx.ui.notify(text, 'warning');
+  else process.stderr.write(text + '\\n');
+};
+
 export default function outfitterWorkspaceHooks(pi) {
-  pi.on('agent_end', async () => {
+  pi.on('agent_end', async (_event, ctx) => {
     const result = await pi.exec(process.execPath, [
       DISPATCHER,
       '--harness', 'pi',
@@ -183,17 +192,17 @@ export default function outfitterWorkspaceHooks(pi) {
       '--continuation-active', String(continuationActive),
       '--native-event-json', '{}',
     ]);
-    if (result.stderr) process.stderr.write(result.stderr);
+    if (result.stderr) report(ctx, result.stderr);
     if (result.code !== 2) {
       continuationActive = false;
       if (result.code !== 0) {
-        process.stderr.write('Warning: workspace hook dispatcher failed; continuing the session.\\n');
+        report(ctx, 'Warning: workspace hook dispatcher failed; continuing the session.');
       }
       return;
     }
     if (continuationActive) {
       continuationActive = false;
-      process.stderr.write('Warning: a workspace stop hook requested continuation twice; stopping to prevent a loop.\\n');
+      report(ctx, 'Warning: a workspace stop hook requested continuation twice; stopping to prevent a loop.');
       return;
     }
     continuationActive = true;
@@ -208,7 +217,7 @@ const projectPi = (
   dispatcherPath: string,
   launch: AgentLaunchPlan,
 ): WorkspaceHookProjection => {
-  const extensionPath = join(input.rootDirectory, ...runtimeDirectoryName.split('/'), 'pi-extension.js');
+  const extensionPath = join(runtimeRoot(input.rootDirectory), 'pi-extension.js');
   writeFileSync(extensionPath, piExtensionSource(dispatcherPath));
   return { launch: { ...launch, args: ['--extension', extensionPath, ...launch.args] }, warnings: [] };
 };
@@ -221,19 +230,17 @@ export const projectWorkspaceHooks = (
 ): WorkspaceHookProjection => {
   const snapshot = composition.workspaceHooks;
   if (snapshot === undefined || snapshot.hooks.length === 0) return { launch, warnings: [] };
-  const dispatcherPath = writeSnapshot(snapshot, input.rootDirectory);
-
-  switch (input.harness) {
-    case 'claude':
-      return projectClaude(snapshot, input, dispatcherPath, launch);
-    case 'pi':
-      return projectPi(input, dispatcherPath, launch);
-    case 'codex':
-      return {
-        launch,
-        warnings: [
-          'codex adapter cannot safely project workspace stop hooks: Codex has no alternate project hook-file flag for the temporary runtime, session hooks need trust for the changing dispatcher path, and notify hooks cannot request continuation. No workspace hooks were attached.',
-        ],
-      };
+  if (input.harness === 'codex') {
+    return {
+      launch,
+      warnings: [
+        'codex adapter cannot safely project workspace stop hooks: Codex has no alternate project hook-file flag for the temporary runtime, session hooks need trust for the changing dispatcher path, and notify hooks cannot request continuation. No workspace hooks were attached.',
+      ],
+    };
   }
+
+  const dispatcherPath = writeSnapshot(snapshot, input.rootDirectory);
+  return input.harness === 'claude'
+    ? projectClaude(snapshot, input, dispatcherPath, launch)
+    : projectPi(input, dispatcherPath, launch);
 };

--- a/code/cli/src/hooks/HookProjection.ts
+++ b/code/cli/src/hooks/HookProjection.ts
@@ -1,0 +1,239 @@
+// Materializes portable hook snapshots and translates the stop event through native harness
+// mechanisms. Hook packages run as argv, without a shell, from the active workspace.
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import type { CompositionPlan } from '../composer/Composition.js';
+import type { AgentLaunchPlan, ProjectionInput } from '../projection/Projection.js';
+import type { WorkspaceHooksSnapshot } from './WorkspaceHook.js';
+
+export interface WorkspaceHookProjection {
+  readonly launch: AgentLaunchPlan;
+  readonly warnings: readonly string[];
+}
+
+const runtimeDirectoryName = '.outfitter/workspace-hooks';
+
+const dispatcherSource = (snapshot: WorkspaceHooksSnapshot, packageRoot: string): string => {
+  const hooks = snapshot.hooks.flatMap((hook) => {
+    const command = hook.events.stop;
+    return command === undefined
+      ? []
+      : [
+          {
+            slug: hook.slug,
+            name: hook.name,
+            command: join(packageRoot, hook.slug, ...command.command.split('/')),
+            args: command.args,
+            timeoutMilliseconds: command.timeoutSeconds * 1000,
+          },
+        ];
+  });
+  const configuration = JSON.stringify({ workspace: snapshot.workspaceDirectory, hooks });
+
+  return `#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+const configuration = ${configuration};
+const option = (name) => {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? undefined : process.argv[index + 1];
+};
+const harness = option('--harness');
+const event = option('--event');
+let nativeEvent = {};
+try {
+  const input = option('--native-event-json') ?? readFileSync(0, 'utf8');
+  nativeEvent = input.trim() === '' ? {} : JSON.parse(input);
+} catch (error) {
+  process.stderr.write('Warning: workspace hook dispatcher received invalid native event JSON: ' + String(error) + '\\n');
+}
+const continuationActive = nativeEvent.stop_hook_active === true || option('--continuation-active') === 'true';
+const continuationSupported = harness === 'claude' || harness === 'pi';
+const reasons = [];
+
+for (const hook of configuration.hooks) {
+  const payload = {
+    version: 1,
+    event,
+    harness,
+    workspace: configuration.workspace,
+    hook: { slug: hook.slug, name: hook.name },
+    continuation: { active: continuationActive, supported: continuationSupported },
+  };
+  const result = spawnSync(hook.command, hook.args, {
+    cwd: configuration.workspace,
+    input: JSON.stringify(payload) + '\\n',
+    encoding: 'utf8',
+    shell: false,
+    timeout: hook.timeoutMilliseconds,
+    maxBuffer: 1024 * 1024,
+  });
+  const output = [result.stdout, result.stderr].filter(Boolean).join('\\n').trim();
+  if (result.status === 2) {
+    if (harness === 'claude' && continuationActive) {
+      process.stderr.write("Warning: workspace hook '" + hook.slug + "' requested continuation while a Claude stop-hook continuation is active; stopping to prevent a loop.\\n");
+      if (output !== '') process.stderr.write(output + '\\n');
+    } else {
+      reasons.push("Workspace hook '" + hook.slug + "' requested continuation" + (output === '' ? '.' : ':\\n' + output));
+    }
+  } else if (result.status !== 0) {
+    const detail = result.error ? String(result.error) : result.signal ? 'signal ' + result.signal : 'exit ' + String(result.status);
+    process.stderr.write("Warning: workspace hook '" + hook.slug + "' failed (" + detail + "); continuing the session.\\n");
+    if (output !== '') process.stderr.write(output + '\\n');
+  }
+}
+
+if (reasons.length > 0) {
+  process.stderr.write(reasons.join('\\n\\n') + '\\n');
+  process.exit(2);
+}
+`;
+};
+
+const writeSnapshot = (snapshot: WorkspaceHooksSnapshot, rootDirectory: string): string => {
+  const runtimeRoot = join(rootDirectory, ...runtimeDirectoryName.split('/'));
+  const packageRoot = join(runtimeRoot, 'packages');
+  for (const hook of snapshot.hooks) {
+    for (const file of hook.files) {
+      const target = join(packageRoot, hook.slug, ...file.path.split('/'));
+      mkdirSync(dirname(target), { recursive: true });
+      writeFileSync(target, file.content, { mode: file.mode });
+      chmodSync(target, file.mode);
+    }
+  }
+  const dispatcherPath = join(runtimeRoot, 'dispatcher.mjs');
+  mkdirSync(dirname(dispatcherPath), { recursive: true });
+  writeFileSync(dispatcherPath, dispatcherSource(snapshot, packageRoot), { mode: 0o755 });
+  return dispatcherPath;
+};
+
+const stopTimeoutSeconds = (snapshot: WorkspaceHooksSnapshot): number =>
+  snapshot.hooks.reduce((sum, hook) => sum + (hook.events.stop?.timeoutSeconds ?? 0), 0) + 5;
+
+const claudeHookDocument = (command: string, timeout: number): Record<string, unknown> => ({
+  hooks: {
+    Stop: [{ hooks: [{ type: 'command', command, timeout }] }],
+  },
+});
+
+const objectValue = (value: unknown): Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+
+const arrayValue = (value: unknown): readonly unknown[] => (Array.isArray(value) ? (value as readonly unknown[]) : []);
+
+const mergeClaudeIsolatedSettings = (rootDirectory: string, portable: Record<string, unknown>): void => {
+  const settingsPath = join(rootDirectory, 'settings.json');
+  let settings: Record<string, unknown> = {};
+  try {
+    const parsed = JSON.parse(readFileSync(settingsPath, 'utf8')) as unknown;
+    if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed))
+      settings = parsed as Record<string, unknown>;
+  } catch {
+    // The projection owns this file. An absent file starts with an empty object.
+  }
+  const existingHooks = objectValue(settings.hooks);
+  const portableHooks = objectValue(portable.hooks);
+  const existingStop = arrayValue(existingHooks.Stop);
+  const portableStop = arrayValue(portableHooks.Stop);
+  writeFileSync(
+    settingsPath,
+    `${JSON.stringify(
+      {
+        ...settings,
+        hooks: { ...existingHooks, ...portableHooks, Stop: [...existingStop, ...portableStop] },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+};
+
+const projectClaude = (
+  snapshot: WorkspaceHooksSnapshot,
+  input: ProjectionInput,
+  dispatcherPath: string,
+  launch: AgentLaunchPlan,
+): WorkspaceHookProjection => {
+  const inherited = input.isolation !== 'isolated';
+  const target = inherited ? '$CLAUDE_PLUGIN_ROOT/.outfitter/workspace-hooks/dispatcher.mjs' : dispatcherPath;
+  const command = `node "${target.replaceAll('"', '\\"')}" --harness claude --event stop`;
+  const document = claudeHookDocument(command, stopTimeoutSeconds(snapshot));
+  if (inherited) {
+    const hooksPath = join(input.rootDirectory, 'hooks', 'hooks.json');
+    mkdirSync(dirname(hooksPath), { recursive: true });
+    writeFileSync(hooksPath, `${JSON.stringify(document, null, 2)}\n`);
+  } else {
+    mergeClaudeIsolatedSettings(input.rootDirectory, document);
+  }
+  return { launch, warnings: [] };
+};
+
+const piExtensionSource = (dispatcherPath: string): string => `
+const DISPATCHER = ${JSON.stringify(dispatcherPath)};
+let continuationActive = false;
+
+export default function outfitterWorkspaceHooks(pi) {
+  pi.on('agent_end', async () => {
+    const result = await pi.exec(process.execPath, [
+      DISPATCHER,
+      '--harness', 'pi',
+      '--event', 'stop',
+      '--continuation-active', String(continuationActive),
+      '--native-event-json', '{}',
+    ]);
+    if (result.stderr) process.stderr.write(result.stderr);
+    if (result.code !== 2) {
+      continuationActive = false;
+      if (result.code !== 0) {
+        process.stderr.write('Warning: workspace hook dispatcher failed; continuing the session.\\n');
+      }
+      return;
+    }
+    if (continuationActive) {
+      continuationActive = false;
+      process.stderr.write('Warning: a workspace stop hook requested continuation twice; stopping to prevent a loop.\\n');
+      return;
+    }
+    continuationActive = true;
+    const reason = (result.stderr || result.stdout || 'A workspace hook requested more work.').trim();
+    pi.sendUserMessage(reason, { deliverAs: 'followUp' });
+  });
+}
+`;
+
+const projectPi = (
+  input: ProjectionInput,
+  dispatcherPath: string,
+  launch: AgentLaunchPlan,
+): WorkspaceHookProjection => {
+  const extensionPath = join(input.rootDirectory, ...runtimeDirectoryName.split('/'), 'pi-extension.js');
+  writeFileSync(extensionPath, piExtensionSource(dispatcherPath));
+  return { launch: { ...launch, args: ['--extension', extensionPath, ...launch.args] }, warnings: [] };
+};
+
+/** Projects portable hooks without changing durable native harness configuration. */
+export const projectWorkspaceHooks = (
+  composition: CompositionPlan,
+  input: ProjectionInput,
+  launch: AgentLaunchPlan,
+): WorkspaceHookProjection => {
+  const snapshot = composition.workspaceHooks;
+  if (snapshot === undefined || snapshot.hooks.length === 0) return { launch, warnings: [] };
+  const dispatcherPath = writeSnapshot(snapshot, input.rootDirectory);
+
+  switch (input.harness) {
+    case 'claude':
+      return projectClaude(snapshot, input, dispatcherPath, launch);
+    case 'pi':
+      return projectPi(input, dispatcherPath, launch);
+    case 'codex':
+      return {
+        launch,
+        warnings: [
+          'codex adapter cannot safely project workspace stop hooks: Codex has no alternate project hook-file flag for the temporary runtime, session hooks need trust for the changing dispatcher path, and notify hooks cannot request continuation. No workspace hooks were attached.',
+        ],
+      };
+  }
+};

--- a/code/cli/src/hooks/WorkspaceHook.ts
+++ b/code/cli/src/hooks/WorkspaceHook.ts
@@ -1,0 +1,169 @@
+// Discovers and snapshots portable hooks from the active workspace only. A composition receives
+// file bytes instead of source paths, so later workspace edits cannot change an active launch.
+import { lstatSync, readFileSync, readdirSync } from 'node:fs';
+import { join, posix, relative, resolve, sep } from 'node:path';
+
+import { compareSlugs } from '../resolver/Resource.js';
+import { formatValidationIssues, validateSchema } from '../validation/SchemaValidator.js';
+import { parseYamlDocument } from '../validation/YamlDocument.js';
+
+export type WorkspaceHookEventName = 'stop';
+
+export interface WorkspaceHookCommand {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly timeoutSeconds: number;
+}
+
+export interface WorkspaceHookFile {
+  /** Portable, slash-separated path below the hook package root. */
+  readonly path: string;
+  readonly content: Uint8Array;
+  readonly mode: number;
+}
+
+export interface WorkspaceHookSnapshot {
+  readonly slug: string;
+  readonly name: string;
+  readonly description: string;
+  readonly events: Readonly<Partial<Record<WorkspaceHookEventName, WorkspaceHookCommand>>>;
+  readonly files: readonly WorkspaceHookFile[];
+}
+
+export interface WorkspaceHooksSnapshot {
+  readonly workspaceDirectory: string;
+  readonly hooks: readonly WorkspaceHookSnapshot[];
+}
+
+interface WorkspaceHookDocument {
+  readonly version: 1;
+  readonly name: string;
+  readonly description: string;
+  readonly events: Readonly<
+    Partial<
+      Record<
+        WorkspaceHookEventName,
+        { readonly command: string; readonly args: readonly string[]; readonly timeout_seconds: number }
+      >
+    >
+  >;
+}
+
+const slugPattern = /^[a-z0-9][a-z0-9-]*$/u;
+
+const assertDirectory = (path: string, label: string): void => {
+  const entry = lstatSync(path, { throwIfNoEntry: false });
+  if (entry?.isSymbolicLink()) throw new Error(`Invalid workspace hooks: ${label} '${path}' must not be a symlink.`);
+  if (entry?.isDirectory() !== true)
+    throw new Error(`Invalid workspace hooks: ${label} '${path}' must be a directory.`);
+};
+
+const snapshotDirectory = (root: string, directory: string, files: WorkspaceHookFile[]): void => {
+  const entries = readdirSync(directory, { withFileTypes: true }).sort((left, right) =>
+    compareSlugs(left.name, right.name),
+  );
+
+  for (const entry of entries) {
+    const path = join(directory, entry.name);
+    const stat = lstatSync(path);
+    const portablePath = relative(root, path).split(sep).join('/');
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Invalid workspace hook package '${root}': '${portablePath}' must not be a symlink.`);
+    }
+    if (stat.isDirectory()) {
+      snapshotDirectory(root, path, files);
+    } else if (stat.isFile()) {
+      files.push({ path: portablePath, content: readFileSync(path), mode: stat.mode & 0o777 });
+    } else {
+      throw new Error(`Invalid workspace hook package '${root}': '${portablePath}' must be a regular file.`);
+    }
+  }
+};
+
+const readDocument = (manifestPath: string): WorkspaceHookDocument => {
+  const parsed = parseYamlDocument(readFileSync(manifestPath, 'utf8'), manifestPath);
+  if (!parsed.ok) throw new Error(`Invalid workspace hook '${manifestPath}': ${parsed.issue.message}`);
+  const validation = validateSchema('workspace-hook', parsed.document);
+  if (!validation.valid) {
+    throw new Error(`Invalid workspace hook: ${formatValidationIssues(manifestPath, validation.issues)}`);
+  }
+  return parsed.document as WorkspaceHookDocument;
+};
+
+/** Maps a `./`-relative manifest command onto its portable package-relative path. */
+const resolveCommandPath = (command: string): string => {
+  const portable = posix.normalize(command.slice(2));
+  if (portable === '.' || portable === '..' || portable.startsWith('../') || posix.isAbsolute(portable)) {
+    throw new Error(`Invalid workspace hook command '${command}': command must stay inside the hook package.`);
+  }
+  return portable;
+};
+
+const readEvents = (
+  slug: string,
+  document: WorkspaceHookDocument,
+  files: readonly WorkspaceHookFile[],
+): Readonly<Partial<Record<WorkspaceHookEventName, WorkspaceHookCommand>>> => {
+  const events: Partial<Record<WorkspaceHookEventName, WorkspaceHookCommand>> = {};
+  for (const [eventName, command] of Object.entries(document.events) as [
+    WorkspaceHookEventName,
+    NonNullable<WorkspaceHookDocument['events']['stop']>,
+  ][]) {
+    const portable = resolveCommandPath(command.command);
+    const commandFile = files.find((file) => file.path === portable);
+    if (commandFile === undefined) {
+      throw new Error(`Invalid workspace hook '${slug}': command '${command.command}' must name a regular file.`);
+    }
+    if ((commandFile.mode & 0o111) === 0) {
+      throw new Error(`Invalid workspace hook '${slug}': command '${command.command}' must be executable.`);
+    }
+    events[eventName] = {
+      command: portable,
+      args: [...command.args],
+      timeoutSeconds: command.timeout_seconds,
+    };
+  }
+  return events;
+};
+
+const readHook = (hookDirectory: string, slug: string): WorkspaceHookSnapshot => {
+  assertDirectory(hookDirectory, `hook '${slug}'`);
+  const manifestPath = join(hookDirectory, 'hook.yml');
+  const manifestStat = lstatSync(manifestPath, { throwIfNoEntry: false });
+  if (manifestStat?.isSymbolicLink()) {
+    throw new Error(`Invalid workspace hook '${slug}': '${manifestPath}' must not be a symlink.`);
+  }
+  if (manifestStat?.isFile() !== true) {
+    throw new Error(`Invalid workspace hook '${slug}': '${manifestPath}' must be a regular file.`);
+  }
+
+  const document = readDocument(manifestPath);
+  if (document.name !== slug) {
+    throw new Error(`Invalid workspace hook '${slug}': manifest name '${document.name}' must match its directory.`);
+  }
+
+  const files: WorkspaceHookFile[] = [];
+  snapshotDirectory(hookDirectory, hookDirectory, files);
+  const events = readEvents(slug, document, files);
+
+  return { slug, name: document.name, description: document.description, events, files };
+};
+
+/** Reads only `<workspace>/.agents/hooks/<slug>/hook.yml`, in deterministic slug order. */
+export const readWorkspaceHooks = (workspaceDirectory: string): WorkspaceHooksSnapshot => {
+  const hooksDirectory = join(workspaceDirectory, '.agents', 'hooks');
+  const rootStat = lstatSync(hooksDirectory, { throwIfNoEntry: false });
+  if (rootStat === undefined) return { workspaceDirectory: resolve(workspaceDirectory), hooks: [] };
+  assertDirectory(hooksDirectory, 'directory');
+
+  const hooks = readdirSync(hooksDirectory, { withFileTypes: true })
+    .sort((left, right) => compareSlugs(left.name, right.name))
+    .map((entry) => {
+      if (!slugPattern.test(entry.name)) {
+        throw new Error(`Invalid workspace hook slug '${entry.name}'. Use lowercase letters, digits, and hyphens.`);
+      }
+      return readHook(join(hooksDirectory, entry.name), entry.name);
+    });
+
+  return { workspaceDirectory: resolve(workspaceDirectory), hooks };
+};

--- a/code/cli/src/projection/ProjectHarness.ts
+++ b/code/cli/src/projection/ProjectHarness.ts
@@ -3,6 +3,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { PI_SESSION_DIRECTORY_ENV } from '../agents/PiSessionDirectory.js';
 import type { CompositionPlan } from '../composer/Composition.js';
+import { projectWorkspaceHooks } from '../hooks/HookProjection.js';
 import type { Harness, Isolation } from '../settings/Settings.js';
 import { projectCodexMcpServers } from './CodexMcp.js';
 import type { MaterializedComposition } from './Materialize.js';
@@ -242,25 +243,39 @@ export const projectComposition = (composition: CompositionPlan, input: Projecti
 
   if (input.harness === 'codex') {
     const codexMcp = projectCodexMcpServers(composition.loadout.mcp, composition.loadout.mcpServers);
-    const launch = buildCodexLaunchPlan(input, codexMcp.args, projectedModel);
+    const hookProjection = projectWorkspaceHooks(
+      composition,
+      input,
+      buildCodexLaunchPlan(input, codexMcp.args, projectedModel),
+    );
     const warnings = [
       ...(input.appendPromptPaths?.length
         ? ['codex adapter does not project supplied append-prompt documents; they will be dropped.']
         : []),
       ...codexMcp.warnings,
       ...projectedModel.warnings,
+      ...hookProjection.warnings,
     ];
-    return { rootDirectory: input.rootDirectory, launch, unsupported, warnings };
+    return { rootDirectory: input.rootDirectory, launch: hookProjection.launch, unsupported, warnings };
   }
 
   // Caller documents follow the composition's own, so a persona is read against the agent it adopts.
-  const launch = buildPiOrClaudeLaunchPlan(
+  const hookProjection = projectWorkspaceHooks(
     composition,
     input,
-    materialized,
-    [...materialized.appendPromptPaths, ...(input.appendPromptPaths ?? [])],
-    projectedModel,
+    buildPiOrClaudeLaunchPlan(
+      composition,
+      input,
+      materialized,
+      [...materialized.appendPromptPaths, ...(input.appendPromptPaths ?? [])],
+      projectedModel,
+    ),
   );
 
-  return { rootDirectory: input.rootDirectory, launch, unsupported, warnings: projectedModel.warnings };
+  return {
+    rootDirectory: input.rootDirectory,
+    launch: hookProjection.launch,
+    unsupported,
+    warnings: [...projectedModel.warnings, ...hookProjection.warnings],
+  };
 };

--- a/code/cli/src/schemas/workspace-hook.schema.json
+++ b/code/cli/src/schemas/workspace-hook.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://outfitter.dev/schemas/workspace-hook.schema.json",
+  "title": "Outfitter workspace hook",
+  "type": "object",
+  "required": ["version", "name", "description", "events"],
+  "properties": {
+    "version": { "const": 1 },
+    "name": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+    "description": { "type": "string", "minLength": 1 },
+    "events": {
+      "type": "object",
+      "minProperties": 1,
+      "properties": {
+        "stop": { "$ref": "#/$defs/command" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "command": {
+      "type": "object",
+      "required": ["command", "args", "timeout_seconds"],
+      "properties": {
+        "command": { "type": "string", "pattern": "^\\./[^\\u0000]+$" },
+        "args": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "timeout_seconds": { "type": "integer", "minimum": 1, "maximum": 600 }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/code/cli/src/system/SystemExtensionHook.ts
+++ b/code/cli/src/system/SystemExtensionHook.ts
@@ -18,7 +18,7 @@ import { isAbsolute, join } from 'node:path';
 
 import type { AgentLaunchPlan } from '../projection/Projection.js';
 import type { Harness } from '../settings/Settings.js';
-import { validateSchema } from '../validation/SchemaValidator.js';
+import { formatValidationIssues, validateSchema } from '../validation/SchemaValidator.js';
 import { parseYamlDocument } from '../validation/YamlDocument.js';
 
 const linuxSystemDirectory = '/etc/outfitter/system.d';
@@ -88,11 +88,6 @@ export const resolveSystemExtensionHookSource = (
       return undefined;
   }
 };
-
-const formatValidationIssues = (
-  filePath: string,
-  issues: readonly { readonly path: string; readonly message: string }[],
-): string => issues.map((issue) => `${filePath}#${issue.path} ${issue.message}`).join('; ');
 
 const resolvePhysicalPath = (path: string, errorMessage: string): string => {
   try {

--- a/code/cli/src/validation/SchemaValidator.ts
+++ b/code/cli/src/validation/SchemaValidator.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs';
 import type { AnySchema, ErrorObject, ValidateFunction } from 'ajv';
 import { Ajv2020 } from 'ajv/dist/2020.js';
 
-export type SchemaName = 'settings' | 'agent' | 'system-extension-hook';
+export type SchemaName = 'settings' | 'agent' | 'system-extension-hook' | 'workspace-hook';
 
 export interface ValidationIssue {
   readonly path: string;
@@ -22,6 +22,7 @@ const readSchema = (schemaFileName: string): unknown =>
 const settingsSchema = readSchema('settings.schema.json');
 const agentSchema = readSchema('agent.schema.json');
 const systemExtensionHookSchema = readSchema('system-extension-hook.schema.json');
+const workspaceHookSchema = readSchema('workspace-hook.schema.json');
 
 const ajv = new Ajv2020({ allErrors: true });
 
@@ -29,12 +30,17 @@ const validators: Record<SchemaName, ValidateFunction> = {
   settings: ajv.compile(settingsSchema as AnySchema),
   agent: ajv.compile(agentSchema as AnySchema),
   'system-extension-hook': ajv.compile(systemExtensionHookSchema as AnySchema),
+  'workspace-hook': ajv.compile(workspaceHookSchema as AnySchema),
 };
 
 export const createValidationResult = (issues: readonly ValidationIssue[]): ValidationResult => ({
   valid: issues.length === 0,
   issues,
 });
+
+/** Renders schema issues as one `<file>#<path> <message>` list for a read-boundary error. */
+export const formatValidationIssues = (filePath: string, issues: readonly ValidationIssue[]): string =>
+  issues.map((issue) => `${filePath}#${issue.path} ${issue.message}`).join('; ');
 
 export const validateSchema = (schemaName: SchemaName, document: unknown): ValidationResult => {
   const validate = validators[schemaName];

--- a/code/cli/tests/unit/workspace-hooks.test.ts
+++ b/code/cli/tests/unit/workspace-hooks.test.ts
@@ -11,6 +11,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { spawnSync } from 'node:child_process';
 
 import { afterEach, describe, expect, it } from 'vitest';
@@ -374,6 +375,65 @@ describe('workspace hook projection and dispatch', () => {
     expect(extension).toContain("pi.on('agent_end'");
     expect(extension).toContain("pi.sendUserMessage(reason, { deliverAs: 'followUp' })");
     expect(extension).toContain('requested continuation twice');
+  });
+
+  it('delivers Pi hook warnings through the channel the active run mode actually renders', async () => {
+    const project = root();
+    addHook(project, 'check');
+    const projectionRoot = root();
+    const projection = projectComposition(composition(readWorkspaceHooks(project)), {
+      harness: 'pi',
+      rootDirectory: projectionRoot,
+      homeDirectory: root(),
+    });
+    const module = (await import(pathToFileURL(projection.launch.args[1]).href)) as {
+      default: (api: unknown) => void;
+    };
+
+    // pi loads the extension in-process. A TUI owns the terminal and renders notify() while a raw
+    // stderr write lands inside the frame; a headless run has the opposite pair, because its
+    // fallback notify() is a no-op. The OFTR-012.6.2 loop warning must survive either way, so
+    // drive the same two-turn refusal through both run modes.
+    const refuseSecondContinuation = async (
+      hasUI: boolean,
+    ): Promise<{ readonly notified: string; readonly written: string; readonly followUps: number }> => {
+      const notified: string[] = [];
+      const written: string[] = [];
+      let followUps = 0;
+      let handler: ((event: unknown, ctx: unknown) => Promise<void>) | undefined;
+      module.default({
+        on: (_event: string, registered: (event: unknown, ctx: unknown) => Promise<void>) => {
+          handler = registered;
+        },
+        exec: () => Promise.resolve({ stdout: '', stderr: '', code: 2, killed: false }),
+        sendUserMessage: () => {
+          followUps += 1;
+        },
+      });
+      const ctx = { hasUI, ui: { notify: (message: string) => notified.push(message) } };
+
+      const originalWrite = process.stderr.write.bind(process.stderr);
+      process.stderr.write = (chunk: string) => {
+        written.push(String(chunk));
+        return true;
+      };
+      try {
+        await handler!({}, ctx);
+        await handler!({}, ctx);
+      } finally {
+        process.stderr.write = originalWrite;
+      }
+      return { notified: notified.join(' '), written: written.join(' '), followUps };
+    };
+
+    const rendered = await refuseSecondContinuation(true);
+    expect(rendered.followUps).toBe(1);
+    expect(rendered.notified).toContain('requested continuation twice');
+    expect(rendered.written).not.toContain('requested continuation twice');
+
+    const headless = await refuseSecondContinuation(false);
+    expect(headless.followUps).toBe(1);
+    expect(headless.written).toContain('requested continuation twice');
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-012.9).

--- a/code/cli/tests/unit/workspace-hooks.test.ts
+++ b/code/cli/tests/unit/workspace-hooks.test.ts
@@ -1,0 +1,434 @@
+// Tests workspace-only portable hook discovery, immutable snapshots, dispatch, and adapters.
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { CompositionPlan } from '../../src/composer/Composition.js';
+import { compose } from '../../src/composer/Composer.js';
+import { readWorkspaceHooks } from '../../src/hooks/WorkspaceHook.js';
+import { projectComposition } from '../../src/projection/ProjectHarness.js';
+import { discoverLayers } from '../../src/resolver/Layer.js';
+import { resolveResources } from '../../src/resolver/Resolver.js';
+import { validateSchema } from '../../src/validation/SchemaValidator.js';
+
+const roots: string[] = [];
+const root = (): string => {
+  const directory = mkdtempSync(join(tmpdir(), 'outfitter-workspace-hooks-'));
+  roots.push(directory);
+  return directory;
+};
+
+afterEach(() => {
+  for (const directory of roots.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+const write = (path: string, content: string, mode?: number): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+  if (mode !== undefined) chmodSync(path, mode);
+};
+
+const hookManifest = (name: string, command = './scripts/check.mjs', args: readonly string[] = []): string =>
+  [
+    'version: 1',
+    `name: ${name}`,
+    `description: ${name} checks the workspace.`,
+    'events:',
+    '  stop:',
+    `    command: ${command}`,
+    `    args: ${JSON.stringify(args)}`,
+    '    timeout_seconds: 30',
+    '',
+  ].join('\n');
+
+const addHook = (project: string, slug: string, script = '#!/usr/bin/env node\nprocess.exit(0);\n'): string => {
+  const directory = join(project, '.agents', 'hooks', slug);
+  write(join(directory, 'hook.yml'), hookManifest(slug));
+  write(join(directory, 'scripts', 'check.mjs'), script, 0o755);
+  return directory;
+};
+
+const composition = (snapshot: ReturnType<typeof readWorkspaceHooks>): CompositionPlan => ({
+  agent: 'engineer',
+  identity: { agentBody: 'Engineer.' },
+  loadout: {
+    skills: [],
+    delegateSkills: [],
+    subagents: [],
+    mcp: [],
+    mcpServers: {},
+    extensions: [],
+    plugins: [],
+  },
+  workspaceHooks: snapshot,
+  warnings: [],
+});
+
+describe('workspace hook schema and discovery', () => {
+  // THIS TEST VALIDATES HARD REQUIREMENTS (OFTR-012.1 AND OFTR-012.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('discovers only root workspace hooks in slug order and snapshots package bytes', () => {
+    const project = root();
+    addHook(project, 'z-last');
+    const first = addHook(project, 'a-first');
+    write(join(project, '.agents', 'agents', 'engineer', 'hooks', 'ignored', 'hook.yml'), hookManifest('ignored'));
+    write(join(project, '.agents', 'hooks', 'a-first', 'data', 'message.txt'), 'before');
+
+    const snapshot = readWorkspaceHooks(project);
+    write(join(first, 'data', 'message.txt'), 'after');
+
+    expect(snapshot.workspaceDirectory).toBe(project);
+    expect(snapshot.hooks.map((hook) => hook.slug)).toEqual(['a-first', 'z-last']);
+    expect(snapshot.hooks[0]?.files.map((file) => file.path)).toEqual([
+      'data/message.txt',
+      'hook.yml',
+      'scripts/check.mjs',
+    ]);
+    expect(Buffer.from(snapshot.hooks[0].files[0].content).toString()).toBe('before');
+  });
+
+  it('treats an absent workspace hook directory as empty', () => {
+    const project = root();
+    expect(readWorkspaceHooks(project)).toEqual({ workspaceDirectory: project, hooks: [] });
+  });
+
+  it('validates the v1 manifest schema', () => {
+    expect(
+      validateSchema('workspace-hook', {
+        version: 1,
+        name: 'check',
+        description: 'Checks.',
+        events: { stop: { command: './check', args: [], timeout_seconds: 1 } },
+      }).valid,
+    ).toBe(true);
+    expect(validateSchema('workspace-hook', { version: 2 }).valid).toBe(false);
+  });
+
+  // THIS TEST VALIDATES HARD REQUIREMENTS (OFTR-012.2 AND OFTR-012.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('rejects symlinks, invalid paths, missing commands, and non-executable commands', () => {
+    const linkedRoot = root();
+    const physical = join(linkedRoot, 'physical');
+    mkdirSync(physical);
+    mkdirSync(join(linkedRoot, '.agents'));
+    symlinkSync(physical, join(linkedRoot, '.agents', 'hooks'));
+    expect(() => readWorkspaceHooks(linkedRoot)).toThrow(/must not be a symlink/u);
+
+    const linkedPackage = root();
+    const packageDirectory = addHook(linkedPackage, 'linked-file');
+    write(join(packageDirectory, 'real'), 'x');
+    symlinkSync(join(packageDirectory, 'real'), join(packageDirectory, 'link'));
+    expect(() => readWorkspaceHooks(linkedPackage)).toThrow(/must not be a symlink/u);
+
+    const escaping = root();
+    const escapingDirectory = addHook(escaping, 'escaping');
+    write(join(escapingDirectory, 'hook.yml'), hookManifest('escaping', './../outside'));
+    expect(() => readWorkspaceHooks(escaping)).toThrow(/must stay inside/u);
+
+    const missing = root();
+    const missingDirectory = addHook(missing, 'missing');
+    write(join(missingDirectory, 'hook.yml'), hookManifest('missing', './scripts/absent'));
+    expect(() => readWorkspaceHooks(missing)).toThrow(/must name a regular file/u);
+
+    const notExecutable = root();
+    addHook(notExecutable, 'not-executable');
+    chmodSync(join(notExecutable, '.agents', 'hooks', 'not-executable', 'scripts', 'check.mjs'), 0o644);
+    expect(() => readWorkspaceHooks(notExecutable)).toThrow(/must be executable/u);
+  });
+
+  it('rejects malformed manifests, name mismatches, and invalid root entries', () => {
+    const malformed = root();
+    const malformedDirectory = addHook(malformed, 'malformed');
+    write(join(malformedDirectory, 'hook.yml'), 'version: [unterminated\n');
+    expect(() => readWorkspaceHooks(malformed)).toThrow(/Invalid workspace hook/u);
+
+    const schemaInvalid = root();
+    const invalidDirectory = addHook(schemaInvalid, 'invalid');
+    write(join(invalidDirectory, 'hook.yml'), 'version: 1\nname: invalid\ndescription: x\nevents:\n  stop: {}\n');
+    expect(() => readWorkspaceHooks(schemaInvalid)).toThrow(/required property/u);
+
+    const mismatch = root();
+    const mismatchDirectory = addHook(mismatch, 'directory-name');
+    write(join(mismatchDirectory, 'hook.yml'), hookManifest('other-name'));
+    expect(() => readWorkspaceHooks(mismatch)).toThrow(/must match its directory/u);
+
+    const badSlug = root();
+    write(join(badSlug, '.agents', 'hooks', 'BAD', 'hook.yml'), hookManifest('bad'));
+    expect(() => readWorkspaceHooks(badSlug)).toThrow(/Invalid workspace hook slug/u);
+
+    const fileEntry = root();
+    write(join(fileEntry, '.agents', 'hooks', 'not-a-package'), 'x');
+    expect(() => readWorkspaceHooks(fileEntry)).toThrow(/must be a directory/u);
+
+    const fileRoot = root();
+    write(join(fileRoot, '.agents', 'hooks'), 'x');
+    expect(() => readWorkspaceHooks(fileRoot)).toThrow(/must be a directory/u);
+
+    const linkedManifest = root();
+    const linkedManifestDirectory = addHook(linkedManifest, 'linked-manifest');
+    const physicalManifest = join(linkedManifestDirectory, 'physical.yml');
+    write(physicalManifest, hookManifest('linked-manifest'));
+    rmSync(join(linkedManifestDirectory, 'hook.yml'));
+    symlinkSync(physicalManifest, join(linkedManifestDirectory, 'hook.yml'));
+    expect(() => readWorkspaceHooks(linkedManifest)).toThrow(/must not be a symlink/u);
+
+    const missingManifest = root();
+    const missingManifestDirectory = addHook(missingManifest, 'missing-manifest');
+    rmSync(join(missingManifestDirectory, 'hook.yml'));
+    expect(() => readWorkspaceHooks(missingManifest)).toThrow(/must be a regular file/u);
+  });
+
+  it('returns hook validation failures as composition errors', () => {
+    const project = root();
+    write(join(project, '.agents', 'agents', 'engineer', 'agent.md'), '---\nname: engineer\n---\n\nBody.\n');
+    write(join(project, '.agents', 'hooks', 'bad', 'hook.yml'), 'bad: true\n');
+    const layers = discoverLayers({ homeDirectory: join(project, 'home'), projectDirectory: project, settings: {} });
+    const result = compose(resolveResources(layers.layers), 'engineer', { projectDirectory: project });
+    expect(result.plan).toBeUndefined();
+    expect(result.errors.join(' ')).toContain('Invalid workspace hook');
+  });
+});
+
+describe('workspace hook projection and dispatch', () => {
+  // THIS TEST VALIDATES HARD REQUIREMENTS (OFTR-012.4, OFTR-012.5, AND OFTR-012.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('runs snapshot commands as argv with normalized stdin and returns continuation reasons', () => {
+    const project = root();
+    addHook(
+      project,
+      'capture',
+      [
+        '#!/usr/bin/env node',
+        "import { readFileSync } from 'node:fs';",
+        "const payload = JSON.parse(readFileSync(0, 'utf8'));",
+        'process.stdout.write(JSON.stringify(payload));',
+        'process.exit(2);',
+        '',
+      ].join('\n'),
+    );
+    const projectionRoot = root();
+    projectComposition(composition(readWorkspaceHooks(project)), {
+      harness: 'claude',
+      rootDirectory: projectionRoot,
+      homeDirectory: root(),
+    });
+    const dispatcher = join(projectionRoot, '.outfitter', 'workspace-hooks', 'dispatcher.mjs');
+    const result = spawnSync(process.execPath, [dispatcher, '--harness', 'claude', '--event', 'stop'], {
+      input: JSON.stringify({ stop_hook_active: false }),
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("Workspace hook 'capture' requested continuation");
+    expect(result.stderr).toContain(`"workspace":"${project}"`);
+    expect(result.stderr).toContain('"continuation":{"active":false,"supported":true}');
+    expect(result.stderr).toContain('"hook":{"slug":"capture","name":"capture"}');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-012.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('fails open when a Claude hook requests a second continuation', () => {
+    const project = root();
+    addHook(
+      project,
+      'capture',
+      [
+        '#!/usr/bin/env node',
+        "import { readFileSync } from 'node:fs';",
+        "process.stdout.write(readFileSync(0, 'utf8'));",
+        'process.exit(2);',
+        '',
+      ].join('\n'),
+    );
+    const projectionRoot = root();
+    projectComposition(composition(readWorkspaceHooks(project)), {
+      harness: 'claude',
+      rootDirectory: projectionRoot,
+      homeDirectory: root(),
+    });
+    const dispatcher = join(projectionRoot, '.outfitter', 'workspace-hooks', 'dispatcher.mjs');
+    const result = spawnSync(process.execPath, [dispatcher, '--harness', 'claude', '--event', 'stop'], {
+      input: JSON.stringify({ stop_hook_active: true }),
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain('stopping to prevent a loop');
+    expect(result.stderr).toContain('"continuation":{"active":true,"supported":true}');
+    expect(result.stderr).not.toContain("Workspace hook 'capture' requested continuation:");
+  });
+
+  it('warns and fails open for ordinary failure and timeout', () => {
+    const project = root();
+    addHook(project, 'failed', '#!/usr/bin/env node\nprocess.stderr.write("bad\\n"); process.exit(1);\n');
+    const snapshot = readWorkspaceHooks(project);
+    const timedSnapshot = {
+      ...snapshot,
+      hooks: snapshot.hooks.map((hook) => ({
+        ...hook,
+        events: { stop: { ...hook.events.stop!, timeoutSeconds: 0.001 } },
+      })),
+    };
+    const projectionRoot = root();
+    projectComposition(composition(timedSnapshot), {
+      harness: 'pi',
+      rootDirectory: projectionRoot,
+      homeDirectory: root(),
+    });
+    const dispatcher = join(projectionRoot, '.outfitter', 'workspace-hooks', 'dispatcher.mjs');
+    const result = spawnSync(
+      process.execPath,
+      [dispatcher, '--harness', 'pi', '--event', 'stop', '--native-event-json', '{}'],
+      { encoding: 'utf8' },
+    );
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("Warning: workspace hook 'failed' failed");
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-012.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('projects Claude hooks into only the temporary inherited plugin or isolated settings', () => {
+    const project = root();
+    addHook(project, 'check');
+    const snapshot = readWorkspaceHooks(project);
+    const inheritedRoot = root();
+    const inherited = projectComposition(composition(snapshot), {
+      harness: 'claude',
+      rootDirectory: inheritedRoot,
+      homeDirectory: root(),
+    });
+    const inheritedHooks = JSON.parse(readFileSync(join(inheritedRoot, 'hooks', 'hooks.json'), 'utf8')) as {
+      hooks: { Stop: { hooks: { command: string }[] }[] };
+    };
+    expect(inheritedHooks.hooks.Stop[0].hooks[0].command).toContain('$CLAUDE_PLUGIN_ROOT');
+    expect(inherited.launch.args).toEqual(expect.arrayContaining(['--plugin-dir', inheritedRoot]));
+
+    const isolatedRoot = root();
+    write(
+      join(isolatedRoot, 'settings.json'),
+      JSON.stringify({
+        preserved: true,
+        hooks: {
+          SessionStart: [{ hooks: [{ type: 'command', command: 'existing-start' }] }],
+          Stop: [{ hooks: [{ type: 'command', command: 'existing-stop' }] }],
+        },
+      }),
+    );
+    const isolated = projectComposition(composition(snapshot), {
+      harness: 'claude',
+      rootDirectory: isolatedRoot,
+      homeDirectory: root(),
+      isolation: 'isolated',
+    });
+    const isolatedSettings = JSON.parse(readFileSync(join(isolatedRoot, 'settings.json'), 'utf8')) as Record<
+      string,
+      unknown
+    >;
+    expect(isolatedSettings.preserved).toBe(true);
+    expect(isolatedSettings.hooks).toMatchObject({
+      SessionStart: [{ hooks: [{ command: 'existing-start' }] }],
+      Stop: [{ hooks: [{ command: 'existing-stop' }] }, { hooks: [{ type: 'command' }] }],
+    });
+    expect(isolated.launch.env.CLAUDE_CONFIG_DIR).toBe(isolatedRoot);
+
+    const invalidSettingsRoot = root();
+    write(join(invalidSettingsRoot, 'settings.json'), '{not json');
+    projectComposition(composition(snapshot), {
+      harness: 'claude',
+      rootDirectory: invalidSettingsRoot,
+      homeDirectory: root(),
+      isolation: 'isolated',
+    });
+    const repairedSettings = JSON.parse(readFileSync(join(invalidSettingsRoot, 'settings.json'), 'utf8')) as {
+      hooks?: { Stop?: unknown };
+    };
+    expect(Array.isArray(repairedSettings.hooks?.Stop)).toBe(true);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-012.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('projects a Pi extension that carries continuation state and prevents a second continuation', () => {
+    const project = root();
+    addHook(project, 'check');
+    const projectionRoot = root();
+    const projection = projectComposition(composition(readWorkspaceHooks(project)), {
+      harness: 'pi',
+      rootDirectory: projectionRoot,
+      homeDirectory: root(),
+    });
+    const extensionPath = projection.launch.args[1];
+    const extension = readFileSync(extensionPath, 'utf8');
+    expect(projection.launch.args.slice(0, 2)).toEqual(['--extension', extensionPath]);
+    expect(extension).toContain("pi.on('agent_end'");
+    expect(extension).toContain("pi.sendUserMessage(reason, { deliverAs: 'followUp' })");
+    expect(extension).toContain('requested continuation twice');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-012.9).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('leaves Codex configuration unchanged and reports the verified compatibility limit', () => {
+    const project = root();
+    addHook(project, 'check');
+    const projection = projectComposition(composition(readWorkspaceHooks(project)), {
+      harness: 'codex',
+      rootDirectory: root(),
+      homeDirectory: root(),
+      passThroughArgs: ['exec', 'work'],
+    });
+    expect(projection.launch.args).toEqual(['exec', 'work']);
+    expect(projection.warnings.join(' ')).toContain('cannot safely project workspace stop hooks');
+    expect(projection.warnings.join(' ')).toContain('notify hooks cannot request continuation');
+  });
+
+  it('does nothing when a composition has no workspace hooks', () => {
+    const noSnapshot = { ...composition({ workspaceDirectory: root(), hooks: [] }), workspaceHooks: undefined };
+    const emptySnapshot = composition({ workspaceDirectory: root(), hooks: [] });
+    for (const plan of [noSnapshot, emptySnapshot]) {
+      const projectionRoot = root();
+      const projection = projectComposition(plan, {
+        harness: 'pi',
+        rootDirectory: projectionRoot,
+        homeDirectory: root(),
+      });
+      expect(projection.warnings).toEqual([]);
+      expect(existsSync(join(projectionRoot, '.outfitter', 'workspace-hooks'))).toBe(false);
+    }
+  });
+
+  it('keeps the dispatcher generic when a future snapshot has no stop handler', () => {
+    const workspaceDirectory = root();
+    const plan = composition({
+      workspaceDirectory,
+      hooks: [
+        {
+          slug: 'future-event',
+          name: 'future-event',
+          description: 'A future event.',
+          events: {},
+          files: [],
+        },
+      ],
+    });
+    const projectionRoot = root();
+    projectComposition(plan, {
+      harness: 'claude',
+      rootDirectory: projectionRoot,
+      homeDirectory: root(),
+    });
+    const dispatcher = readFileSync(join(projectionRoot, '.outfitter', 'workspace-hooks', 'dispatcher.mjs'), 'utf8');
+    expect(dispatcher).toContain(`"workspace":"${workspaceDirectory}"`);
+    expect(dispatcher).toContain('"hooks":[]');
+  });
+});

--- a/code/doc_site/next-env.d.ts
+++ b/code/doc_site/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts';
+import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/docs/architecture/controllable-elements.md
+++ b/docs/architecture/controllable-elements.md
@@ -136,10 +136,13 @@ Reusable multi-step procedures selected by an agent's loadout.
 ### Hooks
 
 Deterministic code at fixed session points.
-No protocol resource exists yet; see [Hooks](../documentation/hooks.md) for the roadmap TODO on an Outfitter hooks extension.
+Outfitter discovers the workspace-only v1 entity at `.agents/hooks/<slug>/hook.yml`.
+Composition snapshots each package before projection.
+The v1 surface supports the `stop` event.
 
-- Pi name: bootstrap extension via `--extension` / `-e`; per-event hooks are extension territory
-- Claude name: `hooks` in the generated `settings.json`
+- Pi name: generated `agent_end` extension via `--extension` / `-e`
+- Claude name: `Stop` in temporary plugin hooks or isolated `settings.json`
+- Codex name: compatibility warning; no safe additive continuation projection is available
 
 ### Tool Availability
 

--- a/docs/architecture/file_structure.md
+++ b/docs/architecture/file_structure.md
@@ -48,6 +48,7 @@ Outfitter is organized around a private npm workspace root, clear TypeScript pac
 │   │   │   ├── sources/               # cache paths, atomic Git checkout, redaction, private-catalog gating, and transitive catalog-source expansion
 │   │   │   ├── resolver/              # .agents layer resolution into one effective resource set
 │   │   │   ├── composer/              # harness-neutral CompositionPlan from the effective set
+│   │   │   ├── hooks/                 # workspace-only portable hook discovery, snapshots, and projection
 │   │   │   ├── projection/            # materialize a composition + build pi/claude/codex launch plans
 │   │   │   │   └── CodexMcp.ts        # translate selected MCP definitions to Codex TOML CLI overrides
 │   │   │   ├── dump/                  # deterministic self-contained `.agents` tree output
@@ -58,7 +59,7 @@ Outfitter is organized around a private npm workspace root, clear TypeScript pac
 │   │   │   │   └── PiCredentialPersistence.ts     # durable Pi credential/provider seed and copy-back
 │   │   │   ├── paths/                 # Outfitter cache root and repository/packaged asset resolution
 │   │   │   ├── system/                 # root-owned launcher-scope system extension hook loading
-│   │   │   ├── schemas/                # JSON Schema artifacts for persisted settings, agents, and system hooks
+│   │   │   ├── schemas/                # JSON Schema artifacts for settings, agents, and hook manifests
 │   │   │   └── validation/            # shared validation helpers
 │   │   ├── tests/                     # automated CLI package tests and fixtures
 │   │   ├── tsconfig.json              # strict package typecheck configuration

--- a/docs/documentation/agents.md
+++ b/docs/documentation/agents.md
@@ -15,7 +15,7 @@ See [Profiles](./profiles.md).
       config.json   # optional
       skills/       # capabilities private to engineer
         release-debug/SKILL.md
-      hooks/        # reserved for a future portable hook entity
+      hooks/        # reserved agent-local namespace
     code-reviewer/
       agent.md
 ```
@@ -178,7 +178,7 @@ Those runtime-owned resources therefore cannot be replaced accidentally by a pro
 `agents/<agent>/mcp.json` merges by server id over layered tree-root `mcp.json` files.
 The Pi projection writes only the servers selected by the active agent's `mcp` loadout into the runtime `mcp.json`.
 
-The per-agent `agents/<agent>/hooks/` namespace remains reserved and is not yet projected (adapter parity is tracked in [#183](https://github.com/ai-outfitter/outfitter/issues/183)).
+The per-agent `agents/<agent>/hooks/` namespace remains reserved and is not projected. Portable v1 hooks live at the workspace root under `.agents/hooks/<hook>/hook.yml`. See [Hooks](./hooks.md).
 Its presence surfaces a validation warning so content placed there is never silently dropped.
 
 ## config.json

--- a/docs/documentation/concepts.md
+++ b/docs/documentation/concepts.md
@@ -27,7 +27,8 @@ Outfitter stores and exchanges all agent configuration in the vendor-neutral [Do
   agents/<id>/agent.md # agent definitions (+ optional config.json)
   agents/<id>/skills/  # skills private to one agent (also knowledge/, commands/)
   agents/<id>/mcp.json # per-agent MCP config (discovered; projection deferred, #183)
-  agents/<id>/hooks/   # reserved namespace (not yet resolved)
+  hooks/<id>/hook.yml  # workspace-only portable hooks
+  agents/<id>/hooks/   # reserved agent-local namespace
   skills/<id>/...      # Agent Skills packages
   tasks/<id>/task.md   # named execution contracts
   knowledge/...        # reference documents

--- a/docs/documentation/hooks.md
+++ b/docs/documentation/hooks.md
@@ -1,19 +1,69 @@
 # Hooks
 
-Hooks let deterministic code run at fixed points in an agent session — before tool calls, after edits, at session start — independent of what the model decides. The `.agents` protocol does not yet define a hooks resource, so hook wiring is harness-specific today. This page documents what works per adapter and where this is heading.
+Hooks run deterministic code at fixed points in an agent session. The model does not decide when a hook runs.
 
-## Claude Code
+## Portable workspace hooks
 
-Claude Code hooks live in its native `settings.json` (`hooks` key), matching tool events to shell commands. Outfitter projects hook configuration into the composite `settings.json` it generates for a Claude launch, so a composition can ship hooks the same way it ships skills:
+Outfitter v1 discovers hooks only from the active workspace:
 
-- Keep hook scripts in a skill's `scripts/` directory or under `commands/`, so they travel with the tree and pass through the same [trust review](./catalogs.md#trust-and-review) as other executable content.
-- Machine-specific hook wiring stays in your local layer and is projected as harness-native config (the Claude `settings.json` Outfitter composes for that launch), not in a `settings.yml` key — the protocol schema defines no hooks field. Keep it out of shared catalogs.
+```text
+.agents/
+└── hooks/
+    └── catalog-authoring/
+        ├── hook.yml
+        └── scripts/
+            └── remind.py
+```
 
-See the [Claude Code hooks documentation](https://code.claude.com/docs/en/hooks) for event types and matcher syntax.
+Outfitter does not discover portable hooks from `~/.agents`, configured sources, or `agents/<agent>/hooks/`. It reads hooks in slug order. It validates each manifest. It then captures all regular package files in the composition. A file change after composition does not change the active launch.
 
-## Pi
+```yaml
+version: 1
+name: catalog-authoring
+description: Remind the agent to update catalog metadata.
+events:
+  stop:
+    command: ./scripts/remind.py
+    args: []
+    timeout_seconds: 30
+```
 
-Pi supports a bootstrap hook via its extension mechanism: an extension passed with `--extension` runs at session start and can register tools, providers, and runtime behavior. Outfitter's own onboarding flow uses this channel. For recurring per-event behavior, Pi extensions are the native surface.
+V1 supports the `stop` event. The manifest name must match the directory slug. A command must start with `./`. It must name an executable regular file inside its package. The package must not contain symlinks. Outfitter runs the command with its argument array. It does not use a shell. The command working directory is the active workspace.
+
+Each command receives one normalized JSON object on stdin:
+
+```json
+{
+  "version": 1,
+  "event": "stop",
+  "harness": "claude",
+  "workspace": "/workspace/project",
+  "hook": {
+    "slug": "catalog-authoring",
+    "name": "catalog-authoring"
+  },
+  "continuation": {
+    "active": false,
+    "supported": true
+  }
+}
+```
+
+The command must use these exit codes:
+
+- Exit 0 allows the session to stop.
+- Exit 2 requests one more agent turn. Outfitter uses command output as the reason.
+- Any other exit, timeout, signal, or launch error produces a warning. Outfitter fails open.
+
+The `continuation.active` value tells the command that a prior stop hook caused the current turn. Claude supplies this state as `stop_hook_active`. Outfitter fails open if a Claude hook requests continuation again while this state is active. The Pi adapter keeps equivalent state and rejects a second consecutive continuation request. Both guards prevent loops.
+
+Outfitter projects the event as follows:
+
+- Claude inherited mode loads temporary plugin hooks. Claude isolated mode writes temporary settings. Outfitter does not change `~/.claude` settings.
+- Pi loads a temporary extension through `--extension`. The extension maps `agent_end` to `stop` and sends an exit-2 reason as a follow-up message.
+- Codex produces a compatibility warning and does not attach the hook. Codex 0.147 reads a project hook from the durable `.codex/hooks.json` path. Its CLI does not provide an alternate hook-file flag for Outfitter's temporary runtime. A session hook also needs review and trust for its exact command. The temporary dispatcher path changes on each run, so Outfitter cannot reuse that trust safely. The legacy `notify` command cannot request continuation and has one user-owned slot. Outfitter does not write `.codex/hooks.json`, replace `notify`, or bypass hook trust. `--strict` makes this warning fatal. See the [Codex hooks documentation](https://developers.openai.com/codex/hooks).
+
+Only `outfitter run` projects these hooks. A direct `claude`, `codex`, or `pi` launch does not run them.
 
 ## System extension hooks
 
@@ -48,6 +98,6 @@ The `--no-extensions` option does not disable explicitly passed `--extension` pa
 
 The normal Linux and macOS directories are root-owned. Outfitter deliberately fails closed on their operator errors: a malformed file should fail on a canary boot, while failing open could silently produce fleet sessions without collection. Those sessions must be treated as unattested rather than clean.
 
-## Roadmap
+## Agent-local hook roadmap
 
-> **TODO (protocol gap):** hooks are the one behavioral surface the pinned protocol revision does not model, which means hook definitions cannot yet be expressed portably in a `.agents` tree and projected per harness. The path `agents/<agent-id>/hooks/<hook-id>/` is reserved for a future agent-local hook entity and deliberately has no resolution or projection behavior today. Outfitter may need to ship its own hooks extension that adapters translate to Claude `settings.json` hooks and Pi extensions respectively, or drive the concept into a future protocol revision. Until one of those lands, treat hooks as harness-native configuration and keep them thin: call scripts that live in the tree rather than embedding logic in hook definitions.
+The path `agents/<agent-id>/hooks/<hook-id>/` remains reserved. Outfitter does not resolve or project it. V1 hooks apply to every Outfitter session that starts in the workspace.

--- a/docs/documentation/support-matrix.md
+++ b/docs/documentation/support-matrix.md
@@ -27,14 +27,14 @@ Tasks and bake are not in this matrix — they are the subject of a [separate up
 | Plugins (agent `plugins:` loadout)                                       | Supported | Roadmap     | Roadmap    |
 | Credentials and environment                                              | Supported | Supported   | Roadmap    |
 | DeepWork job selection                                                   | Supported | Roadmap     | Roadmap    |
-| Hooks                                                                    | Partial   | Partial     | Roadmap    |
+| Workspace hooks (`.agents/hooks/<id>`)                                   | Supported | Supported   | Roadmap³   |
 | Tool availability (agent `tools:` loadout)                               | Supported | Supported   | Roadmap    |
 | Theme / UI presentation                                                  | Roadmap   | Roadmap     | Roadmap    |
 | Working directory                                                        | Roadmap   | Roadmap     | Roadmap    |
 | Pass-through arguments                                                   | Supported | Supported   | Supported  |
 | Bootstrap hook                                                           | Supported | Roadmap     | Roadmap    |
 
-¹ Canonical `anthropic-messages` providers. ² Canonical `openai-responses` providers. Other dialects warn and fail under `--strict` rather than changing endpoints.
+¹ Canonical `anthropic-messages` providers. ² Canonical `openai-responses` providers. Other dialects warn and fail under `--strict` rather than changing endpoints. ³ Codex warns and does not attach the hook because its safe temporary continuation path is not verified.
 
 ## Codex CLI notes
 
@@ -45,6 +45,7 @@ Tasks and bake are not in this matrix — they are the subject of a [separate up
 - **MCP servers (Partial)** — selected stdio fields (`command`, `args`, `env`, `cwd`) and streamable HTTP fields (`url`, `headers`) become repeated TOML-valued `-c mcp_servers.<id>.<key>=...` overrides. Server ids must contain only letters, digits, `_`, or `-`; other ids cannot be expressed by Codex `-c` key paths and are skipped with a warning. Legacy SSE and other HTTP transport types are also skipped with a warning. User and project `config.toml` servers remain active because Codex has no strict MCP isolation mode, so every launch warns that projection is additive, even when no servers are selected.
 - **Stdio environment safety** — `${ENV_NAME}` becomes an `env_vars` reference only when the stdio `env` key is also `ENV_NAME`; a reference that would rename the variable is dropped with a warning. Literal values pass through `env` and are visible in process arguments.
 - **HTTP header safety** — `${ENV_NAME}` becomes an `env_http_headers` reference, while `Authorization: Bearer ${ENV_NAME}` becomes `bearer_token_env_var`. Other header values pass through `http_headers` and are visible in process arguments. Outfitter warns for every literal stdio environment or HTTP header entry exposed in argv, so use environment references for secrets.
+- **Workspace hooks (Roadmap)** — Codex 0.147 reads project hooks from durable `.codex/hooks.json`. It has no alternate hook-file flag for Outfitter's temporary runtime. Session hooks need trust for the exact command, and each launch creates a new dispatcher path. The legacy `notify` program cannot request continuation and has one user-owned slot. Outfitter leaves all three surfaces unchanged and warns. `--strict` makes this warning fatal.
 
 ## Claude Code notes
 
@@ -55,7 +56,7 @@ Tasks and bake are not in this matrix — they are the subject of a [separate up
 - **Subagents** — selected `agents/<id>` definitions are materialized into the composition's agents directory. An inherited run loads them under the plugin's name (`<profile>:<subagent>`); an isolated run finds them natively under `CLAUDE_CONFIG_DIR`.
 - **Skills (Partial)** — selected skills are materialized into the config directory's skills surface; remaining gaps are tracked per release. The bundled Outfitter skill ships through the plugin channel.
 - **Model selection** — an agent's `provider/model` selection resolves from layered `models.json`. Anthropic Messages providers map to native `--model`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, and custom-header controls. Unsupported dialects warn and omit the target instead of reusing its model ID against Claude's default endpoint. Thinking level maps to `--effort`.
-- **Hooks** — Outfitter does not project hook configuration for Claude, and there is no portable protocol hooks resource yet. An inherited run keeps the hooks in your own `~/.claude/settings.json`; an isolated run has none. See [Hooks](./hooks.md).
+- **Workspace hooks** — Outfitter adds workspace stop hooks to the temporary plugin for inherited runs and to temporary settings for isolated runs. User settings remain unchanged. See [Hooks](./hooks.md).
 - **Tool availability** — `tools.allow` (after `tools.deny` removes entries) maps to both `--tools` (_availability_: an unlisted builtin is not in the session) and `--allowedTools` (_permission_: the granted tools are pre-approved, so a headless session is not stopped by a prompt); `tools.deny` always maps to `--disallowedTools`, including when both are declared, and a bare denied name removes the tool from context per Claude's docs. An allowlist that `tools.deny` empties maps to `--tools ""`, Claude's documented "disable all tools" form. Caveat: per the CLI reference, `--tools` governs the built-in set only — MCP tools (`mcp__server__*`) are unaffected and are governed by which MCP servers the loadout selects, so `--tools ""` is not exactly pi's zero-tool session when MCP servers are present. Claude's behavior here comes from `claude --help` and the CLI reference, not local measurement.
 - **DeepWork jobs** — job selection is Pi-only today and warns on Claude.
 - **Bundled Outfitter skill** — every launch also publishes Outfitter's own self-documentation skill as a bundled plugin, so the agent can explain Outfitter and this launch's configuration.
@@ -64,7 +65,7 @@ Tasks and bake are not in this matrix — they are the subject of a [separate up
 
 - Pi projects the full resource set: agent identity, subagents (via the subagent extension), skills (`--skill`), commands, model configuration, MCP, extensions (`--extension`) and plugins as first-class loadout elements, environment, pass-through args, session directory, and DeepWork job selection.
 - Selected skills resolve across layers following [layer precedence](./concepts.md#layer-precedence); `references`, `scripts`, and `assets` frontmatter materialize into a generated skill passed via `--skill`. `outfitter validate` checks selections and references before launch.
-- **Hooks (Partial)** — bootstrap behavior uses an explicit Pi extension via `--extension`; recurring per-event hooks are extension territory. See [Hooks](./hooks.md).
+- **Workspace hooks** — a temporary extension maps `agent_end` to portable `stop` hooks. It can queue one follow-up when a hook exits 2. It rejects a second consecutive continuation request. See [Hooks](./hooks.md).
 - **Tool availability** — `tools.allow` (after `tools.deny` removes entries) maps to `--no-tools --tools a,b,c`, and `tools.deny` maps to `--exclude-tools a,b,c`. `--tools` is a hard allowlist across built-in, extension, and custom tools, so the session's tool set is exactly that list. An allowlist that `tools.deny` empties maps to `--no-tools` alone, a session with no tools at all. Note that `--no-builtin-tools` is deliberately not used: it keeps extension and custom tools enabled, so it does not express an empty tool set.
 - Every launch also passes Outfitter's own self-documentation skill through `--skill`.
 

--- a/docs/requirements/OFTR-012-workspace-hooks.md
+++ b/docs/requirements/OFTR-012-workspace-hooks.md
@@ -1,0 +1,66 @@
+# OFTR-012: Portable Workspace Hooks
+
+## OFTR-012.1: Scope and discovery
+
+1. Outfitter MUST discover portable hooks only at `<workspace>/.agents/hooks/<slug>/hook.yml`.
+2. Outfitter MUST NOT discover portable hooks from global layers, configured sources, or agent-local hook directories.
+3. Outfitter MUST order hooks by slug with locale-independent code-unit comparison.
+4. A direct native harness launch MUST NOT run an Outfitter portable hook.
+
+## OFTR-012.2: Manifest and snapshot
+
+1. Outfitter MUST validate each `hook.yml` against a bundled JSON Schema at the read boundary.
+2. A v1 manifest MUST contain `version`, `name`, `description`, and at least one supported event.
+3. A v1 event MUST contain `command`, `args`, and `timeout_seconds`.
+4. The manifest name MUST match its directory slug.
+5. Outfitter MUST reject a symlink or non-regular file in a portable hook package.
+6. Outfitter MUST capture each package file and mode in the composition before projection.
+7. A source change after composition MUST NOT change the captured package.
+
+## OFTR-012.3: Command safety
+
+1. A command MUST start with `./` and MUST resolve to a regular file inside its hook package.
+2. A command file MUST have at least one executable mode bit.
+3. Outfitter MUST run a command with its declared argument array.
+4. Outfitter MUST NOT run a portable command through a shell.
+5. Outfitter MUST run the command from the active workspace.
+
+## OFTR-012.4: Normalized event
+
+1. Outfitter MUST write one JSON object to each hook command on stdin.
+2. The object MUST contain `version`, `event`, `harness`, `workspace`, `hook`, and `continuation`.
+3. The `hook` object MUST contain the hook `slug` and `name`.
+4. The `continuation` object MUST contain `active` and `supported` booleans.
+
+## OFTR-012.5: Result policy
+
+1. Exit code 0 MUST allow the harness event.
+2. Exit code 2 MUST request continuation when the harness supports continuation.
+3. Outfitter MUST use command output as the continuation reason.
+4. A timeout, signal, launch error, or other exit code MUST warn and fail open.
+
+## OFTR-012.6: Continuation loops
+
+1. Outfitter MUST expose the native or projected continuation state as `continuation.active`.
+2. The Pi adapter MUST stop a second consecutive continuation request and MUST warn.
+3. The Claude adapter MUST fail open and MUST warn when a hook requests continuation while `stop_hook_active` is true.
+
+## OFTR-012.7: Claude projection
+
+1. An inherited Claude launch MUST load the dispatcher through the temporary Outfitter plugin.
+2. An isolated Claude launch MUST add the hook to temporary projected settings.
+3. Claude projection MUST NOT change durable Claude settings.
+
+## OFTR-012.8: Pi projection
+
+1. A Pi launch MUST load a temporary extension through an explicit `--extension` argument.
+2. The extension MUST map Pi `agent_end` to the portable `stop` event.
+3. The extension MUST queue the continuation reason as a follow-up user message.
+4. Pi projection MUST NOT change durable Pi settings.
+
+## OFTR-012.9: Codex compatibility
+
+1. Outfitter MUST NOT replace a user's Codex `notify` command.
+2. Outfitter MUST NOT persist or bypass Codex hook trust for a temporary hook.
+3. When a composition contains a stop hook, the Codex adapter MUST warn that it cannot safely project continuation.
+4. The normal `--strict` warning policy MUST make this compatibility warning fatal before launch.


### PR DESCRIPTION
Adds workspace-only portable stop hooks under .agents/hooks. Outfitter validates and snapshots hook packages, projects temporary Claude and Pi integrations, and warns for the current Codex compatibility limit. Direct harness launches remain unchanged.\n\nVerification:\n- npm run check-ci\n- 598 tests passed\n- 98.06% branch coverage\n- independent review approved