### PR TITLE
fix(pi): normalize Windows Ctrl-C exits [staging-only]

### DIFF
--- a/code/cli/src/agents/AgentLaunch.ts
+++ b/code/cli/src/agents/AgentLaunch.ts
@@ -136,6 +136,20 @@ export const createProcessGroupSignalTarget = (
   },
 });
 
+// A Ctrl-C delivered by the Windows console is not a POSIX signal termination. libuv reports the
+// unsigned STATUS_CONTROL_C_EXIT DWORD as the child exit code, with no signal, so normalize that
+// one native status to the same shell-compatible code as SIGINT. Other NTSTATUS failures remain
+// unchanged instead of being mistaken for cancellation.
+const WINDOWS_CONTROL_C_EXIT_STATUS = 0xc000013a;
+export const normalizeChildExitCode = (
+  code: number | null,
+  signal: NodeJS.Signals | null,
+  platform: NodeJS.Platform = process.platform,
+): number => {
+  if (signal !== null) return 128 + (os.constants.signals[signal] ?? 0);
+  if (platform === 'win32' && code === WINDOWS_CONTROL_C_EXIT_STATUS) return 130;
+  return code ?? 0;
+};
 /* v8 ignore start -- real process spawn is covered by end-to-end smoke usage, not unit tests. */
 export const createSpawnLauncher = (
   stdio: 'inherit' | 'ignore',
@@ -158,9 +172,7 @@ export const createSpawnLauncher = (
       });
       child.on('close', (code, signal) => {
         detach();
-        // 128+n is the shell convention for "died on signal n", and it is what a caller inspecting
-        // our exit status expects to see when the harness was terminated rather than returning.
-        resolve(code ?? (signal ? 128 + (os.constants.signals[signal] ?? 0) : 0));
+        resolve(normalizeChildExitCode(code, signal));
       });
     });
   },

--- a/code/cli/tests/unit/agent-launch.test.ts
+++ b/code/cli/tests/unit/agent-launch.test.ts
@@ -8,6 +8,7 @@ import {
   attachSignalForwarding,
   createProcessGroupSignalTarget,
   launchAgentProcess,
+  normalizeChildExitCode,
   resolveAgentLaunchExecutable,
 } from '../../src/agents/AgentLaunch.js';
 import type { AgentLaunchPlan } from '../../src/projection/Projection.js';
@@ -167,5 +168,24 @@ describe('termination forwarding', () => {
 
     expect(child.signals).toEqual(['SIGTERM']);
     expect(createProcessGroupSignalTarget(fakeChild()).kill('SIGHUP')).toBe(true);
+  });
+});
+
+describe('child exit normalization', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('maps the native Windows Ctrl-C status to the signal-derived exit code', () => {
+    expect(normalizeChildExitCode(0xc000013a, null, 'win32')).toBe(130);
+    expect(normalizeChildExitCode(null, 'SIGINT', 'win32')).toBe(130);
+  });
+
+  it('does not reinterpret POSIX exits or unrelated Windows NTSTATUS failures', () => {
+    expect(normalizeChildExitCode(0xc000013a, null, 'darwin')).toBe(0xc000013a);
+    expect(normalizeChildExitCode(0xc0000005, null, 'win32')).toBe(0xc0000005);
+    expect(normalizeChildExitCode(7, null, 'win32')).toBe(7);
+  });
+
+  it('treats a clean close without explicit exit data as success', () => {
+    expect(normalizeChildExitCode(null, null, 'linux')).toBe(0);
   });
 });

--- a/docs/requirements/OFTR-010-onboarding-welcome.md
+++ b/docs/requirements/OFTR-010-onboarding-welcome.md
@@ -39,6 +39,9 @@ Amendment (2026-09-04): statement 9 defines cancellation as a terminal startup o
 POSIX installer-tree termination. Previously, a forwarded signal ended only the current pi wrapper;
 the queue could continue into another install or the agent launch while a spawned npm process lived on.
 
+Amendment (2026-09-04): statement 10 normalizes the native Windows Ctrl-C status to the same
+shell-compatible cancellation code used for SIGINT without reinterpreting other Windows failures.
+
 1. An Outfitter-managed interactive Pi session MUST default `quietStartup` to `true` when the
    selected profile does not set it explicitly.
 2. A profile's explicit `quietStartup` value MUST take precedence over the Outfitter default.
@@ -59,6 +62,9 @@ the queue could continue into another install or the agent launch while a spawne
    stop the remaining install queue, MUST NOT launch the agent, and MUST return the signal-derived
    exit code. On POSIX systems, the installer and its descendants MUST receive that signal so an npm
    subprocess cannot outlive the cancelled Outfitter run.
+10. On Windows, the native `STATUS_CONTROL_C_EXIT` status MUST be normalized to exit code 130 so
+    console Ctrl-C follows the same cancellation path as SIGINT; unrelated Windows exit statuses
+    MUST remain unchanged.
 
 ## OFTR-010.2: Exact walkthrough
 


### PR DESCRIPTION
## Historical status

This PR was merged only into the staging branch for #366; it did **not** land on `main`. The active #366 carries this exact reviewed Windows change together with the related extension-bootstrap reliability delta from historical #362.

Continue review and eventual merge through #361, then #366. Do not merge this historical PR again.

## Change represented here

- Normalize Windows `STATUS_CONTROL_C_EXIT` to shell-compatible exit code 130.
- Preserve signal-derived exits, ordinary exit codes, unrelated NTSTATUS failures, and clean-close behavior.
- Document and test the Windows-specific cancellation contract.

Windows console Ctrl-C may arrive from libuv as an unsigned native exit status with no signal. Without normalization, callers cannot recognize the same user cancellation that POSIX reports as SIGINT-derived exit 130.

## Validation

- `npx -y -p node@24.18.0 -c 'node -v && npm run check-ci'`
- 62 test files passed; 679 tests passed on the complete staged stack.
- Coverage: 99.23% statements, 98.02% branches, 99.14% functions, 99.49% lines.
