### PR TITLE
chore(setup): pin the default catalog to community-profiles v1.9.0

### DIFF
--- a/code/cli/src/setup/DefaultCatalog.ts
+++ b/code/cli/src/setup/DefaultCatalog.ts
@@ -22,7 +22,7 @@ export const defaultCatalogSource = {
   github: 'ai-outfitter/community-profiles',
   // TODO(release-automation): when community-profiles publishes a new Release Please tag, open a
   // conventional dependency-bump commit in Outfitter so its next Release Please release ships it.
-  ref: 'v1.7.0',
+  ref: 'v1.9.0',
 } as const satisfies RemoteSourceReference;
 
 /** Superseded default catalogs; setup replaces their pins instead of keeping them alongside. */

--- a/code/cli/tests/unit/default-catalog.test.ts
+++ b/code/cli/tests/unit/default-catalog.test.ts
@@ -46,7 +46,7 @@ describe('default catalog bootstrap', () => {
   it('ships the canonical catalog at one immutable Release Please tag', () => {
     expect(defaultCatalogSource).toEqual({
       github: 'ai-outfitter/community-profiles',
-      ref: 'v1.7.0',
+      ref: 'v1.9.0',
     });
   });
 

--- a/docs/documentation/local-development.md
+++ b/docs/documentation/local-development.md
@@ -32,7 +32,7 @@ default_agent: founder
 
 sources:
   - github: ai-outfitter/community-profiles
-    ref: 32311cbf9eb17ae812c2ab5e91fa5f34d5946ca6 # v1.7.0
+    ref: 0bea9d16b103972a6612a9542b46f9ee096064cd # v1.9.0
   - path: . # this repository's own resources win last
 ```
 

--- a/docs/documentation/settings.md
+++ b/docs/documentation/settings.md
@@ -28,7 +28,7 @@ isolation: inherit # inherit (default) or isolated; see below. Honored only from
 # Where protocol resources come from, beyond this tree and ~/.agents.
 sources:
   - github: ai-outfitter/community-profiles # owner/repo shorthand
-    ref: v1.7.0 # pin a commit, tag, or branch
+    ref: v1.9.0 # pin a commit, tag, or branch
     # path: optional subdirectory containing the payload
   - uri: git+https://git.example.com/team/agents.git
     ref: v1.2.0


### PR DESCRIPTION
Bumps the pinned default catalog from v1.7.0 to v1.9.0 so the setup screen shows the expanded Engineer and Founder descriptions (ai-outfitter/community-profiles#84). Updates the source constant, its test, and the two docs that quote the pin (`settings.md` tag, `local-development.md` immutable sha `0bea9d1`).

Between the pins the catalog also removed the `resident-engineer` profile, refactored `luce`, and added the software-factory and issue-triage workflow outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ro3oEjhxseTLWVhhf1yDhX