### PR TITLE
feat(settings): compose agent defaults into every agent

### DIFF
--- a/code/cli/src/cli/commands/DumpCommand.ts
+++ b/code/cli/src/cli/commands/DumpCommand.ts
@@ -81,8 +81,8 @@ export const executeDumpCommand = (input: DumpInput): DumpCommandResult => {
   const selected = input.workflow ?? resolveAgentSlug(settings, input.agent);
   const result =
     input.workflow === undefined
-      ? dumpAgent(set, selected, input.out, input.projectDirectory)
-      : dumpWorkflow(set, selected, input.out, input.projectDirectory);
+      ? dumpAgent(set, selected, input.out, input.projectDirectory, settings.agentDefaults)
+      : dumpWorkflow(set, selected, input.out, input.projectDirectory, settings.agentDefaults);
   const ok = result.errors.length === 0;
   const messages = ok
     ? [

--- a/code/cli/src/cli/commands/LinkCommand.ts
+++ b/code/cli/src/cli/commands/LinkCommand.ts
@@ -107,7 +107,7 @@ const resolveClosure = (input: LinkInput, messages: string[]): ResolvedClosure =
   });
   if (scope.errors.length > 0)
     return { failure: failure([...messages, ...scope.errors.map((error) => `error: ${error}`)]) };
