### PR TITLE
feat(bin): add prod-tmp-home to run the published release through first-run

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,7 @@ node_modules
 doc_site/.next
 doc_site/next-env.d.ts
 bin/dev-tmp-home
+bin/prod-tmp-home
 # Nix sources are formatted by nixfmt; Prettier does not infer these extensions.
 flake.nix
 flake.lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,17 @@ bin/dev-tmp-home
 
 This is the safest local smoke test for onboarding and setup changes because it does not write to your real `~/.outfitter` state.
 
+### Run the published release through first-run
+
+Use `bin/prod-tmp-home` to install the latest `@ai-outfitter/outfitter` from npm into a temporary prefix, create a temporary `HOME`, and start `outfitter` with no configuration so the setup walkthrough, the provider step, and the profile relaunch all run as a new user sees them. Everything is removed on exit:
+
+```sh
+bin/prod-tmp-home            # latest
+bin/prod-tmp-home 1.16.0     # a specific version or dist-tag
+```
+
+Pi credentials are not copied by default so the provider step is exercised; set `OUTFITTER_PROD_TMP_HOME_AUTH=1` to copy `~/.pi/agent/auth.json` and skip it.
+
 ### Run setup against a specific source
 
 Use `bin/dev-setup-source` when you intentionally want to preserve the caller's `HOME` and current working directory while running this checkout's build against a real setup source:

--- a/bin/prod-tmp-home
+++ b/bin/prod-tmp-home
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Runs the published Outfitter release through the first-run flow in a throwaway HOME: installs the
+# latest @ai-outfitter/outfitter from npm into a temporary prefix, starts `outfitter` with no
+# configuration so the setup walkthrough, provider step, and profile relaunch all run, then removes
+# everything on exit. Pass a version or dist-tag as the first argument to test something other than
+# `latest`. Existing Pi credentials are not copied, so the provider step is exercised; set
+# OUTFITTER_PROD_TMP_HOME_AUTH=1 to copy ~/.pi/agent/auth.json and skip it.
+set -Eeuo pipefail
+
+PACKAGE="@ai-outfitter/outfitter@${1:-latest}"
+PROD_HOME="$(mktemp -d -t outfitter-prod-home.XXXXXX)"
+
+cleanup() {
+  [[ -n "${PROD_HOME:-}" && -d "$PROD_HOME" ]] && rm -rf -- "$PROD_HOME"
+}
+trap cleanup EXIT
+
+mkdir -p "$PROD_HOME/.pi/agent" "$PROD_HOME/npm"
+
+if [[ "${OUTFITTER_PROD_TMP_HOME_AUTH:-0}" == "1" && -f "${HOME:-}/.pi/agent/auth.json" ]]; then
+  install -m 600 "$HOME/.pi/agent/auth.json" "$PROD_HOME/.pi/agent/auth.json"
+fi
+
+echo "Installing $PACKAGE into $PROD_HOME/npm"
+npm install --prefix "$PROD_HOME/npm" --no-audit --no-fund --loglevel=error "$PACKAGE"
+
+OUTFITTER="$PROD_HOME/npm/node_modules/.bin/outfitter"
+echo "Installed outfitter $("$OUTFITTER" --version)"
+echo "Outfitter prod HOME: $PROD_HOME"
+# No subcommand: the same implicit first-run path a new user hits.
+HOME="$PROD_HOME" "$OUTFITTER"


### PR DESCRIPTION
Companion to `bin/dev-tmp-home` for the published package: installs `@ai-outfitter/outfitter@latest` (or the version/dist-tag given as the first argument) from npm into a temporary prefix, creates a temporary `HOME`, prints the installed version, and starts `outfitter` with no subcommand so the implicit first-run path runs: setup walkthrough, provider step, profile relaunch. Everything is removed on exit.

Pi credentials are not copied by default so the provider step is exercised; `OUTFITTER_PROD_TMP_HOME_AUTH=1` copies `~/.pi/agent/auth.json` to skip it. Documented in CONTRIBUTING and added to `.prettierignore` alongside the dev script.

Verified locally: the install step pulls 1.16.0 from the registry and `outfitter --version` / `--help` run from the temp prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ro3oEjhxseTLWVhhf1yDhX