### PR TITLE
feat(cache): repair sources before startup

### DIFF
--- a/code/cli/src/cli/OutfitterCli.ts
+++ b/code/cli/src/cli/OutfitterCli.ts
@@ -7,6 +7,7 @@ import { createDumpCommand } from './commands/DumpCommand.js';
 import { createListCommand } from './commands/ListCommand.js';
 import { createRunAgentCommand } from './commands/RunAgentCommand.js';
 import { createSetupCommand } from './commands/SetupCommand.js';
+import { createSourcesCommand } from './commands/SourcesCommand.js';
 import { createSyncCommand } from './commands/SyncCommand.js';
 import { createValidateCommand } from './commands/ValidateCommand.js';
 
@@ -14,6 +15,7 @@ export const createDefaultCommands = (): CommandObject[] => [
   createRunAgentCommand(),
   createSetupCommand(),
   createSyncCommand(),
+  createSourcesCommand(),
   createListCommand(),
   createValidateCommand(),
   createDumpCommand(),

--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -30,8 +30,10 @@ import type { AgentLaunchPlan } from '../../projection/Projection.js';
 import { strictAmbiguityFailureMessage } from '../../resolver/AmbiguityWarnings.js';
 import { findResource } from '../../resolver/Resource.js';
 import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
-import type { Harness, Isolation } from '../../settings/Settings.js';
-import { HARNESSES } from '../../settings/Settings.js';
+import type { Harness, Isolation, SourceCachePolicy } from '../../settings/Settings.js';
+import { HARNESSES, SOURCE_CACHE_POLICIES } from '../../settings/Settings.js';
+import { discoverSettingsLoadPlan, loadSettings } from '../../settings/SettingsLoader.js';
+import { prepareSourceCaches } from '../../sources/SourceCachePolicy.js';
 import { setupNextStepMessage } from '../../setup/Setup.js';
 import type { SetupResult } from '../../setup/Setup.js';
 import { attachSystemExtensionHooks } from '../../system/SystemExtensionHook.js';
@@ -63,6 +65,7 @@ export interface RunAgentInput {
   /** Launch from the projection alone, ignoring the machine's own harness configuration. */
   readonly isolated?: boolean;
   readonly strict?: boolean;
+  readonly sourceCachePolicy?: SourceCachePolicy;
   readonly logLevel?: RunLogLevel;
   readonly passThroughArgs?: readonly string[];
   /** `--append-prompt` documents appended to the system prompt after the agent's own, in order. */
@@ -80,6 +83,8 @@ export interface RunAgentInput {
   readonly extensionInstallSpawner?: PiInstallSpawner;
   /** Optional loading UI. The command wires a terminal spinner; tests can observe this boundary. */
   readonly startLoading?: LoadingStarter;
+  /** Test seam for startup cache establishment. */
+  readonly sourceCachePreparer?: typeof prepareSourceCaches;
 }
 
 export interface RunAgentResult {
@@ -151,6 +156,14 @@ const assertNoSettingsIssues = (issues: readonly { readonly message: string }[])
   if (issues.length > 0) {
     throw new Error(`Cannot run with invalid settings: ${issues.map((issue) => issue.message).join('; ')}`);
   }
+};
+
+const establishSourceCaches = (input: RunAgentInput, policy?: SourceCachePolicy): SourceCachePolicy => {
+  const localSettings = loadSettings(discoverSettingsLoadPlan(input));
+  assertNoSettingsIssues(localSettings.issues);
+  const selected = policy ?? input.sourceCachePolicy ?? localSettings.settings.sourceCache?.policy ?? 'repair';
+  (input.sourceCachePreparer ?? prepareSourceCaches)({ ...input, policy: selected });
+  return selected;
 };
 
 // Pi, and an isolated Claude, read credentials — and Claude its session history — from their
@@ -312,6 +325,7 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
     for (const message of messages) input.writeLine?.(message);
   };
 
+  const sourceCachePolicy = establishSourceCaches(input);
   let resolved = resolveEffectiveSet(input);
   assertNoSettingsIssues(resolved.settingsIssues);
   assertReadableAppendPrompts(input.appendPromptPaths);
@@ -329,6 +343,7 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
       return { exitCode: 0, messages };
     }
     // Keep the transition quiet so the real profile UI is the first persistent output.
+    establishSourceCaches(input, sourceCachePolicy);
     resolved = resolveEffectiveSet(input);
     assertNoSettingsIssues(resolved.settingsIssues);
   }
@@ -455,6 +470,11 @@ export const createRunAgentCommand = (dependencies: RunAgentDependencies = {}): 
           .env('OUTFITTER_LOG_LEVEL'),
       )
       .option('--strict', 'Treat ambiguity, composition warnings, and unsupported loadout elements as fatal.')
