### PR TITLE
fix(pi): isolate materialized skill paths

### DIFF
--- a/.deepwork/schemas/onboarding_architecture/deepschema.yml
+++ b/.deepwork/schemas/onboarding_architecture/deepschema.yml
@@ -29,7 +29,7 @@ requirements:
     folder only and does not automatically trust parent folders.
   default-catalog-source: >
     The document MUST state that default profile labels and descriptions are
-    read from the synchronized ai-outfitter/default-profiles catalog cache, not
+    read from the synchronized ai-outfitter/community-profiles catalog cache, not
     from hardcoded profile choices in the extension.
   custom-profile-picker: >
     The document MUST explain why ctx.ui.select is insufficient for per-profile
@@ -42,8 +42,8 @@ requirements:
   install-target-description-selector: >
     The document SHOULD describe the install-target screen as a described-option
     selector and include the user-wide and project-local explanatory copy.
-  founder-default-selection: >
-    The document MUST state that founder is the initial highlighted/default
+  engineer-default-selection: >
+    The document MUST state that engineer is the initial highlighted/default
     profile when present and no current default profile exists.
   login-credential-boundary: >
     The document MUST state that /login is opened through Pi when no models are

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ default_agent: engineer
 `outfitter setup` restores the original Pi-native profile-catalog walkthrough on top of `.agents`:
 choose the default Outfitter catalog, create your own profile, or provide another catalog, then pick
 the home/project target and default CLI agent. The default picker is fetched from the immutable
