### PR TITLE
fix(pi): abort interrupted extension startup

### DIFF
--- a/.deepwork/schemas/onboarding_architecture/deepschema.yml
+++ b/.deepwork/schemas/onboarding_architecture/deepschema.yml
@@ -29,7 +29,7 @@ requirements:
     folder only and does not automatically trust parent folders.
   default-catalog-source: >
     The document MUST state that default profile labels and descriptions are
-    read from the synchronized ai-outfitter/default-profiles catalog cache, not
+    read from the synchronized ai-outfitter/community-profiles catalog cache, not
     from hardcoded profile choices in the extension.
   custom-profile-picker: >
     The document MUST explain why ctx.ui.select is insufficient for per-profile
@@ -42,8 +42,8 @@ requirements:
   install-target-description-selector: >
     The document SHOULD describe the install-target screen as a described-option
     selector and include the user-wide and project-local explanatory copy.
-  founder-default-selection: >
-    The document MUST state that founder is the initial highlighted/default
+  engineer-default-selection: >
+    The document MUST state that engineer is the initial highlighted/default
     profile when present and no current default profile exists.
   login-credential-boundary: >
     The document MUST state that /login is opened through Pi when no models are

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ default_agent: engineer
 `outfitter setup` restores the original Pi-native profile-catalog walkthrough on top of `.agents`:
 choose the default Outfitter catalog, create your own profile, or provide another catalog, then pick
 the home/project target and default CLI agent. The default picker is fetched from the immutable