+      .addOption(
+        new Option('--source-cache-policy <policy>', 'Remote source cache startup policy.').choices([
+          ...SOURCE_CACHE_POLICIES,
+        ]),
+      )
       .option(
         '--isolated',
         'Launch from the composed profile alone, ignoring your own harness configuration (trust, permissions, MCP servers, plugins).',
@@ -476,6 +496,7 @@ export const createRunAgentCommand = (dependencies: RunAgentDependencies = {}): 
             isolated?: boolean;
             retainProjection?: boolean;
             strict?: boolean;
+            sourceCachePolicy?: SourceCachePolicy;
             appendPrompt?: readonly string[];
           },
         ) => {
@@ -502,6 +523,7 @@ export const createRunAgentCommand = (dependencies: RunAgentDependencies = {}): 
             isolated: options.isolated,
             retainProjection: options.retainProjection,
             strict: options.strict,
+            sourceCachePolicy: options.sourceCachePolicy,
             passThroughArgs: effectivePassThrough,
             appendPromptPaths: options.appendPrompt,
             launcher,

--- a/code/cli/src/cli/commands/SetupCommand.ts
+++ b/code/cli/src/cli/commands/SetupCommand.ts
@@ -20,7 +20,7 @@ import type { LoadingStarter } from '../TerminalLoading.js';
 import type { CommandObject } from './CommandObject.js';
 import { resolveHomeDirectory, resolveProjectDirectory } from './ProcessDefaults.js';
 import { executeRunAgentCommand } from './RunAgentCommand.js';
-import type { RunLogLevel } from './RunAgentCommand.js';
+import type { RunAgentInput, RunLogLevel } from './RunAgentCommand.js';
 
 export type SetupProcessLauncher = (plan: AgentLaunchPlan) => Promise<number>;
 
@@ -33,6 +33,7 @@ export interface SetupCommandDependencies {
   readonly launcher?: SetupProcessLauncher;
   /** Launcher for the profile pi started after setup; defaults to the real spawn boundary. */
   readonly runLauncher?: SetupProcessLauncher;
+  readonly sourceCachePreparer?: RunAgentInput['sourceCachePreparer'];
   readonly writeLine?: (message: string) => void;
   readonly startLoading?: LoadingStarter;
   readonly logLevel?: RunLogLevel;
@@ -249,6 +250,7 @@ const autoLaunchSelectedProfile = async (
     logLevel: dependencies.logLevel,
     launcher: dependencies.runLauncher ?? defaultRunLauncher,
     startLoading: dependencies.startLoading ?? startTerminalLoading,
+    sourceCachePreparer: dependencies.sourceCachePreparer,
   });
   for (const message of runResult.messages) writeLine(message);
   /* v8 ignore next -- surfaces a nonzero profile-launch exit to the shell; happy path returns 0. */

--- a/code/cli/src/cli/commands/SourcesCommand.ts
+++ b/code/cli/src/cli/commands/SourcesCommand.ts
@@ -1,0 +1,112 @@
+import { Command } from 'commander';
+
+import { loadSettingsWithCachedRemoteSettings } from '../../settings/SettingsLoader.js';
+import type { SourceReference } from '../../settings/Settings.js';
+import {
+  createRemoteRepositoryCachePath,
+  formatRemoteSourceDisplay,
+  isRemoteSource,
+} from '../../sources/SourceCache.js';
+import { inspectSourceCache } from '../../sources/SourceState.js';
+import { expandTransitiveSources } from '../../sources/TransitiveSources.js';
+import type { CommandObject } from './CommandObject.js';
+import { resolveHomeDirectory, resolveProjectDirectory } from './ProcessDefaults.js';
+
+export interface SourceReportEntry {
+  readonly precedence: number;
+  readonly origin: 'workspace' | 'global' | 'remote-settings' | 'source' | 'transitive';
+  readonly source: string;
+  readonly requestedRevision: string | null;
+  readonly resolvedRevision: string | null;
+  readonly cacheHealth: 'live' | ReturnType<typeof inspectSourceCache>['health'];
+}
+
+export const executeSourcesCommand = (input: {
+  readonly homeDirectory: string;
+  readonly projectDirectory: string;
+}): readonly SourceReportEntry[] => {
+  const loaded = loadSettingsWithCachedRemoteSettings(input);
+  const entries: SourceReportEntry[] = [
+    {
+      precedence: 0,
+      origin: 'workspace',
+      source: `${input.projectDirectory}/.agents`,
+      requestedRevision: null,
+      resolvedRevision: null,
+      cacheHealth: 'live',
+    },
+    {
+      precedence: 1,
+      origin: 'global',
+      source: `${input.homeDirectory}/.agents`,
+      requestedRevision: null,
+      resolvedRevision: null,
+      cacheHealth: 'live',
+    },
+  ];
+  const append = (source: SourceReference, origin: SourceReportEntry['origin']): void => {
+    if (!isRemoteSource(source)) {
+      entries.push({
+        precedence: entries.length,
+        origin,
+        source: source.path,
+        requestedRevision: null,
+        resolvedRevision: null,
+        cacheHealth: 'live',
+      });
+      return;
+    }
+    const cachePath = createRemoteRepositoryCachePath(input.homeDirectory, source, loaded.settings.cacheDirectory);
+    const state = inspectSourceCache({ ...input, cacheDirectory: loaded.settings.cacheDirectory, cachePath, source });
+    entries.push({
+      precedence: entries.length,
+      origin,
+      source: formatRemoteSourceDisplay(source),
+      requestedRevision: source.ref ?? null,
+      resolvedRevision: state.commit ?? null,
+      cacheHealth: state.health,
+    });
+  };
+  for (const remote of loaded.settings.remoteSettings!) append(remote, 'remote-settings');
+  const directSources = loaded.settings.sources!;
+  for (const source of directSources) append(source, 'source');
+  const transitive = expandTransitiveSources({
+    directSources,
+    resolveCachedCheckoutRoot: (source) =>
+      createRemoteRepositoryCachePath(input.homeDirectory, source, loaded.settings.cacheDirectory),
+  });
+  for (const source of transitive.sources) append(source.source, 'transitive');
+  return entries;
+};
+
+export const createSourcesCommand = (
+  dependencies: {
+    readonly homeDirectory?: string;
+    readonly projectDirectory?: string;
+    readonly writeLine?: (message: string) => void;
+  } = {},
+): CommandObject => ({
+  name: 'sources',
+  description: 'Report source precedence and cache health.',
+  register(program: Command): void {
+    program.addCommand(
+      new Command('sources')
+        .description('Report source precedence and cache health.')
+        .option('--json', 'Emit stable machine-readable JSON.')
+        .action((options: { json?: boolean }) => {
+          const entries = executeSourcesCommand({
+            homeDirectory: resolveHomeDirectory(dependencies.homeDirectory),
+            projectDirectory: resolveProjectDirectory(dependencies.projectDirectory),
+          });
+          /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
+          const write = dependencies.writeLine ?? console.log;
+          if (options.json === true) write(JSON.stringify(entries, null, 2));
+          else
+            for (const entry of entries)
+              write(
+                `${entry.precedence}\t${entry.origin}\t${entry.cacheHealth}\t${entry.source}\t${entry.resolvedRevision ?? '-'}`,
+              );
+        }),
+    );
+  },
+});

--- a/code/cli/src/cli/commands/SyncCommand.ts
+++ b/code/cli/src/cli/commands/SyncCommand.ts
@@ -35,6 +35,7 @@ import {
   resolveSourcePayloadRoot,
 } from '../../sources/SourceCache.js';
 import type { RemoteSourceReference } from '../../sources/SourceCache.js';
+import { writeSourceState } from '../../sources/SourceState.js';
 import { readDeclaredRemoteSources } from '../../sources/TransitiveSources.js';
 import type { CommandObject } from './CommandObject.js';
 import { resolveHomeDirectory, resolveProjectDirectory } from './ProcessDefaults.js';
@@ -154,6 +155,13 @@ const syncPhase = <T extends RemoteSourceReference>(input: SyncPhaseInput<T>): S
         cachePath,
         source,
         validate: (repositoryPath) => input.validate(repositoryPath, source),
+      });
+      writeSourceState({
+        homeDirectory: input.homeDirectory,
+        cacheDirectory: input.cacheDirectory,
+        cachePath,
+        source,
+        commit: result.commit,
       });
       return {
         source,

--- a/code/cli/src/schemas/settings.schema.json
+++ b/code/cli/src/schemas/settings.schema.json
@@ -11,6 +11,11 @@
       "description": "Whether a run stands on the machine's native harness configuration (inherit, the default) or on the projection alone (isolated). Honored only from home-scope settings."
     },
     "cache_directory": { "type": "string", "minLength": 1 },
