### PR TITLE
fix(docs): update the default catalog references

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -125,7 +125,7 @@ default_harness: pi # which harness to launch: pi, claude, or codex
 cache_directory: ./cache
 
 sources:
-  - github: ai-outfitter/.agent
+  - github: ai-outfitter/community-profiles
     ref: <commit-sha>
   - github: example/payments-service
     ref: v1.2.0

--- a/docs/architecture/enterprise-private-catalog-boundary.md
+++ b/docs/architecture/enterprise-private-catalog-boundary.md
@@ -4,7 +4,8 @@ This document defines the enterprise/private catalog boundary for Outfitter. Pri
 
 ## Current public behavior remains the default
 
-- First-run onboarding and setup continue to use the public default catalog, `github: ai-outfitter/.agent`.
+- First-run onboarding and setup continue to use the public default catalog,
+  `github: ai-outfitter/community-profiles`.
 - `outfitter setup` without an explicit setup source continues to write public default catalog settings.
 - `outfitter sync` continues to use the existing source URI/git synchronization path.
 - Local, public GitHub shorthand, and public URI sources remain supported exactly as they are today.

--- a/docs/documentation/getting-started.md
+++ b/docs/documentation/getting-started.md
@@ -24,7 +24,9 @@ If your configuration lives in `~/.claude` instead, move it into `~/.agents/` an
 
 ## First-time setup
 
-Bootstrap from the Outfitter [default catalog](https://github.com/ai-outfitter/.agent), then launch the default agent:
+Bootstrap from the Outfitter
+[default catalog](https://github.com/ai-outfitter/community-profiles), then launch
+the default agent:
 
 ```bash
 outfitter setup

--- a/docs/documentation/local-development.md
+++ b/docs/documentation/local-development.md
@@ -31,10 +31,8 @@ The committed `settings.yml` consumes shared catalogs **pinned to exact commits*
 default_agent: founder
 
 sources:
-  - github: ai-outfitter/.agent
-    ref: 2f9c1ab0d3e44b6f9d2c8a17e5b40c91d6f3a8e2
   - github: ai-outfitter/community-profiles
-    ref: 8d04c7a1f2e94b3c6a5d80e17f4b29c3d1e6a075
+    ref: 32311cbf9eb17ae812c2ab5e91fa5f34d5946ca6 # v1.7.0
   - path: . # this repository's own resources win last
 ```
 
@@ -47,9 +45,9 @@ When you are changing an upstream catalog itself, override its source in the git
 ```yaml
 # settings.local.yml (gitignored — machine-specific absolute paths)
 sources:
-  - path: /home/ncrmro/repos/unsupervised/ai-outfitters/default-profiles
-  - path: /home/ncrmro/repos/unsupervised/ai-outfitters/worktrees/actions/main
-  - path: /home/ncrmro/repos/ncrmro/.agents
+  - path: /home/developer/src/ai-outfitter/community-profiles
+  - path: /home/developer/src/ai-outfitter/actions
+  - path: /home/developer/.agents
 ```
 
 Because `settings.local.yml` overlays its sibling with higher [precedence](./settings.md#precedence), your machine resolves live working trees while every other consumer of the repo keeps resolving the pinned SHAs. Worktrees keep an iteration branch isolated:
@@ -67,7 +65,7 @@ git worktree add ../worktrees/feat/sharper-review -b feat/sharper-review
 4. Relaunch `outfitter` and test the behavior (a running session keeps the composition it started with).
 5. Fold settled changes back to their home:
    - personal → commit to your `.agents` repo;
-   - shared → commit in the upstream checkout, push, and open a PR against the catalog (`ai-outfitter/default-profiles`, `ai-outfitter/actions`, your org's `.outfitter`, …).
+   - shared → commit in the upstream checkout, push, and open a PR against the catalog (`ai-outfitter/community-profiles`, `ai-outfitter/actions`, your org's `.agents`, …).
 6. After the upstream PR merges: remove the local `path:` override, bump the pinned `ref:` in `settings.yml`, and `outfitter sync`.
 
 ## Consuming your repo from projects

--- a/docs/documentation/settings.md
+++ b/docs/documentation/settings.md
@@ -27,8 +27,8 @@ isolation: inherit # inherit (default) or isolated; see below. Honored only from
 
 # Where protocol resources come from, beyond this tree and ~/.agents.
 sources:
-  - github: ai-outfitter/.agent # owner/repo shorthand
-    ref: 2f9c1ab0d3e44b6f9d2c8a17e5b40c91d6f3a8e2 # pin a commit, tag, or branch
+  - github: ai-outfitter/community-profiles # owner/repo shorthand
+    ref: v1.7.0 # pin a commit, tag, or branch
     # path: optional subdirectory containing the payload
   - uri: git+https://git.example.com/team/agents.git
     ref: v1.2.0


### PR DESCRIPTION
## What

- Replace retired public-catalog references with `ai-outfitter/community-profiles`.
- Pin the local-development reproducibility example to the commit published as `v1.7.0`.
- Replace maintainer-specific checkout paths with generic local-development examples.
- Use `.agents` consistently for organization catalog examples.

## Why

First-run setup now uses `community-profiles`, but several public examples still directed readers to the retired catalog or to machine-specific paths. Following those docs would not reproduce current onboarding.

## Validation

- `npx -y -p node@24.18.0 -c 'node -v && npm run check-ci'`
- 61 test files passed; 668 tests passed.
- Coverage: 99.22% statements, 98.04% branches, 99.14% functions, 99.48% lines.
- Verified `v1.7.0` resolves to `32311cbf9eb17ae812c2ab5e91fa5f34d5946ca6`.
- Scanned the changed docs for retired catalog references and maintainer-specific paths.

## Risk

Documentation-only. The pinned example will need an intentional update when the recommended catalog release changes.
