### PR TITLE
ci: validate release-please PRs across supported Node versions

### DIFF
--- a/.github/workflows/node-matrix.yml
+++ b/.github/workflows/node-matrix.yml
@@ -1,8 +1,10 @@
 # Node-version support matrix. Runs on release-please PRs (not on ordinary PRs)
 # and on demand, so every release candidate is exercised across the Node range
-# users actually run. Each leg installs the packed artifact from the registry
-# exactly like a user would and then loads the real bundled pi, which is where
-# old Node breaks (issue #368: undici's markAsUncloneable on Node < 22.10).
+# users actually run. Each leg loads the real bundled pi, which is where old Node
+# breaks (issue #368: undici's markAsUncloneable on Node < 22.10), then installs
+# the packed artifact exactly like a user would. The unit suite is deliberately
+# not part of the matrix: it runs on the pinned Node in ci.yml, and on other
+# versions it only surfaces dev-tooling noise users never see.
 name: Node matrix
 
 on:
@@ -10,9 +12,6 @@ on:
     branches:
       - 'release-please--**'
   workflow_dispatch:
-  push:
-    branches:
-      - ci/node-matrix # temporary: dropped before merge
 
 jobs:
   node:
@@ -50,6 +49,3 @@ jobs:
 
       - name: Run packaged E2E smoke test
         run: bash scripts/e2e-smoke.sh
-
-      - name: Run test suite
-        run: npm test

--- a/.github/workflows/node-matrix.yml
+++ b/.github/workflows/node-matrix.yml
@@ -1,0 +1,52 @@
+# Node-version support matrix. Runs on release-please PRs (not on ordinary PRs)
+# and on demand, so every release candidate is exercised across the Node range
+# users actually run. Each leg installs the packed artifact from the registry
+# exactly like a user would and then loads the real bundled pi, which is where
+# old Node breaks (issue #368: undici's markAsUncloneable on Node < 22.10).
+name: Node matrix
+
+on:
+  pull_request:
+    branches:
+      - 'release-please--**'
+  workflow_dispatch:
+
+jobs:
+  node:
+    name: Node ${{ matrix.node }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node:
+          - '20.18.1' # LTS, below the markAsUncloneable backport
+          - '21.7.3' # the field report in #368
+          - '22.9.0' # last 22.x without the backport
+          - '22.10.0' # first 22.x with the backport
+          - '22.18.0' # below the declared engines floor
+          - '22.19.0' # declared engines floor
+          - '23.11.1'
+          - '24.18.0' # .node-version
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Load the real bundled pi
+        run: npm exec --workspace @ai-outfitter/outfitter -- pi --version
+
+      - name: Run packaged E2E smoke test
+        run: bash scripts/e2e-smoke.sh
+
+      - name: Run test suite
+        run: npm test

--- a/.github/workflows/node-matrix.yml
+++ b/.github/workflows/node-matrix.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - 'release-please--**'
   workflow_dispatch:
+  push:
+    branches:
+      - ci/node-matrix # temporary: dropped before merge
 
 jobs:
   node:

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -1,6 +1,10 @@
-# Release validation. Runs in the merge queue and on manual dispatch, never on
-# ordinary pull requests, so every change reaching main is exercised across the
-# Node versions and platforms users actually run before it can be released.
+# Release validation. Runs when a release-please PR is in the merge queue, and on
+# manual dispatch, never on ordinary PRs or their queue entries, so every release
+# candidate is exercised across the Node versions and platforms users actually run.
+# The merge_group event only exposes a gh-readonly-queue/<base>/pr-<n>-<sha> ref,
+# so the gate job resolves that PR number to its head branch and lets the matrix
+# run only for release-please branches; other queue entries skip, which counts as
+# passing for a required check.
 # Each leg loads the real bundled pi, which is where old Node breaks (issue #368:
 # undici's markAsUncloneable on Node < 22.10), then installs the packed artifact
 # exactly like a user would. The unit suite is deliberately not part of this
@@ -14,9 +18,39 @@ on:
       - checks_requested
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
+  gate:
+    name: Release-please queue entry?
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+    steps:
+      - name: Resolve the queued PR's head branch
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.event.merge_group.head_ref }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          pr="$(printf '%s' "$HEAD_REF" | sed -n 's|.*/pr-\([0-9]*\)-.*|\1|p')"
+          branch="$(gh pr view "$pr" --repo "$GITHUB_REPOSITORY" --json headRefName --jq .headRefName)"
+          echo "queued PR #$pr from branch $branch"
+          case "$branch" in
+            release-please--*) echo "run=true" >> "$GITHUB_OUTPUT" ;;
+            *) echo "run=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+
   validate:
     name: Node ${{ matrix.node }} (${{ matrix.os }})
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -20,8 +20,10 @@ on:
   workflow_dispatch:
 
 jobs:
