### PR TITLE
fix(pi): skip npm audit during extension bootstrap [staging-only]

### DIFF
--- a/code/cli/src/extensions/PiExtensionCache.ts
+++ b/code/cli/src/extensions/PiExtensionCache.ts
@@ -210,11 +210,19 @@ const evaluateCachedInstall = (installDir: string, mapped: PiExtensionSource, of
 // normal Outfitter signal forwarding terminate the whole installer tree rather than orphaning npm.
 const quietSpawnLauncher = createSpawnLauncher('ignore', { terminateProcessGroup: true });
 const debugSpawnLauncher = createSpawnLauncher('inherit', { terminateProcessGroup: true });
+export const piExtensionInstallEnvironment = (cacheAgentDir: string): Readonly<Record<string, string>> => ({
+  PI_CODING_AGENT_DIR: cacheAgentDir,
+  GIT_TERMINAL_PROMPT: '0',
+  // Extension installs are a runtime bootstrap, not a dependency-maintenance workflow. npm audit
+  // can otherwise hold first launch for its full network timeout after every package has downloaded.
+  NPM_CONFIG_AUDIT: 'false',
+  NPM_CONFIG_FUND: 'false',
+});
 const defaultSpawner: PiInstallSpawner = ({ source, cacheAgentDir, debug }) =>
   launchThroughSpawn(debug === true ? debugSpawnLauncher : quietSpawnLauncher, {
     command: 'pi',
     args: ['install', source],
-    env: { PI_CODING_AGENT_DIR: cacheAgentDir, GIT_TERMINAL_PROMPT: '0' },
+    env: piExtensionInstallEnvironment(cacheAgentDir),
   });
 /* v8 ignore stop */
 

--- a/code/cli/tests/unit/pi-extension-cache.test.ts
+++ b/code/cli/tests/unit/pi-extension-cache.test.ts
@@ -10,6 +10,7 @@ import {
   assertInstallDirInsideCache,
   ensurePiExtensions,
   mapSpecifierToPiSource,
+  piExtensionInstallEnvironment,
 } from '../../src/extensions/PiExtensionCache.js';
 import type { PiInstallSpawner } from '../../src/extensions/PiExtensionCache.js';
 
@@ -310,6 +311,17 @@ describe('ensurePiExtensions', () => {
     });
     expect(spawned).toBe(1);
     expect(result.loadDirs).toEqual([join(dir, 'npm', 'node_modules', 'pi-subagents')]);
+  });
+});
+
+describe('piExtensionInstallEnvironment', () => {
+  it('disables npm audit and funding requests during the first-launch extension bootstrap', () => {
+    expect(piExtensionInstallEnvironment('/tmp/outfitter/pi-extensions')).toEqual({
+      PI_CODING_AGENT_DIR: '/tmp/outfitter/pi-extensions',
+      GIT_TERMINAL_PROMPT: '0',
+      NPM_CONFIG_AUDIT: 'false',
+      NPM_CONFIG_FUND: 'false',
+    });
   });
 });
 


### PR DESCRIPTION
## Historical status

This PR was merged only into the staging branch for #361; it did **not** land on `main`. That staging merge temporarily combined two independently reviewable fixes in #361, so the staging branch was restored to its cancellation-only head.

Replacement PR #366 republishes this exact installer-only change on a new organization branch. Continue review and eventual merge there. The intended order is #361, then #366, then #363.

## Change represented here

- Disable npm audit and funding requests only in the child environment used by `pi install` during profile-extension bootstrap.
- Keep the existing Pi and Git environment controls unchanged.
- Cover the exact installer environment with a focused unit test.

Runtime profile startup is not a dependency-maintenance workflow. npm audit can wait on an unrelated network endpoint after packages have downloaded, making a valid first launch appear hung.

## Validation

- `npx -y -p node@24.18.0 -c 'node -v && npm run check-ci'`
- 62 test files passed; 676 tests passed on the stacked head.
- Coverage: 99.23% statements, 98.05% branches, 99.14% functions, 99.49% lines.
