### PR TITLE
fix(pi): expose selected agent name to provider headers

### DIFF
--- a/code/cli/src/agents/PiCredentialPersistence.ts
+++ b/code/cli/src/agents/PiCredentialPersistence.ts
@@ -5,12 +5,19 @@
 // so the auto sign-in prompt could never converge. To keep provider credentials durable — matching
 // standalone pi and pre-#165 Outfitter — we seed the projection root from pi's persistent agent dir
 // before launch and copy any changes back afterward.
-import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { isDeepStrictEqual } from 'node:util';
 import { join } from 'node:path';
 
 // Files that carry pi credentials and provider/model definitions. Both live in getAgentDir() and
 // must survive across the ephemeral projection root.
 const persistentPiStateFiles = ['auth.json', 'models.json'] as const;
+
+export interface SeededPiCredentials {
+  readonly authJson: string | undefined;
+}
+
+type CredentialMap = Record<string, unknown>;
 
 /** pi's persistent agent directory (`~/.pi/agent`), the durable home for credentials. */
 export const resolvePiUserAgentDirectory = (homeDirectory: string): string => join(homeDirectory, '.pi', 'agent');
@@ -21,13 +28,49 @@ const copyIfPresent = (sourcePath: string, destinationPath: string): void => {
   copyFileSync(sourcePath, destinationPath);
 };
 
