### PR TITLE
fix(pi): stabilize extension startup across environments

### DIFF
--- a/code/cli/src/agents/AgentLaunch.ts
+++ b/code/cli/src/agents/AgentLaunch.ts
@@ -136,6 +136,20 @@ export const createProcessGroupSignalTarget = (
   },
 });
 
+// A Ctrl-C delivered by the Windows console is not a POSIX signal termination. libuv reports the
+// unsigned STATUS_CONTROL_C_EXIT DWORD as the child exit code, with no signal, so normalize that
+// one native status to the same shell-compatible code as SIGINT. Other NTSTATUS failures remain
+// unchanged instead of being mistaken for cancellation.
+const WINDOWS_CONTROL_C_EXIT_STATUS = 0xc000013a;
+export const normalizeChildExitCode = (
+  code: number | null,
+  signal: NodeJS.Signals | null,
+  platform: NodeJS.Platform = process.platform,
+): number => {
+  if (signal !== null) return 128 + (os.constants.signals[signal] ?? 0);
+  if (platform === 'win32' && code === WINDOWS_CONTROL_C_EXIT_STATUS) return 130;
+  return code ?? 0;
+};
 /* v8 ignore start -- real process spawn is covered by end-to-end smoke usage, not unit tests. */
 export const createSpawnLauncher = (
   stdio: 'inherit' | 'ignore',
@@ -158,9 +172,7 @@ export const createSpawnLauncher = (
       });
       child.on('close', (code, signal) => {
         detach();
-        // 128+n is the shell convention for "died on signal n", and it is what a caller inspecting
-        // our exit status expects to see when the harness was terminated rather than returning.
-        resolve(code ?? (signal ? 128 + (os.constants.signals[signal] ?? 0) : 0));
+        resolve(normalizeChildExitCode(code, signal));
       });
     });
   },

--- a/code/cli/src/extensions/PiExtensionCache.ts
+++ b/code/cli/src/extensions/PiExtensionCache.ts
@@ -210,11 +210,19 @@ const evaluateCachedInstall = (installDir: string, mapped: PiExtensionSource, of
 // normal Outfitter signal forwarding terminate the whole installer tree rather than orphaning npm.
 const quietSpawnLauncher = createSpawnLauncher('ignore', { terminateProcessGroup: true });
 const debugSpawnLauncher = createSpawnLauncher('inherit', { terminateProcessGroup: true });
+export const piExtensionInstallEnvironment = (cacheAgentDir: string): Readonly<Record<string, string>> => ({
+  PI_CODING_AGENT_DIR: cacheAgentDir,
+  GIT_TERMINAL_PROMPT: '0',
+  // Extension installs are a runtime bootstrap, not a dependency-maintenance workflow. npm audit
+  // can otherwise hold first launch for its full network timeout after every package has downloaded.
+  NPM_CONFIG_AUDIT: 'false',
+  NPM_CONFIG_FUND: 'false',
+});
 const defaultSpawner: PiInstallSpawner = ({ source, cacheAgentDir, debug }) =>
   launchThroughSpawn(debug === true ? debugSpawnLauncher : quietSpawnLauncher, {
     command: 'pi',
     args: ['install', source],
-    env: { PI_CODING_AGENT_DIR: cacheAgentDir, GIT_TERMINAL_PROMPT: '0' },
+    env: piExtensionInstallEnvironment(cacheAgentDir),
   });
 /* v8 ignore stop */
 

--- a/code/cli/tests/unit/agent-launch.test.ts
+++ b/code/cli/tests/unit/agent-launch.test.ts
@@ -8,6 +8,7 @@ import {
   attachSignalForwarding,
   createProcessGroupSignalTarget,
   launchAgentProcess,
+  normalizeChildExitCode,
   resolveAgentLaunchExecutable,
 } from '../../src/agents/AgentLaunch.js';
 import type { AgentLaunchPlan } from '../../src/projection/Projection.js';
@@ -167,5 +168,24 @@ describe('termination forwarding', () => {
 
     expect(child.signals).toEqual(['SIGTERM']);
     expect(createProcessGroupSignalTarget(fakeChild()).kill('SIGHUP')).toBe(true);
+  });
+});
+
+describe('child exit normalization', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-010.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('maps the native Windows Ctrl-C status to the signal-derived exit code', () => {
+    expect(normalizeChildExitCode(0xc000013a, null, 'win32')).toBe(130);
+    expect(normalizeChildExitCode(null, 'SIGINT', 'win32')).toBe(130);
+  });
+
+  it('does not reinterpret POSIX exits or unrelated Windows NTSTATUS failures', () => {
+    expect(normalizeChildExitCode(0xc000013a, null, 'darwin')).toBe(0xc000013a);
+    expect(normalizeChildExitCode(0xc0000005, null, 'win32')).toBe(0xc0000005);
+    expect(normalizeChildExitCode(7, null, 'win32')).toBe(7);
+  });
+
+  it('treats a clean close without explicit exit data as success', () => {
+    expect(normalizeChildExitCode(null, null, 'linux')).toBe(0);
   });
 });

