### PR TITLE
fix(cli): refuse to run on Node below the published floor

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ For the full argument, read the [Philosophy](./docs/philosophy.md).
 
 ## Quick start
 
+Requires Node 22.19 or newer (the bundled Pi's floor). Older Node installs without error but
+crashes when Pi starts, so Outfitter refuses to run and prints an upgrade hint instead.
+
 Run without installing:
 
 ```bash

--- a/code/cli/src/cli.ts
+++ b/code/cli/src/cli.ts
@@ -11,6 +11,7 @@ import { createOutfitterProgram } from './cli/OutfitterCli.js';
 import { createTelemetryContext } from './telemetry/TelemetryContext.js';
 import { createTelemetryService } from './telemetry/TelemetryService.js';
 import type { TelemetryCommandContext, TelemetryService } from './telemetry/TelemetryService.js';
+import { enforceNodeVersion } from './version/NodeVersionGuard.js';
 import { readOutfitterVersion } from './version/OutfitterVersion.js';
 
 export const createProgram = createOutfitterProgram;
@@ -130,12 +131,18 @@ export const isDirectCliExecution = (moduleUrl: string, argvPath: string | undef
   }
 };
 
-/* v8 ignore next 8 -- direct bin execution is covered by local install smoke tests. */
+/* v8 ignore next 12 -- direct bin execution is covered by local install smoke tests. */
 if (isDirectCliExecution(import.meta.url, process.argv[1])) {
-  try {
-    await runCli(createProgram(), process.argv);
-  } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
+  // Every subcommand can spawn the bundled pi, which crashes on Node below the published
+  // floor, so the guard runs before parsing and before the telemetry notice (issue #368).
+  if (!enforceNodeVersion()) {
     process.exitCode = 1;
+  } else {
+    try {
+      await runCli(createProgram(), process.argv);
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+    }
   }
 }

--- a/code/cli/src/version/NodeVersionGuard.ts
+++ b/code/cli/src/version/NodeVersionGuard.ts
@@ -1,0 +1,67 @@
+// Refuses to run on a Node release below the published `engines.node` floor.
+//
+// npm treats an engines mismatch as a warning, so `npm install -g` and `npx` succeed on
+// old Node. Outfitter's own commands then work, and the process only crashes deep inside
+// the bundled pi once `run` or `setup` spawns it (issue #368). This guard turns that stack
+// trace into a one-line message before any command, including the telemetry notice, runs.
+import { readFileSync } from 'node:fs';
+
+export interface NodeVersionCheck {
+  readonly required: string;
+  readonly current: string;
+  readonly satisfied: boolean;
+}
+
+// Always yields three parts so comparisons never index past the end.
+const parseVersion = (version: string): readonly [number, number, number] => {
+  const [major = 0, minor = 0, patch = 0] = version
+    .replace(/^v/u, '')
+    .split('.')
+    .map((part) => Number.parseInt(part, 10) || 0);
+  return [major, minor, patch];
+};
+
+// `engines.node` is required by OFTR-001.1 to be an unbounded `>=x.y.z` range, so only
+// that shape is supported. Anything else is treated as satisfied rather than blocking.
+const parseMinimum = (range: string): readonly [number, number, number] | undefined => {
+  const match = /^>=\s*v?(\d+\.\d+\.\d+)$/u.exec(range.trim());
+  return match === null ? undefined : parseVersion(match[1]);
+};
+
+export const readRequiredNodeRange = (): string => {
+  const packageJsonPath = new URL('../../package.json', import.meta.url);
+  const manifest = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+    readonly engines: { readonly node: string };
+  };
+  return manifest.engines.node;
+};
+
+export const checkNodeVersion = (current: string, required: string): NodeVersionCheck => {
+  const minimum = parseMinimum(required);
+  if (minimum === undefined) return { required, current, satisfied: true };
+
+  const actual = parseVersion(current);
+  const first = minimum.findIndex((part, index) => part !== actual[index]);
+  const satisfied = first === -1 || actual[first] > minimum[first];
+  return { required, current, satisfied };
+};
+
+export const formatNodeVersionError = (check: NodeVersionCheck): string =>
+  [
+    `Outfitter requires Node ${check.required} but found v${check.current}.`,
+    'Upgrade Node (for example with `nvm install --lts`) and run the command again.',
+  ].join('\n');
+
+/**
+ * Prints the upgrade message and returns false when the running Node is below the
+ * published floor. Callers must not import or spawn pi before this returns true.
+ */
+export const enforceNodeVersion = (
+  current: string = process.versions.node,
+  required: string = readRequiredNodeRange(),
+  writeError: (message: string) => void = console.error,
+): boolean => {
+  const check = checkNodeVersion(current, required);
+  if (!check.satisfied) writeError(formatNodeVersionError(check));
+  return check.satisfied;
+};

--- a/code/cli/tests/unit/node-version-guard.test.ts
+++ b/code/cli/tests/unit/node-version-guard.test.ts
@@ -1,0 +1,73 @@
+// Covers the startup Node-version guard (issue #368): old Node must get a one-line upgrade
+// message instead of the stack trace pi's dependencies throw when spawned.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  checkNodeVersion,
+  enforceNodeVersion,
+  formatNodeVersionError,
+  readRequiredNodeRange,
+} from '../../src/version/NodeVersionGuard.js';
+
+describe('node version guard', () => {
+  it('reads the published engines floor from the package manifest', () => {
+    expect(readRequiredNodeRange()).toBe('>=22.19.0');
+  });
+
+  it.each([
+    ['20.18.1', false],
+    ['21.7.3', false],
+    ['22.9.0', false],
+    ['22.18.9', false],
+    ['22.19.0', true],
+    ['22.20.0', true],
+    ['23.11.1', true],
+    ['24.18.0', true],
+    ['v24.18.0', true],
+    ['22', false],
+    ['23', true],
+    ['22.19', true],
+  ])('compares %s against >=22.19.0 as satisfied=%s', (current, satisfied) => {
+    expect(checkNodeVersion(current, '>=22.19.0').satisfied).toBe(satisfied);
+  });
+
+  it('treats a range it cannot parse as satisfied rather than blocking startup', () => {
+    expect(checkNodeVersion('18.0.0', '^22').satisfied).toBe(true);
+    expect(checkNodeVersion('18.0.0', '').satisfied).toBe(true);
+  });
+
+  it('formats a one-line requirement with the found version and an upgrade hint', () => {
+    const message = formatNodeVersionError(checkNodeVersion('21.7.3', '>=22.19.0'));
+    expect(message).toContain('requires Node >=22.19.0');
+    expect(message).toContain('found v21.7.3');
+    expect(message).toContain('Upgrade Node');
+  });
+
+  it('writes the message and reports failure on old Node', () => {
+    const written: string[] = [];
+    expect(enforceNodeVersion('21.7.3', '>=22.19.0', (message) => written.push(message))).toBe(false);
+    expect(written).toHaveLength(1);
+    expect(written[0]).toContain('found v21.7.3');
+  });
+
+  it('stays silent and reports success on supported Node', () => {
+    const written: string[] = [];
+    expect(enforceNodeVersion('24.18.0', '>=22.19.0', (message) => written.push(message))).toBe(true);
+    expect(written).toHaveLength(0);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('defaults to the running process and the manifest floor', () => {
+    expect(enforceNodeVersion()).toBe(true);
+  });
+
+  it('defaults to console.error for the upgrade message', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    expect(enforceNodeVersion('21.7.3')).toBe(false);
+    expect(error).toHaveBeenCalledOnce();
+    expect(error.mock.calls[0]?.[0]).toContain('found v21.7.3');
+  });
+});


### PR DESCRIPTION
Closes #368.

npm treats an engines mismatch as a warning, so `npx @ai-outfitter/outfitter` and `npm install -g` succeed on old Node. Outfitter's own commands then work, and the process only crashes deep inside the bundled pi's undici (`markAsUncloneable is not a function`) once `run` or `setup` spawns it, after the telemetry notice, with no actionable message.

This adds `NodeVersionGuard`, which compares `process.versions.node` against the published `engines.node` floor read from the package manifest and runs before any command is parsed, so it covers every subcommand and precedes the telemetry notice. On old Node it prints:

```
Outfitter requires Node >=22.19.0 but found v21.7.3.
Upgrade Node (for example with `nvm install --lts`) and run the command again.
```

and exits 1. Verified by running the built `dist/cli.js` with `process.versions.node` overridden to 21.7.3.

The README quick start now states the Node 22.19 floor.

The guard checks a version number only. The real pi launch on supported versions is validated separately by the release validation matrix from #370, which is what catches a pi upgrade that breaks on a supported Node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ro3oEjhxseTLWVhhf1yDhX