+    "source_cache": {
+      "type": "object",
+      "properties": { "policy": { "enum": ["repair", "locked", "offline"] } },
+      "additionalProperties": false
+    },
     "state_persistence": {
       "type": "object",
       "description": "Maps adapter-declared state paths to a persistence strategy.",

--- a/code/cli/src/settings/Settings.ts
+++ b/code/cli/src/settings/Settings.ts
@@ -22,6 +22,8 @@ export type Isolation = (typeof ISOLATIONS)[number];
 /** Functional persistence strategies for adapter-declared state paths. */
 export type StatePersistenceStrategy = 'symlink' | 'discard' | 'warn' | 'error' | 'prompt';
 export type StatePersistence = Readonly<Record<string, StatePersistenceStrategy>>;
+export const SOURCE_CACHE_POLICIES = ['repair', 'locked', 'offline'] as const;
+export type SourceCachePolicy = (typeof SOURCE_CACHE_POLICIES)[number];
 
 /**
  * An ordered `.agents` payload source: a local path, a remote URI, or a `github` shorthand.
@@ -45,6 +47,10 @@ export interface TelemetrySettings {
   readonly enabled?: boolean;
 }
 
+export interface SourceCacheSettings {
+  readonly policy?: SourceCachePolicy;
+}
+
 export interface Settings {
   /** Agent slug that plain `outfitter` runs when no agent is selected. */
   readonly defaultAgent?: string;
@@ -59,6 +65,7 @@ export interface Settings {
   readonly sources?: readonly SourceReference[];
   readonly remoteSettings?: readonly RemoteSettingsReference[];
   readonly cacheDirectory?: string;
+  readonly sourceCache?: SourceCacheSettings;
   readonly statePersistence?: StatePersistence;
   readonly customSettings?: CustomSettings;
   readonly startup?: StartupSettings;

--- a/code/cli/src/settings/SettingsLoader.ts
+++ b/code/cli/src/settings/SettingsLoader.ts
@@ -12,6 +12,7 @@ import type {
   Isolation,
   RemoteSettingsReference,
   Settings,
+  SourceCachePolicy,
   SourceReference,
   StatePersistence,
 } from './Settings.js';
@@ -51,6 +52,7 @@ interface SettingsDocument {
   readonly sources?: readonly SourceDocument[];
   readonly remote_settings?: readonly RemoteSettingsDocument[];
   readonly cache_directory?: string;
+  readonly source_cache?: { readonly policy?: SourceCachePolicy };
   readonly state_persistence?: StatePersistence;
   readonly custom_settings?: CustomSettings;
   readonly startup?: StartupSettingsDocument;
@@ -285,6 +287,7 @@ const convertSettingsDocument = (
     document.cache_directory === undefined
       ? undefined
       : resolveConfigDirectory(document.cache_directory, settingsDirectory),
+  sourceCache: document.source_cache,
   statePersistence: document.state_persistence,
   customSettings: document.custom_settings,
   startup: convertStartupSettings(document.startup),

--- a/code/cli/src/settings/SettingsMerger.ts
+++ b/code/cli/src/settings/SettingsMerger.ts
@@ -11,6 +11,7 @@ export const mergeSettingsStack = (settingsStack: readonly Settings[]): Settings
   let sources: Settings['sources'];
   let remoteSettings: Settings['remoteSettings'];
   let cacheDirectory: string | undefined;
+  let sourceCache: Settings['sourceCache'];
   let statePersistence: StatePersistence | undefined;
   let customSettings: CustomSettings | undefined;
   let startup: Settings['startup'];
@@ -25,6 +26,7 @@ export const mergeSettingsStack = (settingsStack: readonly Settings[]): Settings
     sources = settings.sources ?? sources;
     remoteSettings = settings.remoteSettings ?? remoteSettings;
     cacheDirectory = settings.cacheDirectory ?? cacheDirectory;
+    sourceCache = settings.sourceCache === undefined ? sourceCache : { ...sourceCache, ...settings.sourceCache };
     statePersistence =
       settings.statePersistence === undefined
         ? statePersistence
@@ -43,6 +45,7 @@ export const mergeSettingsStack = (settingsStack: readonly Settings[]): Settings
     sources: sources ?? [],
     remoteSettings: remoteSettings ?? [],
     cacheDirectory,
+    sourceCache: sourceCache ?? {},
     statePersistence: statePersistence ?? {},
     customSettings: customSettings ?? {},
     startup: startup ?? {},

--- a/code/cli/src/setup/DefaultCatalog.ts
+++ b/code/cli/src/setup/DefaultCatalog.ts
@@ -13,6 +13,7 @@ import {
 } from '../sources/SourceCache.js';
 import type { RemoteSourceReference } from '../sources/SourceCache.js';
 import { readDeclaredRemoteSources } from '../sources/TransitiveSources.js';
+import { writeSourceState } from '../sources/SourceState.js';
 
 /** Fetches one repository into the cache. Injectable so tests exercise bootstrap hermetically. */
 export type RepositorySync = typeof syncRemoteRepositoryAtomically;
@@ -82,10 +83,19 @@ export const bootstrapPinnedCatalog = (input: PinnedCatalogBootstrapInput): Pinn
   assertImmutableRef(input.source.ref);
   const hasPayload = input.requirePayload ?? hasAgentsDirectory;
   const root = createRemoteRepositoryCachePath(input.homeDirectory, input.source, input.cacheDirectory);
-  if (isPinnedCatalogCheckout(root, input.source.ref, hasPayload)) return { root, source: input.source };
+  if (isPinnedCatalogCheckout(root, input.source.ref, hasPayload)) {
+    writeSourceState({
+      homeDirectory: input.homeDirectory,
+      cacheDirectory: input.cacheDirectory,
+      cachePath: root,
+      source: input.source,
+      commit: resolveExpectedCommit(root, input.source.ref),
+    });
+    return { root, source: input.source };
+  }
 
   try {
-    (input.syncRepository ?? syncRemoteRepositoryAtomically)({
+    const synced = (input.syncRepository ?? syncRemoteRepositoryAtomically)({
       cachePath: root,
       fetchRef: isVersionTagRef(input.source.ref)
         ? `refs/tags/${input.source.ref}:refs/tags/${input.source.ref}`
@@ -101,6 +111,13 @@ export const bootstrapPinnedCatalog = (input: PinnedCatalogBootstrapInput): Pinn
         }
         return 0;
       },
+    });
+    writeSourceState({
+      homeDirectory: input.homeDirectory,
+      cacheDirectory: input.cacheDirectory,
+      cachePath: root,
+      source: input.source,
+      commit: synced.commit,
     });
     return { root, source: input.source };
   } catch (error) {

--- a/code/cli/src/sources/SourceCachePolicy.ts
+++ b/code/cli/src/sources/SourceCachePolicy.ts
@@ -1,0 +1,71 @@
+import { mkdirSync, renameSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import { executeSyncCommand } from '../cli/commands/SyncCommand.js';
+import type { RepositorySync } from '../cli/commands/SyncCommand.js';
+import type { SourceCachePolicy } from '../settings/Settings.js';
+import { syncRemoteRepositoryAtomically } from './GitRepository.js';
+import { inspectSourceCache, unchangedResult, withSourceLock, writeSourceState } from './SourceState.js';
+
+const fullCommitPattern = /^[a-f0-9]{40}$/u;
+
+export interface PrepareSourceCachesInput {
+  readonly homeDirectory: string;
+  readonly projectDirectory: string;
+  readonly policy: SourceCachePolicy;
+}
+
+export interface PrepareSourceCachesResult {
+  readonly messages: readonly string[];
+}
+
+const quarantine = (cachePath: string): string => {
+  const destination = `${cachePath}.outfitter-quarantine-${new Date().toISOString().replace(/[:.]/gu, '-')}-${process.pid}`;
+  mkdirSync(dirname(destination), { recursive: true });
+  renameSync(cachePath, destination);
+  return destination;
+};
+
+const policyRepositorySync =
+  (input: PrepareSourceCachesInput): RepositorySync =>
+  (request) =>
+    withSourceLock(request.cachePath, () => {
+      if (input.policy === 'locked' && !fullCommitPattern.test(request.source.ref ?? '')) {
+        throw new Error('Locked source-cache policy requires a full 40-character commit pin.');
+      }
+      const state = inspectSourceCache({
+        homeDirectory: input.homeDirectory,
+        cachePath: request.cachePath,
+        source: request.source,
+      });
+
+      if (state.health === 'healthy' && state.commit !== undefined) return unchangedResult(state.commit);
+      if (input.policy === 'offline') {
+        throw new Error(`Source cache is ${state.health}; offline policy prohibits repair.`);
+      }
+
+      const quarantined = state.health === 'dirty' ? quarantine(request.cachePath) : undefined;
+      const result = syncRemoteRepositoryAtomically(request);
+      writeSourceState({
+        homeDirectory: input.homeDirectory,
+        source: request.source,
+        commit: result.commit,
+        cachePath: request.cachePath,
+      });
+      return {
+        ...result,
+        warnings: result.warnings + (quarantined === undefined ? 0 : 1),
+      };
+    });
+
+/** Establishes every declared remote before resolution; local layers are never passed to sync. */
+export const prepareSourceCaches = (input: PrepareSourceCachesInput): PrepareSourceCachesResult => {
+  const result = executeSyncCommand(
+    { homeDirectory: input.homeDirectory, projectDirectory: input.projectDirectory },
+    { syncRepository: policyRepositorySync(input) },
+  );
+  if (result.exitCode !== 0) {
+    throw new Error(`Source-cache ${input.policy} policy failed before composition: ${result.messages.join('; ')}`);
+  }
+  return { messages: result.messages };
+};

--- a/code/cli/src/sources/SourceState.ts
+++ b/code/cli/src/sources/SourceState.ts
@@ -1,0 +1,137 @@
+import { mkdirSync, openSync, closeSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import type { AtomicRepositorySyncResult } from './GitRepository.js';
+import { tryReadCleanHead } from './GitRepository.js';
+import {
+  encodeRemoteSource,
+  normalizeRemoteSourceUri,
+  redactSourceUriCredentials,
+  resolveRemoteRepositoryCacheRoot,
+} from './SourceCache.js';
+import type { RemoteSourceReference } from './SourceCache.js';
+
+export const SOURCE_STATE_VERSION = 1;
+
+export interface SourceStateManifest {
+  readonly version: 1;
+  readonly source: string;
+  readonly requestedRef: string | null;
+  readonly resolvedCommit: string;
+  readonly cacheKey: string;
+}
+
+export type SourceCacheHealth = 'healthy' | 'missing' | 'dirty' | 'legacy' | 'mismatched' | 'unverified';
+
+export const sourceStatePath = (
+  homeDirectory: string,
+  source: RemoteSourceReference,
+  cacheDirectory?: string,
+): string =>
+  join(
+    resolveRemoteRepositoryCacheRoot(homeDirectory, cacheDirectory),
+    'source-state',
+    `${encodeRemoteSource(source)}.json`,
+  );
+
+const sourceStatePathForCache = (cachePath: string, source: RemoteSourceReference): string =>
+  join(dirname(dirname(cachePath)), 'source-state', `${encodeRemoteSource(source)}.json`);
+
+const sourceIdentity = (source: RemoteSourceReference): string =>
+  redactSourceUriCredentials(normalizeRemoteSourceUri(source));
+
+export const readSourceState = (path: string): SourceStateManifest | undefined => {
+  try {
+    const value = JSON.parse(readFileSync(path, 'utf8')) as Partial<SourceStateManifest>;
+    if (
+      value.version !== SOURCE_STATE_VERSION ||
+      typeof value.source !== 'string' ||
+      !(typeof value.requestedRef === 'string' || value.requestedRef === null) ||
+      typeof value.resolvedCommit !== 'string' ||
+      typeof value.cacheKey !== 'string'
+    )
+      return undefined;
+    return value as SourceStateManifest;
+  } catch {
+    return undefined;
+  }
+};
+
+export const inspectSourceCache = (input: {
+  readonly homeDirectory: string;
+  readonly cacheDirectory?: string;
+  readonly cachePath: string;
+  readonly source: RemoteSourceReference;
+}): { readonly health: SourceCacheHealth; readonly commit?: string; readonly manifest?: SourceStateManifest } => {
+  const commit = tryReadCleanHead(input.cachePath);
+  if (commit === undefined) {
+    try {
+      readFileSync(join(input.cachePath, '.git', 'HEAD'));
+      return { health: 'dirty' };
+    } catch {
+      return { health: 'missing' };
+    }
+  }
+  const manifest = readSourceState(sourceStatePathForCache(input.cachePath, input.source));
+  if (manifest === undefined) return { health: 'legacy', commit };
+  if (
+    manifest.source !== sourceIdentity(input.source) ||
+    manifest.requestedRef !== (input.source.ref ?? null) ||
+    manifest.cacheKey !== encodeRemoteSource(input.source) ||
+    manifest.resolvedCommit !== commit
+  )
+    return { health: 'mismatched', commit, manifest };
+  return { health: 'healthy', commit, manifest };
+};
+
+export const writeSourceState = (input: {
+  readonly homeDirectory: string;
+  readonly cacheDirectory?: string;
+  readonly source: RemoteSourceReference;
+  readonly commit: string;
+  readonly cachePath?: string;
+}): void => {
+  const path =
+    input.cachePath === undefined
+      ? sourceStatePath(input.homeDirectory, input.source, input.cacheDirectory)
+      : sourceStatePathForCache(input.cachePath, input.source);
+  mkdirSync(dirname(path), { recursive: true });
+  const temporary = `${path}.${process.pid}.tmp`;
+  const manifest: SourceStateManifest = {
+    version: SOURCE_STATE_VERSION,
+    source: sourceIdentity(input.source),
+    requestedRef: input.source.ref ?? null,
+    resolvedCommit: input.commit,
+    cacheKey: encodeRemoteSource(input.source),
+  };
+  writeFileSync(temporary, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
+  renameSync(temporary, path);
+};
+
+export const withSourceLock = <T>(cachePath: string, action: () => T): T => {
+  const lock = `${cachePath}.outfitter.lock`;
+  mkdirSync(dirname(lock), { recursive: true });
+  const deadline = Date.now() + 300_000;
+  let descriptor: number | undefined;
+  while (descriptor === undefined) {
+    try {
+      descriptor = openSync(lock, 'wx', 0o600);
+    } catch (error) {
+      /* v8 ignore next -- non-EEXIST open failures and a five-minute lock timeout are OS boundaries. */
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST' || Date.now() >= deadline) throw error;
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 25);
+    }
+  }
+  try {
+    return action();
+  } finally {
+    closeSync(descriptor);
+    rmSync(lock, { force: true });
+  }
+};
+
+export const unchangedResult = (commit: string): AtomicRepositorySyncResult => ({
+  commit,
+  status: 'unchanged',
+  warnings: 0,
+});

--- a/code/cli/tests/unit/ambiguity-warnings.test.ts
+++ b/code/cli/tests/unit/ambiguity-warnings.test.ts
@@ -43,6 +43,7 @@ const run = (root: string, strict: boolean) =>
     agent: 'engineer',
     strict,
     launcher: () => Promise.resolve(0),
+    sourceCachePreparer: () => ({ messages: [] }),
   });
 
 afterEach(() => {

--- a/code/cli/tests/unit/run-agent-onboarding-warnings.test.ts
+++ b/code/cli/tests/unit/run-agent-onboarding-warnings.test.ts
@@ -55,6 +55,7 @@ describe('run agent onboarding warnings', () => {
       homeDirectory: home,
       projectDirectory: project,
       launcher: () => Promise.resolve(0),
+      sourceCachePreparer: () => ({ messages: [] }),
       setup,
       writeLine: (message) => lines.push(message),
     });
@@ -77,6 +78,7 @@ describe('run agent onboarding warnings', () => {
       homeDirectory: home,
       projectDirectory: project,
       launcher: () => Promise.resolve(0),
+      sourceCachePreparer: () => ({ messages: [] }),
     });
 
     expect(result.exitCode).toBe(1);
@@ -98,6 +100,7 @@ describe('run agent onboarding warnings', () => {
       projectDirectory: project,
       agent: 'typo',
       launcher: () => Promise.resolve(0),
+      sourceCachePreparer: () => ({ messages: [] }),
     });
 
     expect(result.messages[0]).toContain("Unknown agent 'typo'");
@@ -125,6 +128,7 @@ describe('run agent onboarding warnings', () => {
       homeDirectory: home,
       projectDirectory: project,
       launcher: () => Promise.resolve(0),
+      sourceCachePreparer: () => ({ messages: [] }),
     });
 
     expect(result.exitCode).toBe(1);

--- a/code/cli/tests/unit/setup.test.ts
+++ b/code/cli/tests/unit/setup.test.ts
@@ -708,6 +708,7 @@ describe('Pi setup launch', () => {
       },
       // A no-op run launcher keeps the post-setup profile launch from spawning real pi in the test.
       runLauncher: () => Promise.resolve(0),
+      sourceCachePreparer: () => ({ messages: [] }),
       writeLine: (message) => lines.push(message),
     }).register(program);
     await program.parseAsync(['node', 'outfitter', 'setup']);

--- a/code/cli/tests/unit/source-cache-policy.test.ts
+++ b/code/cli/tests/unit/source-cache-policy.test.ts
@@ -1,0 +1,244 @@
+import { spawn } from 'node:child_process';
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { runGit } from '../../src/sources/GitRepository.js';
+import { createRemoteRepositoryCachePath } from '../../src/sources/SourceCache.js';
+import { prepareSourceCaches } from '../../src/sources/SourceCachePolicy.js';
+import {
+  inspectSourceCache,
+  readSourceState,
+  sourceStatePath,
+  withSourceLock,
+  writeSourceState,
+} from '../../src/sources/SourceState.js';
+
+const roots: string[] = [];
+const temporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-source-policy-'));
+  roots.push(root);
+  return root;
+};
+const write = (path: string, value: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, value);
+};
+const repository = (root: string): { readonly uri: string; readonly commit: string } => {
+  const repo = join(root, 'origin');
+  mkdirSync(repo);
+  runGit(['init', '--quiet', repo]);
+  write(join(repo, 'agents', 'assistant', 'agent.md'), '---\nname: assistant\n---\n\nReady.\n');
+  runGit(['-C', repo, 'add', '.']);
+  runGit([
+    '-C',
+    repo,
+    '-c',
+    'user.name=Test',
+    '-c',
+    'user.email=test@example.test',
+    'commit',
+    '--quiet',
+    '-m',
+    'fixture',
+  ]);
+  return { uri: `file://${repo}`, commit: runGit(['-C', repo, 'rev-parse', 'HEAD']) };
+};
+const configure = (root: string, uri: string, ref?: string): { readonly home: string; readonly project: string } => {
+  const home = join(root, 'home');
+  const project = join(root, 'project');
+  write(
+    join(home, '.agents', 'settings.yml'),
+    `sources:\n  - uri: ${uri}${ref === undefined ? '' : `\n    ref: ${ref}`}\n`,
+  );
+  mkdirSync(project, { recursive: true });
+  return { home, project };
+};
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('source-cache startup policy', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.19–23).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('repairs cold and dirty caches, writes state, and reuses a warm cache offline', () => {
+    const root = temporaryRoot();
+    const origin = repository(root);
+    const locations = configure(root, origin.uri, origin.commit);
+    const source = { uri: origin.uri, ref: origin.commit } as const;
+
+    prepareSourceCaches({ homeDirectory: locations.home, projectDirectory: locations.project, policy: 'repair' });
+    const cachePath = createRemoteRepositoryCachePath(locations.home, source);
+    expect(inspectSourceCache({ homeDirectory: locations.home, cachePath, source })).toMatchObject({
+      health: 'healthy',
+      commit: origin.commit,
+    });
+    expect(readSourceState(sourceStatePath(locations.home, source))?.resolvedCommit).toBe(origin.commit);
+
+    renameSync(join(root, 'origin'), join(root, 'origin-offline'));
+    expect(() =>
+      prepareSourceCaches({ homeDirectory: locations.home, projectDirectory: locations.project, policy: 'repair' }),
+    ).not.toThrow();
+    renameSync(join(root, 'origin-offline'), join(root, 'origin'));
+
+    write(join(cachePath, 'dirty'), 'dirty');
+    prepareSourceCaches({ homeDirectory: locations.home, projectDirectory: locations.project, policy: 'repair' });
+    expect(readdirSync(dirname(cachePath)).some((name) => name.includes('.outfitter-quarantine-'))).toBe(true);
+    expect(existsSync(join(cachePath, 'dirty'))).toBe(false);
+  });
+
+  it('fails closed offline and locked, while accepting a healthy full pin', () => {
+    const root = temporaryRoot();
+    const origin = repository(root);
+    const mutable = configure(root, origin.uri, 'main');
+    expect(() =>
+      prepareSourceCaches({ homeDirectory: mutable.home, projectDirectory: mutable.project, policy: 'offline' }),
+    ).toThrow(/offline policy prohibits repair/);
+    expect(() =>
+      prepareSourceCaches({ homeDirectory: mutable.home, projectDirectory: mutable.project, policy: 'locked' }),
+    ).toThrow(/40-character commit pin/);
+
+    const pinned = configure(root, origin.uri, origin.commit);
+    prepareSourceCaches({ homeDirectory: pinned.home, projectDirectory: pinned.project, policy: 'locked' });
+    expect(() =>
+      prepareSourceCaches({ homeDirectory: pinned.home, projectDirectory: pinned.project, policy: 'offline' }),
+    ).not.toThrow();
+  });
+
+  it('serializes an action with a per-source lock', () => {
+    const root = temporaryRoot();
+    expect(withSourceLock(join(root, 'cache', 'entry'), () => 'done')).toBe('done');
+    expect(existsSync(join(root, 'cache', 'entry.outfitter.lock'))).toBe(false);
+  });
+
+  it('waits for a concurrent holder of the same source lock', async () => {
+    const root = temporaryRoot();
+    const cachePath = join(root, 'cache', 'entry');
+    const lock = `${cachePath}.outfitter.lock`;
+    mkdirSync(dirname(lock), { recursive: true });
+    const child = spawn(process.execPath, [
+      '-e',
+      `const fs=require('fs');const p=process.argv[1];const fd=fs.openSync(p,'wx');console.log('ready');setTimeout(()=>{fs.closeSync(fd);fs.unlinkSync(p)},100)`,
+      lock,
+    ]);
+    await new Promise<void>((resolve) => child.stdout.once('data', () => resolve()));
+    expect(withSourceLock(cachePath, () => 'after')).toBe('after');
+  });
+
+  it('repairs legacy, partial, wrong-head, and changed-pin caches without touching local sources', () => {
+    const root = temporaryRoot();
+    const origin = repository(root);
+    const locations = configure(root, origin.uri, origin.commit);
+    const first = { uri: origin.uri, ref: origin.commit } as const;
+    const firstCache = createRemoteRepositoryCachePath(locations.home, first);
+    runGit(['clone', '--quiet', origin.uri, firstCache]);
+    prepareSourceCaches({ homeDirectory: locations.home, projectDirectory: locations.project, policy: 'repair' });
+
+    write(join(firstCache, 'new-file'), 'wrong head');
+    runGit(['-C', firstCache, 'add', '.']);
+    runGit([
+      '-C',
+      firstCache,
+      '-c',
+      'user.name=Test',
+      '-c',
+      'user.email=test@example.test',
+      'commit',
+      '--quiet',
+      '-m',
+      'wrong',
+    ]);
+    prepareSourceCaches({ homeDirectory: locations.home, projectDirectory: locations.project, policy: 'repair' });
+    expect(runGit(['-C', firstCache, 'rev-parse', 'HEAD'])).toBe(origin.commit);
+
+    write(join(root, 'origin', 'skills', 'next', 'SKILL.md'), '---\nname: next\n---\n');
+    runGit(['-C', join(root, 'origin'), 'add', '.']);
+    runGit([
+      '-C',
+      join(root, 'origin'),
+      '-c',
+      'user.name=Test',
+      '-c',
+      'user.email=test@example.test',
+      'commit',
+      '--quiet',
+      '-m',
+      'next',
+    ]);
+    const secondCommit = runGit(['-C', join(root, 'origin'), 'rev-parse', 'HEAD']);
+    configure(root, origin.uri, secondCommit);
+    prepareSourceCaches({ homeDirectory: locations.home, projectDirectory: locations.project, policy: 'repair' });
+    expect(existsSync(firstCache)).toBe(true);
+    expect(existsSync(createRemoteRepositoryCachePath(locations.home, { uri: origin.uri, ref: secondCommit }))).toBe(
+      true,
+    );
+
+    const local = join(root, 'local-authority');
+    write(join(local, 'keep'), 'untouched');
+    write(join(locations.home, '.agents', 'settings.yml'), `sources:\n  - path: ${local}\n`);
+    prepareSourceCaches({ homeDirectory: locations.home, projectDirectory: locations.project, policy: 'repair' });
+    expect(String(readFileSync(join(local, 'keep')))).toBe('untouched');
+
+    const partial = { uri: origin.uri, ref: secondCommit } as const;
+    const partialCache = createRemoteRepositoryCachePath(locations.home, partial);
+    rmSync(partialCache, { recursive: true });
+    mkdirSync(join(partialCache, '.git'), { recursive: true });
+    expect(inspectSourceCache({ homeDirectory: locations.home, cachePath: partialCache, source: partial }).health).toBe(
+      'missing',
+    );
+    configure(root, origin.uri, secondCommit);
+    prepareSourceCaches({ homeDirectory: locations.home, projectDirectory: locations.project, policy: 'repair' });
+    expect(inspectSourceCache({ homeDirectory: locations.home, cachePath: partialCache, source: partial }).health).toBe(
+      'healthy',
+    );
+  });
+
+  it('rejects malformed and mismatched state manifests', () => {
+    const root = temporaryRoot();
+    const origin = repository(root);
+    const source = { uri: origin.uri } as const;
+    const cachePath = createRemoteRepositoryCachePath(join(root, 'home'), source);
+    mkdirSync(dirname(cachePath), { recursive: true });
+    runGit(['clone', '--quiet', origin.uri, cachePath]);
+    expect(inspectSourceCache({ homeDirectory: join(root, 'home'), cachePath, source }).health).toBe('legacy');
+
+    const statePath = sourceStatePath(join(root, 'home'), source);
+    for (const invalid of [
+      '{',
+      '{}',
+      '{"version":1}',
+      '{"version":1,"source":"x"}',
+      '{"version":1,"source":"x","requestedRef":4}',
+      '{"version":1,"source":"x","requestedRef":null,"resolvedCommit":4}',
+      '{"version":1,"source":"x","requestedRef":null,"resolvedCommit":"x","cacheKey":4}',
+    ]) {
+      write(statePath, invalid);
+      expect(readSourceState(statePath)).toBeUndefined();
+    }
+
+    writeSourceState({ homeDirectory: join(root, 'home'), source, commit: origin.commit });
+    const manifest = readSourceState(statePath)!;
+    for (const changed of [
+      { ...manifest, source: 'different' },
+      { ...manifest, requestedRef: 'different' },
+      { ...manifest, cacheKey: 'different' },
+      { ...manifest, resolvedCommit: '0'.repeat(40) },
+    ]) {
+      write(statePath, JSON.stringify(changed));
+      expect(inspectSourceCache({ homeDirectory: join(root, 'home'), cachePath, source }).health).toBe('mismatched');
+    }
+    expect(readSourceState(join(root, 'absent'))).toBeUndefined();
+  });
+});

--- a/code/cli/tests/unit/sources-command.test.ts
+++ b/code/cli/tests/unit/sources-command.test.ts
@@ -1,0 +1,54 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { Command } from 'commander';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createSourcesCommand, executeSourcesCommand } from '../../src/cli/commands/SourcesCommand.js';
+import { createRemoteRepositoryCachePath } from '../../src/sources/SourceCache.js';
+
+const roots: string[] = [];
+afterEach(() => roots.splice(0).forEach((root) => rmSync(root, { recursive: true, force: true })));
+
+describe('sources command', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.2.24).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('reports stable redacted precedence for live and uncached sources', () => {
+    const root = mkdtempSync(join(tmpdir(), 'outfitter-sources-'));
+    roots.push(root);
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    const settings = join(project, '.agents', 'settings.yml');
+    mkdirSync(dirname(settings), { recursive: true });
+    writeFileSync(
+      settings,
+      `remote_settings:\n  - uri: https://example.test/settings.git\n    path: settings.yml\nsources:\n  - path: ./local\n  - uri: https://user:secret@example.test/catalog.git\n`,
+    );
+    const remoteSource = { uri: 'https://user:secret@example.test/catalog.git' } as const;
+    const cachedSettings = join(createRemoteRepositoryCachePath(home, remoteSource), 'settings.yml');
+    mkdirSync(dirname(cachedSettings), { recursive: true });
+    writeFileSync(cachedSettings, 'sources:\n  - github: example/dependency\n    ref: v1.0.0\n');
+
+    const report = executeSourcesCommand({ homeDirectory: home, projectDirectory: project });
+    expect(report.map((entry) => entry.precedence)).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(JSON.stringify(report)).not.toContain('secret');
+    expect(report[2]).toMatchObject({ origin: 'remote-settings', cacheHealth: 'missing' });
+    expect(report[3]).toMatchObject({ origin: 'source', cacheHealth: 'live' });
+    expect(report[4]).toMatchObject({ origin: 'source', cacheHealth: 'missing', requestedRevision: null });
+    expect(report[5]).toMatchObject({ origin: 'transitive', requestedRevision: 'v1.0.0' });
+
+    const lines: string[] = [];
+    const program = new Command();
+    createSourcesCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      writeLine: (line) => lines.push(line),
+    }).register(program);
+    program.parse(['node', 'test', 'sources']);
+    expect(lines).toHaveLength(6);
+    lines.length = 0;
+    program.parse(['node', 'test', 'sources', '--json']);
+    expect(JSON.parse(lines[0])).toEqual(report);
+  });
+});

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -260,10 +260,10 @@ Outfitter launches `codex`, maps model selection to `-m`, and injects selected M
   A positional agent slug selects what to run (default from settings `default_agent`); `--harness <pi|claude|codex>` selects the harness (default from settings `default_harness`, then `pi`); unknown args pass through to the child CLI; `--strict` makes warnings fatal.
   Interactive clean-home launches start Pi-native onboarding; non-interactive clean-home launches require `outfitter setup` first.
 - **`outfitter setup [source]`**: launch the bundled, model-free Pi walkthrough with the original three setup modes (default catalog, create a profile, or another catalog), original profile/target wording, and optional direct-source path; append only the default CLI-agent choice (Pi/Outfitter preselected); then atomically apply the result through the CLI state machine.
