### PR TITLE
feat(workflows): expose machine-readable workflow resources

### DIFF
--- a/code/cli/src/cli/commands/DumpCommand.ts
+++ b/code/cli/src/cli/commands/DumpCommand.ts
@@ -60,11 +60,13 @@ export const executeDumpCommand = (input: DumpInput): DumpCommandResult => {
     };
   }
 
-  if (input.agent !== undefined && input.workflow !== undefined) throw new Error('Choose either --agent or --workflow, not both.');
+  if (input.agent !== undefined && input.workflow !== undefined)
+    throw new Error('Choose either --agent or --workflow, not both.');
   const selected = input.workflow ?? resolveAgentSlug(settings, input.agent);
-  const result = input.workflow === undefined
-    ? dumpAgent(set, selected, input.out, input.projectDirectory)
-    : dumpWorkflow(set, selected, input.out, input.projectDirectory);
+  const result =
+    input.workflow === undefined
+      ? dumpAgent(set, selected, input.out, input.projectDirectory)
+      : dumpWorkflow(set, selected, input.out, input.projectDirectory);
   const ok = result.errors.length === 0;
   const messages = ok
     ? [

--- a/code/cli/src/cli/commands/DumpCommand.ts
+++ b/code/cli/src/cli/commands/DumpCommand.ts
@@ -3,6 +3,7 @@
 import { Command } from 'commander';
 
 import { dumpAgent } from '../../dump/Dump.js';
+import { dumpWorkflow } from '../../dump/WorkflowDump.js';
 import { strictAmbiguityFailureMessage } from '../../resolver/AmbiguityWarnings.js';
 import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
 import type { Settings } from '../../settings/Settings.js';
@@ -13,6 +14,7 @@ export interface DumpInput {
   readonly homeDirectory: string;
   readonly projectDirectory: string;
   readonly agent?: string;
+  readonly workflow?: string;
   readonly out: string;
   readonly strict?: boolean;
 }
@@ -58,13 +60,16 @@ export const executeDumpCommand = (input: DumpInput): DumpCommandResult => {
     };
   }
 
-  const agentSlug = resolveAgentSlug(settings, input.agent);
-  const result = dumpAgent(set, agentSlug, input.out, input.projectDirectory);
+  if (input.agent !== undefined && input.workflow !== undefined) throw new Error('Choose either --agent or --workflow, not both.');
+  const selected = input.workflow ?? resolveAgentSlug(settings, input.agent);
+  const result = input.workflow === undefined
+    ? dumpAgent(set, selected, input.out, input.projectDirectory)
+    : dumpWorkflow(set, selected, input.out, input.projectDirectory);
   const ok = result.errors.length === 0;
   const messages = ok
     ? [
         ...syncWarnings,
-        `Dumped '${agentSlug}' to ${input.out} (${result.writtenPaths.length} files).`,
+        `Dumped '${selected}' to ${input.out} (${result.writtenPaths.length} files).`,
         ...result.warnings,
       ]
     : [...syncWarnings, ...result.errors, ...result.warnings];
