### PR TITLE
fix(pi-adapter): pass absolute materialized skill directories to --skill

### DIFF
--- a/code/cli/src/projection/ProjectHarness.ts
+++ b/code/cli/src/projection/ProjectHarness.ts
@@ -189,7 +189,7 @@ const buildPiOrClaudeLaunchPlan = (
 ): AgentLaunchPlan => {
   const isPi = input.harness === 'pi';
   const isolation = resolveProjectionIsolation(input);
-  const skillArgs = isPi ? composition.loadout.skills.flatMap((skill) => ['--skill', skill.slug]) : [];
+  const skillArgs = isPi ? materialized.skillDirectories.flatMap((dir) => ['--skill', dir]) : [];
   const extensionArgs = isPi ? (input.extensionLoadDirs ?? []).flatMap((dir) => ['--extension', dir]) : [];
 
   return {

--- a/code/cli/tests/unit/project-harness.test.ts
+++ b/code/cli/tests/unit/project-harness.test.ts
@@ -564,3 +564,32 @@ describe('projectComposition native configuration overlays', () => {
     expect(() => readFileSync(join(dir, 'keybindings.json'), 'utf8')).toThrow();
   });
 });
+
+describe('projectComposition Pi skills', () => {
+  it('passes absolute materialized skill directories to --skill instead of bare slugs', () => {
+    const dir = root();
+    const catalog = root();
+    const reviewSkill = join(catalog, 'skills', 'review', 'SKILL.md');
+    mkdirSync(join(catalog, 'skills', 'review'), { recursive: true });
+    writeFileSync(reviewSkill, '---\nname: review\n---\n\nReview skill.\n');
+
+    const plan: CompositionPlan = {
+      ...planWith([]),
+      loadout: {
+        ...planWith([]).loadout,
+        skills: [skillResource('review', reviewSkill, catalog)],
+      },
+    };
+
+    const projection = projectComposition(plan, {
+      harness: 'pi',
+      rootDirectory: dir,
+      homeDirectory: dir,
+    });
+
+    const expectedSkillDir = join(dir, 'skills', 'review');
+    expect(projection.launch.args).toContain('--skill');
+    expect(projection.launch.args).toContain(expectedSkillDir);
+    expect(projection.launch.args).not.toContain('review');
+  });
+});

--- a/code/cli/tests/unit/run-agent.test.ts
+++ b/code/cli/tests/unit/run-agent.test.ts
@@ -118,7 +118,7 @@ describe('run agent', () => {
         '--system-prompt',
         '--append-system-prompt',
         '--skill',
-        'wiki',
+        expect.stringContaining('/skills/wiki'),
         '--model',
         'gpt-5.2',
         '--thinking',


### PR DESCRIPTION
Fixes #338

### Summary of Changes

1. **Pass Materialized Skill Directories to Pi:** In `code/cli/src/projection/ProjectHarness.ts`, updated `buildPiOrClaudeLaunchPlan` to pass `materialized.skillDirectories` to Pi's `--skill` CLI flags instead of bare unrooted slugs (`skill.slug`).
2. **Eliminates False-Positive Warnings:** Pi's CLI parser resolves `--skill <path>` relative to CWD; passing the absolute path to the materialized skill directory prevents Pi from printing spurious `[Skill conflicts] <cwd>/<slug> skill path does not exist` warnings at startup.
3. **Unit Tests & Regression Coverage:** 
   - Added a unit test in `code/cli/tests/unit/project-harness.test.ts` asserting that Pi launch arguments contain the absolute materialized directory under `<rootDirectory>/skills/<slug>` rather than a bare slug.
   - Updated `code/cli/tests/unit/run-agent.test.ts` expectation.