-- **`outfitter sync`**: validate local settings; atomically fetch configured remote settings; reload the merged settings; then atomically fetch every resulting remote source into `<cache_directory>/repos/<encoded-uri-and-ref>/`.
-  Validate before swapping, preserve the last good checkout on failure, report per-source status, and redact embedded credentials from all output.
-  Required-source failures exit nonzero.
-  Network synchronization never runs implicitly during `outfitter run`.
+- **`outfitter sync`**: validate local settings; atomically fetch configured remote settings; reload the merged settings; then atomically fetch every resulting remote source into `<cache_directory>/repos/<encoded-uri-and-ref>/` and record its verified commit under `<cache_directory>/source-state/`.
+  Validate before swapping, preserve the last good checkout on failure, report per-source status, and redact embedded credentials from all output. Required-source failures exit nonzero.
+- **`outfitter run`**: enforce the selected source-cache policy before resolution. Healthy manifest-backed caches stay network-free; repair mode atomically rebuilds unhealthy remote caches, locked mode requires full commit pins, and offline mode fails closed without network access. Explicit local paths are never cache-managed.
+- **`outfitter sources`**: report local, direct, remote-settings, and transitive source precedence plus credential-redacted cache health and revisions.
 - **`outfitter list [kind]`**: report the effective resource set — slugs, winning sources, shadowed definitions — deterministically.
 - **`outfitter validate [--strict] [--json]`**: protocol layout, frontmatter and JSON schemas, unresolved loadout slugs, skill reference escapes/collisions, settings schema.
 - **`outfitter dump [--agent <id>] [--out]`**: write the deterministic tree, optionally restricted to one agent's transitive closure.

