### PR TITLE
fix(pi): pass materialized skill directories to --skill

### DIFF
--- a/code/cli/src/projection/ProjectHarness.ts
+++ b/code/cli/src/projection/ProjectHarness.ts
@@ -218,7 +218,7 @@ const buildPiOrClaudeLaunchPlan = (
 ): AgentLaunchPlan => {
   const isPi = input.harness === 'pi';
   const isolation = resolveProjectionIsolation(input);
-  const skillArgs = isPi ? composition.loadout.skills.flatMap((skill) => ['--skill', skill.slug]) : [];
+  const skillArgs = isPi ? materialized.skillDirectories.flatMap((dir) => ['--skill', dir]) : [];
   const extensionArgs = isPi ? (input.extensionLoadDirs ?? []).flatMap((dir) => ['--extension', dir]) : [];
 
   return {

--- a/code/cli/tests/unit/run-agent.test.ts
+++ b/code/cli/tests/unit/run-agent.test.ts
@@ -118,7 +118,7 @@ describe('run agent', () => {
         '--system-prompt',
         '--append-system-prompt',
         '--skill',
-        'wiki',
+        join(launch.runtimeDir, 'skills', 'wiki'), // pi's --skill takes a path, not a slug
         '--model',
         'gpt-5.2',
         '--thinking',


### PR DESCRIPTION
pi's `--skill` takes a path. Outfitter passed the bare slug, which pi resolved against the working directory and reported under `[Skill conflicts]` as `skill path does not exist` on every launch. The skills still loaded through agent-dir discovery; pi deduplicates the explicit path against that, so the warning is the only behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uZ1UQDd7SkKQCSEhoR9d9