--- a/code/cli/tests/unit/pi-extension-cache.test.ts
+++ b/code/cli/tests/unit/pi-extension-cache.test.ts
@@ -10,6 +10,7 @@ import {
   assertInstallDirInsideCache,
   ensurePiExtensions,
   mapSpecifierToPiSource,
+  piExtensionInstallEnvironment,
 } from '../../src/extensions/PiExtensionCache.js';
 import type { PiInstallSpawner } from '../../src/extensions/PiExtensionCache.js';
 
@@ -310,6 +311,17 @@ describe('ensurePiExtensions', () => {
     });
     expect(spawned).toBe(1);
     expect(result.loadDirs).toEqual([join(dir, 'npm', 'node_modules', 'pi-subagents')]);
+  });
+});
+
+describe('piExtensionInstallEnvironment', () => {
+  it('disables npm audit and funding requests during the first-launch extension bootstrap', () => {
+    expect(piExtensionInstallEnvironment('/tmp/outfitter/pi-extensions')).toEqual({
+      PI_CODING_AGENT_DIR: '/tmp/outfitter/pi-extensions',
+      GIT_TERMINAL_PROMPT: '0',
+      NPM_CONFIG_AUDIT: 'false',
+      NPM_CONFIG_FUND: 'false',
+    });
   });
 });
 

--- a/docs/requirements/OFTR-010-onboarding-welcome.md
+++ b/docs/requirements/OFTR-010-onboarding-welcome.md
@@ -39,6 +39,9 @@ Amendment (2026-09-04): statement 9 defines cancellation as a terminal startup o
 POSIX installer-tree termination. Previously, a forwarded signal ended only the current pi wrapper;
 the queue could continue into another install or the agent launch while a spawned npm process lived on.
 
+Amendment (2026-09-04): statement 10 normalizes the native Windows Ctrl-C status to the same
+shell-compatible cancellation code used for SIGINT without reinterpreting other Windows failures.
+
 1. An Outfitter-managed interactive Pi session MUST default `quietStartup` to `true` when the
    selected profile does not set it explicitly.
 2. A profile's explicit `quietStartup` value MUST take precedence over the Outfitter default.
@@ -59,6 +62,9 @@ the queue could continue into another install or the agent launch while a spawne
    stop the remaining install queue, MUST NOT launch the agent, and MUST return the signal-derived
    exit code. On POSIX systems, the installer and its descendants MUST receive that signal so an npm
    subprocess cannot outlive the cancelled Outfitter run.
+10. On Windows, the native `STATUS_CONTROL_C_EXIT` status MUST be normalized to exit code 130 so
+    console Ctrl-C follows the same cancellation path as SIGINT; unrelated Windows exit statuses
+    MUST remain unchanged.
 
 ## OFTR-010.2: Exact walkthrough
 


### PR DESCRIPTION
## What

- Disable npm audit and funding requests only while `pi install` bootstraps profile extensions.
- Normalize Windows `STATUS_CONTROL_C_EXIT` to shell-compatible exit code 130.
- Preserve signal-derived exits, ordinary exit codes, unrelated NTSTATUS failures, and clean-close behavior.
- Cover both environment and exit semantics with focused tests and a documented requirement.

## Why

Profile startup should behave deterministically across machines. An unrelated npm audit endpoint can make a valid first launch appear hung, while Windows console Ctrl-C can otherwise surface as an opaque native failure instead of ordinary cancellation.

## Stack and historical PRs

This is **2 of 2** runtime-startup PRs and is based on #361 so its displayed diff contains only the remaining startup reliability and portability changes.

Historical PRs #362 and #363 were merged only into this staging branch, not `main`. This PR carries their exact reviewed implementation deltas. Do not merge those historical PRs again.

Merge #361 first. Because this repository uses squash merges, rebase this branch onto the updated `main`, retarget it to `main`, and wait for fresh green checks before merging.

## Validation

- `npx -y -p node@24.18.0 -c 'node -v && npm run check-ci'`
- 62 test files passed; 679 tests passed on the complete stack.
- Coverage: 99.23% statements, 98.02% branches, 99.14% functions, 99.49% lines.
- Current Ubuntu, macOS, Windows, and packaged E2E checks pass.

## Risk

The npm environment controls apply only to runtime extension installation, not repository maintenance. Windows normalization is restricted to the exact native Ctrl-C status when no signal was reported; unrelated exits remain unchanged.