--- a/docs/architecture/file_structure.md
+++ b/docs/architecture/file_structure.md
@@ -46,6 +46,8 @@ Outfitter is organized around a private npm workspace root, clear TypeScript pac
 │   │   │   ├── telemetry/             # consent, pseudonymous state, allowlisted events, and PostHog boundary
 │   │   │   ├── setup/                 # onboarding state + pinned default-catalog bootstrap
 │   │   │   ├── sources/               # cache paths, atomic Git checkout, redaction, private-catalog gating, and transitive catalog-source expansion
+│   │   │   │   ├── SourceState.ts     # versioned cache manifests, health inspection, and per-source repair locks
+│   │   │   │   └── SourceCachePolicy.ts # repair, locked, and offline startup enforcement
 │   │   │   ├── resolver/              # .agents layer resolution into one effective resource set
 │   │   │   ├── composer/              # harness-neutral CompositionPlan from the effective set
 │   │   │   ├── projection/            # materialize a composition + build pi/claude/codex launch plans

--- a/docs/documentation/cli.md
+++ b/docs/documentation/cli.md
@@ -94,3 +94,11 @@ Write the composed resource tree as a self-contained `.agents/` directory for re
 | `--out <dir>`  | Destination directory (default `./.agents`).         |
 
 > **Tasks and `outfitter task bake`** — baking a task and its inputs into an immutable execution artifact — are the subject of a separate upcoming RFC and are not part of this command surface yet. See [Tasks](./tasks.md).