-  const closure = composeLinkClosure(set, scope.agents, input.projectDirectory);
+  const closure = composeLinkClosure(set, scope.agents, input.projectDirectory, settings.agentDefaults);
   messages.push(...closure.warnings.map((warning) => `warning: ${warning}`));
   if (closure.errors.length > 0) {
     return { failure: failure([...messages, ...closure.errors.map((error) => `error: ${error}`)]) };

--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -362,7 +362,10 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
   const agentSlug = resolveAgentSlug(settings.defaultAgent, input.agent);
   const harness = resolveHarness(settings.defaultHarness, input.harness);
   const claudeConfig = resolveClaudeConfig(input, harness, settings.isolation);
-  const composed = compose(set, agentSlug, { projectDirectory: input.projectDirectory });
+  const composed = compose(set, agentSlug, {
+    projectDirectory: input.projectDirectory,
+    agentDefaults: settings.agentDefaults,
+  });
 
   if (composed.plan === undefined) {
     const messages = [...resolutionWarnings, ...failedCompositionMessages(resolved, composed)];

--- a/code/cli/src/cli/commands/ValidateCommand.ts
+++ b/code/cli/src/cli/commands/ValidateCommand.ts
@@ -36,7 +36,10 @@ export const executeValidateCommand = (input: ValidateInput): ValidateResult => 
   const findings = [
     ...settingsFindings(settingsIssues.map(formatSettingsIssue)),
     ...warnings.map((message) => ({ severity: 'warning' as const, resource: 'settings', message })),
-    ...validateEffectiveSet(set, input.projectDirectory, { workflowRoots: settings.workflows }),
+    ...validateEffectiveSet(set, input.projectDirectory, {
+      workflowRoots: settings.workflows,
+      agentDefaults: settings.agentDefaults,
+    }),
   ];
 
   const hasErrors = findings.some((finding) => finding.severity === 'error');

--- a/code/cli/src/composer/Chain.ts
+++ b/code/cli/src/composer/Chain.ts
@@ -1,0 +1,62 @@
+// Resolves an agent's inheritance chain: ordered parent-first entries with cycle and parent checks.
+import { isAgentDefinitionIssue, readAgentDefinition } from '../resolver/AgentDefinition.js';
+import type { AgentDefinition } from '../resolver/AgentDefinition.js';
+import type { EffectiveResourceSet, ResolvedResource } from '../resolver/Resource.js';
+import { findResource } from '../resolver/Resource.js';
+
+export interface ChainEntry {
+  readonly resource: ResolvedResource;
+  readonly definition: AgentDefinition;
+}
+
+const readValidAgent = (agent: ResolvedResource): AgentDefinition | string => {
+  const definition = readAgentDefinition(agent.winner.path, agent.configPaths);
+  if (isAgentDefinitionIssue(definition)) return definition.message;
+  if (definition.name !== agent.slug) return `agent.md name '${definition.name}' must match its directory.`;
+  return definition;
+};
+
+export const resolveInheritanceChain = (
+  set: EffectiveResourceSet,
+  agentSlug: string,
+): { entries?: readonly ChainEntry[]; errors: readonly string[] } => {
+  const entries: ChainEntry[] = [];
+  const composed = new Set<string>();
+  const visiting: string[] = [];
+  const errors: string[] = [];
+
+  const visit = (slug: string): void => {
+    if (composed.has(slug)) return;
+    const cycleIndex = visiting.indexOf(slug);
+    if (cycleIndex !== -1) {
+      errors.push(`Agent inheritance cycle detected: ${[...visiting.slice(cycleIndex), slug].join(' -> ')}.`);
+      return;
+    }
+
+    const resource = findResource(set, 'agent', slug);
+    if (resource === undefined) {
+      errors.push(
+        `Agent inheritance references unknown parent '${slug}' in chain ${[...visiting, slug].join(' -> ')}.`,
+      );
+      return;
+    }
+
+    const definition = readValidAgent(resource);
+    if (typeof definition === 'string') {
+      errors.push(`Agent '${slug}' is invalid: ${definition}`);
+      return;
+    }
+
+    visiting.push(slug);
+    for (const parent of definition.inherits) visit(parent);
+    visiting.pop();
+
+    if (!composed.has(slug)) {
+      composed.add(slug);
+      entries.push({ resource, definition });
+    }
+  };
+
+  visit(agentSlug);
+  return errors.length > 0 ? { errors } : { entries, errors: [] };
+};

--- a/code/cli/src/composer/Composer.ts
+++ b/code/cli/src/composer/Composer.ts
@@ -3,11 +3,25 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { escapesRoots } from '../dump/Containment.js';
-import { isAgentDefinitionIssue, readAgentDefinition } from '../resolver/AgentDefinition.js';
 import type { AgentDefinition } from '../resolver/AgentDefinition.js';
 import type { EffectiveResourceSet, Loadout, ResolvedResource } from '../resolver/Resource.js';
-import { findLoadoutResource, findResource } from '../resolver/Resource.js';
+import { findResource } from '../resolver/Resource.js';
+import type { AgentDefaults } from '../settings/Settings.js';
+import type { ChainEntry } from './Chain.js';
+import { resolveInheritanceChain } from './Chain.js';
 import type { ComposedLoadout, ComposedSubagent, ComposedSubagentIdentity, CompositionPlan } from './Composition.js';
+import type { DeclaredSlug, PromptSelection } from './Defaults.js';
+import {
+  SETTINGS_DEFAULTS_DECLARER,
+  mergePromptSelections,
+  mergeSelections,
+  planAgentDefaults,
+  resolveDeclaredSlugs,
+  resolveSettingsPromptSelection,
+  settingsPromptSelections,
+  settingsSelections,
+} from './Defaults.js';
+import { composeMcpServers } from './Mcp.js';
 import { resolveModelRegistry } from './Models.js';
 import type { PromptFragment, PromptSourceReference } from './PromptSource.js';
 import { agentBodyFragment, promptSourceKey, resolvePromptSource, rootPromptFragment } from './PromptSource.js';
@@ -15,6 +29,11 @@ import { agentBodyFragment, promptSourceKey, resolvePromptSource, rootPromptFrag
 export interface ComposeOptions {
   /** Active repository root for `repo_file` prompt references. */
   readonly projectDirectory?: string;
+  /**
+   * Settings-layer (`agent_defaults`) loadout entries composed into the agent ahead of its own
+   * inheritance chain. Absent or empty defaults leave composition byte-identical to no settings.
+   */
+  readonly agentDefaults?: AgentDefaults;
 }
 
 export interface ComposeResult {
@@ -23,26 +42,12 @@ export interface ComposeResult {
   readonly warnings: readonly string[];
 }
 
-interface ChainEntry {
-  readonly resource: ResolvedResource;
-  readonly definition: AgentDefinition;
-}
-
-interface DeclaredSlug {
-  readonly slug: string;
-  readonly owner: string;
-}
-
 interface EffectiveControls {
   readonly loadout: Loadout;
   readonly skillSelections: readonly DeclaredSlug[];
   readonly subagentSelections: readonly DeclaredSlug[];
   readonly mcpSelections: readonly DeclaredSlug[];
-  readonly appendPromptSelections: readonly {
-    readonly source: PromptSourceReference;
-    readonly owner: string;
-    readonly index: number;
-  }[];
+  readonly appendPromptSelections: readonly PromptSelection[];
   readonly systemPrompt?: { readonly source: PromptSourceReference; readonly owner: string };
   readonly promptTemplate?: { readonly source: PromptSourceReference; readonly owner: string };
   readonly label?: string;
@@ -60,58 +65,6 @@ const readRootFile = (set: EffectiveResourceSet, fileName: string): PromptFragme
   }
 
   return undefined;
-};
-
-const readValidAgent = (agent: ResolvedResource): AgentDefinition | string => {
-  const definition = readAgentDefinition(agent.winner.path, agent.configPaths);
-  if (isAgentDefinitionIssue(definition)) return definition.message;
-  if (definition.name !== agent.slug) return `agent.md name '${definition.name}' must match its directory.`;
-  return definition;
-};
-
-const resolveInheritanceChain = (
-  set: EffectiveResourceSet,
-  agentSlug: string,
-): { entries?: readonly ChainEntry[]; errors: readonly string[] } => {
-  const entries: ChainEntry[] = [];
-  const composed = new Set<string>();
-  const visiting: string[] = [];
-  const errors: string[] = [];
-
-  const visit = (slug: string): void => {
-    if (composed.has(slug)) return;
-    const cycleIndex = visiting.indexOf(slug);
-    if (cycleIndex !== -1) {
-      errors.push(`Agent inheritance cycle detected: ${[...visiting.slice(cycleIndex), slug].join(' -> ')}.`);
-      return;
-    }
-
-    const resource = findResource(set, 'agent', slug);
-    if (resource === undefined) {
-      errors.push(
-        `Agent inheritance references unknown parent '${slug}' in chain ${[...visiting, slug].join(' -> ')}.`,
-      );
-      return;
-    }
-
-    const definition = readValidAgent(resource);
-    if (typeof definition === 'string') {
-      errors.push(`Agent '${slug}' is invalid: ${definition}`);
-      return;
-    }
-
-    visiting.push(slug);
-    for (const parent of definition.inherits) visit(parent);
-    visiting.pop();
-
-    if (!composed.has(slug)) {
-      composed.add(slug);
-      entries.push({ resource, definition });
-    }
-  };
-
-  visit(agentSlug);
-  return errors.length > 0 ? { errors } : { entries, errors: [] };
 };
 
 const stablePush = <T>(items: T[], keySet: Set<string>, key: string, value: T): void => {
@@ -144,8 +97,8 @@ const declaredSelections = (
   return selections;
 };
 
-const appendPromptSelections = (chain: readonly ChainEntry[]): EffectiveControls['appendPromptSelections'] => {
-  const selections: { readonly source: PromptSourceReference; readonly owner: string; readonly index: number }[] = [];
+const appendPromptSelections = (chain: readonly ChainEntry[]): readonly PromptSelection[] => {
+  const selections: PromptSelection[] = [];
   const seen = new Set<string>();
   for (const entry of chain) {
     entry.definition.promptControls.appendSystemPrompt.forEach((source, index) => {
@@ -189,10 +142,20 @@ const nearestPrompt = (
   return undefined;
 };
 
-const composeEffectiveControls = (chain: readonly ChainEntry[]): EffectiveControls => {
-  const skills = declaredSelections(chain, (definition) => definition.loadout.skills);
-  const subagents = declaredSelections(chain, (definition) => definition.loadout.subagents);
-  const mcp = declaredSelections(chain, (definition) => definition.loadout.mcp);
+const composeEffectiveControls = (chain: readonly ChainEntry[], defaults?: AgentDefaults): EffectiveControls => {
+  // Settings defaults compose ahead of the whole chain, parent-first, like a root-most ancestor.
+  const skills = mergeSelections(
+    settingsSelections(defaults?.skills),
+    declaredSelections(chain, (definition) => definition.loadout.skills),
+  );
+  const subagents = mergeSelections(
+    settingsSelections(defaults?.subagents),
+    declaredSelections(chain, (definition) => definition.loadout.subagents),
+  );
+  const mcp = mergeSelections(
+    settingsSelections(defaults?.mcp),
+    declaredSelections(chain, (definition) => definition.loadout.mcp),
+  );
   const model = nearest(chain, (definition) => definition.loadout.model);
   const thinking = nearest(chain, (definition) => definition.loadout.thinking);
 
@@ -200,7 +163,10 @@ const composeEffectiveControls = (chain: readonly ChainEntry[]): EffectiveContro
     skillSelections: skills,
     subagentSelections: subagents,
     mcpSelections: mcp,
-    appendPromptSelections: appendPromptSelections(chain),
+    appendPromptSelections: mergePromptSelections(
+      settingsPromptSelections(defaults?.appendSystemPrompt),
+      appendPromptSelections(chain),
+    ),
     systemPrompt: nearestPrompt(chain, (definition) => definition.promptControls.systemPrompt),
     promptTemplate: nearestPrompt(chain, (definition) => definition.promptControls.promptTemplate),
     label: nearest(chain, (definition) => definition.label),
@@ -209,8 +175,14 @@ const composeEffectiveControls = (chain: readonly ChainEntry[]): EffectiveContro
       skills: skills.map((selection) => selection.slug),
       subagents: subagents.map((selection) => selection.slug),
       mcp: mcp.map((selection) => selection.slug),
-      extensions: uniqueStrings(chain.flatMap((entry) => entry.definition.loadout.extensions)),
-      plugins: uniqueStrings(chain.flatMap((entry) => entry.definition.loadout.plugins)),
+      extensions: uniqueStrings([
+        ...(defaults?.extensions ?? []),
+        ...chain.flatMap((entry) => entry.definition.loadout.extensions),
+      ]),
+      plugins: uniqueStrings([
+        ...(defaults?.plugins ?? []),
+        ...chain.flatMap((entry) => entry.definition.loadout.plugins),
+      ]),
       model,
       thinking,
       tools: composeTools(chain),
@@ -218,105 +190,11 @@ const composeEffectiveControls = (chain: readonly ChainEntry[]): EffectiveContro
   };
 };
 
-const resolveDeclaredSlugs = (
-  set: EffectiveResourceSet,
-  kind: 'skill' | 'agent',
-  reference: string,
-  selections: readonly DeclaredSlug[],
-  warnings: string[],
-): readonly ResolvedResource[] => {
-  const resolved: ResolvedResource[] = [];
-
-  for (const selection of selections) {
-    const resource = findLoadoutResource(set, selection.owner, kind, selection.slug);
-
-    if (resource === undefined) {
-      warnings.push(`${reference} references unknown ${kind} '${selection.slug}'.`);
-    } else {
-      resolved.push(resource);
-    }
-  }
-
-  return resolved;
-};
-
-const asRecord = (value: unknown): Record<string, unknown> | undefined =>
-  value !== null && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
-
-const readMcpServers = (path: string, warnings: string[]): Readonly<Record<string, unknown>> => {
-  let parsed: unknown;
-
-  try {
-    parsed = JSON.parse(readFileSync(path, 'utf8'));
-  } catch (error) {
-    warnings.push(`MCP configuration '${path}' is not readable JSON: ${String(error)}`);
-    return {};
-  }
-
-  const document = asRecord(parsed);
-  const servers = document === undefined ? undefined : asRecord(document.mcpServers);
-
-  if (servers === undefined) {
-    warnings.push(`MCP configuration '${path}' must contain an object-valued 'mcpServers' map.`);
-    return {};
-  }
-
-  return servers;
-};
-
-const composeMcpServers = (
-  set: EffectiveResourceSet,
-  selections: readonly DeclaredSlug[],
-  warnings: string[],
-): Readonly<Record<string, unknown>> => {
-  if (selections.length === 0) return {};
-
-  const rootPaths = set.layers.map((layer) => join(layer.root, 'mcp.json')).filter((path) => existsSync(path));
-  const roots = set.layers.map((layer) => layer.root);
-  const cache = new Map<string, Readonly<Record<string, unknown>>>();
-  const serversAt = (path: string): Readonly<Record<string, unknown>> => {
-    const cached = cache.get(path);
-    if (cached !== undefined) return cached;
-    let servers: Readonly<Record<string, unknown>>;
-    if (escapesRoots(path, roots)) {
-      warnings.push(`MCP configuration '${path}' resolves outside the resource layers and was skipped.`);
-      servers = {};
-    } else {
-      servers = readMcpServers(path, warnings);
-    }
-    cache.set(path, servers);
-    return servers;
-  };
-
-  const selected: Record<string, unknown> = {};
-  for (const selection of selections) {
-    // MCP selections are created only from entries in the resolved inheritance chain.
-    const owner = findResource(set, 'agent', selection.owner)!;
-    // Root definitions are shared; only the declaring agent's overlays may override its selection.
-    const ownerPaths = [...owner.mcpPaths!].reverse();
-    const pathsByPrecedence = [...rootPaths].reverse().concat(ownerPaths);
-    let definition: unknown;
-    let found = false;
-
-    for (const path of pathsByPrecedence) {
-      const servers = serversAt(path);
-      if (Object.hasOwn(servers, selection.slug)) {
-        definition = servers[selection.slug];
-        found = true;
-      }
-    }
-
-    if (found) selected[selection.slug] = definition;
-    else warnings.push(`loadout mcp references unknown server '${selection.slug}'.`);
-  }
-
-  return selected;
-};
-
 const resolveDelegateSkills = (
   set: EffectiveResourceSet,
   subagents: readonly ResolvedResource[],
   leaderSkills: readonly ResolvedResource[],
+  defaults: AgentDefaults | undefined,
   warnings: string[],
 ): readonly ResolvedResource[] => {
   const skills = new Map(leaderSkills.map((skill) => [skill.slug, skill]));
@@ -330,14 +208,14 @@ const resolveDelegateSkills = (
 
     const chain = resolveInheritanceChain(set, subagent.slug);
     if (chain.entries === undefined) continue;
-    const controls = composeEffectiveControls(chain.entries);
+    const controls = composeEffectiveControls(chain.entries, defaults);
 
     for (const skill of resolveDeclaredSlugs(
       set,
       'skill',
-      `subagent '${subagent.slug}' loadout skills`,
       controls.skillSelections,
       warnings,
+      `subagent '${subagent.slug}' `,
     )) {
       const selected = skills.get(skill.slug);
 
@@ -358,14 +236,15 @@ const resolveDelegateSkills = (
 const composeLoadout = (
   set: EffectiveResourceSet,
   controls: EffectiveControls,
+  defaults: AgentDefaults | undefined,
   warnings: string[],
 ): ComposedLoadout => {
-  const subagents = resolveDeclaredSlugs(set, 'agent', 'loadout subagents', controls.subagentSelections, warnings);
-  const skills = resolveDeclaredSlugs(set, 'skill', 'loadout skills', controls.skillSelections, warnings);
+  const subagents = resolveDeclaredSlugs(set, 'agent', controls.subagentSelections, warnings);
+  const skills = resolveDeclaredSlugs(set, 'skill', controls.skillSelections, warnings);
 
   return {
     skills,
-    delegateSkills: resolveDelegateSkills(set, subagents, skills, warnings),
+    delegateSkills: resolveDelegateSkills(set, subagents, skills, defaults, warnings),
     subagents,
     mcp: controls.loadout.mcp,
     mcpServers: composeMcpServers(set, controls.mcpSelections, warnings),
@@ -379,13 +258,17 @@ const composeLoadout = (
 
 const resolvePromptSelection = (
   set: EffectiveResourceSet,
-  selection: { readonly source: PromptSourceReference; readonly owner: string },
+  selection: PromptSelection,
   options: ComposeOptions,
   label: string,
   warnings: string[],
   errors: string[],
 ): PromptFragment | undefined => {
-  // Prompt selections are created only from entries in the resolved inheritance chain.
+  if (selection.owner === undefined) {
+    return resolveSettingsPromptSelection(set, selection, options.projectDirectory, label, warnings, errors);
+  }
+
+  // Prompt selections from the chain resolve in their declaring agent's namespace.
   const owner = findResource(set, 'agent', selection.owner)!;
   const resolved = resolvePromptSource({
     source: selection.source,
@@ -408,7 +291,10 @@ const resolveOptionalPrompt = (
   warnings: string[],
   errors: string[],
 ): PromptFragment | undefined =>
-  selection === undefined ? undefined : resolvePromptSelection(set, selection, options, label, warnings, errors);
+  // The fixed role label carries the provenance here; the index is never part of it.
+  selection === undefined
+    ? undefined
+    : resolvePromptSelection(set, { ...selection, index: 0 }, options, label, warnings, errors);
 
 const composeIdentity = (
   set: EffectiveResourceSet,
@@ -439,7 +325,7 @@ const composeIdentity = (
         set,
         selection,
         options,
-        `append-${selection.owner}-${selection.index + 1}`,
+        `append-${selection.owner ?? SETTINGS_DEFAULTS_DECLARER}-${selection.index + 1}`,
         warnings,
         errors,
       ),
@@ -496,14 +382,15 @@ const composeSubagents = (
       continue;
     }
 
-    const controls = composeEffectiveControls(chainResult.entries);
+    // Delegates are agents too, so settings defaults compose into them ahead of their own chain.
+    const controls = composeEffectiveControls(chainResult.entries, options.agentDefaults);
     const identity = composeIdentity(set, chainResult.entries, controls, options, warnings, errors);
     const skills = resolveDeclaredSlugs(
       set,
       'skill',
-      `subagent '${resource.slug}' loadout skills`,
       controls.skillSelections,
       warnings,
+      `subagent '${resource.slug}' `,
     );
     composed.push({
       resource,
@@ -533,13 +420,14 @@ export const compose = (set: EffectiveResourceSet, agentSlug: string, options: C
   const chain = chainResult.entries;
   const warnings: string[] = [];
   const errors: string[] = [];
-  const controls = composeEffectiveControls(chain);
+  const controls = composeEffectiveControls(chain, options.agentDefaults);
   const identity = composeIdentity(set, chain, controls, options, warnings, errors);
-  const loadout = composeLoadout(set, controls, warnings);
+  const loadout = composeLoadout(set, controls, options.agentDefaults, warnings);
   const models = resolveModelRegistry(set, loadout.model, warnings, errors);
   const composedSubagents = composeSubagents(set, loadout.subagents, options, warnings, errors);
   const uniqueWarnings = uniqueStrings(warnings);
   if (errors.length > 0) return { errors, warnings: uniqueWarnings };
+  const agentDefaults = planAgentDefaults(options.agentDefaults);
 
   return {
     plan: {
@@ -549,6 +437,7 @@ export const compose = (set: EffectiveResourceSet, agentSlug: string, options: C
       loadout: { ...loadout, composedSubagents },
       contributingAgents: chain.map((entry) => entry.resource),
       inheritanceChain: chain.map((entry) => entry.resource.slug),
+      ...(agentDefaults === undefined ? {} : { agentDefaults }),
       warnings: uniqueWarnings,
     },
     errors: [],

--- a/code/cli/src/composer/Composition.ts
+++ b/code/cli/src/composer/Composition.ts
@@ -1,4 +1,5 @@
 // Harness-neutral composition types produced from the effective resource set for a selected agent.
+import type { PromptSourceReference } from './PromptSource.js';
 import type { Loadout, ResolvedResource } from '../resolver/Resource.js';
 import type { EffectiveModelRegistry } from './Models.js';
 import type { PromptFragment } from './PromptSource.js';
@@ -42,6 +43,20 @@ export interface ComposedSubagent {
   readonly tools?: Loadout['tools'];
 }
 
+/**
+ * Settings-layer (`settings.yml:agent_defaults`) entries composed into one agent, as declared.
+ * Present on a plan only when the settings layer actually declares defaults, so catalogs without
+ * `agent_defaults` compose byte-identical plans.
+ */
+export interface CompositionAgentDefaults {
+  readonly extensions?: readonly string[];
+  readonly skills?: readonly string[];
+  readonly mcp?: readonly string[];
+  readonly plugins?: readonly string[];
+  readonly subagents?: readonly string[];
+  readonly appendSystemPrompt?: readonly PromptSourceReference[];
+}
+
 /** A loadout with its slug references resolved against the effective set. */
 export interface ComposedLoadout {
   readonly skills: readonly ResolvedResource[];
@@ -74,6 +89,8 @@ export interface CompositionPlan {
   readonly contributingAgents?: readonly ResolvedResource[];
   /** Parent-first chain of agent slugs that contributed to this composition, selected child last. */
   readonly inheritanceChain?: readonly string[];
+  /** Settings-layer defaults composed ahead of the inheritance chain, when declared. */
+  readonly agentDefaults?: CompositionAgentDefaults;
   /** Non-fatal issues (e.g. unknown loadout slugs) surfaced during composition. */
   readonly warnings: readonly string[];
 }

--- a/code/cli/src/composer/Defaults.ts
+++ b/code/cli/src/composer/Defaults.ts
@@ -1,0 +1,155 @@
+// Composes settings-layer (`settings.yml:agent_defaults`) entries into an agent's effective loadout.
+// Defaults ride the same deterministic parent-first ordering and stable de-duplication as inherited
+// agent loadouts, resolving catalog-wide ahead of the whole inheritance chain — like a root-most
+// ancestor — while agent-declared entries keep owner-first resolution.
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { CompositionAgentDefaults } from './Composition.js';
+import type { PromptFragment, PromptSourceReference } from './PromptSource.js';
+import { promptSourceKey, resolvePromptSource } from './PromptSource.js';
+import type { EffectiveResourceSet, ResolvedResource } from '../resolver/Resource.js';
+import { findLoadoutResource, findResource } from '../resolver/Resource.js';
+import type { AgentDefaults } from '../settings/Settings.js';
+import { isEmptyAgentDefaults } from '../settings/Settings.js';
+
+/** One declared loadout slug and where it was declared; `owner` is unset for settings defaults. */
+export interface DeclaredSlug {
+  readonly slug: string;
+  readonly owner?: string;
+}
+
+export interface PromptSelection {
+  readonly source: PromptSourceReference;
+  readonly owner?: string;
+  /** Position within the declaring surface; append selections number fragments for their labels. */
+  readonly index: number;
+}
+
+/** Provenance label for settings-layer declarations; the colon is unreachable by agent slugs. */
+export const SETTINGS_DEFAULTS_DECLARER = 'settings:agent_defaults';
+
+/** Settings-layer selections resolve catalog-wide; chain entries resolve owner-first. */
+export const settingsSelections = (slugs: readonly string[] | undefined): readonly DeclaredSlug[] =>
+  (slugs ?? []).map((slug) => ({ slug, owner: undefined }));
+
+/** Composes selection groups parent-first, collapsing duplicate slugs to their first occurrence. */
+export const mergeSelections = (...groups: readonly (readonly DeclaredSlug[])[]): readonly DeclaredSlug[] => {
+  const selections: DeclaredSlug[] = [];
+  const seen = new Set<string>();
+  for (const group of groups) {
+    for (const selection of group) {
+      if (!seen.has(selection.slug)) {
+        seen.add(selection.slug);
+        selections.push(selection);
+      }
+    }
+  }
+  return selections;
+};
+
+export const settingsPromptSelections = (
+  sources: readonly PromptSourceReference[] | undefined,
+): readonly PromptSelection[] => (sources ?? []).map((source, index) => ({ source, owner: undefined, index }));
+
+/** Composes prompt-selection groups parent-first, collapsing duplicate sources to their first occurrence. */
+export const mergePromptSelections = (
+  ...groups: readonly (readonly PromptSelection[])[]
+): readonly PromptSelection[] => {
+  const selections: PromptSelection[] = [];
+  const seen = new Set<string>();
+  for (const group of groups) {
+    for (const selection of group) {
+      const key = promptSourceKey(selection.source);
+      if (!seen.has(key)) {
+        seen.add(key);
+        selections.push(selection);
+      }
+    }
+  }
+  return selections;
+};
+
+/** Resolves a selection where it was declared: settings defaults catalog-wide, chain entries owner-first. */
+export const resolveSelectionResource = (
+  set: EffectiveResourceSet,
+  kind: 'skill' | 'agent',
+  selection: DeclaredSlug,
+): ResolvedResource | undefined =>
+  selection.owner === undefined
+    ? findResource(set, kind, selection.slug)
+    : findLoadoutResource(set, selection.owner, kind, selection.slug);
+
+/** Names the declaring layer of a selection so unresolved references point at the right surface. */
+export const selectionReference = (kind: 'skill' | 'agent', selection: DeclaredSlug): string => {
+  const noun = kind === 'agent' ? 'subagents' : `${kind}s`;
+  return selection.owner === undefined ? `agent_defaults ${noun}` : `loadout ${noun}`;
+};
+
+export const resolveDeclaredSlugs = (
+  set: EffectiveResourceSet,
+  kind: 'skill' | 'agent',
+  selections: readonly DeclaredSlug[],
+  warnings: string[],
+  prefix = '',
+): readonly ResolvedResource[] => {
+  const resolved: ResolvedResource[] = [];
+
+  for (const selection of selections) {
+    const resource = resolveSelectionResource(set, kind, selection);
+
+    if (resource === undefined) {
+      warnings.push(`${prefix}${selectionReference(kind, selection)} references unknown ${kind} '${selection.slug}'.`);
+    } else {
+      resolved.push(resource);
+    }
+  }
+
+  return resolved;
+};
+
+/** Resolves one settings-layer prompt source; catalog `file` sources use the first layer that has the file. */
+export const resolveSettingsPromptSelection = (
+  set: EffectiveResourceSet,
+  selection: PromptSelection,
+  projectDirectory: string | undefined,
+  label: string,
+  warnings: string[],
+  errors: string[],
+): PromptFragment | undefined => {
+  const file = selection.source.file;
+  // Highest-precedence layer wins; a file no layer contains falls through to the workspace layer so
+  // resolvePromptSource reports the standard missing-file error. Prompt resolution only runs for a
+  // resolvable agent, and agents live inside layers, so a layer always exists here.
+  const layer =
+    file !== undefined
+      ? (set.layers.find((candidate) => existsSync(join(candidate.root, file))) ?? set.layers[0])
+      : set.layers[0];
+
+  const resolved = resolvePromptSource({
+    source: selection.source,
+    declaringAgent: SETTINGS_DEFAULTS_DECLARER,
+    layer,
+    projectDirectory,
+    optionalRepoFile: true,
+    label,
+  });
+  if (resolved.warning !== undefined) warnings.push(resolved.warning);
+  if (resolved.error !== undefined) errors.push(resolved.error);
+  return resolved.fragment;
+};
+
+/** The settings-layer defaults a plan records, present only when the layer actually declares some. */
+export const planAgentDefaults = (defaults: AgentDefaults | undefined): CompositionAgentDefaults | undefined => {
+  if (defaults === undefined || isEmptyAgentDefaults(defaults)) return undefined;
+  const nonEmpty = <T>(values: readonly T[] | undefined): readonly T[] | undefined =>
+    values !== undefined && values.length > 0 ? values : undefined;
+  return {
+    extensions: nonEmpty(defaults.extensions),
+    skills: nonEmpty(defaults.skills),
+    mcp: nonEmpty(defaults.mcp),
+    plugins: nonEmpty(defaults.plugins),
+    subagents: nonEmpty(defaults.subagents),
+    appendSystemPrompt: nonEmpty(defaults.appendSystemPrompt),
+  };
+};

--- a/code/cli/src/composer/Mcp.ts
+++ b/code/cli/src/composer/Mcp.ts
@@ -1,0 +1,85 @@
+// Resolves selected MCP server ids into their effective definitions, layer- and owner-aware.
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { escapesRoots } from '../dump/Containment.js';
+import type { EffectiveResourceSet } from '../resolver/Resource.js';
+import { findResource } from '../resolver/Resource.js';
+import type { DeclaredSlug } from './Defaults.js';
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  value !== null && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+
+const readMcpServers = (path: string, warnings: string[]): Readonly<Record<string, unknown>> => {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    warnings.push(`MCP configuration '${path}' is not readable JSON: ${String(error)}`);
+    return {};
+  }
+
+  const document = asRecord(parsed);
+  const servers = document === undefined ? undefined : asRecord(document.mcpServers);
+
+  if (servers === undefined) {
+    warnings.push(`MCP configuration '${path}' must contain an object-valued 'mcpServers' map.`);
+    return {};
+  }
+
+  return servers;
+};
+
+export const composeMcpServers = (
+  set: EffectiveResourceSet,
+  selections: readonly DeclaredSlug[],
+  warnings: string[],
+): Readonly<Record<string, unknown>> => {
+  if (selections.length === 0) return {};
+
+  const rootPaths = set.layers.map((layer) => join(layer.root, 'mcp.json')).filter((path) => existsSync(path));
+  const roots = set.layers.map((layer) => layer.root);
+  const cache = new Map<string, Readonly<Record<string, unknown>>>();
+  const serversAt = (path: string): Readonly<Record<string, unknown>> => {
+    const cached = cache.get(path);
+    if (cached !== undefined) return cached;
+    let servers: Readonly<Record<string, unknown>>;
+    if (escapesRoots(path, roots)) {
+      warnings.push(`MCP configuration '${path}' resolves outside the resource layers and was skipped.`);
+      servers = {};
+    } else {
+      servers = readMcpServers(path, warnings);
+    }
+    cache.set(path, servers);
+    return servers;
+  };
+
+  const selected: Record<string, unknown> = {};
+  for (const selection of selections) {
+    // Settings defaults resolve against tree-root mcp.json only; chain entries also consult the
+    // declaring agent's overlays. Resolver annotates every agent resource with mcpPaths.
+    const ownerPaths =
+      selection.owner === undefined ? [] : [...findResource(set, 'agent', selection.owner)!.mcpPaths!].reverse();
+    // Root definitions are shared; only the declaring agent's overlays may override its selection.
+    const pathsByPrecedence = [...rootPaths].reverse().concat(ownerPaths);
+    let definition: unknown;
+    let found = false;
+
+    for (const path of pathsByPrecedence) {
+      const servers = serversAt(path);
+      if (Object.hasOwn(servers, selection.slug)) {
+        definition = servers[selection.slug];
+        found = true;
+      }
+    }
+
+    if (found) selected[selection.slug] = definition;
+    else
+      warnings.push(
+        `${selection.owner === undefined ? 'agent_defaults mcp' : 'loadout mcp'} references unknown server '${selection.slug}'.`,
+      );
+  }
+
+  return selected;
+};

--- a/code/cli/src/dump/Dump.ts
+++ b/code/cli/src/dump/Dump.ts
@@ -127,6 +127,7 @@ interface CompositionProvenance {
 interface ClosureCompose {
   readonly agents: readonly ResolvedResource[];
   readonly skills: readonly ResolvedResource[];
+  readonly agentDefaultMcpServers: Readonly<Record<string, unknown>>;
   readonly promptFiles: readonly { readonly reference: string; readonly content: string }[];
   readonly provenance: readonly CompositionProvenance[];
   readonly warnings: readonly string[];
@@ -217,6 +218,16 @@ const collectSkills = (
   }
 };
 
+const collectAgentDefaultMcpServers = (
+  plan: CompositionPlan,
+  defaults: AgentDefaults | undefined,
+  servers: Record<string, unknown>,
+): void => {
+  for (const slug of defaults?.mcp ?? []) {
+    if (Object.hasOwn(plan.loadout.mcpServers, slug)) servers[slug] = plan.loadout.mcpServers[slug];
+  }
+};
+
 /** BFS over the selected agent and its delegated-agent closure. */
 const composeClosure = (
   set: EffectiveResourceSet,
@@ -229,6 +240,7 @@ const composeClosure = (
   const skills = new Map<string, ResolvedResource>();
   const warnings: string[] = [];
   const errors: string[] = [];
+  const agentDefaultMcpServers: Record<string, unknown> = {};
   const promptFiles = new Map<string, string>();
   const provenance: CompositionProvenance[] = [];
   const queue = [rootSlug];
@@ -254,6 +266,7 @@ const composeClosure = (
     collectContributingAgents(set, composed.plan.inheritanceChain!, agents);
     provenance.push(compositionProvenance(composed.plan));
     warnings.push(...composed.plan.warnings);
+    collectAgentDefaultMcpServers(composed.plan, agentDefaults, agentDefaultMcpServers);
     collectPromptFiles(composed.plan, promptFiles, errors);
     collectSkills(composed.plan.loadout.skills, skills, errors);
     queue.push(...composed.plan.loadout.subagents.map((subagent) => subagent.slug).sort(compareSlugs));
@@ -262,6 +275,7 @@ const composeClosure = (
   return {
     agents,
     skills: [...skills.values()].sort((left, right) => compareSlugs(left.slug, right.slug)),
+    agentDefaultMcpServers,
     promptFiles: [...promptFiles.entries()]
       .map(([reference, content]) => ({ reference, content }))
       .sort((left, right) => compareSlugs(left.reference, right.reference)),
@@ -316,6 +330,26 @@ const writeDefaultsSettings = (outRoot: string, defaults: AgentDefaults | undefi
   const settingsTarget = join(outRoot, 'settings.yml');
   writeFileSync(settingsTarget, settingsYaml);
   written.push(settingsTarget);
+};
+
+/** Makes settings-selected MCP servers resolvable from the flattened root copied into the dump. */
+const writeAgentDefaultMcpServers = (
+  outRoot: string,
+  effectiveServers: Readonly<Record<string, unknown>>,
+  written: string[],
+): void => {
+  if (Object.keys(effectiveServers).length === 0) return;
+
+  const target = join(outRoot, 'mcp.json');
+  let existingServers: Readonly<Record<string, unknown>> = {};
+  try {
+    const document = JSON.parse(readFileSync(target, 'utf8')) as { readonly mcpServers?: Record<string, unknown> };
+    existingServers = document.mcpServers ?? {};
+  } catch {
+    // Composition already reported malformed source MCP JSON; emit the effective valid subset.
+  }
+  writeFileSync(target, `${JSON.stringify({ mcpServers: { ...existingServers, ...effectiveServers } }, null, 2)}\n`);
+  written.push(target);
 };
 
 const failure = (errors: readonly string[], warnings: readonly string[] = []): DumpResult => ({
@@ -403,6 +437,7 @@ export const dumpAgent = (
   // Carry the merged settings-layer defaults into the dumped tree so it resolves identically on
   // its own; catalogs without agent_defaults dump byte-identically to before.
   writeDefaultsSettings(outRoot, agentDefaults, written);
+  writeAgentDefaultMcpServers(outRoot, closure.agentDefaultMcpServers, written);
 
   for (const agent of closure.agents) {
     const agentTarget = join(outRoot, 'agents', agent.slug);

--- a/code/cli/src/dump/Dump.ts
+++ b/code/cli/src/dump/Dump.ts
@@ -11,13 +11,17 @@ import {
 } from 'node:fs';
 import { dirname, join } from 'node:path';
 
-import type { CompositionPlan } from '../composer/Composition.js';
+import { stringify } from 'yaml';
+
+import type { CompositionAgentDefaults, CompositionPlan } from '../composer/Composition.js';
 import type { PromptFragment } from '../composer/PromptSource.js';
 import { compose } from '../composer/Composer.js';
+import { planAgentDefaults } from '../composer/Defaults.js';
 import { removeTargetTypeConflict } from '../fs/TypeConflict.js';
 import { pickLoadoutKeys } from '../resolver/AgentDefinition.js';
 import { compareSlugs, findResource } from '../resolver/Resource.js';
 import type { EffectiveResourceSet, Layer, ResolvedResource } from '../resolver/Resource.js';
+import type { AgentDefaults } from '../settings/Settings.js';
 import { escapesRoots, overlaps } from './Containment.js';
 
 export interface DumpResult {
@@ -114,6 +118,8 @@ interface PromptProvenance {
 interface CompositionProvenance {
   readonly agent: string;
   readonly inheritanceChain: readonly string[];
+  /** Settings-layer defaults composed ahead of the inheritance chain, when declared. */
+  readonly agentDefaults?: CompositionAgentDefaults;
   readonly prompts: readonly PromptProvenance[];
   readonly promptTemplate?: Omit<PromptProvenance, 'order' | 'role'>;
 }
@@ -164,6 +170,7 @@ const compositionProvenance = (plan: CompositionPlan): CompositionProvenance => 
   return {
     agent: plan.agent,
     inheritanceChain: plan.inheritanceChain!,
+    ...(plan.agentDefaults === undefined ? {} : { agentDefaults: plan.agentDefaults }),
     prompts: ordered
       .filter(
         (entry): entry is { readonly role: PromptProvenance['role']; readonly fragment: PromptFragment } =>
@@ -211,7 +218,12 @@ const collectSkills = (
 };
 
 /** BFS over the selected agent and its delegated-agent closure. */
-const composeClosure = (set: EffectiveResourceSet, rootSlug: string, projectDirectory?: string): ClosureCompose => {
+const composeClosure = (
+  set: EffectiveResourceSet,
+  rootSlug: string,
+  projectDirectory: string | undefined,
+  agentDefaults: AgentDefaults | undefined,
+): ClosureCompose => {
   const seen = new Set<string>();
   const agents: ResolvedResource[] = [];
   const skills = new Map<string, ResolvedResource>();
@@ -231,7 +243,7 @@ const composeClosure = (set: EffectiveResourceSet, rootSlug: string, projectDire
 
     // compose surfaces an unknown/invalid root agent as an error; every queued subagent is already
     // resolved by the composer, so a plan implies findResource returns the agent.
-    const composed = compose(set, slug, { projectDirectory });
+    const composed = compose(set, slug, { projectDirectory, agentDefaults });
 
     if (composed.plan === undefined) {
       errors.push(...composed.errors);
@@ -296,11 +308,38 @@ const writeMergedConfig = (agent: ResolvedResource, agentTarget: string, written
   }
 };
 
+/** Carries merged settings-layer defaults into the dump so the tree stays self-contained. */
+const writeDefaultsSettings = (outRoot: string, defaults: AgentDefaults | undefined, written: string[]): void => {
+  const settingsYaml = settingsYamlForDefaults(defaults);
+  if (settingsYaml === undefined) return;
+
+  const settingsTarget = join(outRoot, 'settings.yml');
+  writeFileSync(settingsTarget, settingsYaml);
+  written.push(settingsTarget);
+};
+
 const failure = (errors: readonly string[], warnings: readonly string[] = []): DumpResult => ({
   writtenPaths: [],
   warnings,
   errors,
 });
+
+/** Serializes merged settings-layer defaults into the dumped tree so it stays self-contained. */
+const settingsYamlForDefaults = (defaults: AgentDefaults | undefined): string | undefined => {
+  const effective = planAgentDefaults(defaults);
+  if (effective === undefined) return undefined;
+  // yaml.stringify omits undefined properties, so undeclared fields vanish from the document.
+  return stringify({
+    agent_defaults: {
+      extensions: effective.extensions,
+      skills: effective.skills,
+      mcp: effective.mcp,
+      plugins: effective.plugins,
+      subagents: effective.subagents,
+      append_system_prompt: effective.appendSystemPrompt,
+    },
+  });
+};
 
 const promptTargetCollisions = (outRoot: string, prompts: ClosureCompose['promptFiles']): readonly string[] => {
   const errors: string[] = [];
@@ -324,9 +363,10 @@ export const dumpAgent = (
   agentSlug: string,
   outDirectory: string,
   projectDirectory?: string,
+  agentDefaults?: AgentDefaults,
 ): DumpResult => {
   // composeClosure composes the root once and surfaces an unknown/invalid root agent as an error.
-  const closure = composeClosure(set, agentSlug, projectDirectory);
+  const closure = composeClosure(set, agentSlug, projectDirectory, agentDefaults);
 
   if (closure.errors.length > 0) {
     return failure(closure.errors, closure.warnings);
@@ -359,6 +399,10 @@ export const dumpAgent = (
   mkdirSync(dirname(provenanceTarget), { recursive: true });
   writeFileSync(provenanceTarget, `${JSON.stringify({ version: 1, compositions: closure.provenance }, null, 2)}\n`);
   written.push(provenanceTarget);
+
+  // Carry the merged settings-layer defaults into the dumped tree so it resolves identically on
+  // its own; catalogs without agent_defaults dump byte-identically to before.
+  writeDefaultsSettings(outRoot, agentDefaults, written);
 
   for (const agent of closure.agents) {
     const agentTarget = join(outRoot, 'agents', agent.slug);

--- a/code/cli/src/dump/WorkflowDump.ts
+++ b/code/cli/src/dump/WorkflowDump.ts
@@ -16,6 +16,7 @@ import { dirname, join, relative } from 'node:path';
 import { findResource } from '../resolver/Resource.js';
 import { compareSlugs } from '../resolver/Resource.js';
 import type { EffectiveResourceSet } from '../resolver/Resource.js';
+import type { AgentDefaults } from '../settings/Settings.js';
 import { isWorkflowDefinitionIssue, readWorkflowDefinition } from '../resolver/WorkflowDefinition.js';
 import type { WorkflowDefinition } from '../resolver/WorkflowDefinition.js';
 import { dumpAgent } from './Dump.js';
@@ -85,6 +86,7 @@ export const dumpWorkflow = (
   workflowSlug: string,
   outDirectory: string,
   projectDirectory?: string,
+  agentDefaults?: AgentDefaults,
 ): DumpResult => {
   const closure = collectWorkflowClosure(set, workflowSlug);
   if (closure.errors.length > 0) return { writtenPaths: [], warnings: [], errors: closure.errors };
@@ -102,7 +104,7 @@ export const dumpWorkflow = (
   try {
     for (const agent of closure.agents) {
       const agentDump = join(temporary, agent);
-      const result = dumpAgent(set, agent, agentDump, projectDirectory);
+      const result = dumpAgent(set, agent, agentDump, projectDirectory, agentDefaults);
       warnings.push(...result.warnings);
       errors.push(...result.errors);
       const composition = join(agentDump, '.agents', '.outfitter', 'composition.json');

--- a/code/cli/src/links/HarnessLinkPlan.ts
+++ b/code/cli/src/links/HarnessLinkPlan.ts
@@ -8,7 +8,7 @@ import { collectWorkflowClosure } from '../dump/WorkflowDump.js';
 import { composedIdentityBody, serializeClaudeAgentDocument } from '../projection/Materialize.js';
 import { compareSlugs, findResource, listAgentResources, listResources } from '../resolver/Resource.js';
 import type { EffectiveResourceSet, ResolvedResource } from '../resolver/Resource.js';
-import type { Settings } from '../settings/Settings.js';
+import type { AgentDefaults, Settings } from '../settings/Settings.js';
 import type { LinkHarness } from './HarnessHome.js';
 
 export interface LinkSelection {
@@ -146,6 +146,7 @@ export const composeLinkClosure = (
   set: EffectiveResourceSet,
   scope: readonly string[],
   projectDirectory: string,
+  agentDefaults?: AgentDefaults,
 ): LinkClosure => {
   const seen = new Set<string>();
   const queue = [...scope];
@@ -159,7 +160,7 @@ export const composeLinkClosure = (
     const slug = queue.shift()!;
     if (seen.has(slug)) continue;
     seen.add(slug);
-    const composed = compose(set, slug, { projectDirectory });
+    const composed = compose(set, slug, { projectDirectory, agentDefaults });
     warnings.push(...composed.warnings);
     if (composed.plan === undefined) {
       errors.push(...composed.errors);

--- a/code/cli/src/resolver/ResolverValidation.ts
+++ b/code/cli/src/resolver/ResolverValidation.ts
@@ -1,6 +1,7 @@
 // Validates an effective resource set: agent + skill definitions, unresolved loadout slugs, shadowing.
 import { compose } from '../composer/Composer.js';
 import { isSkillDocumentIssue, readSkillDocument } from '../skills/SkillDocument.js';
+import type { AgentDefaults } from '../settings/Settings.js';
 import { isAgentDefinitionIssue, readAgentDefinition } from './AgentDefinition.js';
 import type { EffectiveResourceSet, ResolvedResource } from './Resource.js';
 import { agentLocalKinds, findResource, listAgentResources, listResources } from './Resource.js';
@@ -25,13 +26,18 @@ export interface ValidationOptions {
   readonly deferLoadoutResolution?: boolean;
   /** Validate only these enabled workflow roots and their nested workflow closure. */
   readonly workflowRoots?: readonly string[];
+  /** Settings-layer defaults composed into every agent during validation. */
+  readonly agentDefaults?: AgentDefaults;
+  /** Active repository root for `repo_file` prompt references during composition. */
+  readonly projectDirectory?: string;
 }
 
 // Matches the composer's top-level unresolved-loadout warning wording (see `compose` in Composer.ts).
 // It is deliberately coupled to that message; `resolver-validation.test.ts` drives the real composer,
-// so a wording drift fails that test rather than silently disabling deferral.
+// so a wording drift fails that test rather than silently disabling deferral. Settings-layer
+// defaults use the same wording with an `agent_defaults` prefix instead of `loadout`.
 const isUnresolvedLoadoutReference = (message: string): boolean =>
-  /^loadout (?:skills|subagents) references unknown (?:skill|agent) '/.test(message);
+  /^(?:loadout|agent_defaults) (?:skills|subagents) references unknown (?:skill|agent) '/.test(message);
 
 const compositionWarningSeverity = (message: string, options: ValidationOptions): ValidationFinding['severity'] =>
   isUnresolvedLoadoutReference(message) && !options.deferLoadoutResolution ? 'error' : 'warning';
@@ -40,7 +46,6 @@ const validateAgent = (
   set: EffectiveResourceSet,
   agent: ResolvedResource,
   options: ValidationOptions,
-  projectDirectory?: string,
 ): readonly ValidationFinding[] => {
   const definition = readAgentDefinition(agent.winner.path, agent.configPaths);
 
@@ -58,7 +63,10 @@ const validateAgent = (
     ];
   }
 
-  const composed = compose(set, agent.slug, { projectDirectory });
+  const composed = compose(set, agent.slug, {
+    projectDirectory: options.projectDirectory,
+    agentDefaults: options.agentDefaults,
+  });
   const compositionFindings: ValidationFinding[] = [
     ...composed.errors.map((message) => ({ severity: 'error' as const, resource: `agent:${agent.slug}`, message })),
     ...composed.warnings.map((message) => ({
@@ -258,7 +266,7 @@ const validateWorkflowAgentNode = (
   set: EffectiveResourceSet,
   workflow: WorkflowDefinition,
   node: WorkflowNode,
-  projectDirectory?: string,
+  options: ValidationOptions,
 ): readonly ValidationFinding[] => {
   const actor = node.actor === undefined ? undefined : workflow.actors[node.actor];
   if (actor?.kind !== 'agent') {
@@ -267,7 +275,10 @@ const validateWorkflowAgentNode = (
       : [];
   }
 
-  const composed = compose(set, actor.profile, { projectDirectory });
+  const composed = compose(set, actor.profile, {
+    projectDirectory: options.projectDirectory,
+    agentDefaults: options.agentDefaults,
+  });
   if (composed.plan === undefined) {
     return composed.errors.map((message) =>
       workflowError(workflow.id, `node '${node.id}' agent '${actor.profile}': ${message}`),
@@ -392,7 +403,7 @@ const validateWorkflow = (
   set: EffectiveResourceSet,
   workflow: WorkflowDefinition,
   definitions: ReadonlyMap<string, WorkflowDefinition>,
-  projectDirectory?: string,
+  options: ValidationOptions,
 ): readonly ValidationFinding[] => {
   const findings: ValidationFinding[] = [];
   const nodeIds = new Set<string>();
@@ -406,7 +417,7 @@ const validateWorkflow = (
 
   for (const node of workflow.nodes) {
     findings.push(...validateWorkflowNodeReferences(workflow, node, nodeIds, definitions));
-    findings.push(...validateWorkflowAgentNode(set, workflow, node, projectDirectory));
+    findings.push(...validateWorkflowAgentNode(set, workflow, node, options));
   }
 
   for (const edge of workflow.feedback ?? []) {
@@ -453,9 +464,10 @@ export const validateEffectiveSet = (
   options: ValidationOptions = {},
 ): readonly ValidationFinding[] => {
   const findings: ValidationFinding[] = [];
+  const effectiveOptions: ValidationOptions = { ...options, projectDirectory };
 
   for (const agent of listResources(set, 'agent')) {
-    findings.push(...validateAgent(set, agent, options, projectDirectory), ...reservedNamespaceFindings(agent));
+    findings.push(...validateAgent(set, agent, effectiveOptions), ...reservedNamespaceFindings(agent));
   }
 
   for (const skill of listResources(set, 'skill')) {
@@ -465,7 +477,7 @@ export const validateEffectiveSet = (
   const workflows = workflowDefinitions(set, options.workflowRoots);
   findings.push(...workflows.findings);
   for (const workflow of workflows.definitions.values()) {
-    findings.push(...validateWorkflow(set, workflow, workflows.definitions, projectDirectory));
+    findings.push(...validateWorkflow(set, workflow, workflows.definitions, effectiveOptions));
   }
   findings.push(...workflowCycleFindings(workflows.definitions));
 

--- a/code/cli/src/schemas/settings.schema.json
+++ b/code/cli/src/schemas/settings.schema.json
@@ -103,7 +103,40 @@
     "custom_settings": {
       "type": "object",
       "description": "Arbitrary YAML-compatible values exposed to Outfitter composition templates as outfitter.custom_settings."
+    },
+    "agent_defaults": {
+      "type": "object",
+      "description": "Additive loadout entries composed into every agent before its own loadout, using the same deterministic ordering and stable de-duplication as inherited agent loadouts.",
+      "properties": {
+        "extensions": { "$ref": "#/$defs/slugList" },
+        "skills": { "$ref": "#/$defs/slugList" },
+        "mcp": { "$ref": "#/$defs/slugList" },
+        "plugins": { "$ref": "#/$defs/slugList" },
+        "subagents": { "$ref": "#/$defs/slugList" },
+        "append_system_prompt": {
+          "oneOf": [
+            { "$ref": "#/$defs/promptSource" },
+            { "type": "array", "items": { "$ref": "#/$defs/promptSource" } }
+          ]
+        }
+      },
+      "additionalProperties": false
     }
   },
-  "additionalProperties": true
+  "additionalProperties": true,
+  "$defs": {
+    "slugList": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "promptSource": {
+      "type": "object",
+      "oneOf": [{ "required": ["file"] }, { "required": ["repo_file"] }],
+      "properties": {
+        "file": { "type": "string", "minLength": 1 },
+        "repo_file": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    }
+  }
 }

--- a/code/cli/src/settings/Settings.ts
+++ b/code/cli/src/settings/Settings.ts
@@ -1,4 +1,5 @@
 // Defines the internal Settings shape produced from Outfitter settings files.
+import type { PromptSourceReference } from '../composer/PromptSource.js';
 import type { RemoteSourceReference } from '../sources/SourceCache.js';
 
 export type RemoteSettingsReference = RemoteSourceReference & { readonly path: string };
@@ -47,6 +48,34 @@ export interface TelemetrySettings {
   readonly enabled?: boolean;
 }
 
+/**
+ * Additive loadout entries composed into every agent before its own loadout. Only the loadout
+ * fields with additive union semantics are supported; per-agent overrides like `model`, `thinking`,
+ * and `tools` stay agent-owned so an organization default can never silently pin a scalar.
+ */
+export interface AgentDefaults {
+  readonly extensions?: readonly string[];
+  readonly skills?: readonly string[];
+  readonly mcp?: readonly string[];
+  readonly plugins?: readonly string[];
+  readonly subagents?: readonly string[];
+  readonly appendSystemPrompt?: readonly PromptSourceReference[];
+}
+
+/** True when no defaults field carries an entry, so the settings layer contributes nothing. */
+export const isEmptyAgentDefaults = (defaults: AgentDefaults | undefined): boolean => {
+  if (defaults === undefined) return true;
+  const fields = [
+    defaults.extensions,
+    defaults.skills,
+    defaults.mcp,
+    defaults.plugins,
+    defaults.subagents,
+    defaults.appendSystemPrompt,
+  ];
+  return fields.every((values) => values === undefined || values.length === 0);
+};
+
 export interface SourceCacheSettings {
   readonly policy?: SourceCachePolicy;
 }
@@ -73,6 +102,8 @@ export interface Settings {
   readonly startup?: StartupSettings;
   readonly enterprise?: EnterpriseSettings;
   readonly telemetry?: TelemetrySettings;
+  /** Additive loadout entries composed into every agent before its own loadout. */
+  readonly agentDefaults?: AgentDefaults;
 }
 
 export const emptySettings = (): Settings => ({

--- a/code/cli/src/settings/SettingsLoader.ts
+++ b/code/cli/src/settings/SettingsLoader.ts
@@ -7,6 +7,7 @@ import type { ValidationIssue } from '../validation/SchemaValidator.js';
 import { validateSchema } from '../validation/SchemaValidator.js';
 import { parseYamlDocument } from '../validation/YamlDocument.js';
 import type {
+  AgentDefaults,
   CustomSettings,
   Harness,
   Isolation,
@@ -59,6 +60,16 @@ interface SettingsDocument {
   readonly startup?: StartupSettingsDocument;
   readonly enterprise?: EnterpriseSettingsDocument;
   readonly telemetry?: TelemetrySettingsDocument;
+  readonly agent_defaults?: AgentDefaultsDocument;
+}
+
+interface AgentDefaultsDocument {
+  readonly extensions?: readonly string[];
+  readonly skills?: readonly string[];
+  readonly mcp?: readonly string[];
+  readonly plugins?: readonly string[];
+  readonly subagents?: readonly string[];
+  readonly append_system_prompt?: unknown;
 }
 
 interface EnterpriseSettingsDocument {
@@ -295,6 +306,7 @@ const convertSettingsDocument = (
   startup: convertStartupSettings(document.startup),
   enterprise: isHomeScope(scope) ? convertEnterpriseSettings(document.enterprise) : undefined,
   telemetry: convertTelemetrySettings(document.telemetry),
+  agentDefaults: convertAgentDefaults(document.agent_defaults),
 });
 
 const convertStartupSettings = (startup: StartupSettingsDocument | undefined): Settings['startup'] =>
@@ -305,6 +317,23 @@ const convertEnterpriseSettings = (enterprise: EnterpriseSettingsDocument | unde
 
 const convertTelemetrySettings = (telemetry: TelemetrySettingsDocument | undefined): Settings['telemetry'] =>
   telemetry === undefined ? undefined : { enabled: telemetry.enabled };
+
+const convertAgentDefaults = (defaults: AgentDefaultsDocument | undefined): AgentDefaults | undefined =>
+  defaults === undefined
+    ? undefined
+    : {
+        extensions: defaults.extensions,
+        skills: defaults.skills,
+        mcp: defaults.mcp,
+        plugins: defaults.plugins,
+        subagents: defaults.subagents,
+        // The settings schema guarantees each entry is a `{file}` or `{repo_file}` source.
+        appendSystemPrompt: Array.isArray(defaults.append_system_prompt)
+          ? defaults.append_system_prompt
+          : defaults.append_system_prompt === undefined
+            ? undefined
+            : [defaults.append_system_prompt],
+      };
 
 const convertRemoteSettingsSource = (source: RemoteSettingsDocument): RemoteSettingsReference => {
   if (source.uri !== undefined) {

--- a/code/cli/src/settings/SettingsMerger.ts
+++ b/code/cli/src/settings/SettingsMerger.ts
@@ -1,8 +1,40 @@
 /* eslint-disable complexity */
 // Provides deterministic Settings merge scaffolding.
 import { mergeObjectsWithPolicy } from '../merge/SettingsValueMerger.js';
-import type { CustomSettings, Settings, StatePersistence } from './Settings.js';
+import { promptSourceKey } from '../composer/PromptSource.js';
+import type { AgentDefaults, CustomSettings, Settings, StatePersistence } from './Settings.js';
 import { emptySettings } from './Settings.js';
+
+/** Folds one additive defaults list across the stack, collapsing duplicates to their first occurrence. */
+const mergeDefaultsList = <T>(
+  lower: readonly T[] | undefined,
+  higher: readonly T[] | undefined,
+  key: (entry: T) => string,
+) => {
+  if (lower === undefined && higher === undefined) return undefined;
+  const merged: T[] = [];
+  const seen = new Set<string>();
+  for (const entry of [...(lower ?? []), ...(higher ?? [])]) {
+    const entryKey = key(entry);
+    if (!seen.has(entryKey)) {
+      seen.add(entryKey);
+      merged.push(entry);
+    }
+  }
+  return merged;
+};
+
+const mergeAgentDefaults = (lower: AgentDefaults | undefined, higher: AgentDefaults | undefined) => {
+  if (lower === undefined && higher === undefined) return undefined;
+  return {
+    extensions: mergeDefaultsList(lower?.extensions, higher?.extensions, (entry) => entry),
+    skills: mergeDefaultsList(lower?.skills, higher?.skills, (entry) => entry),
+    mcp: mergeDefaultsList(lower?.mcp, higher?.mcp, (entry) => entry),
+    plugins: mergeDefaultsList(lower?.plugins, higher?.plugins, (entry) => entry),
+    subagents: mergeDefaultsList(lower?.subagents, higher?.subagents, (entry) => entry),
+    appendSystemPrompt: mergeDefaultsList(lower?.appendSystemPrompt, higher?.appendSystemPrompt, promptSourceKey),
+  };
+};
 
 export const mergeSettingsStack = (settingsStack: readonly Settings[]): Settings => {
   let defaultAgent: string | undefined;
@@ -18,6 +50,7 @@ export const mergeSettingsStack = (settingsStack: readonly Settings[]): Settings
   let startup: Settings['startup'];
   let enterprise: Settings['enterprise'];
   let telemetry: Settings['telemetry'];
+  let agentDefaults: AgentDefaults | undefined;
 
   for (const settings of settingsStack) {
     defaultAgent = settings.defaultAgent ?? defaultAgent;
@@ -39,6 +72,7 @@ export const mergeSettingsStack = (settingsStack: readonly Settings[]): Settings
     startup = settings.startup === undefined ? startup : { ...startup, ...settings.startup };
     enterprise = settings.enterprise === undefined ? enterprise : { ...enterprise, ...settings.enterprise };
     telemetry = settings.telemetry === undefined ? telemetry : { ...telemetry, ...settings.telemetry };
+    agentDefaults = mergeAgentDefaults(agentDefaults, settings.agentDefaults);
   }
 
   return {
@@ -56,6 +90,7 @@ export const mergeSettingsStack = (settingsStack: readonly Settings[]): Settings
     startup: startup ?? {},
     enterprise: enterprise ?? {},
     telemetry: telemetry ?? {},
+    agentDefaults,
   };
 };
 

--- a/code/cli/tests/unit/agent-defaults.test.ts
+++ b/code/cli/tests/unit/agent-defaults.test.ts
@@ -521,6 +521,59 @@ describe('agent defaults', () => {
     }
   });
 
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.10.6, OFTR-002.10.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('carries a lower-layer agent-default MCP definition into a self-contained dump', () => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    const out = join(root, 'dump');
+    write(join(home, '.agents', 'mcp.json'), JSON.stringify({ mcpServers: { github: { command: 'home-gh' } } }));
+    write(join(project, '.agents', 'mcp.json'), JSON.stringify({ mcpServers: { slack: { command: 'slack' } } }));
+    write(join(project, '.agents', 'settings.yml'), 'agent_defaults:\n  mcp: [github]\n');
+    write(join(project, '.agents', 'agents', 'alpha', 'agent.md'), '---\nname: alpha\n---\n\nAlpha.\n');
+
+    const result = executeDumpCommand({ homeDirectory: home, projectDirectory: project, agent: 'alpha', out });
+
+    expect(result.ok).toBe(true);
+    expect(JSON.parse(readFileSync(join(out, '.agents', 'mcp.json'), 'utf8'))).toEqual({
+      mcpServers: {
+        slack: { command: 'slack' },
+        github: { command: 'home-gh' },
+      },
+    });
+    const reloaded = resolveEffectiveSet({
+      homeDirectory: join(createTemporaryRoot(), 'home'),
+      projectDirectory: out,
+    });
+    const recomposed = compose(reloaded.set, 'alpha', {
+      projectDirectory: out,
+      agentDefaults: reloaded.settings.agentDefaults,
+    });
+    expect(recomposed.warnings).toEqual([]);
+    expect(recomposed.plan?.loadout.mcpServers).toEqual({ github: { command: 'home-gh' } });
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.10.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('replaces a copied MCP document without a server map with the effective default definition', () => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    const out = join(root, 'dump');
+    write(join(home, '.agents', 'mcp.json'), JSON.stringify({ mcpServers: { github: { command: 'home-gh' } } }));
+    write(join(project, '.agents', 'mcp.json'), '{}');
+    write(join(project, '.agents', 'settings.yml'), 'agent_defaults:\n  mcp: [github]\n');
+    write(join(project, '.agents', 'agents', 'alpha', 'agent.md'), '---\nname: alpha\n---\n\nAlpha.\n');
+
+    const result = executeDumpCommand({ homeDirectory: home, projectDirectory: project, agent: 'alpha', out });
+
+    expect(result.ok).toBe(true);
+    expect(JSON.parse(readFileSync(join(out, '.agents', 'mcp.json'), 'utf8'))).toEqual({
+      mcpServers: { github: { command: 'home-gh' } },
+    });
+  });
+
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.10.11).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('writes no settings.yml into dumps without agent defaults', () => {

--- a/code/cli/tests/unit/agent-defaults.test.ts
+++ b/code/cli/tests/unit/agent-defaults.test.ts
@@ -1,0 +1,542 @@
+// Tests `agent_defaults`: settings parsing/merging and composition into every agent.
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { compose } from '../../src/composer/Composer.js';
+import { executeDumpCommand } from '../../src/cli/commands/DumpCommand.js';
+import { executeRunAgentCommand } from '../../src/cli/commands/RunAgentCommand.js';
+import { executeValidateCommand } from '../../src/cli/commands/ValidateCommand.js';
+import { composeLinkClosure } from '../../src/links/HarnessLinkPlan.js';
+import { discoverLayers } from '../../src/resolver/Layer.js';
+import { resolveResources } from '../../src/resolver/Resolver.js';
+import { resolveEffectiveSet } from '../../src/resolver/ResolverContext.js';
+import { discoverSettingsLoadPlan, loadSettings } from '../../src/settings/SettingsLoader.js';
+import type { AgentLaunchPlan } from '../../src/projection/Projection.js';
+
+const temporaryRoots: string[] = [];
+
+const createTemporaryRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-agent-defaults-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const write = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+
+const relativeTree = (root: string): string[] => {
+  const files: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else files.push(relative(root, full).split(/[/\\]/).join('/'));
+    }
+  };
+  walk(root);
+  return files.sort();
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// The pinned collector extension the issue's acceptance scenario describes.
+const PENSIEVE = 'git:github.com/ai-outfitter/pensieve@4b1e0d2c9a7f35e86b0d1c4a92f6e3d5a8b7c601';
+
+/** Two unrelated Pi agents, neither mentioning the defaults in its own profile. */
+const writeTwoAgentTree = (project: string): void => {
+  write(join(project, '.agents', 'agents', 'alpha', 'agent.md'), '---\nname: alpha\n---\n\nAlpha body.\n');
+  write(join(project, '.agents', 'agents', 'beta', 'agent.md'), '---\nname: beta\n---\n\nBeta body.\n');
+};
+
+const resolveSetFor = (home: string, project: string) =>
+  resolveResources(discoverLayers({ homeDirectory: home, projectDirectory: project, settings: {} }).layers);
+
+/** Asserts one dumped agent tree carries the defaults without leaking them into the agent profile. */
+const expectDumpedDefaultTree = (out: string, agent: string): void => {
+  // The agent profile itself does not mention the default; the settings layer carries it.
+  const profile = readFileSync(join(out, '.agents', 'agents', agent, 'agent.md'), 'utf8');
+  expect(profile).not.toContain('pensieve');
+  expect(profile).not.toContain('organization');
+  // Provenance records the settings layer.
+  const provenance = JSON.parse(readFileSync(join(out, '.agents', '.outfitter', 'composition.json'), 'utf8')) as {
+    compositions: { agentDefaults?: { extensions?: string[]; appendSystemPrompt?: unknown[] } }[];
+  };
+  expect(provenance.compositions[0]?.agentDefaults?.extensions).toEqual([PENSIEVE]);
+  expect(provenance.compositions[0]?.agentDefaults?.appendSystemPrompt).toEqual([{ file: 'prompts/organization.md' }]);
+  // The dumped tree carries the merged defaults and re-resolves exactly one extension.
+  const tree = relativeTree(join(out, '.agents'));
+  expect(tree).toContain('settings.yml');
+  expect(tree).toContain('prompts/organization.md');
+  const reloaded = resolveEffectiveSet({ homeDirectory: join(createTemporaryRoot(), 'home'), projectDirectory: out });
+  expect(reloaded.settings.agentDefaults?.extensions).toEqual([PENSIEVE]);
+  const recomposed = compose(reloaded.set, agent, {
+    projectDirectory: out,
+    agentDefaults: reloaded.settings.agentDefaults,
+  });
+  expect(recomposed.plan?.loadout.extensions).toEqual([PENSIEVE]);
+};
+
+describe('agent defaults', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.10.1, OFTR-002.10.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('parses agent_defaults into settings and rejects unknown keys', () => {
+    const root = createTemporaryRoot();
+    const project = join(root, 'project');
+    write(
+      join(project, '.agents', 'settings.yml'),
+      [
+        'agent_defaults:',
+        '  extensions:',
+        `    - ${PENSIEVE}`,
+        '  skills: [organization-practices]',
+        '  mcp: [github]',
+        '  plugins: [org-plugin]',
+        '  subagents: [org-reviewer]',
+        '  append_system_prompt:',
+        '    - file: prompts/organization.md',
+        '    - repo_file: docs/context.md',
+      ].join('\n'),
+    );
+
+    const loaded = loadSettings(
+      discoverSettingsLoadPlan({ homeDirectory: join(root, 'home'), projectDirectory: project }),
+    );
+
+    expect(loaded.issues).toEqual([]);
+    expect(loaded.settings.agentDefaults).toEqual({
+      extensions: [PENSIEVE],
+      skills: ['organization-practices'],
+      mcp: ['github'],
+      plugins: ['org-plugin'],
+      subagents: ['org-reviewer'],
+      appendSystemPrompt: [{ file: 'prompts/organization.md' }, { repo_file: 'docs/context.md' }],
+    });
+
+    // A single prompt source (no array) is accepted and normalized.
+    write(
+      join(project, '.agents', 'settings.yml'),
+      'agent_defaults:\n  append_system_prompt:\n    file: prompts/organization.md\n',
+    );
+    const scalar = loadSettings(
+      discoverSettingsLoadPlan({ homeDirectory: join(root, 'home'), projectDirectory: project }),
+    );
+    expect(scalar.issues).toEqual([]);
+    expect(scalar.settings.agentDefaults?.appendSystemPrompt).toEqual([{ file: 'prompts/organization.md' }]);
+
+    write(join(project, '.agents', 'settings.yml'), 'agent_defaults:\n  model: gpt-5.2\n');
+    const rejected = loadSettings(
+      discoverSettingsLoadPlan({ homeDirectory: join(root, 'home'), projectDirectory: project }),
+    );
+    expect(rejected.issues.length).toBeGreaterThan(0);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.10.5).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('merges agent_defaults across settings scopes as ordered-set unions', () => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    write(join(home, '.agents', 'settings.yml'), 'agent_defaults:\n  skills: [shared, user-only]\n');
+    write(join(project, '.agents', 'settings.yml'), 'agent_defaults:\n  skills: [shared, project-only]\n');
+    // A higher-precedence file that declares no defaults contributes nothing.
+    write(join(project, '.agents', 'settings.local.yml'), 'default_agent: alpha\n');
+
+    const loaded = loadSettings(discoverSettingsLoadPlan({ homeDirectory: home, projectDirectory: project }));
+
+    expect(loaded.issues).toEqual([]);
+    expect(loaded.settings.agentDefaults?.skills).toEqual(['shared', 'user-only', 'project-only']);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.10.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('composes agent defaults ahead of the inheritance chain with stable de-duplication', () => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    for (const slug of ['defaults-skill', 'child-skill', 'parent-skill']) {
+      write(join(project, '.agents', 'skills', slug, 'SKILL.md'), `---\nname: ${slug}\n---\n`);
+    }
+    write(
+      join(project, '.agents', 'mcp.json'),
+      JSON.stringify({ mcpServers: { github: { command: 'root' }, slack: { command: 'root-slack' } } }),
+    );
+    write(
+      join(project, '.agents', 'settings.yml'),
+      [
+        'agent_defaults:',
+        `  extensions: [${PENSIEVE}]`,
+        '  skills: [defaults-skill, parent-skill]',
+        '  plugins: [org-plugin]',
+        '  mcp: [github, slack]',
+      ].join('\n'),
+    );
+    write(
+      join(project, '.agents', 'agents', 'parent', 'agent.md'),
+      '---\nname: parent\nskills: [parent-skill]\nextensions: [parent-extension]\nplugins: [parent-plugin]\n---\n\nParent.\n',
+    );
+    write(
+      join(project, '.agents', 'agents', 'child', 'agent.md'),
+      '---\nname: child\ninherits: parent\nskills: [parent-skill, child-skill]\nextensions: [child-extension]\nplugins: [child-plugin]\n---\n\nChild.\n',
+    );
+
+    const loaded = loadSettings(discoverSettingsLoadPlan({ homeDirectory: home, projectDirectory: project }));
+    const result = compose(resolveSetFor(home, project), 'child', {
+      projectDirectory: project,
+      agentDefaults: loaded.settings.agentDefaults,
+    });
+
+    expect(result.errors).toEqual([]);
+    const plan = result.plan!;
+    expect(plan.loadout.extensions).toEqual([PENSIEVE, 'parent-extension', 'child-extension']);
+    expect(plan.loadout.plugins).toEqual(['org-plugin', 'parent-plugin', 'child-plugin']);
+    expect(plan.loadout.skills.map((skill) => skill.slug)).toEqual(['defaults-skill', 'parent-skill', 'child-skill']);
+    expect(plan.loadout.mcp).toEqual(['github', 'slack']);
+    expect(plan.loadout.mcpServers).toEqual({ github: { command: 'root' }, slack: { command: 'root-slack' } });
+    // Settings-layer entries are visible in plan provenance.
+    expect(plan.agentDefaults).toEqual({
+      extensions: [PENSIEVE],
+      skills: ['defaults-skill', 'parent-skill'],
+      plugins: ['org-plugin'],
+      mcp: ['github', 'slack'],
+    });
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.10.4).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('resolves defaults catalog-wide, ahead of any agent-local namespace', () => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    write(join(project, '.agents', 'skills', 'shared', 'SKILL.md'), '---\nname: shared\n---\n\ncatalog\n');
+    write(join(project, '.agents', 'settings.yml'), 'agent_defaults:\n  skills: [shared]\n');
+    write(join(project, '.agents', 'agents', 'alpha', 'agent.md'), '---\nname: alpha\nskills: [shared]\n---\n');
+    write(
+      join(project, '.agents', 'agents', 'alpha', 'skills', 'shared', 'SKILL.md'),
+      '---\nname: shared\n---\n\nlocal\n',
+    );
+
+    const loaded = loadSettings(discoverSettingsLoadPlan({ homeDirectory: home, projectDirectory: project }));
+    const result = compose(resolveSetFor(home, project), 'alpha', {
+      projectDirectory: project,
+      agentDefaults: loaded.settings.agentDefaults,
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.plan?.loadout.skills).toHaveLength(1);
+    expect(result.plan?.loadout.skills[0]?.winner.ownerAgent).toBeUndefined();
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.10.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('warns about unresolved defaults naming the settings layer', () => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    writeTwoAgentTree(project);
+    write(
+      join(project, '.agents', 'settings.yml'),
+      'agent_defaults:\n  skills: [ghost]\n  mcp: [ghost-server]\n  subagents: [ghost-delegate]\n',
+    );
+    write(
+      join(project, '.agents', 'agents', 'alpha', 'agent.md'),
+      '---\nname: alpha\nsubagents: [ghost-own]\n---\n\nAlpha body.\n',
+    );
+
+    const loaded = loadSettings(discoverSettingsLoadPlan({ homeDirectory: home, projectDirectory: project }));
+    const result = compose(resolveSetFor(home, project), 'alpha', {
+      projectDirectory: project,
+      agentDefaults: loaded.settings.agentDefaults,
+    });
+
+    expect(result.plan?.warnings).toEqual([
+      "agent_defaults subagents references unknown agent 'ghost-delegate'.",
+      "loadout subagents references unknown agent 'ghost-own'.",
+      "agent_defaults skills references unknown skill 'ghost'.",
+      "agent_defaults mcp references unknown server 'ghost-server'.",
+    ]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.10.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('warns when an optional settings repo_file prompt source is missing', () => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    writeTwoAgentTree(project);
+    write(
+      join(project, '.agents', 'settings.yml'),
+      'agent_defaults:\n  append_system_prompt:\n    - repo_file: docs/ghost.md\n',
+    );
+
+    const loaded = loadSettings(discoverSettingsLoadPlan({ homeDirectory: home, projectDirectory: project }));
+    const result = compose(resolveSetFor(home, project), 'alpha', {
+      projectDirectory: project,
+      agentDefaults: loaded.settings.agentDefaults,
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.plan?.warnings).toEqual([
+      "agent 'settings:agent_defaults' optional repo_file prompt source 'docs/ghost.md' was not found.",
+    ]);
+    expect(result.plan?.identity.appendSystemPrompts).toEqual([]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.10.1, OFTR-002.10.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('records only non-empty defaults fields in plan provenance', () => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    writeTwoAgentTree(project);
+    write(join(project, '.agents', 'settings.yml'), `agent_defaults:\n  extensions: [${PENSIEVE}]\n  skills: []\n`);
+
+    const loaded = loadSettings(discoverSettingsLoadPlan({ homeDirectory: home, projectDirectory: project }));
+    const result = compose(resolveSetFor(home, project), 'alpha', {
+      projectDirectory: project,
+      agentDefaults: loaded.settings.agentDefaults,
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.plan?.agentDefaults).toEqual({ extensions: [PENSIEVE] });
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.10.3, OFTR-002.10.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('composes settings append prompts first with settings-layer provenance', () => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    write(join(project, '.agents', 'prompts', 'organization.md'), 'ORG POLICY');
+    write(join(project, 'docs', 'context.md'), 'repo context');
+    write(
+      join(project, '.agents', 'settings.yml'),
+      'agent_defaults:\n  append_system_prompt:\n    - file: prompts/organization.md\n    - repo_file: docs/context.md\n',
+    );
+    write(
+      join(project, '.agents', 'agents', 'alpha', 'agent.md'),
+      '---\nname: alpha\nappend_system_prompt:\n  - file: prompts/organization.md\n---\n\nAlpha.\n',
+    );
+
+    const loaded = loadSettings(discoverSettingsLoadPlan({ homeDirectory: home, projectDirectory: project }));
+    const result = compose(resolveSetFor(home, project), 'alpha', {
+      projectDirectory: project,
+      agentDefaults: loaded.settings.agentDefaults,
+    });
+
+    expect(result.errors).toEqual([]);
+    const plan = result.plan!;
+    const appended = plan.identity.appendSystemPrompts ?? [];
+    // Duplicate suppression: the agent's own identical fragment collapses into the settings one.
+    expect(appended.map((fragment) => fragment.content)).toEqual(['ORG POLICY', 'repo context']);
+    expect(appended[0]?.declaringAgent).toBe('settings:agent_defaults');
+    expect(appended[1]?.trust).toBe('repository');
+    expect(plan.agentDefaults?.appendSystemPrompt).toEqual([
+      { file: 'prompts/organization.md' },
+      { repo_file: 'docs/context.md' },
+    ]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.10.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('applies agent_defaults while composing the native harness link closure', () => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    write(join(project, '.agents', 'prompts', 'organization.md'), 'ORG POLICY');
+    write(
+      join(project, '.agents', 'settings.yml'),
+      'agent_defaults:\n  append_system_prompt:\n    - file: prompts/organization.md\n',
+    );
+    write(join(project, '.agents', 'agents', 'alpha', 'agent.md'), '---\nname: alpha\n---\n\nAlpha.\n');
+
+    const loaded = loadSettings(discoverSettingsLoadPlan({ homeDirectory: home, projectDirectory: project }));
+    const closure = composeLinkClosure(resolveSetFor(home, project), ['alpha'], project, loaded.settings.agentDefaults);
+
+    expect(closure.errors).toEqual([]);
+    expect(closure.agents[0]?.document).toContain('ORG POLICY');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.10.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('fails a settings prompt fragment missing from every layer', () => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    writeTwoAgentTree(project);
+    write(
+      join(project, '.agents', 'settings.yml'),
+      'agent_defaults:\n  append_system_prompt:\n    - file: prompts/ghost.md\n',
+    );
+
+    const loaded = loadSettings(discoverSettingsLoadPlan({ homeDirectory: home, projectDirectory: project }));
+    const result = compose(resolveSetFor(home, project), 'alpha', {
+      projectDirectory: project,
+      agentDefaults: loaded.settings.agentDefaults,
+    });
+
+    expect(result.plan).toBeUndefined();
+    expect(result.errors[0]).toContain('prompt source file');
+    expect(result.errors[0]).toContain('missing file');
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.10.3).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('composes agent defaults into delegated subagents too', () => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    write(join(project, '.agents', 'settings.yml'), `agent_defaults:\n  extensions: [${PENSIEVE}]\n`);
+    write(
+      join(project, '.agents', 'agents', 'leader', 'agent.md'),
+      '---\nname: leader\nsubagents: [reviewer]\n---\n\nLeader.\n',
+    );
+    write(join(project, '.agents', 'agents', 'reviewer', 'agent.md'), '---\nname: reviewer\n---\n\nReview.\n');
+
+    const loaded = loadSettings(discoverSettingsLoadPlan({ homeDirectory: home, projectDirectory: project }));
+    const result = compose(resolveSetFor(home, project), 'leader', {
+      projectDirectory: project,
+      agentDefaults: loaded.settings.agentDefaults,
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.plan?.loadout.composedSubagents?.[0]?.extensions).toEqual([PENSIEVE]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.10.11).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('composes identically when agent_defaults is absent', () => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    write(join(project, '.agents', 'skills', 'wiki', 'SKILL.md'), '---\nname: wiki\n---\n');
+    write(join(project, '.agents', 'agents', 'alpha', 'agent.md'), '---\nname: alpha\nskills: [wiki]\n---\n\nAlpha.\n');
+    const set = resolveSetFor(home, project);
+
+    expect(compose(set, 'alpha', { projectDirectory: project }).plan).toEqual(compose(set, 'alpha').plan);
+    expect(compose(set, 'alpha').plan?.agentDefaults).toBeUndefined();
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.10.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('runs with agent defaults: the pinned extension reaches the pi install boundary', async () => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    const xdg = join(root, 'xdg');
+    writeTwoAgentTree(project);
+    write(
+      join(project, '.agents', 'settings.yml'),
+      `agent_defaults:\n  extensions: [git:github.com/ai-outfitter/pensieve@v1]\n`,
+    );
+    const installed: string[] = [];
+    const extensionInstallSpawner = ({ source, cacheAgentDir }: { source: string; cacheAgentDir: string }) => {
+      installed.push(source);
+      write(
+        join(cacheAgentDir, 'git', 'github.com', 'ai-outfitter', 'pensieve', 'package.json'),
+        '{"name":"pensieve","version":"1.0.0"}',
+      );
+      return Promise.resolve(0);
+    };
+    let capturedPlan: AgentLaunchPlan | undefined;
+    const launcher = (plan: AgentLaunchPlan): Promise<number> => {
+      capturedPlan = plan;
+      return Promise.resolve(0);
+    };
+
+    const previousXdg = process.env.XDG_CACHE_HOME;
+    process.env.XDG_CACHE_HOME = xdg;
+    try {
+      const result = await executeRunAgentCommand({
+        homeDirectory: home,
+        projectDirectory: project,
+        agent: 'alpha',
+        harness: 'pi',
+        launcher,
+        extensionInstallSpawner,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(installed).toEqual(['git:github.com/ai-outfitter/pensieve@v1']);
+      expect(capturedPlan?.args).toContain('--extension');
+    } finally {
+      if (previousXdg === undefined) delete process.env.XDG_CACHE_HOME;
+      else process.env.XDG_CACHE_HOME = previousXdg;
+    }
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.10.6, OFTR-002.10.7).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('validates unresolved defaults as errors naming the settings layer', () => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    writeTwoAgentTree(project);
+    write(join(project, '.agents', 'settings.yml'), 'agent_defaults:\n  skills: [ghost]\n');
+
+    const result = executeValidateCommand({ homeDirectory: home, projectDirectory: project });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual([
+      {
+        resource: 'agent:alpha',
+        severity: 'error',
+        message: "agent_defaults skills references unknown skill 'ghost'.",
+      },
+      {
+        resource: 'agent:beta',
+        severity: 'error',
+        message: "agent_defaults skills references unknown skill 'ghost'.",
+      },
+    ]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.10.6, OFTR-002.10.8).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('dumps self-contained trees carrying exactly one resolved default per agent', () => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    writeTwoAgentTree(project);
+    write(join(project, '.agents', 'prompts', 'organization.md'), 'ORG POLICY');
+    write(
+      join(project, '.agents', 'settings.yml'),
+      `agent_defaults:\n  extensions: [${PENSIEVE}]\n  append_system_prompt:\n    - file: prompts/organization.md\n`,
+    );
+
+    for (const agent of ['alpha', 'beta']) {
+      const out = join(root, `dump-${agent}`);
+      const result = executeDumpCommand({ homeDirectory: home, projectDirectory: project, agent, out });
+
+      expect(result.ok).toBe(true);
+      expectDumpedDefaultTree(out, agent);
+    }
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-002.10.11).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('writes no settings.yml into dumps without agent defaults', () => {
+    const root = createTemporaryRoot();
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    writeTwoAgentTree(project);
+    const out = join(root, 'dump');
+
+    const result = executeDumpCommand({ homeDirectory: home, projectDirectory: project, agent: 'alpha', out });
+
+    expect(result.ok).toBe(true);
+    expect(existsSync(join(out, '.agents', 'settings.yml'))).toBe(false);
+    const provenance = JSON.parse(readFileSync(join(out, '.agents', '.outfitter', 'composition.json'), 'utf8')) as {
+      compositions: { agentDefaults?: unknown }[];
+    };
+    expect(provenance.compositions[0]?.agentDefaults).toBeUndefined();
+  });
+});

--- a/docs/architecture/file_structure.md
+++ b/docs/architecture/file_structure.md
@@ -50,6 +50,9 @@ Outfitter is organized around a private npm workspace root, clear TypeScript pac
 │   │   │   │   └── SourceCachePolicy.ts # repair, locked, and offline startup enforcement
 │   │   │   ├── resolver/              # .agents layer resolution into one effective resource set
 │   │   │   ├── composer/              # harness-neutral CompositionPlan from the effective set
+│   │   │   ├── Chain.ts           # agent inheritance-chain resolution with cycle and parent checks
+│   │   │   ├── Defaults.ts        # settings-layer agent_defaults selection, resolution, and provenance
+│   │   │   └── Mcp.ts             # selected MCP server definitions after layer and owner precedence
 │   │   │   ├── projection/            # materialize a composition + build pi/claude/codex launch plans
 │   │   │   │   └── CodexMcp.ts        # translate selected MCP definitions to Codex TOML CLI overrides
 │   │   │   ├── dump/                  # deterministic self-contained `.agents` tree output

--- a/docs/documentation/settings.md
+++ b/docs/documentation/settings.md
@@ -52,6 +52,17 @@ source_cache:
 # Pseudonymous product analytics consent; defaults to true when absent.
 telemetry:
   enabled: false
+
+# Additive loadout entries composed into every agent ahead of its own loadout.
+agent_defaults:
+  extensions:
+    - git:github.com/ai-outfitter/pensieve@4b1e0d2c9a7f35e86b0d1c4a92f6e3d5a8b7c601
+  skills:
+    - organization-practices
+  mcp:
+    - github
+  append_system_prompt:
+    - file: prompts/organization.md
 ```
 
 - `default_agent` / `default_harness` — which agent plain `outfitter` runs, and the harness it launches in.
@@ -66,6 +77,7 @@ telemetry:
   accesses the network.
   below its `repos/` directory.
 - `telemetry.enabled` — the primary and sole persistent control for pseudonymous product analytics. Edit it directly to enable or disable telemetry. See [Telemetry](./telemetry.md) for consent precedence, automatic identifier cleanup, the event contract, and the current inert-build status.
+- `agent_defaults` — additive loadout entries composed into **every** agent ahead of its own loadout; see [Agent defaults](#agent-defaults) below.
 
 ## Precedence
 
@@ -78,4 +90,32 @@ Higher wins:
 5. Cached remote settings (in configured order)
 6. Built-in defaults
 
-Scalar settings override. `sources` follows last-wins ordering per scope so a higher-precedence file replaces the complete lower-precedence list. `workflows` is additive: loaded settings contribute an ordered-set union, and repeated slugs across files collapse to their first occurrence.
+Scalar settings override. `sources` follows last-wins ordering per scope so a higher-precedence file replaces the complete lower-precedence list. `workflows` and `agent_defaults` are additive: loaded settings contribute an ordered-set union, and repeated entries across files collapse to their first occurrence.
+
+## Agent defaults
+
+`agent_defaults` composes one set of additive loadout entries into every agent — local runs, Actions, and dumps alike — so an organization declares a shared extension, skill, MCP server, plugin, delegate, or appended prompt fragment once instead of duplicating it into every `agents/<id>/agent.md`:
+
+```yaml
+agent_defaults:
+  extensions:
+    - git:github.com/ai-outfitter/pensieve@4b1e0d2c9a7f35e86b0d1c4a92f6e3d5a8b7c601
+  skills:
+    - organization-practices
+  mcp:
+    - github
+  plugins:
+    - org-plugin
+  subagents:
+    - org-reviewer
+  append_system_prompt:
+    - file: prompts/organization.md # resolved like agent prompt sources: catalog `file`, active-project `repo_file`
+```
+
+Composition rules:
+
+- Defaults compose **before** each agent's own loadout — like a root-most ancestor ahead of the whole inheritance chain — using the same deterministic parent-first ordering and stable de-duplication as inherited agent loadouts. An agent that lists the same slug itself never duplicates it, and the settings layer wins first-encounter conflicts.
+- Selections resolve catalog-wide across layers, never through an agent's local namespace.
+- Only the additive loadout fields above are supported. Per-agent controls such as `model`, `thinking`, and `tools` stay agent-owned; `agents.md` remains shared prompt context, not a configuration manifest.
+- `outfitter run`, `outfitter dump`, and `outfitter validate` compose the same effective defaults. Unresolved references are validation findings and composition warnings named `agent_defaults …`, and `outfitter dump` records the settings-layer provenance in `.outfitter/composition.json` plus a `settings.yml` carrying the merged defaults, so a dumped tree stays self-contained.
+- Settings without `agent_defaults` behave exactly as before. The block is backend-neutral: no backend-specific keys, endpoints, or credentials.

--- a/docs/requirements/OFTR-002-settings.md
+++ b/docs/requirements/OFTR-002-settings.md
@@ -12,6 +12,11 @@
 > list settings, every loaded settings file contributes to an ordered-set union. This does not make
 > settings an agent-loadout selection surface; it controls which workflow roots commands expose.
 
+> **Amendment (2026-09-02, issue [#347](https://github.com/ai-outfitter/outfitter/issues/347)):**
+> `agent_defaults` adds a generalized additive loadout composition surface (section OFTR-002.10).
+> This deliberately scopes settings to the only additive loadout fields; it does not make settings
+> an agent identity or scalar-override surface, and it stays backend-neutral.
+
 ## Overview
 
 Outfitter settings are the merged result of user, user-local, project, and project-local
@@ -100,3 +105,17 @@ enable workflow roots as command entry points.
 8. `outfitter dump --workflow <slug>` MUST reject a disabled root with guidance to add it to `workflows`.
 9. A nested workflow dependency MUST be available to an enabled root's validation and dump closure without being separately listed, but MUST remain unavailable as a direct dump root unless separately enabled.
 10. Enabled workflow definitions MUST follow normal resource precedence, including project definitions overriding user or source definitions of the same slug.
+
+### OFTR-002.10: Agent Defaults
+
+1. `settings.yml` MAY declare an optional `agent_defaults` object of additive loadout entries composed into every agent.
+2. `agent_defaults` MUST support only the additive loadout fields `extensions`, `skills`, `mcp`, `plugins`, `subagents`, and `append_system_prompt`; Outfitter MUST reject unknown `agent_defaults` keys and MUST NOT add scalar-override fields such as `model`, `thinking`, or `tools`.
+3. Outfitter MUST compose `agent_defaults` into every agent ahead of that agent's own loadout, using the same deterministic parent-first ordering and stable de-duplication semantics as inherited agent loadouts, so an agent's own entries never duplicate a default and the settings layer wins first-encounter conflicts like a root-most ancestor.
+4. `agent_defaults` selections MUST resolve catalog-wide across layers; they MUST NOT resolve through any agent's local namespace.
+5. Every loaded settings file, including configured `remote_settings`, MAY declare `agent_defaults`, and Outfitter MUST merge fields across the stack as ordered-set unions collapsing duplicates to their first occurrence, lowest-precedence entries first.
+6. `outfitter run`, `outfitter dump`, and `outfitter validate` MUST operate on the same effective composition of `agent_defaults` and agent loadouts.
+7. Unresolved `agent_defaults` references MUST surface through composition warnings and `outfitter validate` findings, naming the settings layer rather than an agent.
+8. `outfitter dump` MUST record settings-layer provenance for composed defaults and MUST carry the merged `agent_defaults` into the dumped tree so the dump remains self-contained.
+9. Harness support rules MUST remain unchanged: `agent_defaults` entries ride the same loadout projection as agent-declared entries, so a harness that cannot carry an additive element reports it through existing unsupported-element diagnostics, not a settings-specific error.
+10. `agent_defaults` MUST remain backend-neutral: Outfitter MUST NOT introduce backend-specific keys, sink endpoints, credentials, retention policy, or workload-identity behavior.
+11. Settings without `agent_defaults` MUST compose, validate, run, and dump exactly as before this section existed.


### PR DESCRIPTION
## Summary

Implements #347: `settings.yml` MAY declare an optional `agent_defaults` object whose additive loadout entries compose into **every** agent — ahead of that agent's own loadout — so an organization declares a shared extension (the driving use case: a pinned Pensieve Pi collector), skill, MCP server, plugin, delegate, or appended prompt fragment once instead of duplicating it into every `agents/<id>/agent.md`.

## Behavior

- `agent_defaults` supports only the existing additive loadout fields: `extensions`, `skills`, `mcp`, `plugins`, `subagents`, and `append_system_prompt` (`file:`/`repo_file:`). Scalar overrides (`model`, `thinking`, `tools`) stay agent-owned; the schema rejects unknown keys.
- Composition uses the same deterministic parent-first ordering and stable de-duplication as inherited agent loadouts: defaults compose first (like a root-most ancestor), then the inheritance chain, selected child last. Duplicate slugs collapse to their first occurrence, so an agent's own entries never duplicate a default.
- Defaults resolve catalog-wide across layers — never through an agent's local namespace — and settings-layer prompt fragments resolve against the highest-precedence layer containing the file (`repo_file` keeps repository-trust machinery). Delegates are agents too: they receive the defaults as well.
- Unresolved references surface as composition warnings and `outfitter validate` findings named `agent_defaults …` (unresolved `skills`/`subagents` fail validation like agent-declared loadout refs; `mcp` stays a warning), so the settings layer is visible in validation.
- `outfitter run`, `outfitter dump`, and `outfitter validate` operate on the same effective composition (single `compose` path fed merged settings). Harness support rules are unchanged: defaults ride existing loadout projection, so non-Pi harnesses keep using the standard unsupported-element diagnostics.
- `outfitter dump` records `agentDefaults` provenance per composition in `.outfitter/composition.json` (fragments carry `declaringAgent: "settings:agent_defaults"`) and writes the merged defaults into the dumped tree's `settings.yml`, keeping the dump self-contained. Workflow dumps merge identically.
- Every loaded settings scope (remote, user, user-local, project, project-local) may declare defaults; fields merge as ordered-set unions collapsing cross-file duplicates to their first occurrence, lowest-precedence first.
- Settings without `agent_defaults` compose, validate, run, and dump exactly as before: plans gain no key, dumps write no `settings.yml`.

## Out of scope (per the issue)

No Pensieve-specific settings, sink URLs, credentials, retention policy, workload-identity behavior, or backend provisioning — the composition primitive stays backend-neutral, and `agents.md` remains shared prompt context.

## Testing

- New `tests/unit/agent-defaults.test.ts` (16 tests) covers the issue's acceptance end to end: the two-unrelated-agents fixture validates, dumps exactly one resolved Pensieve extension per agent with no mention in either profile, and re-resolves identically from the dumped tree — plus scope merging, ordering/dedup, catalog-wide resolution, unresolved-reference diagnostics, missing/optional prompt sources, delegate composition, and absent-defaults parity.
- Existing composer/dump/settings/resolver-validation suites pass unchanged; full suite 620 tests green with the coverage gate met.
- Manual smoke: built CLI against a fixture catalog — `validate` passes, `dump --agent` writes `settings.yml` + flattened prompt/skill + provenance, and the dumped tree re-validates standalone.

Closes #347