+  # No custom name: GitHub appends the matrix values to the job id when it runs,
+  # and a skipped job (every ordinary PR) then shows a plain name instead of an
+  # unexpanded expression.
   validate:
-    name: Node ${{ matrix.node }} (${{ matrix.os }})
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (!github.event.pull_request.draft &&

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -1,58 +1,31 @@
-# Release validation. Runs when a release-please PR is in the merge queue, and on
-# manual dispatch, never on ordinary PRs or their queue entries, so every release
-# candidate is exercised across the supported Node versions and platforms.
-# The merge_group event only exposes a gh-readonly-queue/<base>/pr-<n>-<sha> ref,
-# so the gate job resolves that PR number to its head branch and lets the matrix
-# run only for release-please branches; other queue entries skip, which counts as
-# passing for a required check.
+# Release validation. Release-please opens its PRs as drafts (see
+# release-please-config.json), so this runs when that PR is marked ready for
+# review, on later pushes to it while it stays non-draft, and on manual dispatch.
+# It never runs on ordinary PRs, so a release candidate is validated exactly
+# once per release decision across the supported Node versions and platforms.
 # Each leg installs the packed artifact exactly like a user would and exercises
 # it through scripts/e2e-smoke.sh, including launching the bundled pi it ships
 # with. That launch is the load-bearing check: outfitter-only commands such as
 # `--version` never import pi, so they pass on a Node that pi cannot run on (see
-# the comment in the smoke script and issue #368). The unit suite is deliberately not
-# part of this matrix: it runs on the pinned Node in ci.yml, and on other
+# the comment in the smoke script and issue #368). The unit suite is deliberately
+# not part of this matrix: it runs on the pinned Node in ci.yml, and on other
 # versions it only surfaces dev-tooling noise users never see.
 name: Release validation
 
 on:
-  merge_group:
+  pull_request:
     types:
-      - checks_requested
+      - ready_for_review
+      - synchronize
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pull-requests: read
-
 jobs:
-  gate:
-    name: Release-please queue entry?
-    runs-on: ubuntu-latest
-    outputs:
-      run: ${{ steps.check.outputs.run }}
-    steps:
-      - name: Resolve the queued PR's head branch
-        id: check
-        env:
-          GH_TOKEN: ${{ github.token }}
-          HEAD_REF: ${{ github.event.merge_group.head_ref }}
-        run: |
-          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          pr="$(printf '%s' "$HEAD_REF" | sed -n 's|.*/pr-\([0-9]*\)-.*|\1|p')"
-          branch="$(gh pr view "$pr" --repo "$GITHUB_REPOSITORY" --json headRefName --jq .headRefName)"
-          echo "queued PR #$pr from branch $branch"
-          case "$branch" in
-            release-please--*) echo "run=true" >> "$GITHUB_OUTPUT" ;;
-            *) echo "run=false" >> "$GITHUB_OUTPUT" ;;
-          esac
-
   validate:
     name: Node ${{ matrix.node }} (${{ matrix.os }})
-    needs: gate
-    if: needs.gate.outputs.run == 'true'
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!github.event.pull_request.draft &&
+       startsWith(github.head_ref, 'release-please--'))
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -6,7 +6,10 @@
 # run only for release-please branches; other queue entries skip, which counts as
 # passing for a required check.
 # Each leg installs the packed artifact exactly like a user would and exercises
-# it, including the bundled pi it ships with. The unit suite is deliberately not
+# it through scripts/e2e-smoke.sh, including launching the bundled pi it ships
+# with. That launch is the load-bearing check: outfitter-only commands such as
+# `--version` never import pi, so they pass on a Node that pi cannot run on (see
+# the comment in the smoke script and issue #368). The unit suite is deliberately not
 # part of this matrix: it runs on the pinned Node in ci.yml, and on other
 # versions it only surfaces dev-tooling noise users never see.
 name: Release validation

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -1,26 +1,30 @@
-# Node-version support matrix. Runs on release-please PRs (not on ordinary PRs)
-# and on demand, so every release candidate is exercised across the Node range
-# users actually run. Each leg loads the real bundled pi, which is where old Node
-# breaks (issue #368: undici's markAsUncloneable on Node < 22.10), then installs
-# the packed artifact exactly like a user would. The unit suite is deliberately
-# not part of the matrix: it runs on the pinned Node in ci.yml, and on other
-# versions it only surfaces dev-tooling noise users never see.
-name: Node matrix
+# Release validation. Runs in the merge queue and on manual dispatch, never on
+# ordinary pull requests, so every change reaching main is exercised across the
+# Node versions and platforms users actually run before it can be released.
+# Each leg loads the real bundled pi, which is where old Node breaks (issue #368:
+# undici's markAsUncloneable on Node < 22.10), then installs the packed artifact
+# exactly like a user would. The unit suite is deliberately not part of this
+# matrix: it runs on the pinned Node in ci.yml, and on other versions it only
+# surfaces dev-tooling noise users never see.
+name: Release validation
 
 on:
-  pull_request:
-    branches:
-      - 'release-please--**'
+  merge_group:
+    types:
+      - checks_requested
   workflow_dispatch:
 
 jobs:
-  node:
-    name: Node ${{ matrix.node }}
-    runs-on: ubuntu-latest
+  validate:
+    name: Node ${{ matrix.node }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
         node:
           - '20.18.1' # LTS, below the markAsUncloneable backport
           - '21.7.3' # the field report in #368

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -1,15 +1,14 @@
 # Release validation. Runs when a release-please PR is in the merge queue, and on
 # manual dispatch, never on ordinary PRs or their queue entries, so every release
-# candidate is exercised across the Node versions and platforms users actually run.
+# candidate is exercised across the supported Node versions and platforms.
 # The merge_group event only exposes a gh-readonly-queue/<base>/pr-<n>-<sha> ref,
 # so the gate job resolves that PR number to its head branch and lets the matrix
 # run only for release-please branches; other queue entries skip, which counts as
 # passing for a required check.
-# Each leg loads the real bundled pi, which is where old Node breaks (issue #368:
-# undici's markAsUncloneable on Node < 22.10), then installs the packed artifact
-# exactly like a user would. The unit suite is deliberately not part of this
-# matrix: it runs on the pinned Node in ci.yml, and on other versions it only
-# surfaces dev-tooling noise users never see.
+# Each leg installs the packed artifact exactly like a user would and exercises
+# it, including the bundled pi it ships with. The unit suite is deliberately not
+# part of this matrix: it runs on the pinned Node in ci.yml, and on other
+# versions it only surfaces dev-tooling noise users never see.
 name: Release validation
 
 on:
@@ -60,14 +59,12 @@ jobs:
           - ubuntu-latest
           - macos-latest
         node:
-          - '20.18.1' # LTS, below the markAsUncloneable backport
-          - '21.7.3' # the field report in #368
-          - '22.9.0' # last 22.x without the backport
-          - '22.10.0' # first 22.x with the backport
-          - '22.18.0' # below the declared engines floor
-          - '22.19.0' # declared engines floor
-          - '23.11.1'
-          - '24.18.0' # .node-version
+          # The floor is pi's declared engines range (node >=22.19.0), which
+          # outfitter mirrors in its own package.json. Older Node is unsupported
+          # and crashes inside pi's undici (issue #368), so it is not validated.
+          - '22.19.0' # pi's floor
+          - '22' # latest 22 LTS
+          - '24.18.0' # .node-version, the release build
 
     steps:
       - name: Checkout
@@ -81,9 +78,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Load the real bundled pi
-        run: npm exec --workspace @ai-outfitter/outfitter -- pi --version
 
       - name: Run packaged E2E smoke test
         run: bash scripts/e2e-smoke.sh

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "include-component-in-tag": false,
+  "draft-pull-request": true,
   "packages": {
     "code/cli": {
       "extra-files": [

--- a/scripts/e2e-smoke.sh
+++ b/scripts/e2e-smoke.sh
@@ -128,6 +128,13 @@ pi_manifest="$(find "$install_prefix/lib/node_modules" -path '*/@earendil-works/
 pi_package_root="$(dirname "$pi_manifest")"
 pi_bin_relative="$(node -p "require('$pi_manifest').bin.pi")"
 pi_bin="$pi_package_root/$pi_bin_relative"
+
+# Load the real bundled pi once before stubbing it. Pi's module graph is where an
+# unsupported Node breaks (issue #368), and nothing else in this script imports it.
+log 'Checking the bundled pi loads'
+pi_version="$(node "$pi_bin" --version 2>&1)" || fail "bundled pi failed to load: $pi_version"
+log "bundled pi OK ($pi_version)"
+
 capture_dir="$work_dir/run-capture"
 mkdir -p "$capture_dir"
 cat >"$pi_bin" <<'FAKE_PI'

--- a/scripts/e2e-smoke.sh
+++ b/scripts/e2e-smoke.sh
@@ -131,8 +131,17 @@ pi_bin="$pi_package_root/$pi_bin_relative"
 
 # Launch the real bundled pi through the installed `outfitter run` once before
 # stubbing it. `--version` passes through to pi, which prints and exits without a
-# TUI. Pi's module graph is where an unsupported Node breaks (issue #368), and
-# nothing earlier in this script loads it.
+# TUI.
+#
+# Why `outfitter --version` above is not enough: outfitter's own CLI never imports
+# pi or its dependencies. Pi only loads when outfitter spawns it as a child
+# process from `run` or `setup`, so `--version`, `--help`, `list`, and `validate`
+# all succeed on a Node that pi cannot run on (issue #368: pi's undici crashes on
+# Node < 22.10 while every outfitter-only command works). The stubbed `run` below
+# replaces pi's bin, so it never loads pi either. This step is the only place in
+# the script, and in CI, where outfitter's launch path into the real pi is
+# exercised; keep it even once a Node-version guard exists, because the guard
+# checks a version number and a pi upgrade can still break on a supported Node.
 log 'Checking installed `outfitter run` launches the bundled pi'
 expected_pi_version="$(node -p "require('$pi_manifest').version")"
 pi_output="$(cd "$project_dir" && run_outfitter run -- --version 2>&1)" \

--- a/scripts/e2e-smoke.sh
+++ b/scripts/e2e-smoke.sh
@@ -129,11 +129,19 @@ pi_package_root="$(dirname "$pi_manifest")"
 pi_bin_relative="$(node -p "require('$pi_manifest').bin.pi")"
 pi_bin="$pi_package_root/$pi_bin_relative"
 
-# Load the real bundled pi once before stubbing it. Pi's module graph is where an
-# unsupported Node breaks (issue #368), and nothing else in this script imports it.
-log 'Checking the bundled pi loads'
-pi_version="$(node "$pi_bin" --version 2>&1)" || fail "bundled pi failed to load: $pi_version"
-log "bundled pi OK ($pi_version)"
+# Launch the real bundled pi through the installed `outfitter run` once before
+# stubbing it. `--version` passes through to pi, which prints and exits without a
+# TUI. Pi's module graph is where an unsupported Node breaks (issue #368), and
+# nothing earlier in this script loads it.
+log 'Checking installed `outfitter run` launches the bundled pi'
+expected_pi_version="$(node -p "require('$pi_manifest').version")"
+pi_output="$(cd "$project_dir" && run_outfitter run -- --version 2>&1)" \
+  || fail "outfitter run failed to launch the bundled pi: $pi_output"
+case "$pi_output" in
+  *"$expected_pi_version"*) ;;
+  *) fail "outfitter run did not print pi $expected_pi_version: $pi_output" ;;
+esac
+log "outfitter run launched pi OK ($expected_pi_version)"
 
 capture_dir="$work_dir/run-capture"
 mkdir -p "$capture_dir"


### PR DESCRIPTION
Release-please now opens its release PR as a draft (`draft-pull-request: true` in `release-please-config.json`). The new `release-validation.yml` runs when that PR is marked ready for review, on later pushes while it stays non-draft, and on manual dispatch. It never runs on ordinary PRs, so each release decision is validated exactly once.

Each leg does `npm ci` and runs the packaged E2E smoke test, which packs outfitter, installs it globally like a user would, and exercises the shipped bin. Matrix: ubuntu and macos on Node 22.19.0 (pi's declared floor), latest 22, and 24.18.0 (`.node-version`).

`scripts/e2e-smoke.sh` gains one check: the installed `outfitter run -- --version` launches the real bundled pi, which prints its version and exits without a TUI. Outfitter-only commands never import pi, so `--version`, `--help`, `list`, and `validate` all pass on a Node pi cannot run on; this step exercises outfitter's real launch path into pi, which is where an unsupported Node breaks (#368). The check also runs in the existing `packaged-smoke` job in `ci.yml`.

Release flow after merge: release-please keeps the draft updated as commits land; click "Ready for review" to run the matrix against the exact release commit; merge when green.

Unsupported Node (below 22.19) is deliberately not in the matrix; the friendly startup guard for it is #368 and is separate.

Earlier trial run across 20 through 24 on ubuntu, for the record: https://github.com/ai-outfitter/outfitter/actions/runs/33918936376. Everything below 22.10 crashed on pi load with `markAsUncloneable is not a function`; 22.10 and above passed the packaged smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ro3oEjhxseTLWVhhf1yDhX