+const readIfPresent = (path: string): string | undefined => (existsSync(path) ? readFileSync(path, 'utf8') : undefined);
+
+const parseCredentialMap = (content: string | undefined, path: string): CredentialMap => {
+  if (content === undefined) return {};
+  const parsed: unknown = JSON.parse(content);
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`${path} must contain a JSON object`);
+  }
+  return parsed as CredentialMap;
+};
+
+/** Merge only provider entries changed by this session into the latest durable auth state. */
+const persistPiAuth = (projectionPath: string, durablePath: string, seededContent: string | undefined): void => {
+  const projectionContent = readIfPresent(projectionPath);
+  if (projectionContent === undefined) return;
+
+  const seeded = parseCredentialMap(seededContent, 'seeded auth.json');
+  const projection = parseCredentialMap(projectionContent, projectionPath);
+  const changedProviders = new Set([...Object.keys(seeded), ...Object.keys(projection)]);
+  for (const provider of [...changedProviders]) {
+    if (isDeepStrictEqual(seeded[provider], projection[provider])) changedProviders.delete(provider);
+  }
+  if (changedProviders.size === 0) return;
+
+  const durable = parseCredentialMap(readIfPresent(durablePath), durablePath);
+  for (const provider of changedProviders) {
+    if (Object.hasOwn(projection, provider)) durable[provider] = projection[provider];
+    else delete durable[provider];
+  }
+  mkdirSync(join(durablePath, '..'), { recursive: true });
+  writeFileSync(durablePath, `${JSON.stringify(durable, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+  chmodSync(durablePath, 0o600);
+};
+
 /** Seeds durable state without replacing a models.json already projected from the canonical registry. */
-export const seedPiCredentials = (projectionRoot: string, piUserAgentDirectory: string): void => {
+export const seedPiCredentials = (projectionRoot: string, piUserAgentDirectory: string): SeededPiCredentials => {
+  const authJson = readIfPresent(join(piUserAgentDirectory, 'auth.json'));
   for (const file of persistentPiStateFiles) {
     const destination = join(projectionRoot, file);
     if (file === 'models.json' && existsSync(destination)) continue;
     copyIfPresent(join(piUserAgentDirectory, file), destination);
   }
+  return { authJson };
 };
 
 /** Copies session state back; a catalog-projected models.json is declared config, not user state. */
@@ -35,9 +78,14 @@ export const persistPiCredentials = (
   projectionRoot: string,
   piUserAgentDirectory: string,
   persistModels = true,
+  seeded?: SeededPiCredentials,
 ): void => {
   for (const file of persistentPiStateFiles) {
     if (file === 'models.json' && !persistModels) continue;
+    if (file === 'auth.json' && seeded !== undefined) {
+      persistPiAuth(join(projectionRoot, file), join(piUserAgentDirectory, file), seeded.authJson);
+      continue;
+    }
     copyIfPresent(join(projectionRoot, file), join(piUserAgentDirectory, file));
   }
 };

--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -205,7 +205,8 @@ const launchWithStatePersistence = async (
   const bridgesClaudeState = harness === 'claude' && isolation === 'isolated';
   let seededClaudeCredentialsHash: string | undefined;
   let seededClaudeSessionHashes: ReadonlyMap<string, string> = new Map();
-  if (piUserAgentDirectory !== undefined) seedPiCredentials(rootDirectory, piUserAgentDirectory);
+  const seededPiCredentials =
+    piUserAgentDirectory === undefined ? undefined : seedPiCredentials(rootDirectory, piUserAgentDirectory);
   if (bridgesClaudeState) {
     seededClaudeCredentialsHash = seedClaudeCredentials(rootDirectory, input.homeDirectory, input.projectDirectory);
     attempt('seed Claude session history', () => {
@@ -220,7 +221,7 @@ const launchWithStatePersistence = async (
   } finally {
     if (piUserAgentDirectory !== undefined) {
       attempt('persist Pi credentials', () =>
-        persistPiCredentials(rootDirectory, piUserAgentDirectory, persistPiModels),
+        persistPiCredentials(rootDirectory, piUserAgentDirectory, persistPiModels, seededPiCredentials),
       );
     }
     if (bridgesClaudeState) {

--- a/code/cli/src/projection/ProjectHarness.ts
+++ b/code/cli/src/projection/ProjectHarness.ts
@@ -198,6 +198,9 @@ const claudeArgs = (rootDirectory: string, isolation: Isolation, settingsPath?: 
 const claudeEnv = (rootDirectory: string, isolation: Isolation): Readonly<Record<string, string>> =>
   isolation === 'isolated' ? { CLAUDE_CONFIG_DIR: rootDirectory } : {};
 
+const piAgentEnv = (profileSlug: string | undefined): Readonly<Record<string, string>> =>
+  profileSlug === undefined ? {} : { AGENT_NAME: profileSlug };
+
 /**
  * An inherited Claude run reaches the composition through `--plugin-dir`, which needs the runtime
  * root to declare itself a plugin. Called after materialization so it survives the subagent
@@ -247,6 +250,7 @@ const buildPiOrClaudeLaunchPlan = (
           ...(input.sessionDirectory === undefined ? {} : { [PI_SESSION_DIRECTORY_ENV]: input.sessionDirectory }),
           ...model.env,
           PI_MCP_CONFIG_MODE: 'exclusive',
+          ...piAgentEnv(input.profileSlug),
         }
       : { ...claudeEnv(input.rootDirectory, isolation), ...model.env },
   };

--- a/code/cli/tests/unit/pi-credential-persistence.test.ts
+++ b/code/cli/tests/unit/pi-credential-persistence.test.ts
@@ -66,10 +66,48 @@ describe('pi credential persistence', () => {
     const base = root();
     const userDir = join(base, 'user');
     const projection = join(base, 'projection');
+
+    const seeded = seedPiCredentials(projection, userDir);
     write(join(projection, 'auth.json'), '{"anthropic":"new"}');
 
-    persistPiCredentials(projection, userDir);
-    expect(readFileSync(join(userDir, 'auth.json'), 'utf8')).toBe('{"anthropic":"new"}');
+    persistPiCredentials(projection, userDir, true, seeded);
+    expect(JSON.parse(readFileSync(join(userDir, 'auth.json'), 'utf8'))).toEqual({ anthropic: 'new' });
+  });
+
+  it('does not let an unchanged stale session erase a concurrently added provider', () => {
+    const base = root();
+    const userDir = join(base, 'user');
+    const projection = join(base, 'projection');
+    write(join(userDir, 'auth.json'), '{"openai":{"type":"oauth"}}');
+
+    const seeded = seedPiCredentials(projection, userDir);
+    write(join(userDir, 'auth.json'), '{"openai":{"type":"oauth"},"dgx-spark":{"type":"api_key"}}');
+
+    persistPiCredentials(projection, userDir, true, seeded);
+    expect(JSON.parse(readFileSync(join(userDir, 'auth.json'), 'utf8'))).toEqual({
+      openai: { type: 'oauth' },
+      'dgx-spark': { type: 'api_key' },
+    });
+  });
+
+  it('merges only provider changes made by this session into current durable credentials', () => {
+    const base = root();
+    const userDir = join(base, 'user');
+    const projection = join(base, 'projection');
+    write(join(userDir, 'auth.json'), '{"openai":{"access":"old"},"removed":{"key":"old"}}');
+
+    const seeded = seedPiCredentials(projection, userDir);
+    write(join(projection, 'auth.json'), '{"openai":{"access":"new"}}');
+    write(
+      join(userDir, 'auth.json'),
+      '{"openai":{"access":"old"},"removed":{"key":"old"},"dgx-spark":{"key":"concurrent"}}',
+    );
+
+    persistPiCredentials(projection, userDir, true, seeded);
+    expect(JSON.parse(readFileSync(join(userDir, 'auth.json'), 'utf8'))).toEqual({
+      openai: { access: 'new' },
+      'dgx-spark': { key: 'concurrent' },
+    });
   });
 });
 
@@ -95,9 +133,9 @@ describe('run agent credential write-back', () => {
       launcher,
     });
 
-    expect(readFileSync(join(resolvePiUserAgentDirectory(home), 'auth.json'), 'utf8')).toBe(
-      '{"anthropic":"logged-in"}',
-    );
+    expect(JSON.parse(readFileSync(join(resolvePiUserAgentDirectory(home), 'auth.json'), 'utf8'))).toEqual({
+      anthropic: 'logged-in',
+    });
   });
 
   it('persists an auth.json when the pi launcher throws', async () => {
@@ -119,8 +157,8 @@ describe('run agent credential write-back', () => {
       }),
     ).rejects.toThrow('pi launch failed');
 
-    expect(readFileSync(join(resolvePiUserAgentDirectory(home), 'auth.json'), 'utf8')).toBe(
-      '{"anthropic":"failed-run"}',
-    );
+    expect(JSON.parse(readFileSync(join(resolvePiUserAgentDirectory(home), 'auth.json'), 'utf8'))).toEqual({
+      anthropic: 'failed-run',
+    });
   });
 });

--- a/code/cli/tests/unit/run-agent.test.ts
+++ b/code/cli/tests/unit/run-agent.test.ts
@@ -151,6 +151,20 @@ describe('run agent', () => {
     expect(captured[0].runtimeSettings).toMatchObject({ quietStartup: true });
   });
 
+  it('exports the selected agent slug to Pi as AGENT_NAME', async () => {
+    const { home, project } = tree();
+
+    await executeRunAgentCommand({
+      homeDirectory: home,
+      projectDirectory: project,
+      agent: 'engineer',
+      harness: 'pi',
+      launcher,
+    });
+
+    expect(captured[0].plan.env.AGENT_NAME).toBe('engineer');
+  });
+
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-005.1, OFTR-005.3).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
   it('projects the selected agent-local skill and its packaged files into the harness runtime', async () => {


### PR DESCRIPTION
## Summary

- export the selected agent slug as `AGENT_NAME` for Pi launches
- allow model-provider headers such as `User-Agent: ai-outfitter/${AGENT_NAME}` to resolve normally
- merge Pi auth changes per provider against the session's seeded baseline
- prevent an unchanged stale session from erasing credentials added by another session

## Verification

- focused `run-agent` and `pi-credential-persistence` suites — 30 passed
- live plain `outfitter run researcher -- --print ...` against `dgx-spark/GLM-5.3-Flash-EXL3` — passed before reproducing the stale-session overwrite
- direct gateway request with the Kubernetes-owned token — HTTP 200
- formatting and lint pass
- local full coverage currently reaches 742 passing tests, then hits the unrelated existing `setup.test.ts:907` `EISDIR` failure while reading an extension directory

## Failures fixed

Two independent defects produced misleading Spark authentication errors:

1. Without `AGENT_NAME`, Pi reports `API key auth failed for provider dgx-spark` while resolving an attributed provider header.
2. Outfitter copied the complete projected `auth.json` back on session exit. A session started before a new provider credential was installed could later erase that credential from durable Pi state.

The launch now supplies the selected agent name, and auth persistence applies only provider entries changed relative to that session's seeded state. Concurrently added providers survive stale-session exits.