-`ai-outfitter/default-profiles` Release Please tag pinned by Outfitter—never from a sibling checkout.
+`ai-outfitter/community-profiles` Release Please tag pinned by Outfitter—never from a sibling checkout.
 Managed porting and persistent harness symlinks are deferred to
 [#187](https://github.com/ai-outfitter/outfitter/issues/187).
 

--- a/code/cli/src/projection/ProjectHarness.ts
+++ b/code/cli/src/projection/ProjectHarness.ts
@@ -218,7 +218,12 @@ const buildPiOrClaudeLaunchPlan = (
 ): AgentLaunchPlan => {
   const isPi = input.harness === 'pi';
   const isolation = resolveProjectionIsolation(input);
-  const skillArgs = isPi ? composition.loadout.skills.flatMap((skill) => ['--skill', skill.slug]) : [];
+  // Pi's `--skill` value is a filesystem path, not a discovered-skill slug. Use the materialized
+  // paths explicitly and suppress implicit discovery: otherwise Pi also sees a project source copy
+  // or rediscovers the runtime copy and reports a false collision for the selected skill.
+  const skillArgs = isPi
+    ? ['--no-skills', ...materialized.skillDirectories.flatMap((directory) => ['--skill', directory])]
+    : [];
   const extensionArgs = isPi ? (input.extensionLoadDirs ?? []).flatMap((dir) => ['--extension', dir]) : [];
 
   return {

--- a/code/cli/src/setup/DefaultCatalog.ts
+++ b/code/cli/src/setup/DefaultCatalog.ts
@@ -19,11 +19,14 @@ import { writeSourceState } from '../sources/SourceState.js';
 export type RepositorySync = typeof syncRemoteRepositoryAtomically;
 
 export const defaultCatalogSource = {
-  github: 'ai-outfitter/default-profiles',
-  // TODO(release-automation): when default-profiles publishes a new Release Please tag, open a
+  github: 'ai-outfitter/community-profiles',
+  // TODO(release-automation): when community-profiles publishes a new Release Please tag, open a
   // conventional dependency-bump commit in Outfitter so its next Release Please release ships it.
-  ref: 'v1.1.1',
+  ref: 'v1.7.0',
 } as const satisfies RemoteSourceReference;
+
+/** Superseded default catalogs; setup replaces their pins instead of keeping them alongside. */
+export const retiredDefaultCatalogSources = ['ai-outfitter/default-profiles'] as const;
 
 export interface PinnedCatalogBootstrapInput {
   readonly homeDirectory: string;

--- a/code/cli/src/setup/Setup.ts
+++ b/code/cli/src/setup/Setup.ts
@@ -5,7 +5,7 @@ import { dirname, join } from 'node:path';
 
 import type { Harness } from '../settings/Settings.js';
 import { HARNESSES } from '../settings/Settings.js';
-import { defaultCatalogSource } from './DefaultCatalog.js';
+import { defaultCatalogSource, retiredDefaultCatalogSources } from './DefaultCatalog.js';
 
 export type SetupScope = 'home' | 'project';
 export type SetupMode = 'default' | 'create' | 'catalog' | 'source';
@@ -107,6 +107,7 @@ const discoverAgentsInCatalog = (root: string): readonly SetupAgentChoice[] => {
     try {
       if (!statSync(agentPath).isFile()) return [];
       const content = readFileSync(agentPath, 'utf8');
+      if (readFrontmatterValue(content, 'abstract') === 'true') return [];
       const id = sanitizeAgentSlug(readFrontmatterValue(content, 'name') ?? entry);
       if (id !== entry || !agentSlugPattern.test(id)) return [];
       return [
@@ -121,8 +122,8 @@ const discoverAgentsInCatalog = (root: string): readonly SetupAgentChoice[] => {
     }
   });
   return choices.sort((left, right) => {
-    if (left.id === 'founder') return -1;
-    if (right.id === 'founder') return 1;
+    if (left.id === 'engineer') return -1;
+    if (right.id === 'engineer') return 1;
     return left.id.localeCompare(right.id);
   });
 };
@@ -153,19 +154,40 @@ const upsertDefaultCatalogSource = (content: string): string => {
 
   const lines = content.replace(/\s*$/u, '').split('\n');
   const start = lines.findIndex((line) => /^sources:\s*$/u.test(line));
-  let end = start + 1;
-  while (end < lines.length && (/^\s/u.test(lines[end] ?? '') || (lines[end] ?? '') === '')) end += 1;
-  const existing = lines.findIndex((line, index) => {
-    if (index <= start || index >= end) return false;
-    const match = /^\s*-\s+github:\s*(.+?)\s*$/u.exec(line);
-    return match?.[1]?.replace(/^['"]|['"]$/gu, '') === defaultCatalogSource.github;
-  });
+  const sourcesEnd = (): number => {
+    let boundary = start + 1;
+    while (boundary < lines.length && (/^\s/u.test(lines[boundary] ?? '') || (lines[boundary] ?? '') === ''))
+      boundary += 1;
+    return boundary;
+  };
+  const indexOfSource = (github: string): number => {
+    const boundary = sourcesEnd();
+    return lines.findIndex((line, index) => {
+      if (index <= start || index >= boundary) return false;
+      const match = /^\s*-\s+github:\s*(.+?)\s*$/u.exec(line);
+      return match?.[1]?.replace(/^['"]|['"]$/gu, '') === github;
+    });
+  };
+
+  // Every retired pin leaves, even when the current source is already present;
+  // the first retired pin found donates its position when it is not.
+  for (const retiredName of retiredDefaultCatalogSources) {
+    for (let retired = indexOfSource(retiredName); retired !== -1; retired = indexOfSource(retiredName)) {
+      let retiredEnd = retired + 1;
+      const boundary = sourcesEnd();
+      while (retiredEnd < boundary && !/^\s*-\s+/u.test(lines[retiredEnd] ?? '')) retiredEnd += 1;
+      const replacement = indexOfSource(defaultCatalogSource.github) === -1 ? sourceLines : [];
+      lines.splice(retired, retiredEnd - retired, ...replacement);
+    }
+  }
+  const existing = indexOfSource(defaultCatalogSource.github);
 
   if (existing === -1) {
     lines.splice(start + 1, 0, ...sourceLines);
     return `${lines.join('\n')}\n`;
   }
 
+  const end = sourcesEnd();
   let blockEnd = existing + 1;
   while (blockEnd < end && !/^\s*-\s+/u.test(lines[blockEnd] ?? '')) blockEnd += 1;
   const block = lines.slice(existing, blockEnd).filter((line) => !/^\s+path:\s*/u.test(line));

--- a/code/cli/tests/unit/default-catalog.test.ts
+++ b/code/cli/tests/unit/default-catalog.test.ts
@@ -45,8 +45,8 @@ afterEach(() => {
 describe('default catalog bootstrap', () => {
   it('ships the canonical catalog at one immutable Release Please tag', () => {
     expect(defaultCatalogSource).toEqual({
-      github: 'ai-outfitter/default-profiles',
-      ref: 'v1.1.1',
+      github: 'ai-outfitter/community-profiles',
+      ref: 'v1.7.0',
     });
   });
 

--- a/code/cli/tests/unit/pi-setup-extension.test.ts
+++ b/code/cli/tests/unit/pi-setup-extension.test.ts
@@ -245,14 +245,14 @@ describe('Pi setup extension', () => {
       ],
     });
     expect(context.rendered[0]?.join('\n')).toContain('Outfitter profile setup');
-    expect(context.rendered[0]?.join('\n')).toContain('→ founder — Founder (Recommended)');
+    expect(context.rendered[0]?.join('\n')).toContain('→ engineer — Engineer (Recommended)');
     expect(context.rendered[1]?.join(' ')).toContain('Where should Outfitter install these settings?');
     expect(context.rendered[2]?.join(' ')).toContain('Which CLI agent should Outfitter use by default?');
     expect(context.rendered[2]?.join('\n')).toContain('→ Pi / Outfitter (Recommended)');
     expect(context.rendered[2]?.join('\n')).toContain('Codex CLI');
     expect(JSON.parse(readFileSync(resultPath, 'utf8'))).toEqual({
       setupMode: 'default',
-      agentId: 'founder',
+      agentId: 'engineer',
       harness: 'pi',
       target: 'home',
     });

--- a/code/cli/tests/unit/pi-skill-isolation.test.ts
+++ b/code/cli/tests/unit/pi-skill-isolation.test.ts
@@ -1,0 +1,44 @@
+// Tests that managed Pi skill isolation preserves caller-supplied explicit skill paths.
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { expect, it } from 'vitest';
+
+import type { CompositionPlan } from '../../src/composer/Composition.js';
+import { projectComposition } from '../../src/projection/ProjectHarness.js';
+
+const emptyPlan: CompositionPlan = {
+  agent: 'engineer',
+  identity: { agentBody: 'Body.' },
+  loadout: {
+    skills: [],
+    delegateSkills: [],
+    subagents: [],
+    mcp: [],
+    mcpServers: {},
+    extensions: [],
+    plugins: [],
+  },
+  warnings: [],
+};
+
+// THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.3.12).
+// YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+it('keeps explicit pass-through skills after disabling implicit discovery', () => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-pi-skill-isolation-'));
+  try {
+    const explicitSkill = '/opt/skills/local-review';
+    const projection = projectComposition(emptyPlan, {
+      harness: 'pi',
+      rootDirectory: root,
+      homeDirectory: root,
+      passThroughArgs: ['--skill', explicitSkill],
+    });
+
+    expect(projection.launch.args).toContain('--no-skills');
+    expect(projection.launch.args.slice(-2)).toEqual(['--skill', explicitSkill]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/code/cli/tests/unit/run-agent.test.ts
+++ b/code/cli/tests/unit/run-agent.test.ts
@@ -1,7 +1,7 @@
 // Tests run: resolve → compose → project → launch, launch mapping, cleanup, and strict/validation.
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, isAbsolute, join } from 'node:path';
 
 import { Command } from 'commander';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -113,12 +113,14 @@ describe('run agent', () => {
     expect(result.exitCode).toBe(0);
     expect(result.launchPlan!.command).toBe('pi');
     const launch = captured[0];
+    const skillDirectory = join(launch.runtimeDir, 'skills', 'wiki');
     expect(launch.plan.args).toEqual(
       expect.arrayContaining([
         '--system-prompt',
         '--append-system-prompt',
+        '--no-skills',
         '--skill',
-        'wiki',
+        skillDirectory,
         '--model',
         'gpt-5.2',
         '--thinking',
@@ -128,6 +130,7 @@ describe('run agent', () => {
     );
     expect(launch.systemPrompt).toBe('BASE PROMPT'); // composed identity materialized
     expect(launch.skillPresent).toBe(true); // skill content copied, not an empty dir
+    expect(isAbsolute(skillDirectory)).toBe(true); // Pi interprets --skill as a path relative to cwd
   });
 
   it('stamps the selected profile label and enables quiet Pi startup', async () => {

--- a/code/cli/tests/unit/setup.test.ts
+++ b/code/cli/tests/unit/setup.test.ts
@@ -33,6 +33,10 @@ const createTree = (): { catalog: string; home: string; project: string; root: s
     join(catalog, 'agents', 'engineer', 'agent.md'),
     '---\nname: engineer\ndescription: Engineering profile.\n---\n\n# Engineer\n',
   );
+  write(
+    join(catalog, 'agents', 'environment', 'agent.md'),
+    '---\nname: environment\ndescription: Abstract environment baseline.\nabstract: true\n---\n\n# Environment\n',
+  );
   write(join(catalog, 'skills', 'planning', 'SKILL.md'), '---\nname: planning\n---\n');
   return { catalog, home, project, root };
 };
@@ -62,11 +66,11 @@ afterEach(() => {
 });
 
 describe('setup state machine', () => {
-  it('discovers the default Outfitter catalog with display metadata', () => {
+  it('discovers the default Outfitter catalog with display metadata, engineer first, abstract profiles hidden', () => {
     const { catalog } = createTree();
     expect(discoverSetupAgentChoices({ defaultCatalogRoot: catalog })).toEqual([
-      { id: 'founder', label: 'Founder', description: 'Founder/operator profile.' },
       { id: 'engineer', label: 'Engineer', description: 'Engineering profile.' },
+      { id: 'founder', label: 'Founder', description: 'Founder/operator profile.' },
     ]);
     expect(discoverSetupAgentChoices({})).toEqual([]);
   });
@@ -168,9 +172,31 @@ describe('setup state machine', () => {
     expect(settings).toContain(
       `  - path: ./personal\n  - github: ${defaultCatalogSource.github}\n    ref: ${defaultCatalogSource.ref}\nstartup:`,
     );
-    expect(settings.match(/github: ai-outfitter\/default-profiles/gu)).toHaveLength(1);
+    expect(settings.match(/github: ai-outfitter\/default-profiles/gu)).toBeNull();
+    expect(settings.match(new RegExp(`github: ${defaultCatalogSource.github.replace('/', '\\/')}`, 'gu'))).toHaveLength(
+      1,
+    );
     expect(settings.match(/# telemetry:/gu)).toHaveLength(1);
     expect(settings).not.toContain('path: profiles');
+  });
+
+  it('removes a retired default-catalog pin even when the current source is already present', () => {
+    const { catalog, home, project } = createTree();
+    write(
+      join(home, '.agents', 'settings.yml'),
+      `default_agent: engineer\ndefault_harness: pi\nsources:\n  - github: ${defaultCatalogSource.github}\n    ref: old\n` +
+        '  - github: ai-outfitter/default-profiles\n    ref: v1.1.1\n',
+    );
+    applySetupSelection({
+      homeDirectory: home,
+      projectDirectory: project,
+      defaultCatalogRoot: catalog,
+      availableAgents: discoverSetupAgentChoices({ defaultCatalogRoot: catalog }),
+      selection: { setupMode: 'default', agentId: 'engineer', harness: 'pi', target: 'home' },
+    });
+    const settings = readFileSync(join(home, '.agents', 'settings.yml'), 'utf8');
+    expect(settings.match(/github: ai-outfitter\/default-profiles/gu)).toBeNull();
+    expect(settings).toContain(`    ref: ${defaultCatalogSource.ref}`);
   });
 
   it('adds the pinned default source to an existing source list', () => {

--- a/code/pi-extension/src/outfitter-extension.js
+++ b/code/pi-extension/src/outfitter-extension.js
@@ -109,7 +109,7 @@ export default function outfitter(pi) {
         'The current Pi process keeps the profile it started with; this setting applies on the next launch.',
       ];
       const initialProfileId =
-        currentDefault ?? (profiles.some((profile) => profile.id === 'founder') ? 'founder' : profiles[0]?.id);
+        currentDefault ?? (profiles.some((profile) => profile.id === 'engineer') ? 'engineer' : profiles[0]?.id);
       const selectedId = await selectFromItems(ctx, title, items, initialProfileId);
       if (selectedId === undefined) return undefined;
       return profiles.find((profile) => profile.id === selectedId);
@@ -557,7 +557,7 @@ const selectDescribedOption = (ctx, titleLines, items, initialValue) =>
 
 const formatProfileLabel = (profile, currentDefault) => {
   const current = profile.id === currentDefault ? ' (current)' : '';
-  const recommended = currentDefault === undefined && profile.id === 'founder' ? ' (Recommended)' : '';
+  const recommended = currentDefault === undefined && profile.id === 'engineer' ? ' (Recommended)' : '';
   const label = profile.label ? ' — ' + profile.label : '';
   return profile.id + label + current + recommended;
 };

--- a/docs/architecture/onboarding.md
+++ b/docs/architecture/onboarding.md
@@ -17,7 +17,7 @@ The first prompt and its wording are fixed:
 
 The selected branch follows the original order:
 
-- Default catalog: described profile picker (Founder first and recommended) → home/project target.
+- Default catalog: described profile picker (Engineer first and recommended) → home/project target.
 - Create: profile ID → profile label → home/project target.
 - Different catalog: GitHub `owner/repo` → ref → settings path → private-catalog confirmation when
   applicable → home/project target.
@@ -31,7 +31,7 @@ the first, preselected recommendation; Claude Code and Codex CLI are the other c
 
 Both explicit `outfitter setup [source]` and implicit first-run `outfitter run` use one implementation:
 
-1. Fetch `ai-outfitter/default-profiles` at the immutable Release Please tag shipped by this
+1. Fetch `ai-outfitter/community-profiles` at the immutable Release Please tag shipped by this
    Outfitter version, or reuse that exact release from the normal `~/.agents/cache/repos` source
    cache, then read the current default marker. There is no sibling-checkout or packaged-catalog
    fallback.
@@ -66,7 +66,7 @@ The visible profile-era walkthrough is retained while storage is translated to t
 - the chosen CLI is stored as `default_harness`;
 - home/project targets are `~/.agents/settings.yml` and `<project>/.agents/settings.yml`;
 - a custom profile becomes `agents/<id>/agent.md` and never overwrites an existing file;
-- the default catalog is recorded as `github: ai-outfitter/default-profiles` at the immutable
+- the default catalog is recorded as `github: ai-outfitter/community-profiles` at the immutable
   Release Please version tag shipped by Outfitter; the bootstrap checkout remains derived cache
   data, not copied configuration;
 - remote and provided catalogs retain their `remote_settings` outcome;

--- a/docs/documentation/cli.md
+++ b/docs/documentation/cli.md
@@ -48,7 +48,7 @@ to import**; complete that branch; choose a home/project settings target; then c
 CLI agent. Pi/Outfitter is preselected. Passing `[source]` retains the original direct-source path
 and starts at target selection. Pi hosts the deterministic setup UI without a model provider and
 does not port or symlink harness configuration. The default picker always comes from
-`ai-outfitter/default-profiles` at the immutable Release Please version tag pinned by the installed
+`ai-outfitter/community-profiles` at the immutable Release Please version tag pinned by the installed
 Outfitter version; setup fetches or reuses that release through the normal source cache and writes
 the same GitHub/ref pair to settings. It never reads a sibling checkout or a packaged catalog
 fallback.

--- a/docs/documentation/conventions.md
+++ b/docs/documentation/conventions.md
@@ -15,7 +15,7 @@ Each layer inherits the one above it. ID-addressed resources — agents, skills,
 | Layer            | Location                                                                      | Holds                                                                                       |
 | ---------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | Community        | e.g. `ai-outfitter/community-profiles`                                        | Reviewed building blocks — skills and reference agents anyone can mix and match.            |
-| Curated defaults | e.g. `ai-outfitter/default-profiles`                                          | The pinned, curated assembly — starter agents users adopt as-is.                            |
+| Curated defaults | e.g. `ai-outfitter/community-profiles`                                        | The pinned, curated assembly — starter agents users adopt as-is.                            |
 | Organization     | `owner/.outfitter` [control repo](./usecases/organization-profile-catalog.md) | Bespoke org agents, shared `agents.md`, org-specific skills (brand voice, RBAC, endpoints). |
 | User / project   | `~/.agents`, `<repo>/.agents`                                                 | Personal and repo overrides, loadout-added references, same-ID resource overrides.          |
 

--- a/docs/requirements/OFTR-006-agent-adapters.md
+++ b/docs/requirements/OFTR-006-agent-adapters.md
@@ -34,6 +34,11 @@ Amended (2026-07-17, RFC #165): adapters project a harness-neutral composition, 
 
 ### OFTR-006.3: Pi Launch Controls
 
+Amendment (2026-09-04): statement 12 now requires explicit materialized paths and disables implicit
+skill discovery. Pi treats a bare slug as a path relative to the launch working directory, producing
+a false missing-path diagnostic; leaving discovery enabled can also rediscover the materialized or
+project source copy and produce a false collision diagnostic.
+
 1. The pi adapter MUST use `PI_CODING_AGENT_DIR` as the primary profile-scoped pi configuration boundary.
 2. The pi adapter MUST support profile-controlled environment variables.
 3. The pi adapter MUST support profile-controlled pi CLI arguments.
@@ -45,7 +50,7 @@ Amended (2026-07-17, RFC #165): adapters project a harness-neutral composition, 
 9. The pi adapter SHOULD support pi model, provider, and thinking controls where native pi flags exist.
 10. The pi adapter MUST merge `.mcp.json` files from contributing `cli_specific/pi/` profile folders into the composite profile, adding unique array entries by identity while keeping the last entry for duplicate identities.
 11. The pi adapter MUST make native Pi `models.json` available inside the composite profile so custom providers and model definitions are visible before Pi resolves `--provider` and `--model` flags.
-12. The pi adapter MUST expose valid Agent Skills from contributing profile `skills/` folders as `--skill` arguments, and MAY also expose Pi-specific skills from `cli_specific/pi/skills/`.
+12. The pi adapter MUST disable implicit Pi skill discovery and expose valid Agent Skills from contributing profile `skills/` folders as `--skill` arguments whose values are the absolute materialized skill directories under `PI_CODING_AGENT_DIR`, and MAY also expose Pi-specific skills from `cli_specific/pi/skills/`. Explicit pass-through `--skill` arguments MUST remain usable.
 13. The pi adapter MUST expose DeepWork jobs from contributing profile `deepwork/jobs/` folders through `DEEPWORK_ADDITIONAL_JOBS_FOLDERS`, and MAY also expose Pi-specific jobs from `cli_specific/pi/deepwork/jobs/`.
 14. The pi adapter MUST resolve `controls.deepwork.jobs` entries as DeepWork job names from shared Outfitter job roots such as `.outfitter/deepwork/jobs/<job-name>/job.yml` and expose the matching jobs root through `DEEPWORK_ADDITIONAL_JOBS_FOLDERS`.
 15. The pi adapter MUST NOT treat flat profile source roots as profile-bundled job folders unless a named DeepWork job resolves to a shared jobs root.

--- a/docs/requirements/OFTR-010-onboarding-welcome.md
+++ b/docs/requirements/OFTR-010-onboarding-welcome.md
@@ -57,8 +57,9 @@
 1. The first prompt MUST be `How would you like to set up Outfitter?` with, in order:
    `Use the default Outfitter profile catalog`, `Create your own profile`, and
    `Provide a different catalog to import`.
-2. Default-catalog setup MUST show the original described profile picker. Founder MUST be the first,
-   preselected `Recommended` row unless an existing default is marked `current`.
+2. Default-catalog setup MUST show the original described profile picker. Engineer MUST be the first,
+   preselected `Recommended` row unless an existing default is marked `current`; profiles marked
+   `abstract: true` MUST NOT be offered.
 3. Create setup MUST ask `Profile id`, then `Profile label`, then the install target. It MUST preserve
    an existing profile file.
 4. Different-catalog setup MUST ask the original GitHub repository, ref, and settings-path questions,
@@ -75,8 +76,8 @@
 2. Home/project settings MUST be `~/.agents/settings.yml` and `<project>/.agents/settings.yml`.
 3. The profile choice maps to `default_agent`; the added CLI choice maps to `default_harness`.
 4. Custom profiles map to `agents/<id>/agent.md`. The default catalog MUST map to
-   `github: ai-outfitter/default-profiles` at the immutable Release Please version tag shipped by
-   Outfitter.
+   `github: ai-outfitter/community-profiles` at the immutable Release Please version tag shipped by
+   Outfitter; a retired default-catalog pin in existing settings is replaced, never kept alongside.
 5. Existing resource files and unrelated settings MUST be preserved.
 6. Writes MUST be atomic; cancellation writes nothing; failures roll back only this attempt's changes.
 7. Setup MUST fetch that exact default-catalog revision into the normal remote-source cache or reuse


### PR DESCRIPTION
## What

- Pass selected Pi skills as their absolute materialized directories.
- Add `--no-skills` so Pi does not implicitly rediscover project or runtime copies of the same skills.
- Preserve explicit caller-supplied `--skill` arguments after the managed isolation flags.
- Document and test the complete skill-isolation contract.

## Why

Pi interprets a bare skill slug as a path relative to the launch working directory, which produces false missing-path diagnostics. Absolute paths fix that half of the problem, but implicit discovery can still rediscover another copy and report a false collision.

## Relationship to #339

This intentionally includes the absolute-materialized-path correction diagnosed in #339, then completes the fix by disabling implicit discovery. The two changes are inseparable on current `main`: `--no-skills` without explicit valid paths would hide the selected profile skills.

Fixes #338.

## Validation

- `npx -y -p node@24.18.0 -c 'node -v && npm run check-ci'`
- 62 test files passed; 669 tests passed.
- Coverage: 99.22% statements, 98.04% branches, 99.14% functions, 99.48% lines.

## Risk

Outfitter-managed Pi runs will no longer load ambient skills through implicit discovery. Profile-selected skills remain explicit, and callers can still append their own `--skill <path>` arguments.