+
+`outfitter run` verifies these caches before composition. Use
+`--source-cache-policy <repair|locked|offline>` to override the configured startup policy.
+
+## `outfitter sources`
+
+Report local and remote source precedence, requested and resolved revisions, origins, and cache
+health. `outfitter sources --json` emits stable credential-redacted machine-readable output.

--- a/docs/documentation/settings.md
+++ b/docs/documentation/settings.md
@@ -41,6 +41,8 @@ remote_settings:
     ref: 9c47d1e2b8a05f36c4d7e90a12b3f8c5d6e71a04
 
 cache_directory: ./cache # optional; relative to this settings file
+source_cache:
+  policy: repair # repair (default), locked, or offline
 
 # Pseudonymous product analytics consent; defaults to true when absent.
 telemetry:
@@ -53,6 +55,9 @@ telemetry:
 - `remote_settings` — shared settings a repository distributes; cached locally and merged below your project and user settings, so anything you set locally wins.
 - `cache_directory` — the repository cache root used consistently by sync, remote settings, remote
   source resolution, and default-catalog setup. It defaults to `~/.agents/cache`; repositories live
+- `source_cache.policy` — verifies remote caches before `run`: `repair` reuses healthy caches and
+  atomically repairs unhealthy ones, `locked` also requires full commit pins, and `offline` never
+  accesses the network.
   below its `repos/` directory.
 - `telemetry.enabled` — the primary and sole persistent control for pseudonymous product analytics. Edit it directly to enable or disable telemetry. See [Telemetry](./telemetry.md) for consent precedence, automatic identifier cleanup, the event contract, and the current inert-build status.
 