-`ai-outfitter/default-profiles` Release Please tag pinned by Outfitter—never from a sibling checkout.
+`ai-outfitter/community-profiles` Release Please tag pinned by Outfitter—never from a sibling checkout.
 Managed porting and persistent harness symlinks are deferred to
 [#187](https://github.com/ai-outfitter/outfitter/issues/187).
 

--- a/code/cli/src/agents/AgentLaunch.ts
+++ b/code/cli/src/agents/AgentLaunch.ts
@@ -11,6 +11,15 @@ export interface AgentProcessLauncher {
   launch(plan: AgentLaunchPlan): Promise<number>;
 }
 
+interface SignalTarget {
+  readonly killed: boolean;
+  kill(signal?: NodeJS.Signals): boolean;
+}
+
+interface ProcessGroupChild extends SignalTarget {
+  readonly pid?: number;
+}
+
 export const launchAgentProcess = async (
   launcher: AgentProcessLauncher,
   launchPlan: AgentLaunchPlan,
@@ -79,7 +88,7 @@ const TERMINATION_GRACE_MS = 10_000;
  * listeners must come off afterwards or repeated launches in one process leak them.
  */
 export const attachSignalForwarding = (
-  child: { kill(signal?: NodeJS.Signals): boolean; killed: boolean },
+  child: SignalTarget,
   emitter: NodeJS.EventEmitter = process,
   graceMs: number = TERMINATION_GRACE_MS,
 ): (() => void) => {
@@ -103,13 +112,46 @@ export const attachSignalForwarding = (
   };
 };
 
+/**
+ * Targets the whole POSIX process group created for a subprocess, not only its immediate child.
+ * Package installers commonly spawn npm or git; signalling only the pi wrapper can otherwise leave
+ * that descendant running after the Outfitter command has returned.
+ */
+export const createProcessGroupSignalTarget = (
+  child: ProcessGroupChild,
+  killProcess: (pid: number, signal?: NodeJS.Signals | number) => true = (pid, signal) => process.kill(pid, signal),
+): SignalTarget => ({
+  get killed(): boolean {
+    return child.killed;
+  },
+  kill(signal?: NodeJS.Signals): boolean {
+    if (child.pid === undefined) return child.kill(signal);
+    try {
+      return killProcess(-child.pid, signal);
+    } catch {
+      // A platform/runtime that rejects process-group signalling still gets the pre-existing
+      // immediate-child termination as a safe fallback.
+      return child.kill(signal);
+    }
+  },
+});
+
 /* v8 ignore start -- real process spawn is covered by end-to-end smoke usage, not unit tests. */
-export const createSpawnLauncher = (stdio: 'inherit' | 'ignore'): AgentProcessLauncher => ({
+export const createSpawnLauncher = (
+  stdio: 'inherit' | 'ignore',
+  options: { readonly terminateProcessGroup?: boolean } = {},
+): AgentProcessLauncher => ({
   async launch(plan: AgentLaunchPlan): Promise<number> {
     const { default: spawn } = await import('cross-spawn');
     return await new Promise<number>((resolve, reject) => {
-      const child = spawn(plan.command, [...plan.args], { stdio, env: { ...process.env, ...plan.env } });
-      const detach = attachSignalForwarding(child);
+      const useProcessGroup = options.terminateProcessGroup === true && process.platform !== 'win32';
+      const child = spawn(plan.command, [...plan.args], {
+        stdio,
+        env: { ...process.env, ...plan.env },
+        detached: useProcessGroup,
+      });
+      const signalTarget = useProcessGroup ? createProcessGroupSignalTarget(child) : child;
+      const detach = attachSignalForwarding(signalTarget);
       child.on('error', (error) => {
         detach();
         reject(error); // ENOENT surfaces as an actionable install message

--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -23,7 +23,7 @@ import { resolvePiSessionDirectory } from '../../agents/PiSessionDirectory.js';
 import type { CompositionPlan } from '../../composer/Composition.js';
 import { compose } from '../../composer/Composer.js';
 import { ensurePiExtensions } from '../../extensions/PiExtensionCache.js';
-import type { PiInstallSpawner } from '../../extensions/PiExtensionCache.js';
+import type { EnsurePiExtensionsResult, PiInstallSpawner } from '../../extensions/PiExtensionCache.js';
 import { resolveOutfitterCacheDir } from '../../paths/OutfitterCache.js';
 import { projectComposition } from '../../projection/ProjectHarness.js';
 import type { AgentLaunchPlan } from '../../projection/Projection.js';
@@ -91,6 +91,12 @@ export interface RunAgentResult {
   readonly launchPlan?: AgentLaunchPlan;
   readonly exitCode: number;
   readonly messages: readonly string[];
+}
+
+class ExtensionInstallInterrupted extends Error {
+  constructor(readonly result: EnsurePiExtensionsResult & { readonly interruptedExitCode: number }) {
+    super(result.warnings.join('\n'));
+  }
 }
 
 export interface RunAgentDependencies {
@@ -248,7 +254,7 @@ const resolvePiExtensions = async (
   input: RunAgentInput,
   harness: Harness,
   extensionSpecs: readonly string[],
-): Promise<{ readonly loadDirs: readonly string[]; readonly warnings: readonly string[] }> => {
+): Promise<EnsurePiExtensionsResult> => {
   if (harness !== 'pi') return { loadDirs: [], warnings: [] };
   return ensurePiExtensions(extensionSpecs, {
     cacheAgentDir: join(resolveOutfitterCacheDir(process.env, input.homeDirectory), 'pi-extensions'),
@@ -269,7 +275,11 @@ const loadPiExtensions = async (
     ? (input.startLoading?.(`Loading ${agentSlug} profile…`) ?? (() => undefined))
     : () => undefined;
   try {
-    return await resolvePiExtensions(input, harness, extensionSpecs);
+    const result = await resolvePiExtensions(input, harness, extensionSpecs);
+    if (result.interruptedExitCode !== undefined) {
+      throw new ExtensionInstallInterrupted({ ...result, interruptedExitCode: result.interruptedExitCode });
+    }
+    return result;
   } finally {
     stopLoading();
   }
@@ -321,7 +331,7 @@ const failedCompositionMessages = (
 
 const harnessDefaultsFor = (settings: Settings, harness: Harness) => settings.harnessDefaults?.[harness];
 
-export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunAgentResult> => {
+const executeRunAgentCommandInner = async (input: RunAgentInput): Promise<RunAgentResult> => {
   // Flush messages to the terminal (before launch); they are also returned so callers can inspect them.
   const emit = (messages: readonly string[]): void => {
     for (const message of messages) input.writeLine?.(message);
@@ -450,6 +460,16 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
     if (input.retainProjection !== true) {
       rmSync(rootDirectory, { recursive: true, force: true });
     }
+  }
+};
+
+export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunAgentResult> => {
+  try {
+    return await executeRunAgentCommandInner(input);
+  } catch (error) {
+    if (!(error instanceof ExtensionInstallInterrupted)) throw error;
+    for (const message of error.result.warnings) input.writeLine?.(message);
+    return { exitCode: error.result.interruptedExitCode, messages: error.result.warnings };
   }
 };
 

--- a/code/cli/src/extensions/PiExtensionCache.ts
+++ b/code/cli/src/extensions/PiExtensionCache.ts
@@ -19,7 +19,7 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve, sep } from 'node:path';
 
-import { createSpawnLauncher, launchThroughSpawn, spawnLauncher } from '../agents/AgentLaunch.js';
+import { createSpawnLauncher, launchThroughSpawn } from '../agents/AgentLaunch.js';
 import { runGit } from '../sources/GitRepository.js';
 
 /** Spawns `pi install <source>` against the cache agent dir; injectable so tests avoid the network. */
@@ -43,6 +43,8 @@ export interface EnsurePiExtensionsResult {
   readonly loadDirs: readonly string[];
   /** One message per specifier that could not be loaded (unsupported, offline-missing, or failed). */
   readonly warnings: readonly string[];
+  /** Signal-derived installer exit code; when present, no later specifier was attempted. */
+  readonly interruptedExitCode?: number;
 }
 
 interface PiExtensionSource {
@@ -204,16 +206,22 @@ const evaluateCachedInstall = (installDir: string, mapped: PiExtensionSource, of
 };
 
 /* v8 ignore start -- real `pi install` subprocess; ensurePiExtensions is unit-tested with a fake spawner. */
-const quietSpawnLauncher = createSpawnLauncher('ignore');
+// Extension installation can spawn npm/git beneath pi. A dedicated POSIX process group lets the
+// normal Outfitter signal forwarding terminate the whole installer tree rather than orphaning npm.
+const quietSpawnLauncher = createSpawnLauncher('ignore', { terminateProcessGroup: true });
+const debugSpawnLauncher = createSpawnLauncher('inherit', { terminateProcessGroup: true });
 const defaultSpawner: PiInstallSpawner = ({ source, cacheAgentDir, debug }) =>
-  launchThroughSpawn(debug === true ? spawnLauncher : quietSpawnLauncher, {
+  launchThroughSpawn(debug === true ? debugSpawnLauncher : quietSpawnLauncher, {
     command: 'pi',
     args: ['install', source],
     env: { PI_CODING_AGENT_DIR: cacheAgentDir, GIT_TERMINAL_PROMPT: '0' },
   });
 /* v8 ignore stop */
 
-type SpecifierOutcome = { readonly loadDir: string } | { readonly warning: string };
+type SpecifierOutcome =
+  { readonly loadDir: string } | { readonly warning: string; readonly interruptedExitCode?: number };
+
+const forwardedSignalExitCodes = new Set([129, 130, 143]); // SIGHUP, SIGINT, SIGTERM (128 + signal)
 
 /** Resolves one specifier to a cached load directory, installing it when online and missing. */
 const ensureOneExtension = async (
@@ -236,6 +244,12 @@ const ensureOneExtension = async (
   mkdirSync(input.cacheAgentDir, { recursive: true });
   try {
     const exitCode = await spawn({ source: mapped.source, cacheAgentDir: input.cacheAgentDir, debug: input.debug });
+    if (forwardedSignalExitCodes.has(exitCode)) {
+      return {
+        warning: `extension '${specifier}' installation was interrupted (pi install exited ${exitCode}); remaining extensions and agent launch were cancelled.`,
+        interruptedExitCode: exitCode,
+      };
+    }
     if (exitCode !== 0 || !existsSync(installDir)) {
       return { warning: `extension '${specifier}' failed to install (pi install exited ${exitCode}).` };
     }
@@ -262,6 +276,9 @@ export const ensurePiExtensions = async (
       if (!loadDirs.includes(outcome.loadDir)) loadDirs.push(outcome.loadDir);
     } else {
       warnings.push(outcome.warning);
+      if (outcome.interruptedExitCode !== undefined) {
+        return { loadDirs, warnings, interruptedExitCode: outcome.interruptedExitCode };
+      }
     }
   }
 

--- a/code/cli/src/setup/DefaultCatalog.ts
+++ b/code/cli/src/setup/DefaultCatalog.ts
@@ -19,11 +19,14 @@ import { writeSourceState } from '../sources/SourceState.js';
 export type RepositorySync = typeof syncRemoteRepositoryAtomically;
 
 export const defaultCatalogSource = {
-  github: 'ai-outfitter/default-profiles',
-  // TODO(release-automation): when default-profiles publishes a new Release Please tag, open a
+  github: 'ai-outfitter/community-profiles',
+  // TODO(release-automation): when community-profiles publishes a new Release Please tag, open a
   // conventional dependency-bump commit in Outfitter so its next Release Please release ships it.
-  ref: 'v1.1.1',
+  ref: 'v1.7.0',
 } as const satisfies RemoteSourceReference;
+
+/** Superseded default catalogs; setup replaces their pins instead of keeping them alongside. */
+export const retiredDefaultCatalogSources = ['ai-outfitter/default-profiles'] as const;
 
 export interface PinnedCatalogBootstrapInput {
   readonly homeDirectory: string;

--- a/code/cli/src/setup/Setup.ts
+++ b/code/cli/src/setup/Setup.ts
@@ -5,7 +5,7 @@ import { dirname, join } from 'node:path';
 
 import type { Harness } from '../settings/Settings.js';
 import { HARNESSES } from '../settings/Settings.js';
-import { defaultCatalogSource } from './DefaultCatalog.js';
+import { defaultCatalogSource, retiredDefaultCatalogSources } from './DefaultCatalog.js';
 
 export type SetupScope = 'home' | 'project';
 export type SetupMode = 'default' | 'create' | 'catalog' | 'source';
@@ -107,6 +107,7 @@ const discoverAgentsInCatalog = (root: string): readonly SetupAgentChoice[] => {
     try {
       if (!statSync(agentPath).isFile()) return [];
       const content = readFileSync(agentPath, 'utf8');
+      if (readFrontmatterValue(content, 'abstract') === 'true') return [];
       const id = sanitizeAgentSlug(readFrontmatterValue(content, 'name') ?? entry);
       if (id !== entry || !agentSlugPattern.test(id)) return [];
       return [
@@ -121,8 +122,8 @@ const discoverAgentsInCatalog = (root: string): readonly SetupAgentChoice[] => {
     }
   });
   return choices.sort((left, right) => {
-    if (left.id === 'founder') return -1;
-    if (right.id === 'founder') return 1;
+    if (left.id === 'engineer') return -1;
+    if (right.id === 'engineer') return 1;
     return left.id.localeCompare(right.id);
   });
 };
@@ -153,19 +154,40 @@ const upsertDefaultCatalogSource = (content: string): string => {
 
   const lines = content.replace(/\s*$/u, '').split('\n');
   const start = lines.findIndex((line) => /^sources:\s*$/u.test(line));
-  let end = start + 1;
-  while (end < lines.length && (/^\s/u.test(lines[end] ?? '') || (lines[end] ?? '') === '')) end += 1;
-  const existing = lines.findIndex((line, index) => {
-    if (index <= start || index >= end) return false;
-    const match = /^\s*-\s+github:\s*(.+?)\s*$/u.exec(line);
-    return match?.[1]?.replace(/^['"]|['"]$/gu, '') === defaultCatalogSource.github;
-  });
+  const sourcesEnd = (): number => {
+    let boundary = start + 1;
+    while (boundary < lines.length && (/^\s/u.test(lines[boundary] ?? '') || (lines[boundary] ?? '') === ''))
+      boundary += 1;
+    return boundary;
+  };
+  const indexOfSource = (github: string): number => {
+    const boundary = sourcesEnd();
+    return lines.findIndex((line, index) => {
+      if (index <= start || index >= boundary) return false;
+      const match = /^\s*-\s+github:\s*(.+?)\s*$/u.exec(line);
+      return match?.[1]?.replace(/^['"]|['"]$/gu, '') === github;
+    });
+  };
+
+  // Every retired pin leaves, even when the current source is already present;
+  // the first retired pin found donates its position when it is not.
+  for (const retiredName of retiredDefaultCatalogSources) {
+    for (let retired = indexOfSource(retiredName); retired !== -1; retired = indexOfSource(retiredName)) {
+      let retiredEnd = retired + 1;
+      const boundary = sourcesEnd();
+      while (retiredEnd < boundary && !/^\s*-\s+/u.test(lines[retiredEnd] ?? '')) retiredEnd += 1;
+      const replacement = indexOfSource(defaultCatalogSource.github) === -1 ? sourceLines : [];
+      lines.splice(retired, retiredEnd - retired, ...replacement);
+    }
+  }
+  const existing = indexOfSource(defaultCatalogSource.github);
 
   if (existing === -1) {
     lines.splice(start + 1, 0, ...sourceLines);
     return `${lines.join('\n')}\n`;
   }
 
+  const end = sourcesEnd();
   let blockEnd = existing + 1;
   while (blockEnd < end && !/^\s*-\s+/u.test(lines[blockEnd] ?? '')) blockEnd += 1;
   const block = lines.slice(existing, blockEnd).filter((line) => !/^\s+path:\s*/u.test(line));

--- a/code/cli/tests/unit/agent-launch.test.ts
+++ b/code/cli/tests/unit/agent-launch.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   attachSignalForwarding,
+  createProcessGroupSignalTarget,
   launchAgentProcess,
   resolveAgentLaunchExecutable,
 } from '../../src/agents/AgentLaunch.js';
@@ -117,5 +118,54 @@ describe('termination forwarding', () => {
 
     emitter.emit('SIGTERM');
     expect(child.signals).toEqual([]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('signals a dedicated installer process group so descendants terminate with their wrapper', () => {
+    const child = { ...fakeChild(), pid: 417 };
+    const groupSignals: Array<[number, NodeJS.Signals | number | undefined]> = [];
+    const target = createProcessGroupSignalTarget(child, (pid, signal) => {
+      groupSignals.push([pid, signal]);
+      return true;
+    });
+
+    target.kill('SIGINT');
+
+    expect(groupSignals).toEqual([[-417, 'SIGINT']]);
+    expect(child.signals).toEqual([]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('uses Node process-group signalling by default and mirrors child termination state', () => {
+    const child = { ...fakeChild(), pid: 417 };
+    const killProcess = vi.spyOn(process, 'kill').mockReturnValue(true);
+
+    try {
+      const target = createProcessGroupSignalTarget(child);
+      expect(target.killed).toBe(false);
+
+      target.kill('SIGINT');
+      child.killed = true;
+
+      expect(killProcess).toHaveBeenCalledWith(-417, 'SIGINT');
+      expect(target.killed).toBe(true);
+      expect(child.signals).toEqual([]);
+    } finally {
+      killProcess.mockRestore();
+    }
+  });
+
+  it('falls back to the immediate child when process-group signalling is unavailable', () => {
+    const child = { ...fakeChild(), pid: 417 };
+    const target = createProcessGroupSignalTarget(child, () => {
+      throw new Error('no process group');
+    });
+
+    target.kill('SIGTERM');
+
+    expect(child.signals).toEqual(['SIGTERM']);
+    expect(createProcessGroupSignalTarget(fakeChild()).kill('SIGHUP')).toBe(true);
   });
 });

--- a/code/cli/tests/unit/default-catalog.test.ts
+++ b/code/cli/tests/unit/default-catalog.test.ts
@@ -45,8 +45,8 @@ afterEach(() => {
 describe('default catalog bootstrap', () => {
   it('ships the canonical catalog at one immutable Release Please tag', () => {
     expect(defaultCatalogSource).toEqual({
-      github: 'ai-outfitter/default-profiles',
-      ref: 'v1.1.1',
+      github: 'ai-outfitter/community-profiles',
+      ref: 'v1.7.0',
     });
   });
 

--- a/code/cli/tests/unit/pi-extension-cache.test.ts
+++ b/code/cli/tests/unit/pi-extension-cache.test.ts
@@ -241,6 +241,27 @@ describe('ensurePiExtensions', () => {
     expect(result.warnings[0]).toContain('failed to install');
   });
 
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it.each([129, 130, 143])('stops the install queue after signal-derived exit code %i', async (exitCode) => {
+    const dir = cacheDir();
+    const sources: string[] = [];
+    const result = await ensurePiExtensions(['npm:first', 'npm:never-started'], {
+      cacheAgentDir: dir,
+      offline: false,
+      spawn: ({ source }) => {
+        sources.push(source);
+        return Promise.resolve(exitCode);
+      },
+    });
+
+    expect(sources).toEqual(['npm:first']);
+    expect(result.interruptedExitCode).toBe(exitCode);
+    expect(result.warnings).toEqual([
+      `extension 'npm:first' installation was interrupted (pi install exited ${exitCode}); remaining extensions and agent launch were cancelled.`,
+    ]);
+  });
+
   it('de-duplicates repeated specifiers into a single load dir', async () => {
     const dir = cacheDir();
     writePackage(join(dir, 'npm', 'node_modules', 'pi-nolo'), '1.0.0');

--- a/code/cli/tests/unit/pi-setup-extension.test.ts
+++ b/code/cli/tests/unit/pi-setup-extension.test.ts
@@ -245,14 +245,14 @@ describe('Pi setup extension', () => {
       ],
     });
     expect(context.rendered[0]?.join('\n')).toContain('Outfitter profile setup');
-    expect(context.rendered[0]?.join('\n')).toContain('→ founder — Founder (Recommended)');
+    expect(context.rendered[0]?.join('\n')).toContain('→ engineer — Engineer (Recommended)');
     expect(context.rendered[1]?.join(' ')).toContain('Where should Outfitter install these settings?');
     expect(context.rendered[2]?.join(' ')).toContain('Which CLI agent should Outfitter use by default?');
     expect(context.rendered[2]?.join('\n')).toContain('→ Pi / Outfitter (Recommended)');
     expect(context.rendered[2]?.join('\n')).toContain('Codex CLI');
     expect(JSON.parse(readFileSync(resultPath, 'utf8'))).toEqual({
       setupMode: 'default',
-      agentId: 'founder',
+      agentId: 'engineer',
       harness: 'pi',
       target: 'home',
     });

--- a/code/cli/tests/unit/run-agent-extension-interruption.test.ts
+++ b/code/cli/tests/unit/run-agent-extension-interruption.test.ts
@@ -1,0 +1,55 @@
+// Tests that an interrupted extension installer aborts the run before any later installer or agent launch.
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { executeRunAgentCommand } from '../../src/cli/commands/RunAgentCommand.js';
+
+const roots: string[] = [];
+const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+
+afterEach(() => {
+  if (originalXdgCacheHome === undefined) delete process.env.XDG_CACHE_HOME;
+  else process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('run agent extension interruption', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('does not continue the install queue or launch pi after an interrupted extension install', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'outfitter-run-interruption-'));
+    roots.push(root);
+    const home = join(root, 'home');
+    const project = join(root, 'project');
+    const agentDefinition = join(project, '.agents', 'agents', 'dev', 'agent.md');
+    mkdirSync(dirname(agentDefinition), { recursive: true });
+    writeFileSync(agentDefinition, '---\nname: dev\nextensions: ["npm:first", "npm:never-started"]\n---\n\nBody.\n');
+    process.env.XDG_CACHE_HOME = join(root, 'cache');
+    const installed: string[] = [];
+    let launches = 0;
+
+    const result = await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      agent: 'dev',
+      harness: 'pi',
+      launcher: () => {
+        launches += 1;
+        return Promise.resolve(0);
+      },
+      extensionInstallSpawner: ({ source }) => {
+        installed.push(source);
+        return Promise.resolve(130);
+      },
+    });
+
+    expect(result.exitCode).toBe(130);
+    expect(result.launchPlan).toBeUndefined();
+    expect(installed).toEqual(['npm:first']);
+    expect(launches).toBe(0);
+    expect(result.messages.join(' ')).toContain('remaining extensions and agent launch were cancelled');
+  });
+});

--- a/code/cli/tests/unit/setup.test.ts
+++ b/code/cli/tests/unit/setup.test.ts
@@ -33,6 +33,10 @@ const createTree = (): { catalog: string; home: string; project: string; root: s
     join(catalog, 'agents', 'engineer', 'agent.md'),
     '---\nname: engineer\ndescription: Engineering profile.\n---\n\n# Engineer\n',
   );
+  write(
+    join(catalog, 'agents', 'environment', 'agent.md'),
+    '---\nname: environment\ndescription: Abstract environment baseline.\nabstract: true\n---\n\n# Environment\n',
+  );
   write(join(catalog, 'skills', 'planning', 'SKILL.md'), '---\nname: planning\n---\n');
   return { catalog, home, project, root };
 };
@@ -62,11 +66,11 @@ afterEach(() => {
 });
 
 describe('setup state machine', () => {
-  it('discovers the default Outfitter catalog with display metadata', () => {
+  it('discovers the default Outfitter catalog with display metadata, engineer first, abstract profiles hidden', () => {
     const { catalog } = createTree();
     expect(discoverSetupAgentChoices({ defaultCatalogRoot: catalog })).toEqual([
-      { id: 'founder', label: 'Founder', description: 'Founder/operator profile.' },
       { id: 'engineer', label: 'Engineer', description: 'Engineering profile.' },
+      { id: 'founder', label: 'Founder', description: 'Founder/operator profile.' },
     ]);
     expect(discoverSetupAgentChoices({})).toEqual([]);
   });
@@ -168,9 +172,31 @@ describe('setup state machine', () => {
     expect(settings).toContain(
       `  - path: ./personal\n  - github: ${defaultCatalogSource.github}\n    ref: ${defaultCatalogSource.ref}\nstartup:`,
     );
-    expect(settings.match(/github: ai-outfitter\/default-profiles/gu)).toHaveLength(1);
+    expect(settings.match(/github: ai-outfitter\/default-profiles/gu)).toBeNull();
+    expect(settings.match(new RegExp(`github: ${defaultCatalogSource.github.replace('/', '\\/')}`, 'gu'))).toHaveLength(
+      1,
+    );
     expect(settings.match(/# telemetry:/gu)).toHaveLength(1);
     expect(settings).not.toContain('path: profiles');
+  });
+
+  it('removes a retired default-catalog pin even when the current source is already present', () => {
+    const { catalog, home, project } = createTree();
+    write(
+      join(home, '.agents', 'settings.yml'),
+      `default_agent: engineer\ndefault_harness: pi\nsources:\n  - github: ${defaultCatalogSource.github}\n    ref: old\n` +
+        '  - github: ai-outfitter/default-profiles\n    ref: v1.1.1\n',
+    );
+    applySetupSelection({
+      homeDirectory: home,
+      projectDirectory: project,
+      defaultCatalogRoot: catalog,
+      availableAgents: discoverSetupAgentChoices({ defaultCatalogRoot: catalog }),
+      selection: { setupMode: 'default', agentId: 'engineer', harness: 'pi', target: 'home' },
+    });
+    const settings = readFileSync(join(home, '.agents', 'settings.yml'), 'utf8');
+    expect(settings.match(/github: ai-outfitter\/default-profiles/gu)).toBeNull();
+    expect(settings).toContain(`    ref: ${defaultCatalogSource.ref}`);
   });
 
   it('adds the pinned default source to an existing source list', () => {

--- a/code/pi-extension/src/outfitter-extension.js
+++ b/code/pi-extension/src/outfitter-extension.js
@@ -109,7 +109,7 @@ export default function outfitter(pi) {
         'The current Pi process keeps the profile it started with; this setting applies on the next launch.',
       ];
       const initialProfileId =
-        currentDefault ?? (profiles.some((profile) => profile.id === 'founder') ? 'founder' : profiles[0]?.id);
+        currentDefault ?? (profiles.some((profile) => profile.id === 'engineer') ? 'engineer' : profiles[0]?.id);
       const selectedId = await selectFromItems(ctx, title, items, initialProfileId);
       if (selectedId === undefined) return undefined;
       return profiles.find((profile) => profile.id === selectedId);
@@ -557,7 +557,7 @@ const selectDescribedOption = (ctx, titleLines, items, initialValue) =>
 
 const formatProfileLabel = (profile, currentDefault) => {
   const current = profile.id === currentDefault ? ' (current)' : '';
-  const recommended = currentDefault === undefined && profile.id === 'founder' ? ' (Recommended)' : '';
+  const recommended = currentDefault === undefined && profile.id === 'engineer' ? ' (Recommended)' : '';
   const label = profile.label ? ' — ' + profile.label : '';
   return profile.id + label + current + recommended;
 };

--- a/docs/architecture/onboarding.md
+++ b/docs/architecture/onboarding.md
@@ -17,7 +17,7 @@ The first prompt and its wording are fixed:
 
 The selected branch follows the original order:
 
-- Default catalog: described profile picker (Founder first and recommended) → home/project target.
+- Default catalog: described profile picker (Engineer first and recommended) → home/project target.
 - Create: profile ID → profile label → home/project target.
 - Different catalog: GitHub `owner/repo` → ref → settings path → private-catalog confirmation when
   applicable → home/project target.
@@ -31,7 +31,7 @@ the first, preselected recommendation; Claude Code and Codex CLI are the other c
 
 Both explicit `outfitter setup [source]` and implicit first-run `outfitter run` use one implementation:
 
-1. Fetch `ai-outfitter/default-profiles` at the immutable Release Please tag shipped by this
+1. Fetch `ai-outfitter/community-profiles` at the immutable Release Please tag shipped by this
    Outfitter version, or reuse that exact release from the normal `~/.agents/cache/repos` source
    cache, then read the current default marker. There is no sibling-checkout or packaged-catalog
    fallback.
@@ -66,7 +66,7 @@ The visible profile-era walkthrough is retained while storage is translated to t
 - the chosen CLI is stored as `default_harness`;
 - home/project targets are `~/.agents/settings.yml` and `<project>/.agents/settings.yml`;
 - a custom profile becomes `agents/<id>/agent.md` and never overwrites an existing file;
-- the default catalog is recorded as `github: ai-outfitter/default-profiles` at the immutable
+- the default catalog is recorded as `github: ai-outfitter/community-profiles` at the immutable
   Release Please version tag shipped by Outfitter; the bootstrap checkout remains derived cache
   data, not copied configuration;
 - remote and provided catalogs retain their `remote_settings` outcome;

--- a/docs/documentation/cli.md
+++ b/docs/documentation/cli.md
@@ -48,7 +48,7 @@ to import**; complete that branch; choose a home/project settings target; then c
 CLI agent. Pi/Outfitter is preselected. Passing `[source]` retains the original direct-source path
 and starts at target selection. Pi hosts the deterministic setup UI without a model provider and
 does not port or symlink harness configuration. The default picker always comes from
-`ai-outfitter/default-profiles` at the immutable Release Please version tag pinned by the installed
+`ai-outfitter/community-profiles` at the immutable Release Please version tag pinned by the installed
 Outfitter version; setup fetches or reuses that release through the normal source cache and writes
 the same GitHub/ref pair to settings. It never reads a sibling checkout or a packaged catalog
 fallback.

--- a/docs/documentation/conventions.md
+++ b/docs/documentation/conventions.md
@@ -15,7 +15,7 @@ Each layer inherits the one above it. ID-addressed resources — agents, skills,
 | Layer            | Location                                                                      | Holds                                                                                       |
 | ---------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | Community        | e.g. `ai-outfitter/community-profiles`                                        | Reviewed building blocks — skills and reference agents anyone can mix and match.            |
-| Curated defaults | e.g. `ai-outfitter/default-profiles`                                          | The pinned, curated assembly — starter agents users adopt as-is.                            |
+| Curated defaults | e.g. `ai-outfitter/community-profiles`                                        | The pinned, curated assembly — starter agents users adopt as-is.                            |
 | Organization     | `owner/.outfitter` [control repo](./usecases/organization-profile-catalog.md) | Bespoke org agents, shared `agents.md`, org-specific skills (brand voice, RBAC, endpoints). |
 | User / project   | `~/.agents`, `<repo>/.agents`                                                 | Personal and repo overrides, loadout-added references, same-ID resource overrides.          |
 

--- a/docs/requirements/OFTR-010-onboarding-welcome.md
+++ b/docs/requirements/OFTR-010-onboarding-welcome.md
@@ -35,6 +35,10 @@
 
 ## OFTR-010.6: Quiet runtime startup
 
+Amendment (2026-09-04): statement 9 defines cancellation as a terminal startup outcome and requires
+POSIX installer-tree termination. Previously, a forwarded signal ended only the current pi wrapper;
+the queue could continue into another install or the agent launch while a spawned npm process lived on.
+
 1. An Outfitter-managed interactive Pi session MUST default `quietStartup` to `true` when the
    selected profile does not set it explicitly.
 2. A profile's explicit `quietStartup` value MUST take precedence over the Outfitter default.
@@ -51,6 +55,10 @@
 8. Normal startup MUST hide profile-extension installer output behind one loading state. Debug log
    level MUST expose the underlying Pi, Git, and npm output. Installation failures MUST remain
    visible as concise warnings after the loading state stops.
+9. If a profile-extension install is interrupted by a forwarded termination signal, Outfitter MUST
+   stop the remaining install queue, MUST NOT launch the agent, and MUST return the signal-derived
+   exit code. On POSIX systems, the installer and its descendants MUST receive that signal so an npm
+   subprocess cannot outlive the cancelled Outfitter run.
 
 ## OFTR-010.2: Exact walkthrough
 

--- a/docs/requirements/OFTR-010-onboarding-welcome.md
+++ b/docs/requirements/OFTR-010-onboarding-welcome.md
@@ -57,8 +57,9 @@
 1. The first prompt MUST be `How would you like to set up Outfitter?` with, in order:
    `Use the default Outfitter profile catalog`, `Create your own profile`, and
    `Provide a different catalog to import`.
-2. Default-catalog setup MUST show the original described profile picker. Founder MUST be the first,
-   preselected `Recommended` row unless an existing default is marked `current`.
+2. Default-catalog setup MUST show the original described profile picker. Engineer MUST be the first,
+   preselected `Recommended` row unless an existing default is marked `current`; profiles marked
+   `abstract: true` MUST NOT be offered.
 3. Create setup MUST ask `Profile id`, then `Profile label`, then the install target. It MUST preserve
    an existing profile file.
 4. Different-catalog setup MUST ask the original GitHub repository, ref, and settings-path questions,
@@ -75,8 +76,8 @@
 2. Home/project settings MUST be `~/.agents/settings.yml` and `<project>/.agents/settings.yml`.
 3. The profile choice maps to `default_agent`; the added CLI choice maps to `default_harness`.
 4. Custom profiles map to `agents/<id>/agent.md`. The default catalog MUST map to
-   `github: ai-outfitter/default-profiles` at the immutable Release Please version tag shipped by
-   Outfitter.
+   `github: ai-outfitter/community-profiles` at the immutable Release Please version tag shipped by
+   Outfitter; a retired default-catalog pin in existing settings is replaced, never kept alongside.
 5. Existing resource files and unrelated settings MUST be preserved.
 6. Writes MUST be atomic; cancellation writes nothing; failures roll back only this attempt's changes.
 7. Setup MUST fetch that exact default-catalog revision into the normal remote-source cache or reuse


### PR DESCRIPTION
## What

- Stop processing profile extensions when `pi install` exits from SIGHUP, SIGINT, or SIGTERM.
- Skip the agent launch and preserve the signal-derived exit code.
- Launch the installer in a dedicated POSIX process group so npm/git descendants receive cancellation too.

## Why

Forwarding a signal only to the immediate Pi process can leave installer descendants running. The extension queue could then continue after cancellation and eventually launch the agent, contrary to the user's interrupt.

## Stack and merge order

This is **1 of 2** runtime-startup PRs and is based directly on `main`. Merge this PR first, followed by #366.

Historical PRs #362 and #363 were merged only into staging branches, not `main`. Their reviewed changes are carried by #366.

## Validation

- `npx -y -p node@24.18.0 -c 'node -v && npm run check-ci'`
- 62 test files passed; 675 tests passed.
- Coverage: 99.23% statements, 98.05% branches, 99.14% functions, 99.49% lines.

## Risk

The process-group behavior is POSIX-only; Windows retains immediate-child signaling. If process-group signaling is unavailable, Outfitter falls back to the prior immediate-child behavior.