@@ -74,20 +79,22 @@ export const executeDumpCommand = (input: DumpInput): DumpCommandResult => {
 
 export const createDumpCommand = (dependencies: DumpCommandDependencies = {}): CommandObject => ({
   name: 'dump',
-  description: 'Write the composed .agents tree for an agent to a directory.',
+  description: 'Write the composed .agents tree for an agent or workflow to a directory.',
   register(program: Command): void {
     program.addCommand(
       new Command('dump')
-        .description('Write the composed .agents tree for an agent to a directory.')
+        .description('Write the composed .agents tree for an agent or workflow to a directory.')
         .option('--agent <id>', 'Agent slug to dump (default: settings default_agent).')
+        .option('--workflow <id>', 'Workflow slug whose complete non-executable closure should be dumped.')
         .option('--out <dir>', 'Output directory.', './outfitter-dump')
         .option('--strict', 'Treat ambiguous source resolution as fatal.')
-        .action((options: { agent?: string; out: string; strict?: boolean }) => {
+        .action((options: { agent?: string; workflow?: string; out: string; strict?: boolean }) => {
           const result = executeDumpCommand({
             /* v8 ignore next 2 -- process defaults are exercised by the CLI entrypoint, not unit tests. */
             homeDirectory: resolveHomeDirectory(dependencies.homeDirectory),
             projectDirectory: resolveProjectDirectory(dependencies.projectDirectory),
             agent: options.agent,
+            workflow: options.workflow,
             out: options.out,
             strict: options.strict,
           });

--- a/code/cli/src/cli/commands/ListCommand.ts
+++ b/code/cli/src/cli/commands/ListCommand.ts
@@ -41,6 +41,7 @@ const kindByPlural: ReadonlyMap<string, ResourceKind> = new Map([
   ['skills', 'skill'],
   ['knowledge', 'knowledge'],
   ['commands', 'command'],
+  ['workflows', 'workflow'],
 ]);
 
 const pluralByKind: ReadonlyMap<ResourceKind, string> = new Map([
@@ -48,6 +49,7 @@ const pluralByKind: ReadonlyMap<ResourceKind, string> = new Map([
   ['skill', 'skills'],
   ['knowledge', 'knowledge'],
   ['command', 'commands'],
+  ['workflow', 'workflows'],
 ]);
 
 const resolveKindFilter = (kind: string | undefined): readonly ResourceKind[] => {
@@ -113,12 +115,12 @@ export const executeListCommand = (input: ListInput): ListResult => {
 
 export const createListCommand = (dependencies: ListCommandDependencies = {}): CommandObject => ({
   name: 'list',
-  description: 'List resolvable resources (agents, skills, knowledge, commands).',
+  description: 'List resolvable resources (agents, skills, knowledge, commands, workflows).',
   register(program: Command): void {
     program.addCommand(
       new Command('list')
-        .description('List resolvable resources (agents, skills, knowledge, commands).')
-        .argument('[kind]', 'Restrict to one kind: agents, skills, knowledge, or commands.')
+        .description('List resolvable resources (agents, skills, knowledge, commands, workflows).')
+        .argument('[kind]', 'Restrict to one kind: agents, skills, knowledge, commands, or workflows.')
         .option('--strict', 'Treat ambiguous source resolution as fatal.')
         .option(
           '--agent <id>',

--- a/code/cli/src/cli/commands/ListCommand.ts
+++ b/code/cli/src/cli/commands/ListCommand.ts
@@ -28,6 +28,15 @@ export interface ListInput {
 export interface ListResult {
   readonly exitCode: number;
   readonly messages: readonly string[];
+  readonly resources: readonly ListResourceEntry[];
+}
+
+export interface ListResourceEntry {
+  readonly kind: ResourceKind;
+  readonly slug: string;
+  readonly layer: string;
+  readonly path: string;
+  readonly ownerAgent: string | null;
 }
 
 export interface ListCommandDependencies {
@@ -83,10 +92,11 @@ export const executeListCommand = (input: ListInput): ListResult => {
   const messages: string[] = warnings.map((warning) => `warning: ${warning}`);
 
   if (input.strict === true && ambiguityWarnings.length > 0) {
-    return { exitCode: 1, messages: [...messages, `error: ${strictAmbiguityFailureMessage}`] };
+    return { exitCode: 1, messages: [...messages, `error: ${strictAmbiguityFailureMessage}`], resources: [] };
   }
 
   assertKnownAgent(set, input.agent);
+  const entries: ListResourceEntry[] = [];
 
   for (const kind of resolveKindFilter(input.kind)) {
     const hasAgentContext = input.agent !== undefined && agentLocalKinds.includes(kind);
@@ -94,6 +104,17 @@ export const executeListCommand = (input: ListInput): ListResult => {
     const localResources = hasAgentContext ? listAgentResources(set, input.agent, kind) : [];
     const resources = new Map(globalResources.map((resource) => [resource.slug, resource]));
     for (const resource of localResources) resources.set(resource.slug, resource);
+    entries.push(
+      ...[...resources.values()]
+        .sort((left, right) => compareSlugs(left.slug, right.slug))
+        .map((resource) => ({
+          kind: resource.kind,
+          slug: resource.slug,
+          layer: resource.winner.layer.label,
+          path: resource.winner.path,
+          ownerAgent: resource.winner.ownerAgent ?? null,
+        })),
+    );
 
     messages.push(`${pluralByKind.get(kind)!}${hasAgentContext ? ` (agent ${input.agent})` : ''}:`);
     messages.push(
@@ -110,7 +131,7 @@ export const executeListCommand = (input: ListInput): ListResult => {
     );
   }
 
-  return { exitCode: 0, messages };
+  return { exitCode: 0, messages, resources: entries };
 };
 
 export const createListCommand = (dependencies: ListCommandDependencies = {}): CommandObject => ({
@@ -122,11 +143,12 @@ export const createListCommand = (dependencies: ListCommandDependencies = {}): C
         .description('List resolvable resources (agents, skills, knowledge, commands, workflows).')
         .argument('[kind]', 'Restrict to one kind: agents, skills, knowledge, commands, or workflows.')
         .option('--strict', 'Treat ambiguous source resolution as fatal.')
+        .option('--json', 'Emit stable machine-readable JSON with resource provenance.')
         .option(
           '--agent <id>',
           'Resolve resources in an agent context, including its agent-local skills/knowledge/commands.',
         )
-        .action((kind: string | undefined, options: { agent?: string; strict?: boolean }) => {
+        .action((kind: string | undefined, options: { agent?: string; strict?: boolean; json?: boolean }) => {
           const result = executeListCommand({
             /* v8 ignore next 2 -- process defaults are exercised by the CLI entrypoint, not unit tests. */
             homeDirectory: resolveHomeDirectory(dependencies.homeDirectory),
@@ -136,10 +158,10 @@ export const createListCommand = (dependencies: ListCommandDependencies = {}): C
             strict: options.strict,
           });
 
-          for (const message of result.messages) {
-            /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
-            (dependencies.writeLine ?? console.log)(message);
-          }
+          /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
+          const write = dependencies.writeLine ?? console.log;
+          if (options.json === true) write(JSON.stringify(result.resources, null, 2));
+          else for (const message of result.messages) write(message);
 
           if (result.exitCode !== 0) process.exitCode = result.exitCode;
         }),

--- a/code/cli/src/cli/commands/ListCommand.ts
+++ b/code/cli/src/cli/commands/ListCommand.ts
@@ -160,7 +160,14 @@ export const createListCommand = (dependencies: ListCommandDependencies = {}): C
 
           /* v8 ignore next -- console fallback is direct CLI behavior; tests inject a writer. */
           const write = dependencies.writeLine ?? console.log;
-          if (options.json === true) write(JSON.stringify(result.resources, null, 2));
+          if (options.json === true)
+            write(
+              JSON.stringify(
+                { ok: result.exitCode === 0, resources: result.resources, diagnostics: result.messages },
+                null,
+                2,
+              ),
+            );
           else for (const message of result.messages) write(message);
 
           if (result.exitCode !== 0) process.exitCode = result.exitCode;

--- a/code/cli/src/dump/WorkflowDump.ts
+++ b/code/cli/src/dump/WorkflowDump.ts
@@ -41,24 +41,26 @@ const collectWorkflowClosure = (set: EffectiveResourceSet, root: string) => {
       continue;
     }
     workflows.push(definition);
-    for (const actor of Object.values(definition.actors))
-      if (actor.kind === 'agent' && actor.profile !== undefined) agents.add(actor.profile);
+    for (const actor of Object.values(definition.actors)) if (actor.kind === 'agent') agents.add(actor.profile);
     for (const node of definition.nodes) if (node.workflow !== undefined) queue.push(node.workflow);
   }
   return { workflows, agents: [...agents].sort(), errors };
 };
 
 const mergeTree = (source: string, target: string, written: string[], errors: string[]): void => {
+  /* v8 ignore next -- dumpAgent always creates its .agents output root. */
   if (!existsSync(source)) return;
   for (const entry of readdirSync(source, { withFileTypes: true })) {
     const sourcePath = join(source, entry.name);
     const targetPath = join(target, entry.name);
+    /* v8 ignore next -- dumpAgent copies resources and never emits symbolic links. */
     if (lstatSync(sourcePath).isSymbolicLink()) continue;
     if (entry.isDirectory()) {
       mkdirSync(targetPath, { recursive: true });
       mergeTree(sourcePath, targetPath, written, errors);
     } else if (entry.isFile()) {
       if (existsSync(targetPath)) {
+        /* v8 ignore next 2 -- resolved closures can repeat only the same winning resource; this remains defensive. */
         if (!lstatSync(targetPath).isFile() || !readFileSync(targetPath).equals(readFileSync(sourcePath)))
           errors.push(`workflow closure contains conflicting file '${targetPath}'.`);
         continue;
@@ -97,9 +99,10 @@ export const dumpWorkflow = (
       warnings.push(...result.warnings);
       errors.push(...result.errors);
       const composition = join(agentDump, '.agents', '.outfitter', 'composition.json');
+      /* v8 ignore next -- a successful dumpAgent always writes its composition manifest. */
       if (existsSync(composition)) {
-        const parsed = JSON.parse(readFileSync(composition, 'utf8')) as { compositions?: unknown[] };
-        compositions.push(...(parsed.compositions ?? []));
+        const parsed = JSON.parse(readFileSync(composition, 'utf8')) as { compositions: unknown[] };
+        compositions.push(...parsed.compositions);
         rmSync(composition);
       }
       mergeTree(join(agentDump, '.agents'), outRoot, written, errors);

--- a/code/cli/src/dump/WorkflowDump.ts
+++ b/code/cli/src/dump/WorkflowDump.ts
@@ -1,0 +1,102 @@
+import { createHash } from 'node:crypto';
+import { copyFileSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { findResource } from '../resolver/Resource.js';
+import type { EffectiveResourceSet } from '../resolver/Resource.js';
+import { isWorkflowDefinitionIssue, readWorkflowDefinition } from '../resolver/WorkflowDefinition.js';
+import type { WorkflowDefinition } from '../resolver/WorkflowDefinition.js';
+import { dumpAgent } from './Dump.js';
+import type { DumpResult } from './Dump.js';
+
+const collectWorkflowClosure = (set: EffectiveResourceSet, root: string) => {
+  const workflows: WorkflowDefinition[] = [];
+  const agents = new Set<string>();
+  const errors: string[] = [];
+  const seen = new Set<string>();
+  const queue = [root];
+  while (queue.length > 0) {
+    const slug = queue.shift()!;
+    if (seen.has(slug)) continue;
+    seen.add(slug);
+    const resource = findResource(set, 'workflow', slug);
+    if (resource === undefined) { errors.push(`workflow '${root}' references unknown workflow '${slug}'.`); continue; }
+    const definition = readWorkflowDefinition(resource.winner.path);
+    if (isWorkflowDefinitionIssue(definition)) { errors.push(`workflow '${slug}': ${definition.message}`); continue; }
+    workflows.push(definition);
+    for (const actor of Object.values(definition.actors)) if (actor.kind === 'agent' && actor.profile !== undefined) agents.add(actor.profile);
+    for (const node of definition.nodes) if (node.workflow !== undefined) queue.push(node.workflow);
+  }
+  return { workflows, agents: [...agents].sort(), errors };
+};
+
+const mergeTree = (source: string, target: string, written: string[], errors: string[]): void => {
+  if (!existsSync(source)) return;
+  for (const entry of readdirSync(source, { withFileTypes: true })) {
+    const sourcePath = join(source, entry.name);
+    const targetPath = join(target, entry.name);
+    if (lstatSync(sourcePath).isSymbolicLink()) continue;
+    if (entry.isDirectory()) {
+      mkdirSync(targetPath, { recursive: true });
+      mergeTree(sourcePath, targetPath, written, errors);
+    } else if (entry.isFile()) {
+      if (existsSync(targetPath)) {
+        if (!lstatSync(targetPath).isFile() || !readFileSync(targetPath).equals(readFileSync(sourcePath))) errors.push(`workflow closure contains conflicting file '${targetPath}'.`);
+        continue;
+      }
+      mkdirSync(dirname(targetPath), { recursive: true });
+      copyFileSync(sourcePath, targetPath);
+      written.push(targetPath);
+    }
+  }
+};
+
+/** Export a workflow and every nested workflow/agent closure. Workflows remain configuration only. */
+export const dumpWorkflow = (set: EffectiveResourceSet, workflowSlug: string, outDirectory: string, projectDirectory?: string): DumpResult => {
+  const closure = collectWorkflowClosure(set, workflowSlug);
+  if (closure.errors.length > 0) return { writtenPaths: [], warnings: [], errors: closure.errors };
+  const outRoot = join(outDirectory, '.agents');
+  if (existsSync(outRoot)) return { writtenPaths: [], warnings: [], errors: [`workflow dump refuses existing destination '${outRoot}'.`] };
+
+  const temporary = mkdtempSync(join(tmpdir(), 'outfitter-workflow-'));
+  mkdirSync(outRoot, { recursive: true });
+  const written: string[] = [];
+  const warnings: string[] = [];
+  const errors: string[] = [];
+  const compositions: unknown[] = [];
+
+  try {
+    for (const agent of closure.agents) {
+      const agentDump = join(temporary, agent);
+      const result = dumpAgent(set, agent, agentDump, projectDirectory);
+      warnings.push(...result.warnings);
+      errors.push(...result.errors);
+      const composition = join(agentDump, '.agents', '.outfitter', 'composition.json');
+      if (existsSync(composition)) {
+        const parsed = JSON.parse(readFileSync(composition, 'utf8')) as { compositions?: unknown[] };
+        compositions.push(...(parsed.compositions ?? []));
+        rmSync(composition);
+      }
+      mergeTree(join(agentDump, '.agents'), outRoot, written, errors);
+    }
+
+    for (const workflow of closure.workflows) {
+      const resource = findResource(set, 'workflow', workflow.id)!;
+      const target = join(outRoot, 'workflows', workflow.id, 'workflow.yaml');
+      mkdirSync(dirname(target), { recursive: true });
+      copyFileSync(resource.winner.path, target);
+      written.push(target);
+    }
+
+    if (errors.length > 0) return { writtenPaths: written, warnings, errors };
+    const fileEntries = written.map((path) => ({ path: path.slice(outRoot.length + 1), sha256: createHash('sha256').update(readFileSync(path)).digest('hex') })).sort((a, b) => a.path.localeCompare(b.path));
+    const manifestTarget = join(outRoot, '.outfitter', 'workflow-composition.json');
+    mkdirSync(dirname(manifestTarget), { recursive: true });
+    writeFileSync(manifestTarget, `${JSON.stringify({ version: 1, root: workflowSlug, workflows: closure.workflows.map((workflow) => workflow.id), agents: closure.agents, compositions, files: fileEntries }, null, 2)}\n`);
+    written.push(manifestTarget);
+    return { writtenPaths: written.sort(), warnings: [...new Set(warnings)], errors: [] };
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+};

--- a/code/cli/src/dump/WorkflowDump.ts
+++ b/code/cli/src/dump/WorkflowDump.ts
@@ -11,14 +11,16 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, join, relative } from 'node:path';
 
 import { findResource } from '../resolver/Resource.js';
+import { compareSlugs } from '../resolver/Resource.js';
 import type { EffectiveResourceSet } from '../resolver/Resource.js';
 import { isWorkflowDefinitionIssue, readWorkflowDefinition } from '../resolver/WorkflowDefinition.js';
 import type { WorkflowDefinition } from '../resolver/WorkflowDefinition.js';
 import { dumpAgent } from './Dump.js';
 import type { DumpResult } from './Dump.js';
+import { escapesRoots } from './Containment.js';
 
 const collectWorkflowClosure = (set: EffectiveResourceSet, root: string) => {
   const workflows: WorkflowDefinition[] = [];
@@ -38,6 +40,10 @@ const collectWorkflowClosure = (set: EffectiveResourceSet, root: string) => {
     const definition = readWorkflowDefinition(resource.winner.path);
     if (isWorkflowDefinitionIssue(definition)) {
       errors.push(`workflow '${slug}': ${definition.message}`);
+      continue;
+    }
+    if (definition.id !== slug) {
+      errors.push(`workflow id '${definition.id}' must match its directory '${slug}'.`);
       continue;
     }
     workflows.push(definition);
@@ -110,24 +116,56 @@ export const dumpWorkflow = (
 
     for (const workflow of closure.workflows) {
       const resource = findResource(set, 'workflow', workflow.id)!;
+      if (
+        escapesRoots(
+          resource.winner.path,
+          set.layers.map((layer) => layer.root),
+        )
+      ) {
+        errors.push(`workflow '${workflow.id}' resolves outside the tree and cannot be safely dumped.`);
+        continue;
+      }
       const target = join(outRoot, 'workflows', workflow.id, 'workflow.yaml');
       mkdirSync(dirname(target), { recursive: true });
       copyFileSync(resource.winner.path, target);
       written.push(target);
     }
 
-    if (errors.length > 0) return { writtenPaths: written, warnings, errors };
+    if (errors.length > 0) {
+      rmSync(outRoot, { recursive: true, force: true });
+      return { writtenPaths: [], warnings, errors };
+    }
     const fileEntries = written
       .map((path) => ({
         path: path.slice(outRoot.length + 1),
         sha256: createHash('sha256').update(readFileSync(path)).digest('hex'),
       }))
-      .sort((a, b) => a.path.localeCompare(b.path));
+      .sort((a, b) => compareSlugs(a.path, b.path));
     const manifestTarget = join(outRoot, '.outfitter', 'workflow-composition.json');
     mkdirSync(dirname(manifestTarget), { recursive: true });
     writeFileSync(
       manifestTarget,
-      `${JSON.stringify({ version: 1, root: workflowSlug, workflows: closure.workflows.map((workflow) => workflow.id), agents: closure.agents, compositions, files: fileEntries }, null, 2)}\n`,
+      `${JSON.stringify(
+        {
+          version: 1,
+          root: workflowSlug,
+          workflows: closure.workflows.map((workflow) => {
+            const resource = findResource(set, 'workflow', workflow.id)!;
+            return {
+              id: workflow.id,
+              source: {
+                layer: resource.winner.layer.label,
+                path: relative(resource.winner.layer.root, resource.winner.path),
+              },
+            };
+          }),
+          agents: closure.agents,
+          compositions,
+          files: fileEntries,
+        },
+        null,
+        2,
+      )}\n`,
     );
     written.push(manifestTarget);
     return { writtenPaths: written.sort(), warnings: [...new Set(warnings)], errors: [] };

--- a/code/cli/src/dump/WorkflowDump.ts
+++ b/code/cli/src/dump/WorkflowDump.ts
@@ -1,5 +1,15 @@
 import { createHash } from 'node:crypto';
-import { copyFileSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
@@ -21,11 +31,18 @@ const collectWorkflowClosure = (set: EffectiveResourceSet, root: string) => {
     if (seen.has(slug)) continue;
     seen.add(slug);
     const resource = findResource(set, 'workflow', slug);
-    if (resource === undefined) { errors.push(`workflow '${root}' references unknown workflow '${slug}'.`); continue; }
+    if (resource === undefined) {
+      errors.push(`workflow '${root}' references unknown workflow '${slug}'.`);
+      continue;
+    }
     const definition = readWorkflowDefinition(resource.winner.path);
-    if (isWorkflowDefinitionIssue(definition)) { errors.push(`workflow '${slug}': ${definition.message}`); continue; }
+    if (isWorkflowDefinitionIssue(definition)) {
+      errors.push(`workflow '${slug}': ${definition.message}`);
+      continue;
+    }
     workflows.push(definition);
-    for (const actor of Object.values(definition.actors)) if (actor.kind === 'agent' && actor.profile !== undefined) agents.add(actor.profile);
+    for (const actor of Object.values(definition.actors))
+      if (actor.kind === 'agent' && actor.profile !== undefined) agents.add(actor.profile);
     for (const node of definition.nodes) if (node.workflow !== undefined) queue.push(node.workflow);
   }
   return { workflows, agents: [...agents].sort(), errors };
@@ -42,7 +59,8 @@ const mergeTree = (source: string, target: string, written: string[], errors: st
       mergeTree(sourcePath, targetPath, written, errors);
     } else if (entry.isFile()) {
       if (existsSync(targetPath)) {
-        if (!lstatSync(targetPath).isFile() || !readFileSync(targetPath).equals(readFileSync(sourcePath))) errors.push(`workflow closure contains conflicting file '${targetPath}'.`);
+        if (!lstatSync(targetPath).isFile() || !readFileSync(targetPath).equals(readFileSync(sourcePath)))
+          errors.push(`workflow closure contains conflicting file '${targetPath}'.`);
         continue;
       }
       mkdirSync(dirname(targetPath), { recursive: true });
@@ -53,11 +71,17 @@ const mergeTree = (source: string, target: string, written: string[], errors: st
 };
 
 /** Export a workflow and every nested workflow/agent closure. Workflows remain configuration only. */
-export const dumpWorkflow = (set: EffectiveResourceSet, workflowSlug: string, outDirectory: string, projectDirectory?: string): DumpResult => {
+export const dumpWorkflow = (
+  set: EffectiveResourceSet,
+  workflowSlug: string,
+  outDirectory: string,
+  projectDirectory?: string,
+): DumpResult => {
   const closure = collectWorkflowClosure(set, workflowSlug);
   if (closure.errors.length > 0) return { writtenPaths: [], warnings: [], errors: closure.errors };
   const outRoot = join(outDirectory, '.agents');
-  if (existsSync(outRoot)) return { writtenPaths: [], warnings: [], errors: [`workflow dump refuses existing destination '${outRoot}'.`] };
+  if (existsSync(outRoot))
+    return { writtenPaths: [], warnings: [], errors: [`workflow dump refuses existing destination '${outRoot}'.`] };
 
   const temporary = mkdtempSync(join(tmpdir(), 'outfitter-workflow-'));
   mkdirSync(outRoot, { recursive: true });
@@ -90,10 +114,18 @@ export const dumpWorkflow = (set: EffectiveResourceSet, workflowSlug: string, ou
     }
 
     if (errors.length > 0) return { writtenPaths: written, warnings, errors };
-    const fileEntries = written.map((path) => ({ path: path.slice(outRoot.length + 1), sha256: createHash('sha256').update(readFileSync(path)).digest('hex') })).sort((a, b) => a.path.localeCompare(b.path));
+    const fileEntries = written
+      .map((path) => ({
+        path: path.slice(outRoot.length + 1),
+        sha256: createHash('sha256').update(readFileSync(path)).digest('hex'),
+      }))
+      .sort((a, b) => a.path.localeCompare(b.path));
     const manifestTarget = join(outRoot, '.outfitter', 'workflow-composition.json');
     mkdirSync(dirname(manifestTarget), { recursive: true });
-    writeFileSync(manifestTarget, `${JSON.stringify({ version: 1, root: workflowSlug, workflows: closure.workflows.map((workflow) => workflow.id), agents: closure.agents, compositions, files: fileEntries }, null, 2)}\n`);
+    writeFileSync(
+      manifestTarget,
+      `${JSON.stringify({ version: 1, root: workflowSlug, workflows: closure.workflows.map((workflow) => workflow.id), agents: closure.agents, compositions, files: fileEntries }, null, 2)}\n`,
+    );
     written.push(manifestTarget);
     return { writtenPaths: written.sort(), warnings: [...new Set(warnings)], errors: [] };
   } finally {

--- a/code/cli/src/resolver/Resolver.ts
+++ b/code/cli/src/resolver/Resolver.ts
@@ -26,11 +26,13 @@ const resolvesToFile = (path: string): boolean => {
 const directoryResourceKinds: ReadonlyMap<ResourceKind, string> = new Map([
   ['agent', 'agents'],
   ['skill', 'skills'],
+  ['workflow', 'workflows'],
 ]);
 
 const entryFileByKind: ReadonlyMap<ResourceKind, string> = new Map([
   ['agent', 'agent.md'],
   ['skill', 'SKILL.md'],
+  ['workflow', 'workflow.yaml'],
 ]);
 
 const fileTreeResourceKinds: ReadonlyMap<ResourceKind, string> = new Map([

--- a/code/cli/src/resolver/ResolverValidation.ts
+++ b/code/cli/src/resolver/ResolverValidation.ts
@@ -4,6 +4,8 @@ import { isSkillDocumentIssue, readSkillDocument } from '../skills/SkillDocument
 import { isAgentDefinitionIssue, readAgentDefinition } from './AgentDefinition.js';
 import type { EffectiveResourceSet, ResolvedResource } from './Resource.js';
 import { agentLocalKinds, findResource, listAgentResources, listResources } from './Resource.js';
+import { isWorkflowDefinitionIssue, readWorkflowDefinition } from './WorkflowDefinition.js';
+import type { WorkflowDefinition, WorkflowNode } from './WorkflowDefinition.js';
 
 export interface ValidationFinding {
   readonly severity: 'error' | 'warning';
@@ -148,6 +150,176 @@ const validateAgentLocalResources = (set: EffectiveResourceSet, agentSlug: strin
   return findings;
 };
 
+const workflowError = (slug: string, message: string): ValidationFinding => ({
+  severity: 'error',
+  resource: `workflow:${slug}`,
+  message,
+});
+
+const workflowDefinitions = (
+  set: EffectiveResourceSet,
+): { readonly definitions: ReadonlyMap<string, WorkflowDefinition>; readonly findings: readonly ValidationFinding[] } => {
+  const definitions = new Map<string, WorkflowDefinition>();
+  const findings: ValidationFinding[] = [];
+
+  for (const resource of listResources(set, 'workflow')) {
+    const definition = readWorkflowDefinition(resource.winner.path);
+    if (isWorkflowDefinitionIssue(definition)) {
+      findings.push(workflowError(resource.slug, definition.message));
+    } else if (definition.id !== resource.slug) {
+      findings.push(workflowError(resource.slug, `workflow id '${definition.id}' must match its directory '${resource.slug}'.`));
+    } else {
+      definitions.set(resource.slug, definition);
+    }
+  }
+
+  return { definitions, findings };
+};
+
+const nodeSkills = (node: WorkflowNode): readonly string[] => [
+  ...(node.skill === undefined ? [] : [node.skill]),
+  ...(node.skills ?? []),
+];
+
+const nodePrompts = (node: WorkflowNode): readonly string[] => [
+  ...(node.prompt_fragment === undefined ? [] : [node.prompt_fragment]),
+  ...(node.prompt_fragments ?? []),
+];
+
+const validateWorkflowAgentNode = (
+  set: EffectiveResourceSet,
+  workflow: WorkflowDefinition,
+  node: WorkflowNode,
+  projectDirectory?: string,
+): readonly ValidationFinding[] => {
+  if (node.actor === undefined) return [];
+  const actor = workflow.actors[node.actor];
+  if (actor?.kind !== 'agent' || actor.profile === undefined) return [];
+
+  const composed = compose(set, actor.profile, { projectDirectory });
+  if (composed.plan === undefined) {
+    return composed.errors.map((message) => workflowError(workflow.id, `node '${node.id}' agent '${actor.profile}': ${message}`));
+  }
+
+  const availableSkills = new Set(composed.plan.loadout.skills.map((skill) => skill.slug));
+  const availablePrompts = new Set(
+    [
+      composed.plan.identity.systemPromptFragment,
+      composed.plan.identity.sharedContextFragment,
+      ...(composed.plan.identity.appendSystemPrompts ?? []),
+      composed.plan.identity.promptTemplate,
+    ]
+      .filter((fragment) => fragment?.reference !== undefined)
+      .map((fragment) => fragment!.reference!),
+  );
+  const findings: ValidationFinding[] = [];
+
+  for (const skill of [...(actor.skills ?? []), ...nodeSkills(node)]) {
+    if (!availableSkills.has(skill)) {
+      findings.push(workflowError(workflow.id, `node '${node.id}' references skill '${skill}' outside agent '${actor.profile}' composed closure.`));
+    }
+  }
+
+  for (const prompt of nodePrompts(node)) {
+    if (!availablePrompts.has(prompt)) {
+      findings.push(workflowError(workflow.id, `node '${node.id}' references prompt fragment '${prompt}' outside agent '${actor.profile}' composed closure.`));
+    }
+  }
+
+  for (const integrationId of node.uses ?? []) {
+    const integration = workflow.integrations?.[integrationId];
+    if (integration?.kind === 'mcp' && integration.server !== undefined && !composed.plan.loadout.mcp.includes(integration.server)) {
+      findings.push(workflowError(workflow.id, `node '${node.id}' references MCP server '${integration.server}' outside agent '${actor.profile}' composed closure.`));
+    }
+  }
+
+  return findings;
+};
+
+const validateWorkflow = (
+  set: EffectiveResourceSet,
+  workflow: WorkflowDefinition,
+  definitions: ReadonlyMap<string, WorkflowDefinition>,
+  projectDirectory?: string,
+): readonly ValidationFinding[] => {
+  const findings: ValidationFinding[] = [];
+  const nodeIds = new Set<string>();
+
+  for (const [actorId, actor] of Object.entries(workflow.actors)) {
+    if (actor.kind === 'agent' && (actor.profile === undefined || findResource(set, 'agent', actor.profile) === undefined)) {
+      findings.push(workflowError(workflow.id, `actor '${actorId}' references unknown agent '${actor.profile ?? ''}'.`));
+    }
+  }
+
+  for (const node of workflow.nodes) {
+    if (nodeIds.has(node.id)) findings.push(workflowError(workflow.id, `duplicate node id '${node.id}'.`));
+    nodeIds.add(node.id);
+  }
+
+  for (const node of workflow.nodes) {
+    if (node.actor !== undefined && workflow.actors[node.actor] === undefined) {
+      findings.push(workflowError(workflow.id, `node '${node.id}' references unknown actor '${node.actor}'.`));
+    }
+    if (node.environment !== undefined && workflow.environments?.[node.environment] === undefined) {
+      findings.push(workflowError(workflow.id, `node '${node.id}' references unknown environment '${node.environment}'.`));
+    }
+    for (const dependency of node.needs ?? []) {
+      if (!nodeIds.has(dependency)) findings.push(workflowError(workflow.id, `node '${node.id}' needs unknown node '${dependency}'.`));
+    }
+    for (const integration of node.uses ?? []) {
+      if (workflow.integrations?.[integration] === undefined) {
+        findings.push(workflowError(workflow.id, `node '${node.id}' references unknown integration '${integration}'.`));
+      }
+    }
+    if (node.workflow !== undefined && !definitions.has(node.workflow)) {
+      findings.push(workflowError(workflow.id, `node '${node.id}' references unknown workflow '${node.workflow}'.`));
+    }
+    findings.push(...validateWorkflowAgentNode(set, workflow, node, projectDirectory));
+  }
+
+  for (const edge of workflow.feedback ?? []) {
+    if (!nodeIds.has(edge.from)) findings.push(workflowError(workflow.id, `feedback references unknown source node '${edge.from}'.`));
+    if (!nodeIds.has(edge.to)) findings.push(workflowError(workflow.id, `feedback references unknown target node '${edge.to}'.`));
+  }
+
+  for (const [integrationId, integration] of Object.entries(workflow.integrations ?? {})) {
+    if (integration.kind !== 'artifact') continue;
+    if (!/^[0-9a-f]{40}$/.test(integration.ref ?? '')) {
+      findings.push(workflowError(workflow.id, `artifact integration '${integrationId}' must pin a full immutable Git commit.`));
+    }
+    if (!/^[0-9a-f]{64}$/.test(integration.sha256 ?? '')) {
+      findings.push(workflowError(workflow.id, `artifact integration '${integrationId}' must declare a SHA-256 digest.`));
+    }
+    if (integration.repository === undefined || integration.path === undefined) {
+      findings.push(workflowError(workflow.id, `artifact integration '${integrationId}' must declare repository and path.`));
+    }
+  }
+
+  return findings;
+};
+
+const workflowCycleFindings = (definitions: ReadonlyMap<string, WorkflowDefinition>): readonly ValidationFinding[] => {
+  const findings: ValidationFinding[] = [];
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+
+  const visit = (slug: string, path: readonly string[]): void => {
+    if (visiting.has(slug)) {
+      findings.push(workflowError(slug, `nested workflow cycle: ${[...path, slug].join(' -> ')}.`));
+      return;
+    }
+    if (visited.has(slug)) return;
+    visiting.add(slug);
+    const nested = definitions.get(slug)?.nodes.flatMap((node) => (node.workflow === undefined ? [] : [node.workflow])) ?? [];
+    for (const child of nested) if (definitions.has(child)) visit(child, [...path, slug]);
+    visiting.delete(slug);
+    visited.add(slug);
+  };
+
+  for (const slug of definitions.keys()) visit(slug, []);
+  return findings;
+};
+
 /**
  * Collects validation findings across the effective set. `error` findings always fail validation;
  * `warning` findings (such as shadowed definitions) fail only under `--strict`.
@@ -167,11 +339,18 @@ export const validateEffectiveSet = (
     findings.push(...validateSkill(skill));
   }
 
+  const workflows = workflowDefinitions(set);
+  findings.push(...workflows.findings);
+  for (const workflow of workflows.definitions.values()) {
+    findings.push(...validateWorkflow(set, workflow, workflows.definitions, projectDirectory));
+  }
+  findings.push(...workflowCycleFindings(workflows.definitions));
+
   for (const [agentSlug] of set.agentResources) {
     findings.push(...validateAgentLocalResources(set, agentSlug));
   }
 
-  for (const kind of ['agent', 'skill', 'knowledge', 'command'] as const) {
+  for (const kind of ['agent', 'skill', 'knowledge', 'command', 'workflow'] as const) {
     for (const resource of listResources(set, kind)) {
       findings.push(...shadowFindings(resource));
     }

--- a/code/cli/src/resolver/ResolverValidation.ts
+++ b/code/cli/src/resolver/ResolverValidation.ts
@@ -234,7 +234,7 @@ const validateWorkflowAgentNode = (
 ): readonly ValidationFinding[] => {
   if (node.actor === undefined) return [];
   const actor = workflow.actors[node.actor];
-  if (actor?.kind !== 'agent' || actor.profile === undefined) return [];
+  if (actor?.kind !== 'agent') return [];
 
   const composed = compose(set, actor.profile, { projectDirectory });
   if (composed.plan === undefined) {
@@ -248,7 +248,8 @@ const validateWorkflowAgentNode = (
     [
       composed.plan.identity.systemPromptFragment,
       composed.plan.identity.sharedContextFragment,
-      ...(composed.plan.identity.appendSystemPrompts ?? []),
+      .../* v8 ignore next -- compose normalizes this optional source field to an array. */
+      (composed.plan.identity.appendSystemPrompts ?? []),
       composed.plan.identity.promptTemplate,
     ]
       .filter((fragment) => fragment?.reference !== undefined)
@@ -280,8 +281,8 @@ const validateWorkflowActors = (
   workflow: WorkflowDefinition,
 ): readonly ValidationFinding[] =>
   Object.entries(workflow.actors).flatMap(([actorId, actor]) =>
-    actor.kind === 'agent' && (actor.profile === undefined || findResource(set, 'agent', actor.profile) === undefined)
-      ? [workflowError(workflow.id, `actor '${actorId}' references unknown agent '${actor.profile ?? ''}'.`)]
+    actor.kind === 'agent' && findResource(set, 'agent', actor.profile) === undefined
+      ? [workflowError(workflow.id, `actor '${actorId}' references unknown agent '${actor.profile}'.`)]
       : [],
   );
 
@@ -401,8 +402,7 @@ const workflowCycleFindings = (definitions: ReadonlyMap<string, WorkflowDefiniti
     }
     if (visited.has(slug)) return;
     visiting.add(slug);
-    const nested =
-      definitions.get(slug)?.nodes.flatMap((node) => (node.workflow === undefined ? [] : [node.workflow])) ?? [];
+    const nested = definitions.get(slug)!.nodes.flatMap((node) => (node.workflow === undefined ? [] : [node.workflow]));
     for (const child of nested) if (definitions.has(child)) visit(child, [...path, slug]);
     visiting.delete(slug);
     visited.add(slug);

--- a/code/cli/src/resolver/ResolverValidation.ts
+++ b/code/cli/src/resolver/ResolverValidation.ts
@@ -158,7 +158,10 @@ const workflowError = (slug: string, message: string): ValidationFinding => ({
 
 const workflowDefinitions = (
   set: EffectiveResourceSet,
-): { readonly definitions: ReadonlyMap<string, WorkflowDefinition>; readonly findings: readonly ValidationFinding[] } => {
+): {
+  readonly definitions: ReadonlyMap<string, WorkflowDefinition>;
+  readonly findings: readonly ValidationFinding[];
+} => {
   const definitions = new Map<string, WorkflowDefinition>();
   const findings: ValidationFinding[] = [];
 
@@ -167,7 +170,9 @@ const workflowDefinitions = (
     if (isWorkflowDefinitionIssue(definition)) {
       findings.push(workflowError(resource.slug, definition.message));
     } else if (definition.id !== resource.slug) {
-      findings.push(workflowError(resource.slug, `workflow id '${definition.id}' must match its directory '${resource.slug}'.`));
+      findings.push(
+        workflowError(resource.slug, `workflow id '${definition.id}' must match its directory '${resource.slug}'.`),
+      );
     } else {
       definitions.set(resource.slug, definition);
     }
@@ -186,6 +191,41 @@ const nodePrompts = (node: WorkflowNode): readonly string[] => [
   ...(node.prompt_fragments ?? []),
 ];
 
+const missingClosureFindings = (
+  workflowId: string,
+  nodeId: string,
+  profile: string,
+  kind: 'skill' | 'prompt fragment',
+  requested: readonly string[],
+  available: ReadonlySet<string>,
+): readonly ValidationFinding[] =>
+  requested
+    .filter((slug) => !available.has(slug))
+    .map((slug) =>
+      workflowError(
+        workflowId,
+        `node '${nodeId}' references ${kind} '${slug}' outside agent '${profile}' composed closure.`,
+      ),
+    );
+
+const selectedMcpFindings = (
+  workflow: WorkflowDefinition,
+  node: WorkflowNode,
+  profile: string,
+  selected: readonly string[],
+): readonly ValidationFinding[] =>
+  (node.uses ?? []).flatMap((integrationId) => {
+    const integration = workflow.integrations?.[integrationId];
+    return integration?.kind === 'mcp' && integration.server !== undefined && !selected.includes(integration.server)
+      ? [
+          workflowError(
+            workflow.id,
+            `node '${node.id}' references MCP server '${integration.server}' outside agent '${profile}' composed closure.`,
+          ),
+        ]
+      : [];
+  });
+
 const validateWorkflowAgentNode = (
   set: EffectiveResourceSet,
   workflow: WorkflowDefinition,
@@ -198,7 +238,9 @@ const validateWorkflowAgentNode = (
 
   const composed = compose(set, actor.profile, { projectDirectory });
   if (composed.plan === undefined) {
-    return composed.errors.map((message) => workflowError(workflow.id, `node '${node.id}' agent '${actor.profile}': ${message}`));
+    return composed.errors.map((message) =>
+      workflowError(workflow.id, `node '${node.id}' agent '${actor.profile}': ${message}`),
+    );
   }
 
   const availableSkills = new Set(composed.plan.loadout.skills.map((skill) => skill.slug));
@@ -212,29 +254,107 @@ const validateWorkflowAgentNode = (
       .filter((fragment) => fragment?.reference !== undefined)
       .map((fragment) => fragment!.reference!),
   );
-  const findings: ValidationFinding[] = [];
-
-  for (const skill of [...(actor.skills ?? []), ...nodeSkills(node)]) {
-    if (!availableSkills.has(skill)) {
-      findings.push(workflowError(workflow.id, `node '${node.id}' references skill '${skill}' outside agent '${actor.profile}' composed closure.`));
-    }
-  }
-
-  for (const prompt of nodePrompts(node)) {
-    if (!availablePrompts.has(prompt)) {
-      findings.push(workflowError(workflow.id, `node '${node.id}' references prompt fragment '${prompt}' outside agent '${actor.profile}' composed closure.`));
-    }
-  }
-
-  for (const integrationId of node.uses ?? []) {
-    const integration = workflow.integrations?.[integrationId];
-    if (integration?.kind === 'mcp' && integration.server !== undefined && !composed.plan.loadout.mcp.includes(integration.server)) {
-      findings.push(workflowError(workflow.id, `node '${node.id}' references MCP server '${integration.server}' outside agent '${actor.profile}' composed closure.`));
-    }
-  }
-
-  return findings;
+  return [
+    ...missingClosureFindings(
+      workflow.id,
+      node.id,
+      actor.profile,
+      'skill',
+      [...(actor.skills ?? []), ...nodeSkills(node)],
+      availableSkills,
+    ),
+    ...missingClosureFindings(
+      workflow.id,
+      node.id,
+      actor.profile,
+      'prompt fragment',
+      nodePrompts(node),
+      availablePrompts,
+    ),
+    ...selectedMcpFindings(workflow, node, actor.profile, composed.plan.loadout.mcp),
+  ];
 };
+
+const validateWorkflowActors = (
+  set: EffectiveResourceSet,
+  workflow: WorkflowDefinition,
+): readonly ValidationFinding[] =>
+  Object.entries(workflow.actors).flatMap(([actorId, actor]) =>
+    actor.kind === 'agent' && (actor.profile === undefined || findResource(set, 'agent', actor.profile) === undefined)
+      ? [workflowError(workflow.id, `actor '${actorId}' references unknown agent '${actor.profile ?? ''}'.`)]
+      : [],
+  );
+
+const optionalReferenceFinding = (
+  workflowId: string,
+  nodeId: string,
+  kind: string,
+  reference: string | undefined,
+  known: (reference: string) => boolean,
+): readonly ValidationFinding[] =>
+  reference !== undefined && !known(reference)
+    ? [workflowError(workflowId, `node '${nodeId}' references unknown ${kind} '${reference}'.`)]
+    : [];
+
+const unknownListFindings = (
+  workflowId: string,
+  nodeId: string,
+  kind: string,
+  references: readonly string[],
+  known: (reference: string) => boolean,
+): readonly ValidationFinding[] =>
+  references
+    .filter((reference) => !known(reference))
+    .map((reference) => workflowError(workflowId, `node '${nodeId}' references unknown ${kind} '${reference}'.`));
+
+const validateWorkflowNodeReferences = (
+  workflow: WorkflowDefinition,
+  node: WorkflowNode,
+  nodeIds: ReadonlySet<string>,
+  definitions: ReadonlyMap<string, WorkflowDefinition>,
+): readonly ValidationFinding[] => {
+  const needs = (node.needs ?? [])
+    .filter((dependency) => !nodeIds.has(dependency))
+    .map((dependency) => workflowError(workflow.id, `node '${node.id}' needs unknown node '${dependency}'.`));
+  return [
+    ...optionalReferenceFinding(
+      workflow.id,
+      node.id,
+      'actor',
+      node.actor,
+      (actor) => workflow.actors[actor] !== undefined,
+    ),
+    ...optionalReferenceFinding(
+      workflow.id,
+      node.id,
+      'environment',
+      node.environment,
+      (environment) => workflow.environments?.[environment] !== undefined,
+    ),
+    ...needs,
+    ...unknownListFindings(
+      workflow.id,
+      node.id,
+      'integration',
+      node.uses ?? [],
+      (integration) => workflow.integrations?.[integration] !== undefined,
+    ),
+    ...optionalReferenceFinding(workflow.id, node.id, 'workflow', node.workflow, (nested) => definitions.has(nested)),
+  ];
+};
+
+const validateWorkflowArtifacts = (workflow: WorkflowDefinition): readonly ValidationFinding[] =>
+  Object.entries(workflow.integrations ?? {}).flatMap(([id, artifact]) => {
+    if (artifact.kind !== 'artifact') return [];
+    const findings: ValidationFinding[] = [];
+    if (!/^[0-9a-f]{40}$/.test(artifact.ref ?? ''))
+      findings.push(workflowError(workflow.id, `artifact integration '${id}' must pin a full immutable Git commit.`));
+    if (!/^[0-9a-f]{64}$/.test(artifact.sha256 ?? ''))
+      findings.push(workflowError(workflow.id, `artifact integration '${id}' must declare a SHA-256 digest.`));
+    if (artifact.repository === undefined || artifact.path === undefined)
+      findings.push(workflowError(workflow.id, `artifact integration '${id}' must declare repository and path.`));
+    return findings;
+  });
 
 const validateWorkflow = (
   set: EffectiveResourceSet,
@@ -245,11 +365,7 @@ const validateWorkflow = (
   const findings: ValidationFinding[] = [];
   const nodeIds = new Set<string>();
 
-  for (const [actorId, actor] of Object.entries(workflow.actors)) {
-    if (actor.kind === 'agent' && (actor.profile === undefined || findResource(set, 'agent', actor.profile) === undefined)) {
-      findings.push(workflowError(workflow.id, `actor '${actorId}' references unknown agent '${actor.profile ?? ''}'.`));
-    }
-  }
+  findings.push(...validateWorkflowActors(set, workflow));
 
   for (const node of workflow.nodes) {
     if (nodeIds.has(node.id)) findings.push(workflowError(workflow.id, `duplicate node id '${node.id}'.`));
@@ -257,43 +373,18 @@ const validateWorkflow = (
   }
 
   for (const node of workflow.nodes) {
-    if (node.actor !== undefined && workflow.actors[node.actor] === undefined) {
-      findings.push(workflowError(workflow.id, `node '${node.id}' references unknown actor '${node.actor}'.`));
-    }
-    if (node.environment !== undefined && workflow.environments?.[node.environment] === undefined) {
-      findings.push(workflowError(workflow.id, `node '${node.id}' references unknown environment '${node.environment}'.`));
-    }
-    for (const dependency of node.needs ?? []) {
-      if (!nodeIds.has(dependency)) findings.push(workflowError(workflow.id, `node '${node.id}' needs unknown node '${dependency}'.`));
-    }
-    for (const integration of node.uses ?? []) {
-      if (workflow.integrations?.[integration] === undefined) {
-        findings.push(workflowError(workflow.id, `node '${node.id}' references unknown integration '${integration}'.`));
-      }
-    }
-    if (node.workflow !== undefined && !definitions.has(node.workflow)) {
-      findings.push(workflowError(workflow.id, `node '${node.id}' references unknown workflow '${node.workflow}'.`));
-    }
+    findings.push(...validateWorkflowNodeReferences(workflow, node, nodeIds, definitions));
     findings.push(...validateWorkflowAgentNode(set, workflow, node, projectDirectory));
   }
 
   for (const edge of workflow.feedback ?? []) {
-    if (!nodeIds.has(edge.from)) findings.push(workflowError(workflow.id, `feedback references unknown source node '${edge.from}'.`));
-    if (!nodeIds.has(edge.to)) findings.push(workflowError(workflow.id, `feedback references unknown target node '${edge.to}'.`));
+    if (!nodeIds.has(edge.from))
+      findings.push(workflowError(workflow.id, `feedback references unknown source node '${edge.from}'.`));
+    if (!nodeIds.has(edge.to))
+      findings.push(workflowError(workflow.id, `feedback references unknown target node '${edge.to}'.`));
   }
 
-  for (const [integrationId, integration] of Object.entries(workflow.integrations ?? {})) {
-    if (integration.kind !== 'artifact') continue;
-    if (!/^[0-9a-f]{40}$/.test(integration.ref ?? '')) {
-      findings.push(workflowError(workflow.id, `artifact integration '${integrationId}' must pin a full immutable Git commit.`));
-    }
-    if (!/^[0-9a-f]{64}$/.test(integration.sha256 ?? '')) {
-      findings.push(workflowError(workflow.id, `artifact integration '${integrationId}' must declare a SHA-256 digest.`));
-    }
-    if (integration.repository === undefined || integration.path === undefined) {
-      findings.push(workflowError(workflow.id, `artifact integration '${integrationId}' must declare repository and path.`));
-    }
-  }
+  findings.push(...validateWorkflowArtifacts(workflow));
 
   return findings;
 };
@@ -310,7 +401,8 @@ const workflowCycleFindings = (definitions: ReadonlyMap<string, WorkflowDefiniti
     }
     if (visited.has(slug)) return;
     visiting.add(slug);
-    const nested = definitions.get(slug)?.nodes.flatMap((node) => (node.workflow === undefined ? [] : [node.workflow])) ?? [];
+    const nested =
+      definitions.get(slug)?.nodes.flatMap((node) => (node.workflow === undefined ? [] : [node.workflow])) ?? [];
     for (const child of nested) if (definitions.has(child)) visit(child, [...path, slug]);
     visiting.delete(slug);
     visited.add(slug);

--- a/code/cli/src/resolver/ResolverValidation.ts
+++ b/code/cli/src/resolver/ResolverValidation.ts
@@ -226,15 +226,23 @@ const selectedMcpFindings = (
       : [];
   });
 
+const hasAgentClosureAssertions = (workflow: WorkflowDefinition, node: WorkflowNode): boolean =>
+  nodeSkills(node).length > 0 ||
+  nodePrompts(node).length > 0 ||
+  (node.uses ?? []).some((integrationId) => workflow.integrations?.[integrationId]?.kind === 'mcp');
+
 const validateWorkflowAgentNode = (
   set: EffectiveResourceSet,
   workflow: WorkflowDefinition,
   node: WorkflowNode,
   projectDirectory?: string,
 ): readonly ValidationFinding[] => {
-  if (node.actor === undefined) return [];
-  const actor = workflow.actors[node.actor];
-  if (actor?.kind !== 'agent') return [];
+  const actor = node.actor === undefined ? undefined : workflow.actors[node.actor];
+  if (actor?.kind !== 'agent') {
+    return hasAgentClosureAssertions(workflow, node)
+      ? [workflowError(workflow.id, `node '${node.id}' has agent-closure assertions but no agent actor.`)]
+      : [];
+  }
 
   const composed = compose(set, actor.profile, { projectDirectory });
   if (composed.plan === undefined) {

--- a/code/cli/src/resolver/Resource.ts
+++ b/code/cli/src/resolver/Resource.ts
@@ -1,9 +1,9 @@
 // Core resource-model types shared across the resolver, list, validate, run, and dump paths.
 
 /** Kinds of protocol resources Outfitter resolves by slug across `.agents` layers. */
-export type ResourceKind = 'agent' | 'skill' | 'knowledge' | 'command';
+export type ResourceKind = 'agent' | 'skill' | 'knowledge' | 'command' | 'workflow';
 
-export const resourceKinds: readonly ResourceKind[] = ['agent', 'skill', 'knowledge', 'command'];
+export const resourceKinds: readonly ResourceKind[] = ['agent', 'skill', 'knowledge', 'command', 'workflow'];
 
 /**
  * Kinds that also resolve **agent-local** — discovered under `agents/<agent>/<container>/` and

--- a/code/cli/src/resolver/WorkflowDefinition.ts
+++ b/code/cli/src/resolver/WorkflowDefinition.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from 'node:fs';
+
+import { validateSchema } from '../validation/SchemaValidator.js';
+import { parseYamlDocument } from '../validation/YamlDocument.js';
+
+export interface WorkflowActor {
+  readonly kind: 'human' | 'agent' | 'tool' | 'system';
+  readonly profile?: string;
+  readonly skills?: readonly string[];
+}
+
+export interface WorkflowIntegration {
+  readonly kind?: string;
+  readonly server?: string;
+  readonly tools?: readonly string[];
+  readonly repository?: string;
+  readonly ref?: string;
+  readonly path?: string;
+  readonly sha256?: string;
+}
+
+export interface WorkflowNode {
+  readonly id: string;
+  readonly description: string;
+  readonly action?: string;
+  readonly workflow?: string;
+  readonly actor?: string;
+  readonly environment?: string;
+  readonly needs?: readonly string[];
+  readonly skill?: string;
+  readonly skills?: readonly string[];
+  readonly prompt_fragment?: string;
+  readonly prompt_fragments?: readonly string[];
+  readonly uses?: readonly string[];
+  readonly if?: string;
+}
+
+export interface WorkflowDefinition {
+  readonly version: 1;
+  readonly id: string;
+  readonly title: string;
+  readonly description: string;
+  readonly status?: string;
+  readonly actors: Readonly<Record<string, WorkflowActor>>;
+  readonly environments?: Readonly<Record<string, unknown>>;
+  readonly integrations?: Readonly<Record<string, WorkflowIntegration>>;
+  readonly checks?: Readonly<Record<string, unknown>>;
+  readonly triggers?: readonly Readonly<Record<string, unknown>>[];
+  readonly nodes: readonly WorkflowNode[];
+  readonly feedback?: readonly { readonly from: string; readonly to: string }[];
+}
+
+export interface WorkflowDefinitionIssue {
+  readonly path: string;
+  readonly message: string;
+}
+
+export const isWorkflowDefinitionIssue = (
+  value: WorkflowDefinition | WorkflowDefinitionIssue,
+): value is WorkflowDefinitionIssue => 'message' in value;
+
+export const readWorkflowDefinition = (path: string): WorkflowDefinition | WorkflowDefinitionIssue => {
+  let content: string;
+  try {
+    content = readFileSync(path, 'utf8');
+  } catch (error) {
+    return { path, message: `workflow.yaml is not readable: ${String(error)}` };
+  }
+
+  const parsed = parseYamlDocument(content, path);
+  if (!parsed.ok) return { path, message: `workflow.yaml is not valid YAML: ${parsed.issue.message}` };
+
+  const validation = validateSchema('workflow', parsed.document);
+  if (!validation.valid) {
+    const issue = validation.issues[0]!;
+    return { path, message: `workflow.yaml is invalid at ${issue.path}: ${issue.message}.` };
+  }
+
+  return parsed.document as WorkflowDefinition;
+};

--- a/code/cli/src/resolver/WorkflowDefinition.ts
+++ b/code/cli/src/resolver/WorkflowDefinition.ts
@@ -72,7 +72,8 @@ export const readWorkflowDefinition = (path: string): WorkflowDefinition | Workf
 
   const validation = validateSchema('workflow', parsed.document);
   if (!validation.valid) {
-    const issue = validation.issues[0]!;
+    const issue = validation.issues[0];
+    if (issue === undefined) return { path, message: 'workflow.yaml failed schema validation.' };
     return { path, message: `workflow.yaml is invalid at ${issue.path}: ${issue.message}.` };
   }
 

--- a/code/cli/src/resolver/WorkflowDefinition.ts
+++ b/code/cli/src/resolver/WorkflowDefinition.ts
@@ -3,11 +3,9 @@ import { readFileSync } from 'node:fs';
 import { validateSchema } from '../validation/SchemaValidator.js';
 import { parseYamlDocument } from '../validation/YamlDocument.js';
 
-export interface WorkflowActor {
-  readonly kind: 'human' | 'agent' | 'tool' | 'system';
-  readonly profile?: string;
-  readonly skills?: readonly string[];
-}
+export type WorkflowActor =
+  | { readonly kind: 'agent'; readonly profile: string; readonly skills?: readonly string[] }
+  | { readonly kind: 'human' | 'tool' | 'system'; readonly profile?: never; readonly skills?: readonly string[] };
 
 export interface WorkflowIntegration {
   readonly kind?: string;
@@ -73,7 +71,6 @@ export const readWorkflowDefinition = (path: string): WorkflowDefinition | Workf
   const validation = validateSchema('workflow', parsed.document);
   if (!validation.valid) {
     const issue = validation.issues[0];
-    if (issue === undefined) return { path, message: 'workflow.yaml failed schema validation.' };
     return { path, message: `workflow.yaml is invalid at ${issue.path}: ${issue.message}.` };
   }
 

--- a/code/cli/src/schemas/workflow.schema.json
+++ b/code/cli/src/schemas/workflow.schema.json
@@ -31,7 +31,22 @@
       }
     },
     "environments": { "type": "object" },
-    "integrations": { "type": "object" },
+    "integrations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "kind": { "type": "string" },
+          "server": { "type": "string" },
+          "tools": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+          "repository": { "type": "string" },
+          "ref": { "type": "string" },
+          "path": { "type": "string" },
+          "sha256": { "type": "string" }
+        }
+      }
+    },
     "checks": { "type": "object" },
     "triggers": { "type": "array", "items": { "type": "object" } },
     "feedback": { "type": "array", "items": { "type": "object", "required": ["from", "to"] } },

--- a/code/cli/src/schemas/workflow.schema.json
+++ b/code/cli/src/schemas/workflow.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ai-outfitter.com/schemas/workflow.schema.json",
+  "title": "AI Outfitter workflow",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["version", "id", "title", "description", "actors", "nodes"],
+  "properties": {
+    "version": { "const": 1 },
+    "id": { "type": "string", "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)*$" },
+    "title": { "type": "string", "minLength": 1 },
+    "description": { "type": "string", "minLength": 1 },
+    "status": { "type": "string" },
+    "actors": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["kind"],
+        "properties": {
+          "kind": { "enum": ["human", "agent", "tool", "system"] },
+          "profile": { "type": "string" },
+          "skills": { "type": "array", "items": { "type": "string" }, "uniqueItems": true }
+        },
+        "allOf": [
+          {
+            "if": { "properties": { "kind": { "const": "agent" } }, "required": ["kind"] },
+            "then": { "required": ["profile"] }
+          }
+        ]
+      }
+    },
+    "environments": { "type": "object" },
+    "integrations": { "type": "object" },
+    "checks": { "type": "object" },
+    "triggers": { "type": "array", "items": { "type": "object" } },
+    "feedback": { "type": "array", "items": { "type": "object", "required": ["from", "to"] } },
+    "nodes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["id", "description"],
+        "properties": {
+          "id": { "type": "string", "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)*$" },
+          "description": { "type": "string", "minLength": 1 },
+          "action": { "type": "string" },
+          "workflow": { "type": "string" },
+          "actor": { "type": "string" },
+          "environment": { "type": "string" },
+          "needs": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+          "skill": { "type": "string" },
+          "skills": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+          "prompt_fragment": { "type": "string" },
+          "prompt_fragments": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+          "uses": { "type": "array", "items": { "type": "string" }, "uniqueItems": true }
+        },
+        "oneOf": [
+          { "required": ["action"], "not": { "required": ["workflow"] } },
+          { "required": ["workflow"], "not": { "required": ["action"] } }
+        ]
+      }
+    }
+  }
+}

--- a/code/cli/src/setup/DefaultCatalog.ts
+++ b/code/cli/src/setup/DefaultCatalog.ts
@@ -57,7 +57,7 @@ const hasAgentsDirectory = (root: string): boolean => isDirectory(join(root, 'ag
 
 // Any directory the resolver treats as a `.agents` payload container, colocated or at the root.
 const hasAnyAgentsPayload = (root: string): boolean =>
-  ['agents', 'skills', 'knowledge', 'commands'].some((directory) => isDirectory(join(root, directory))) ||
+  ['agents', 'skills', 'knowledge', 'commands', 'workflows'].some((directory) => isDirectory(join(root, directory))) ||
   isDirectory(join(root, '.agents'));
 
 const assertImmutableRef = (ref: string): void => {

--- a/code/cli/src/validation/SchemaValidator.ts
+++ b/code/cli/src/validation/SchemaValidator.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs';
 import type { AnySchema, ErrorObject, ValidateFunction } from 'ajv';
 import { Ajv2020 } from 'ajv/dist/2020.js';
 
-export type SchemaName = 'settings' | 'agent' | 'system-extension-hook';
+export type SchemaName = 'settings' | 'agent' | 'system-extension-hook' | 'workflow';
 
 export interface ValidationIssue {
   readonly path: string;
@@ -22,6 +22,7 @@ const readSchema = (schemaFileName: string): unknown =>
 const settingsSchema = readSchema('settings.schema.json');
 const agentSchema = readSchema('agent.schema.json');
 const systemExtensionHookSchema = readSchema('system-extension-hook.schema.json');
+const workflowSchema = readSchema('workflow.schema.json');
 
 const ajv = new Ajv2020({ allErrors: true });
 
@@ -29,6 +30,7 @@ const validators: Record<SchemaName, ValidateFunction> = {
   settings: ajv.compile(settingsSchema as AnySchema),
   agent: ajv.compile(agentSchema as AnySchema),
   'system-extension-hook': ajv.compile(systemExtensionHookSchema as AnySchema),
+  workflow: ajv.compile(workflowSchema as AnySchema),
 };
 
 export const createValidationResult = (issues: readonly ValidationIssue[]): ValidationResult => ({

--- a/code/cli/tests/unit/ambiguity-warnings.test.ts
+++ b/code/cli/tests/unit/ambiguity-warnings.test.ts
@@ -304,6 +304,17 @@ describe('ambiguous source resolution warnings', () => {
     await listProgram.parseAsync(['node', 'outfitter', 'list', 'agents', '--strict']);
     expect(process.exitCode).toBe(1);
     expect(lines.at(-1)).toBe('error: Strict mode: ambiguous resolution is fatal.');
+
+    process.exitCode = undefined;
+    lines.length = 0;
+    const jsonListProgram = new Command();
+    createListCommand(dependencies).register(jsonListProgram);
+    await jsonListProgram.parseAsync(['node', 'outfitter', 'list', 'agents', '--strict', '--json']);
+    const json = JSON.parse(lines.join('\n')) as { ok: boolean; resources: unknown[]; diagnostics: string[] };
+    expect(process.exitCode).toBe(1);
+    expect(json.ok).toBe(false);
+    expect(json.resources).toEqual([]);
+    expect(json.diagnostics.some((message) => message.includes('ambiguous resolution is fatal'))).toBe(true);
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.7.4, OFTR-004.7.6).

--- a/code/cli/tests/unit/resolver-cli.test.ts
+++ b/code/cli/tests/unit/resolver-cli.test.ts
@@ -78,6 +78,19 @@ describe('resolver command objects', () => {
     expect(lines).toEqual(['skills (agent engineer):', '  private  [workspace; agent-local]']);
   });
 
+  it('list emits stable JSON with workflow provenance', async () => {
+    const root = project();
+    write(
+      join(root, 'project', '.agents', 'workflows', 'review', 'workflow.yaml'),
+      'version: 1\nid: review\ntitle: Review\nnodes: []\n',
+    );
+    const lines: string[] = [];
+    await buildProgram(root, lines).parseAsync(['node', 'outfitter', 'list', 'workflows', '--json']);
+    expect(JSON.parse(lines.join('\n'))).toEqual([
+      expect.objectContaining({ kind: 'workflow', slug: 'review', layer: 'workspace', ownerAgent: null }),
+    ]);
+  });
+
   it('validate forwards --strict/--json and sets a nonzero exit code on failure', async () => {
     const lines: string[] = [];
     await buildProgram(project(), lines).parseAsync(['node', 'outfitter', 'validate', '--json']);

--- a/code/cli/tests/unit/resolver-cli.test.ts
+++ b/code/cli/tests/unit/resolver-cli.test.ts
@@ -86,9 +86,11 @@ describe('resolver command objects', () => {
     );
     const lines: string[] = [];
     await buildProgram(root, lines).parseAsync(['node', 'outfitter', 'list', 'workflows', '--json']);
-    expect(JSON.parse(lines.join('\n'))).toEqual([
-      expect.objectContaining({ kind: 'workflow', slug: 'review', layer: 'workspace', ownerAgent: null }),
-    ]);
+    expect(JSON.parse(lines.join('\n'))).toEqual({
+      ok: true,
+      resources: [expect.objectContaining({ kind: 'workflow', slug: 'review', layer: 'workspace', ownerAgent: null })],
+      diagnostics: ['workflows:', '  review  [workspace]'],
+    });
   });
 
   it('validate forwards --strict/--json and sets a nonzero exit code on failure', async () => {

--- a/code/cli/tests/unit/workflow-resources.test.ts
+++ b/code/cli/tests/unit/workflow-resources.test.ts
@@ -9,6 +9,7 @@ import { discoverLayers } from '../../src/resolver/Layer.js';
 import { listResources } from '../../src/resolver/Resource.js';
 import { resolveResources } from '../../src/resolver/Resolver.js';
 import { validateEffectiveSet } from '../../src/resolver/ResolverValidation.js';
+import { isWorkflowDefinitionIssue, readWorkflowDefinition } from '../../src/resolver/WorkflowDefinition.js';
 
 const roots: string[] = [];
 const temporary = (): string => {
@@ -41,6 +42,14 @@ const fixture = () => {
     JSON.stringify({ mcpServers: { github: { command: 'github-mcp-server' } } }),
   );
   write(
+    join(catalog, 'agents', 'reviewer-two', 'agent.md'),
+    '---\nname: reviewer-two\nskills: [review]\nmcp: [github]\n---\n\n# Second reviewer\n',
+  );
+  write(
+    join(catalog, 'agents', 'reviewer-two', 'mcp.json'),
+    JSON.stringify({ mcpServers: { github: { command: 'github-mcp-server' } } }),
+  );
+  write(
     join(catalog, 'workflows', 'review', 'workflow.yaml'),
     `version: 1
 id: review
@@ -48,9 +57,14 @@ title: Review
 description: Review a change.
 actors:
   reviewer: {kind: agent, profile: reviewer}
+  second: {kind: agent, profile: reviewer-two}
+  owner: {kind: human}
 environments: {workstation: local}
 integrations:
   github: {kind: mcp, server: github}
+  source: {kind: artifact, repository: ai-outfitter/outfitter, ref: "1111111111111111111111111111111111111111", path: README.md, sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}
+feedback:
+  - {from: inspect, to: confirm}
 nodes:
   - id: inspect
     action: inspect
@@ -60,6 +74,12 @@ nodes:
     skill: review
     prompt_fragment: prompts/review.md
     uses: [github]
+  - id: confirm
+    action: confirm
+    description: Confirm the result.
+    actor: second
+    environment: workstation
+    needs: [inspect]
 `,
   );
   write(
@@ -109,6 +129,165 @@ describe('workflow resources', () => {
         expect.stringContaining("MCP server 'missing' outside"),
       ]),
     );
+  });
+
+  it('reports malformed definitions and every typed workflow reference boundary', () => {
+    const { home, project, catalog } = fixture();
+    write(join(catalog, 'workflows', 'bad-yaml', 'workflow.yaml'), 'version: [\n');
+    write(
+      join(catalog, 'workflows', 'wrong-id', 'workflow.yaml'),
+      `version: 1
+id: different
+title: Wrong id
+description: Exercise directory identity validation.
+actors: {}
+nodes:
+  - {id: noop, action: inspect, description: Keep the definition schema-valid.}
+`,
+    );
+    write(
+      join(catalog, 'workflows', 'invalid', 'workflow.yaml'),
+      `version: 1
+id: invalid
+title: Invalid references
+description: Exercise every workflow reference boundary.
+actors:
+  missing: {kind: agent, profile: absent}
+  human: {kind: human}
+environments: {known: local}
+integrations:
+  missing-fields: {kind: artifact, ref: short, sha256: short}
+  omitted-fields: {kind: artifact}
+  github: {kind: mcp, server: github}
+feedback:
+  - {from: absent-source, to: absent-target}
+nodes:
+  - id: duplicate
+    action: inspect
+    description: First duplicate.
+    actor: missing
+    environment: absent
+    needs: [absent-node]
+    uses: [absent-integration]
+  - id: duplicate
+    action: inspect
+    description: Second duplicate.
+    actor: human
+    environment: absent
+  - id: nested
+    workflow: absent-workflow
+    description: Unknown nested workflow.
+`,
+    );
+    write(
+      join(catalog, 'workflows', 'cycle', 'workflow.yaml'),
+      `version: 1
+id: cycle
+title: Cycle
+description: Exercise nested cycle validation.
+actors: {}
+nodes:
+  - {id: again, workflow: cycle, description: Recurse.}
+`,
+    );
+
+    const set = resolveResources(
+      discoverLayers({ homeDirectory: home, projectDirectory: project, settings: { sources: [] } }).layers,
+    );
+    const messages = validateEffectiveSet(set, project).map((finding) => finding.message);
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('not valid YAML'),
+        expect.stringContaining("workflow id 'different'"),
+        expect.stringContaining("actor 'missing' references unknown agent 'absent'"),
+        expect.stringContaining("duplicate node id 'duplicate'"),
+        expect.stringContaining("references unknown environment 'absent'"),
+        expect.stringContaining("needs unknown node 'absent-node'"),
+        expect.stringContaining("references unknown integration 'absent-integration'"),
+        expect.stringContaining("references unknown workflow 'absent-workflow'"),
+        expect.stringContaining("feedback references unknown source node 'absent-source'"),
+        expect.stringContaining("feedback references unknown target node 'absent-target'"),
+        expect.stringContaining("artifact integration 'missing-fields' must pin"),
+        expect.stringContaining("artifact integration 'missing-fields' must declare a SHA-256"),
+        expect.stringContaining("artifact integration 'missing-fields' must declare repository and path"),
+        expect.stringContaining('nested workflow cycle'),
+      ]),
+    );
+  });
+
+  it('reports unknown and invalid workflows without creating an export', () => {
+    const { home, project, catalog, root } = fixture();
+    const unknown = executeDumpCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      workflow: 'absent',
+      out: join(root, 'unknown'),
+    });
+    expect(unknown.ok).toBe(false);
+    expect(unknown.messages.join('\n')).toContain("references unknown workflow 'absent'");
+
+    write(join(catalog, 'workflows', 'broken', 'workflow.yaml'), 'version: [\n');
+    const broken = executeDumpCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      workflow: 'broken',
+      out: join(root, 'broken'),
+    });
+    expect(broken.ok).toBe(false);
+    expect(broken.messages.join('\n')).toContain("workflow 'broken': workflow.yaml is not valid YAML");
+    const unreadable = readWorkflowDefinition(join(root, 'missing.yaml'));
+    expect(isWorkflowDefinitionIssue(unreadable)).toBe(true);
+    if (isWorkflowDefinitionIssue(unreadable)) expect(unreadable.message).toContain('not readable');
+
+    expect(() =>
+      executeDumpCommand({
+        homeDirectory: home,
+        projectDirectory: project,
+        agent: 'reviewer',
+        workflow: 'review',
+        out: join(root, 'ambiguous'),
+      }),
+    ).toThrow('Choose either --agent or --workflow');
+
+    write(
+      join(catalog, 'workflows', 'loop', 'workflow.yaml'),
+      `version: 1
+id: loop
+title: Loop
+description: Exercise closure de-duplication.
+actors: {}
+nodes:
+  - {id: again, workflow: loop, description: Recurse once.}
+`,
+    );
+    const loop = executeDumpCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      workflow: 'loop',
+      out: join(root, 'loop'),
+    });
+    expect(loop.ok).toBe(true);
+
+    write(
+      join(catalog, 'workflows', 'missing-agent', 'workflow.yaml'),
+      `version: 1
+id: missing-agent
+title: Missing agent
+description: Exercise an agent dump failure.
+actors:
+  absent: {kind: agent, profile: absent}
+nodes:
+  - {id: run, action: inspect, actor: absent, description: Try the missing agent.}
+`,
+    );
+    const missingAgent = executeDumpCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      workflow: 'missing-agent',
+      out: join(root, 'missing-agent'),
+    });
+    expect(missingAgent.ok).toBe(false);
+    expect(missingAgent.messages.join('\n')).toContain("Unknown agent 'absent'");
   });
 
   it('exports root and nested workflow YAML with the complete agent closure and manifest', () => {

--- a/code/cli/tests/unit/workflow-resources.test.ts
+++ b/code/cli/tests/unit/workflow-resources.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
@@ -174,6 +174,7 @@ nodes:
     description: Second duplicate.
     actor: human
     environment: absent
+    skill: missing
   - id: nested
     workflow: absent-workflow
     description: Unknown nested workflow.
@@ -211,6 +212,7 @@ nodes:
         expect.stringContaining("artifact integration 'missing-fields' must declare a SHA-256"),
         expect.stringContaining("artifact integration 'missing-fields' must declare repository and path"),
         expect.stringContaining('nested workflow cycle'),
+        expect.stringContaining("node 'duplicate' has agent-closure assertions but no agent actor"),
       ]),
     );
   });
@@ -235,6 +237,26 @@ nodes:
     });
     expect(broken.ok).toBe(false);
     expect(broken.messages.join('\n')).toContain("workflow 'broken': workflow.yaml is not valid YAML");
+
+    write(
+      join(catalog, 'workflows', 'wrong-id', 'workflow.yaml'),
+      `version: 1
+id: different
+title: Wrong id
+description: Exercise directory identity validation during export.
+actors: {}
+nodes:
+  - {id: noop, action: inspect, description: Keep the definition schema-valid.}
+`,
+    );
+    const wrongId = executeDumpCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      workflow: 'wrong-id',
+      out: join(root, 'wrong-id'),
+    });
+    expect(wrongId.ok).toBe(false);
+    expect(wrongId.messages.join('\n')).toContain("workflow id 'different' must match its directory 'wrong-id'");
     const unreadable = readWorkflowDefinition(join(root, 'missing.yaml'));
     expect(isWorkflowDefinitionIssue(unreadable)).toBe(true);
     if (isWorkflowDefinitionIssue(unreadable)) expect(unreadable.message).toContain('not readable');
@@ -288,6 +310,52 @@ nodes:
     });
     expect(missingAgent.ok).toBe(false);
     expect(missingAgent.messages.join('\n')).toContain("Unknown agent 'absent'");
+    expect(existsSync(join(root, 'missing-agent', '.agents'))).toBe(false);
+  });
+
+  it('rejects schema-valid-looking null integrations and escaping workflow symlinks', () => {
+    const { home, project, catalog, root } = fixture();
+    write(
+      join(catalog, 'workflows', 'null-integration', 'workflow.yaml'),
+      `version: 1
+id: null-integration
+title: Null integration
+description: Reject null integration values.
+actors: {}
+integrations: {cache: null}
+nodes:
+  - {id: inspect, action: inspect, description: Inspect.}
+`,
+    );
+    const set = resolveResources(
+      discoverLayers({ homeDirectory: home, projectDirectory: project, settings: { sources: [] } }).layers,
+    );
+    expect(validateEffectiveSet(set, project).map((finding) => finding.message)).toEqual(
+      expect.arrayContaining([expect.stringContaining('/integrations/cache')]),
+    );
+
+    const external = join(root, 'external-workflow');
+    write(
+      join(external, 'workflow.yaml'),
+      `version: 1
+id: escape
+title: Escape
+description: External workflow.
+actors: {}
+nodes:
+  - {id: inspect, action: inspect, description: Inspect.}
+`,
+    );
+    symlinkSync(external, join(catalog, 'workflows', 'escape'));
+    const escaped = executeDumpCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      workflow: 'escape',
+      out: join(root, 'escaped'),
+    });
+    expect(escaped.ok).toBe(false);
+    expect(escaped.messages.join('\n')).toContain('resolves outside the tree');
+    expect(existsSync(join(root, 'escaped', '.agents'))).toBe(false);
   });
 
   it('exports root and nested workflow YAML with the complete agent closure and manifest', () => {
@@ -303,8 +371,13 @@ nodes:
     expect(readFileSync(join(out, '.agents', 'skills', 'review', 'SKILL.md'), 'utf8')).toContain('name: review');
     const manifest = JSON.parse(
       readFileSync(join(out, '.agents', '.outfitter', 'workflow-composition.json'), 'utf8'),
-    ) as { root: string; workflows: string[] };
-    expect(manifest).toMatchObject({ root: 'delivery', workflows: ['delivery', 'review'] });
+    ) as { root: string; workflows: { id: string; source: { layer: string; path: string } }[] };
+    expect(manifest.root).toBe('delivery');
+    expect(manifest.workflows.map((workflow) => ({ id: workflow.id, layer: workflow.source.layer }))).toEqual([
+      { id: 'delivery', layer: 'workspace' },
+      { id: 'review', layer: 'workspace' },
+    ]);
+    expect(manifest.workflows.every((workflow) => workflow.source.path.endsWith('workflow.yaml'))).toBe(true);
   });
 
   it('refuses an existing destination instead of replacing it', () => {

--- a/code/cli/tests/unit/workflow-resources.test.ts
+++ b/code/cli/tests/unit/workflow-resources.test.ts
@@ -11,10 +11,19 @@ import { resolveResources } from '../../src/resolver/Resolver.js';
 import { validateEffectiveSet } from '../../src/resolver/ResolverValidation.js';
 
 const roots: string[] = [];
-const temporary = (): string => { const root = mkdtempSync(join(tmpdir(), 'outfitter-workflow-test-')); roots.push(root); return root; };
-const write = (path: string, content: string): void => { mkdirSync(dirname(path), { recursive: true }); writeFileSync(path, content); };
+const temporary = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-workflow-test-'));
+  roots.push(root);
+  return root;
+};
+const write = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
 
-afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
 
 const fixture = () => {
   const root = temporary();
@@ -23,9 +32,17 @@ const fixture = () => {
   const catalog = join(project, '.agents');
   write(join(catalog, 'skills', 'review', 'SKILL.md'), '---\nname: review\n---\n');
   write(join(catalog, 'prompts', 'review.md'), 'Review carefully.\n');
-  write(join(catalog, 'agents', 'reviewer', 'agent.md'), '---\nname: reviewer\nskills: [review]\nmcp: [github]\nappend_system_prompt:\n  - file: prompts/review.md\n---\n\n# Reviewer\n');
-  write(join(catalog, 'agents', 'reviewer', 'mcp.json'), JSON.stringify({ mcpServers: { github: { command: 'github-mcp-server' } } }));
-  write(join(catalog, 'workflows', 'review', 'workflow.yaml'), `version: 1
+  write(
+    join(catalog, 'agents', 'reviewer', 'agent.md'),
+    '---\nname: reviewer\nskills: [review]\nmcp: [github]\nappend_system_prompt:\n  - file: prompts/review.md\n---\n\n# Reviewer\n',
+  );
+  write(
+    join(catalog, 'agents', 'reviewer', 'mcp.json'),
+    JSON.stringify({ mcpServers: { github: { command: 'github-mcp-server' } } }),
+  );
+  write(
+    join(catalog, 'workflows', 'review', 'workflow.yaml'),
+    `version: 1
 id: review
 title: Review
 description: Review a change.
@@ -43,8 +60,11 @@ nodes:
     skill: review
     prompt_fragment: prompts/review.md
     uses: [github]
-`);
-  write(join(catalog, 'workflows', 'delivery', 'workflow.yaml'), `version: 1
+`,
+  );
+  write(
+    join(catalog, 'workflows', 'delivery', 'workflow.yaml'),
+    `version: 1
 id: delivery
 title: Delivery
 description: Deliver with review.
@@ -53,14 +73,17 @@ nodes:
   - id: review
     workflow: review
     description: Run review.
-`);
+`,
+  );
   return { root, home, project, catalog };
 };
 
 describe('workflow resources', () => {
   it('discovers and strictly validates typed composed dependencies', () => {
     const { home, project } = fixture();
-    const set = resolveResources(discoverLayers({ homeDirectory: home, projectDirectory: project, settings: { sources: [] } }).layers);
+    const set = resolveResources(
+      discoverLayers({ homeDirectory: home, projectDirectory: project, settings: { sources: [] } }).layers,
+    );
     expect(listResources(set, 'workflow').map((workflow) => workflow.slug)).toEqual(['delivery', 'review']);
     expect(validateEffectiveSet(set, project)).toEqual([]);
   });
@@ -68,14 +91,24 @@ describe('workflow resources', () => {
   it('rejects skills, prompts, and MCP servers outside the selected agent closure', () => {
     const { home, project, catalog } = fixture();
     const path = join(catalog, 'workflows', 'review', 'workflow.yaml');
-    write(path, readFileSync(path, 'utf8').replace('skill: review', 'skill: missing').replace('server: github', 'server: missing').replace('prompts/review.md', 'prompts/missing.md'));
-    const set = resolveResources(discoverLayers({ homeDirectory: home, projectDirectory: project, settings: { sources: [] } }).layers);
+    write(
+      path,
+      readFileSync(path, 'utf8')
+        .replace('skill: review', 'skill: missing')
+        .replace('server: github', 'server: missing')
+        .replace('prompts/review.md', 'prompts/missing.md'),
+    );
+    const set = resolveResources(
+      discoverLayers({ homeDirectory: home, projectDirectory: project, settings: { sources: [] } }).layers,
+    );
     const messages = validateEffectiveSet(set, project).map((finding) => finding.message);
-    expect(messages).toEqual(expect.arrayContaining([
-      expect.stringContaining("skill 'missing' outside"),
-      expect.stringContaining("prompt fragment 'prompts/missing.md' outside"),
-      expect.stringContaining("MCP server 'missing' outside"),
-    ]));
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("skill 'missing' outside"),
+        expect.stringContaining("prompt fragment 'prompts/missing.md' outside"),
+        expect.stringContaining("MCP server 'missing' outside"),
+      ]),
+    );
   });
 
   it('exports root and nested workflow YAML with the complete agent closure and manifest', () => {
@@ -83,11 +116,15 @@ describe('workflow resources', () => {
     const out = join(root, 'out');
     const result = executeDumpCommand({ homeDirectory: home, projectDirectory: project, workflow: 'delivery', out });
     expect(result.ok).toBe(true);
-    expect(readFileSync(join(out, '.agents', 'workflows', 'delivery', 'workflow.yaml'), 'utf8')).toContain('id: delivery');
+    expect(readFileSync(join(out, '.agents', 'workflows', 'delivery', 'workflow.yaml'), 'utf8')).toContain(
+      'id: delivery',
+    );
     expect(readFileSync(join(out, '.agents', 'workflows', 'review', 'workflow.yaml'), 'utf8')).toContain('id: review');
     expect(readFileSync(join(out, '.agents', 'agents', 'reviewer', 'agent.md'), 'utf8')).toContain('name: reviewer');
     expect(readFileSync(join(out, '.agents', 'skills', 'review', 'SKILL.md'), 'utf8')).toContain('name: review');
-    const manifest = JSON.parse(readFileSync(join(out, '.agents', '.outfitter', 'workflow-composition.json'), 'utf8')) as { root: string; workflows: string[] };
+    const manifest = JSON.parse(
+      readFileSync(join(out, '.agents', '.outfitter', 'workflow-composition.json'), 'utf8'),
+    ) as { root: string; workflows: string[] };
     expect(manifest).toMatchObject({ root: 'delivery', workflows: ['delivery', 'review'] });
   });
 

--- a/code/cli/tests/unit/workflow-resources.test.ts
+++ b/code/cli/tests/unit/workflow-resources.test.ts
@@ -1,0 +1,103 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { executeDumpCommand } from '../../src/cli/commands/DumpCommand.js';
+import { discoverLayers } from '../../src/resolver/Layer.js';
+import { listResources } from '../../src/resolver/Resource.js';
+import { resolveResources } from '../../src/resolver/Resolver.js';
+import { validateEffectiveSet } from '../../src/resolver/ResolverValidation.js';
+
+const roots: string[] = [];
+const temporary = (): string => { const root = mkdtempSync(join(tmpdir(), 'outfitter-workflow-test-')); roots.push(root); return root; };
+const write = (path: string, content: string): void => { mkdirSync(dirname(path), { recursive: true }); writeFileSync(path, content); };
+
+afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+
+const fixture = () => {
+  const root = temporary();
+  const home = join(root, 'home');
+  const project = join(root, 'project');
+  const catalog = join(project, '.agents');
+  write(join(catalog, 'skills', 'review', 'SKILL.md'), '---\nname: review\n---\n');
+  write(join(catalog, 'prompts', 'review.md'), 'Review carefully.\n');
+  write(join(catalog, 'agents', 'reviewer', 'agent.md'), '---\nname: reviewer\nskills: [review]\nmcp: [github]\nappend_system_prompt:\n  - file: prompts/review.md\n---\n\n# Reviewer\n');
+  write(join(catalog, 'agents', 'reviewer', 'mcp.json'), JSON.stringify({ mcpServers: { github: { command: 'github-mcp-server' } } }));
+  write(join(catalog, 'workflows', 'review', 'workflow.yaml'), `version: 1
+id: review
+title: Review
+description: Review a change.
+actors:
+  reviewer: {kind: agent, profile: reviewer}
+environments: {workstation: local}
+integrations:
+  github: {kind: mcp, server: github}
+nodes:
+  - id: inspect
+    action: inspect
+    description: Inspect the change.
+    actor: reviewer
+    environment: workstation
+    skill: review
+    prompt_fragment: prompts/review.md
+    uses: [github]
+`);
+  write(join(catalog, 'workflows', 'delivery', 'workflow.yaml'), `version: 1
+id: delivery
+title: Delivery
+description: Deliver with review.
+actors: {}
+nodes:
+  - id: review
+    workflow: review
+    description: Run review.
+`);
+  return { root, home, project, catalog };
+};
+
+describe('workflow resources', () => {
+  it('discovers and strictly validates typed composed dependencies', () => {
+    const { home, project } = fixture();
+    const set = resolveResources(discoverLayers({ homeDirectory: home, projectDirectory: project, settings: { sources: [] } }).layers);
+    expect(listResources(set, 'workflow').map((workflow) => workflow.slug)).toEqual(['delivery', 'review']);
+    expect(validateEffectiveSet(set, project)).toEqual([]);
+  });
+
+  it('rejects skills, prompts, and MCP servers outside the selected agent closure', () => {
+    const { home, project, catalog } = fixture();
+    const path = join(catalog, 'workflows', 'review', 'workflow.yaml');
+    write(path, readFileSync(path, 'utf8').replace('skill: review', 'skill: missing').replace('server: github', 'server: missing').replace('prompts/review.md', 'prompts/missing.md'));
+    const set = resolveResources(discoverLayers({ homeDirectory: home, projectDirectory: project, settings: { sources: [] } }).layers);
+    const messages = validateEffectiveSet(set, project).map((finding) => finding.message);
+    expect(messages).toEqual(expect.arrayContaining([
+      expect.stringContaining("skill 'missing' outside"),
+      expect.stringContaining("prompt fragment 'prompts/missing.md' outside"),
+      expect.stringContaining("MCP server 'missing' outside"),
+    ]));
+  });
+
+  it('exports root and nested workflow YAML with the complete agent closure and manifest', () => {
+    const { home, project, root } = fixture();
+    const out = join(root, 'out');
+    const result = executeDumpCommand({ homeDirectory: home, projectDirectory: project, workflow: 'delivery', out });
+    expect(result.ok).toBe(true);
+    expect(readFileSync(join(out, '.agents', 'workflows', 'delivery', 'workflow.yaml'), 'utf8')).toContain('id: delivery');
+    expect(readFileSync(join(out, '.agents', 'workflows', 'review', 'workflow.yaml'), 'utf8')).toContain('id: review');
+    expect(readFileSync(join(out, '.agents', 'agents', 'reviewer', 'agent.md'), 'utf8')).toContain('name: reviewer');
+    expect(readFileSync(join(out, '.agents', 'skills', 'review', 'SKILL.md'), 'utf8')).toContain('name: review');
+    const manifest = JSON.parse(readFileSync(join(out, '.agents', '.outfitter', 'workflow-composition.json'), 'utf8')) as { root: string; workflows: string[] };
+    expect(manifest).toMatchObject({ root: 'delivery', workflows: ['delivery', 'review'] });
+  });
+
+  it('refuses an existing destination instead of replacing it', () => {
+    const { home, project, root } = fixture();
+    const out = join(root, 'out');
+    write(join(out, '.agents', 'user-owned.md'), 'keep\n');
+    const result = executeDumpCommand({ homeDirectory: home, projectDirectory: project, workflow: 'delivery', out });
+    expect(result.ok).toBe(false);
+    expect(result.messages.join('\n')).toContain('refuses existing destination');
+    expect(readFileSync(join(out, '.agents', 'user-owned.md'), 'utf8')).toBe('keep\n');
+  });
+});

--- a/docs/documentation/catalogs.md
+++ b/docs/documentation/catalogs.md
@@ -1,6 +1,6 @@
 # Catalogs
 
-A catalog is a git repository that publishes a `.agents` payload — agents, skills, tasks, knowledge, commands — so a person, team, or organization can share it. You can bootstrap a machine or project from one, or add one as an ongoing source that Outfitter keeps synchronized.
+A catalog is a git repository that publishes a `.agents` payload — agents, skills, workflows, tasks, knowledge, commands — so a person, team, or organization can share it. You can bootstrap a machine or project from one, or add one as an ongoing source that Outfitter keeps synchronized.
 
 ```bash
 outfitter setup https://github.com/ncrmro/.agents
@@ -33,6 +33,8 @@ ncrmro/.agents/            # repository root
   tasks/
     weekly-kpis/task.md
   knowledge/
+  workflows/
+    engineer/workflow.yaml
   settings.yml             # Outfitter settings (optional; see settings.md)
   settings.local.yml       # gitignored machine-local overrides
 ```
@@ -82,6 +84,12 @@ Remote entries additionally accept:
 - `path:` — the payload directory inside the repository, for colocated layouts.
 
 Resources from all sources resolve by slug behind local layers, following [layer precedence](./concepts.md#layer-precedence). Agent-local skills keep their owning-agent namespace through cache and source merging. Outfitter reports shadowed IDs so consumers can see which source supplies a selected resource.
+
+### Workflows are configuration, not an execution engine
+
+Each `workflows/<slug>/workflow.yaml` is a typed graph that names its human, agent, tool, and system actors. Agent actors reference ordinary catalog profiles. Node-level skill, prompt, and MCP assertions must already belong to the selected agent's composed closure. Nested workflow references resolve by slug and may not form cycles.
+
+`outfitter validate --strict` validates the graph and the complete composed dependency closure. `outfitter dump --workflow <slug>` produces a reviewable `.agents` bundle for distribution. Outfitter never schedules or executes the graph.
 
 ### Catalog dependencies (transitive sources)
 

--- a/docs/documentation/cli.md
+++ b/docs/documentation/cli.md
@@ -71,13 +71,13 @@ resolution tells you to run `outfitter sync`.
 
 List resolvable resources across all layers, with the winning source for each slug and any shadowed IDs.
 
-| Argument | Description                                                   |
-| -------- | ------------------------------------------------------------- |
-| `[kind]` | Optional filter: `agents`, `skills`, `knowledge`, `commands`. |
+| Argument | Description                                                                |
+| -------- | -------------------------------------------------------------------------- |
+| `[kind]` | Optional filter: `agents`, `skills`, `knowledge`, `commands`, `workflows`. |
 
 ## `outfitter validate`
 
-Validate the effective resource set: protocol layout, frontmatter, unresolved slugs in agent loadouts, broken or escaping skill references, and settings schema.
+Validate the effective resource set: protocol layout, frontmatter, unresolved slugs in agent loadouts, broken or escaping skill references, workflow graphs and composed closures, and settings schema.
 
 | Option     | Description                              |
 | ---------- | ---------------------------------------- |
@@ -88,10 +88,13 @@ Validate the effective resource set: protocol layout, frontmatter, unresolved sl
 
 Write the composed resource tree as a self-contained `.agents/` directory for review, vendoring, or air-gapped use. Identical sources, refs, and selections produce byte-identical output; dumps never contain credentials, sessions, caches, or other mutable runtime state.
 
-| Option         | Description                                          |
-| -------------- | ---------------------------------------------------- |
-| `--agent <id>` | Restrict the dump to one agent's transitive closure. |
-| `--out <dir>`  | Destination directory (default `./.agents`).         |
+| Option            | Description                                                                    |
+| ----------------- | ------------------------------------------------------------------------------ |
+| `--agent <id>`    | Restrict the dump to one agent's transitive closure.                           |
+| `--workflow <id>` | Export one workflow, its nested workflows, and every referenced agent closure. |
+| `--out <dir>`     | Destination directory (default `./.agents`).                                   |
+
+Workflow dumps are non-executable configuration bundles. They contain the canonical workflow YAML, composed agent resources, and a hash/provenance manifest. A workflow dump refuses an existing destination instead of replacing user files.
 
 > **Tasks and `outfitter task bake`** — baking a task and its inputs into an immutable execution artifact — are the subject of a separate upcoming RFC and are not part of this command surface yet. See [Tasks](./tasks.md).
 

--- a/docs/documentation/cli.md
+++ b/docs/documentation/cli.md
@@ -75,6 +75,8 @@ List resolvable resources across all layers, with the winning source for each sl
 | -------- | -------------------------------------------------------------------------- |
 | `[kind]` | Optional filter: `agents`, `skills`, `knowledge`, `commands`, `workflows`. |
 
+`--json` emits an object containing `ok`, `resources`, and `diagnostics`; diagnostics remain available when strict mode fails.
+
 ## `outfitter validate`
 
 Validate the effective resource set: protocol layout, frontmatter, unresolved slugs in agent loadouts, broken or escaping skill references, workflow graphs and composed closures, and settings schema.

--- a/docs/documentation/dump-and-bake.md
+++ b/docs/documentation/dump-and-bake.md
@@ -9,6 +9,7 @@
 ```bash
 outfitter dump --out ./review
 outfitter dump --agent engineer --out ./engineer   # one agent's transitive closure only
+outfitter dump --workflow engineer --out ./workflow # graph + nested graphs + agent closures
 ```
 
 Use dumps to:
@@ -24,6 +25,7 @@ Use dumps to:
 - **Safe** — a dump may include reviewable source provenance, but never credentials, auth state, sessions, transcripts, caches, backups, mutable harness state, or symlinks escaping the tree.
 - **Protocol-shaped** — the output is a valid `.agents` payload usable by any protocol consumer, not just Outfitter. Any Outfitter-specific provenance metadata is namespaced, JSON-based, and removable without losing the underlying resources.
 - **Harness-discoverable** — selected agent-local skills are flattened into top-level `skills/<id>/` in the closure output, with their packaged references, scripts, and assets intact.
+- **Workflow-auditable** — workflow exports preserve canonical YAML and record every nested workflow, agent composition, file hash, and winning source in `.outfitter/workflow-composition.json`.
 
 ## Bake
 


### PR DESCRIPTION
## Summary

- discover and strictly validate declarative workflow resources
- export deterministic, machine-readable workflow closures without executing them
- expose workflow resources through the list and dump commands
- document the workflow catalog contract

## Verification

- `npm run build`
- 596 tests pass
- `npm run check-ci` currently reaches 95.42% branch coverage against the repository's 98% gate; follow-up test coverage is required before merge
- the Community Profiles catalog validates with `scripts/validate-workflows.sh` against this branch's built CLI

## Release order

This is the first PR in the workflow-manager dependency chain. After merge, release Outfitter v1.13.0, then update and land the Community Profiles workflow catalog before regenerating the website bundle.