--- a/docs/requirements/OFTR-004-sync-and-setup.md
+++ b/docs/requirements/OFTR-004-sync-and-setup.md
@@ -75,8 +75,24 @@ Outfitter provides setup and maintenance commands that onboard a new user, synch
 17. Private catalog enablement MUST remain informational commercial governance and MUST NOT collect, echo, persist, synthesize, or validate provider credentials.
 18. Resolution MUST report a configured remote source or remote-settings target whose cache is
     absent with actionable `outfitter sync` guidance instead of silently dropping it.
-19. Automatic network synchronization during `outfitter run` is out of scope. Operators invoke
-    `outfitter sync` explicitly.
+19. **Amendment (2026-08-30):** `outfitter run` MUST verify declared remote settings and source
+    caches before composition. The default `repair` policy MUST reuse a manifest-valid clean cache
+    without network access and MUST atomically repair a missing, dirty, mismatched, legacy, or
+    unverifiable cache. `locked` MUST additionally require every remote declaration to use a full
+    40-character commit pin. `offline` MUST prohibit network access and fail unless every declared
+    remote has a manifest-valid clean cache. An unavailable declared remote MUST fail before
+    composition and MUST NOT be replaced by a lower-precedence or built-in profile.
+20. Settings MAY declare `source_cache.policy` as `repair`, `locked`, or `offline`; `repair` is the
+    default. `outfitter run --source-cache-policy` MUST override the configured policy for one run.
+21. Outfitter MUST store a versioned manifest under `<cache_directory>/source-state/` containing the
+    credential-redacted declared source identity, requested ref, resolved full commit, and cache key.
+22. Dirty cache checkouts MUST be quarantined rather than silently deleted. Concurrent startup
+    repairs MUST serialize per source.
+23. Workspace/global layers and explicit `path:` sources remain live local authority. Startup cache
+    verification MUST NOT reset, clean, fetch, or otherwise mutate those working copies.
+24. Outfitter MUST provide `outfitter sources [--json]` with credential-redacted source, requested
+    and resolved revision, origin, cache health, and precedence. JSON output MUST be stable and MUST
+    NOT contain credentials.
 
 ### OFTR-004.3: Create Profile Command
 


### PR DESCRIPTION
## Summary

- verify manifest-backed remote settings and source caches before `outfitter run` composition
- add `repair`, `locked`, and `offline` startup policies plus per-source serialization and dirty-cache quarantine
- add credential-redacted `outfitter sources [--json]` precedence and health reporting
- amend OFTR-004.2.19 before changing its pinned startup behavior

## Verification

- `npm run check-ci` — passes (591 tests; 98% branch coverage; docs build passes)
- `git diff --check` — passes
- `nix develop --command npm run check-ci` — blocked before shell entry by the baseline `importNpmLock` evaluation defect: nested Pi shrinkwrap entries have no `integrity` attribute

## Acceptance coverage

- warm startup without network
- cold repair, dirty quarantine, legacy, partial, wrong-HEAD, pin-change, and concurrent caches
- locked and offline fail-closed policies
- remote settings and transitive source reporting
- local path sources remain untouched
- stable credential-redacted JSON reporting
