### PR TITLE
fix(sync): defer transitive inheritance resolution

### DIFF
--- a/code/cli/src/cli/commands/SyncCommand.ts
+++ b/code/cli/src/cli/commands/SyncCommand.ts
@@ -118,10 +118,13 @@ const validateSourceCheckout = (repositoryPath: string, source: RemoteSourceRefe
     throw new Error(`Configured source path '${source.path}' was not found in the fetched repository.`);
   }
 
-  // A source is validated in isolation here, so an unresolved loadout slug is deferred (a warning,
-  // not a failure): a catalog may reference a skill supplied by a catalog it declares as a transitive
-  // dependency (OFTR-004.6), and loadout wholeness is validated against the merged tree at resolution.
-  const findings = validateEffectiveSet(resolveResources([layer]), undefined, { deferLoadoutResolution: true });
+  // A source is validated in isolation here, so unresolved loadout slugs and inheritance parents
+  // are deferred (warnings, not failures): a catalog may reference resources supplied by a catalog
+  // it declares as a transitive dependency (OFTR-004.6). The merged tree remains authoritative.
+  const findings = validateEffectiveSet(resolveResources([layer]), undefined, {
+    deferLoadoutResolution: true,
+    deferInheritanceResolution: true,
+  });
   const errors = findings.filter((finding) => finding.severity === 'error');
   if (errors.length > 0) {
     throw new Error(

--- a/code/cli/src/resolver/ResolverValidation.ts
+++ b/code/cli/src/resolver/ResolverValidation.ts
@@ -15,15 +15,15 @@ export interface ValidationFinding {
 }
 
 /**
- * Options for {@link validateEffectiveSet}. `deferLoadoutResolution` downgrades an unresolved
- * loadout slug reference from an error to a warning — used when validating a single remote source
- * in isolation during `outfitter sync`, where a catalog may legitimately reference a skill supplied
- * by a catalog it declares as a dependency (OFTR-004.6). Loadout wholeness is then authoritatively
- * enforced against the merged effective set by `outfitter validate`; the run-time composer surfaces
- * an unresolved reference as a non-fatal warning (OFTR-005.3.4), fatal only under `run --strict`.
+ * Options for {@link validateEffectiveSet}. The deferral options downgrade unresolved references
+ * from errors to warnings while validating a single remote source in isolation during
+ * `outfitter sync`, where a catalog may legitimately reference resources supplied by a catalog it
+ * declares as a dependency (OFTR-004.6). Reference wholeness is then authoritatively enforced
+ * against the merged effective set by `outfitter validate`.
  */
 export interface ValidationOptions {
   readonly deferLoadoutResolution?: boolean;
+  readonly deferInheritanceResolution?: boolean;
   /** Validate only these enabled workflow roots and their nested workflow closure. */
   readonly workflowRoots?: readonly string[];
   /** Settings-layer defaults composed into every agent during validation. */
@@ -38,6 +38,18 @@ export interface ValidationOptions {
 // defaults use the same wording with an `agent_defaults` prefix instead of `loadout`.
 const isUnresolvedLoadoutReference = (message: string): boolean =>
   /^(?:loadout|agent_defaults) (?:skills|subagents) references unknown (?:skill|agent) '/.test(message);
+
+// Matches the inheritance resolver's missing-parent error wording (see `resolveInheritanceChain`
+// in Chain.ts). A missing parent is deferrable only for isolated source validation: the source may
+// declare a transitive catalog that supplies it, while cycles and invalid parent definitions remain
+// structural errors.
+const isUnresolvedInheritanceReference = (message: string): boolean =>
+  /^(?:Subagent '[^']+' is invalid: )?Agent inheritance references unknown parent '[^']+' in chain [a-z0-9._-]+(?: -> [a-z0-9._-]+)*\.$/.test(
+    message,
+  );
+
+const compositionErrorSeverity = (message: string, options: ValidationOptions): ValidationFinding['severity'] =>
+  isUnresolvedInheritanceReference(message) && options.deferInheritanceResolution ? 'warning' : 'error';
 
 const compositionWarningSeverity = (message: string, options: ValidationOptions): ValidationFinding['severity'] =>
   isUnresolvedLoadoutReference(message) && !options.deferLoadoutResolution ? 'error' : 'warning';
@@ -68,7 +80,11 @@ const validateAgent = (
     agentDefaults: options.agentDefaults,
   });
   const compositionFindings: ValidationFinding[] = [
-    ...composed.errors.map((message) => ({ severity: 'error' as const, resource: `agent:${agent.slug}`, message })),
+    ...composed.errors.map((message) => ({
+      severity: compositionErrorSeverity(message, options),
+      resource: `agent:${agent.slug}`,
+      message,
+    })),
     ...composed.warnings.map((message) => ({
       severity: compositionWarningSeverity(message, options),
       resource: `agent:${agent.slug}`,
@@ -280,9 +296,11 @@ const validateWorkflowAgentNode = (
     agentDefaults: options.agentDefaults,
   });
   if (composed.plan === undefined) {
-    return composed.errors.map((message) =>
-      workflowError(workflow.id, `node '${node.id}' agent '${actor.profile}': ${message}`),
-    );
+    return composed.errors.map((message) => ({
+      severity: compositionErrorSeverity(message, options),
+      resource: `workflow:${workflow.id}`,
+      message: `node '${node.id}' agent '${actor.profile}': ${message}`,
+    }));
   }
 
   const availableSkills = new Set(composed.plan.loadout.skills.map((skill) => skill.slug));

--- a/code/cli/tests/unit/resolver-validation.test.ts
+++ b/code/cli/tests/unit/resolver-validation.test.ts
@@ -1,5 +1,5 @@
-// Tests loadout-resolution deferral: `outfitter sync` validates a source in isolation and must not
-// fail an unresolved loadout slug (a transitive dependency may supply it), while resolution does.
+// Tests dependency-resolution deferral: `outfitter sync` validates a source in isolation and must
+// not fail references a transitive dependency may supply, while merged resolution still does.
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -27,7 +27,30 @@ const effectiveSet = () => {
   temporaryRoots.push(root);
   const project = join(root, 'project');
   write(join(project, '.agents', 'agents', 'engineer', 'agent.md'), agentMd('engineer', 'skills: [from-dependency]\n'));
+  write(join(project, '.agents', 'agents', 'child', 'agent.md'), agentMd('child', 'inherits: dependency-parent\n'));
+  write(join(project, '.agents', 'agents', 'leader', 'agent.md'), agentMd('leader', 'subagents: [delegate]\n'));
+  write(
+    join(project, '.agents', 'agents', 'delegate', 'agent.md'),
+    agentMd('delegate', 'inherits: dependency-parent\n'),
+  );
+  write(join(project, '.agents', 'agents', 'cycle-a', 'agent.md'), agentMd('cycle-a', 'inherits: cycle-b\n'));
+  write(join(project, '.agents', 'agents', 'cycle-b', 'agent.md'), agentMd('cycle-b', 'inherits: cycle-a\n'));
   write(join(project, '.agents', 'agents', 'mislabeled', 'agent.md'), agentMd('other'));
+  write(
+    join(project, '.agents', 'workflows', 'inheritance', 'workflow.yaml'),
+    `version: 1
+id: inheritance
+title: Inheritance
+description: Exercise an inherited workflow actor.
+actors:
+  child: {kind: agent, profile: child}
+nodes:
+  - id: run
+    action: review
+    description: Run the child agent.
+    actor: child
+`,
+  );
   return resolveResources(
     discoverLayers({ homeDirectory: join(root, 'home'), projectDirectory: project, settings: {} }).layers,
   );
@@ -35,6 +58,25 @@ const effectiveSet = () => {
 
 const engineerLoadout = (findings: ReturnType<typeof validateEffectiveSet>) =>
   findings.filter((f) => f.resource === 'agent:engineer' && f.message.includes("unknown skill 'from-dependency'"));
+
+const childInheritance = (findings: ReturnType<typeof validateEffectiveSet>) =>
+  findings.filter(
+    (finding) => finding.resource === 'agent:child' && finding.message.includes("unknown parent 'dependency-parent'"),
+  );
+
+const leaderSubagentInheritance = (findings: ReturnType<typeof validateEffectiveSet>) =>
+  findings.filter(
+    (finding) =>
+      finding.resource === 'agent:leader' &&
+      finding.message.includes("Subagent 'delegate' is invalid: Agent inheritance references unknown parent"),
+  );
+
+const workflowActorInheritance = (findings: ReturnType<typeof validateEffectiveSet>) =>
+  findings.filter(
+    (finding) =>
+      finding.resource === 'workflow:inheritance' &&
+      finding.message.includes("node 'run' agent 'child': Agent inheritance references unknown parent"),
+  );
 
 afterEach(() => {
   for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true });
@@ -61,6 +103,34 @@ describe('loadout resolution deferral', () => {
       findings.some(
         (f) =>
           f.resource === 'agent:mislabeled' && f.severity === 'error' && f.message.includes('must match its directory'),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('inheritance resolution deferral', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.11).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('treats an unresolved inheritance parent as an error by default (merged resolution)', () => {
+    const findings = validateEffectiveSet(effectiveSet());
+    expect(childInheritance(findings)).toEqual([expect.objectContaining({ severity: 'error' })]);
+    expect(workflowActorInheritance(findings)).toEqual([expect.objectContaining({ severity: 'error' })]);
+  });
+
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.11).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('defers an unresolved inheritance parent while preserving structural inheritance errors', () => {
+    const findings = validateEffectiveSet(effectiveSet(), undefined, { deferInheritanceResolution: true });
+
+    expect(childInheritance(findings)).toEqual([expect.objectContaining({ severity: 'warning' })]);
+    expect(leaderSubagentInheritance(findings)).toEqual([expect.objectContaining({ severity: 'warning' })]);
+    expect(workflowActorInheritance(findings)).toEqual([expect.objectContaining({ severity: 'warning' })]);
+    expect(
+      findings.some(
+        (finding) =>
+          finding.resource === 'agent:cycle-a' &&
+          finding.severity === 'error' &&
+          finding.message.includes('inheritance cycle'),
       ),
     ).toBe(true);
   });

--- a/code/cli/tests/unit/sync-inheritance-deferral.test.ts
+++ b/code/cli/tests/unit/sync-inheritance-deferral.test.ts
@@ -1,0 +1,98 @@
+// Guards the sync wiring for OFTR-004.6.11: isolated validation must defer an inheritance parent
+// that a catalog's transitive dependency supplies, then sync must discover and fetch that catalog.
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { executeSyncCommand } from '../../src/cli/commands/SyncCommand.js';
+import { compose } from '../../src/composer/Composer.js';
+import { discoverLayers } from '../../src/resolver/Layer.js';
+import { resolveResources } from '../../src/resolver/Resolver.js';
+import { validateEffectiveSet } from '../../src/resolver/ResolverValidation.js';
+import { discoverSettingsLoadPlan, loadSettings } from '../../src/settings/SettingsLoader.js';
+import { syncRemoteRepositoryAtomically } from '../../src/sources/GitRepository.js';
+
+const temporaryRoots: string[] = [];
+
+const git = (args: readonly string[]): string =>
+  execFileSync('git', [...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+
+const write = (path: string, content: string): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+};
+
+const createRepository = (files: Readonly<Record<string, string>>, tag?: string): string => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-inheritance-deferral-'));
+  temporaryRoots.push(root);
+  git(['init', '--quiet', root]);
+  git(['-C', root, 'config', 'user.name', 'Outfitter Tests']);
+  git(['-C', root, 'config', 'user.email', 'tests@outfitter.dev']);
+  git(['-C', root, 'config', 'commit.gpgsign', 'false']);
+  git(['-C', root, 'config', 'tag.gpgsign', 'false']);
+  for (const [path, content] of Object.entries(files)) write(join(root, path), content);
+  git(['-C', root, 'add', '.']);
+  git(['-C', root, 'commit', '--quiet', '-m', 'init']);
+  if (tag !== undefined) git(['-C', root, 'tag', tag]);
+  return root;
+};
+
+const githubFixtureSync =
+  (fixtures: Readonly<Record<string, string>>): typeof syncRemoteRepositoryAtomically =>
+  (input) => {
+    if (input.source.github === undefined) return syncRemoteRepositoryAtomically(input);
+    const local = fixtures[input.source.github];
+    if (local === undefined) throw new Error(`no fixture for github:${input.source.github}`);
+    return syncRemoteRepositoryAtomically({ ...input, source: { uri: local, ref: input.source.ref } });
+  };
+
+afterEach(() => {
+  process.exitCode = undefined;
+  for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('sync inheritance-resolution deferral', () => {
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.6.11).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('syncs a source whose agent inherits a parent supplied by its declared dependency', () => {
+    const root = mkdtempSync(join(tmpdir(), 'outfitter-inheritance-deferral-home-'));
+    temporaryRoots.push(root);
+    const home = join(root, 'home');
+    const dependency = createRepository(
+      { 'agents/base/agent.md': '---\nname: base\ndescription: Base.\n---\n\n# Base\n' },
+      'v1.0.0',
+    );
+    const top = createRepository({
+      'agents/child/agent.md': '---\nname: child\ndescription: Child.\ninherits: base\n---\n\n# Child\n',
+      'settings.yml': 'sources:\n  - github: ai-outfitter/community-profiles\n    ref: v1.0.0\n',
+    });
+    write(join(home, '.agents', 'settings.yml'), `sources:\n  - uri: ${JSON.stringify(top)}\n`);
+
+    const result = executeSyncCommand(
+      { homeDirectory: home, projectDirectory: join(root, 'project') },
+      {
+        classifier: { classify: () => 'public' },
+        syncRepository: githubFixtureSync({ 'ai-outfitter/community-profiles': dependency }),
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.results.map(({ kind, status }) => ({ kind, status }))).toEqual([
+      { kind: 'source', status: 'updated' },
+      { kind: 'transitive', status: 'updated' },
+    ]);
+    expect(result.messages.join('\n')).toContain('validated with 1 warning(s)');
+
+    // Resolution after sync uses both cached catalogs. The dependency must do more than fetch: it
+    // must satisfy `child`'s parent and participate in the authoritative merged composition.
+    const projectDirectory = join(root, 'project');
+    const settings = loadSettings(discoverSettingsLoadPlan({ homeDirectory: home, projectDirectory })).settings;
+    const layers = discoverLayers({ homeDirectory: home, projectDirectory, settings }).layers;
+    const merged = resolveResources(layers);
+    expect(validateEffectiveSet(merged).filter((finding) => finding.message.includes('unknown parent'))).toEqual([]);
+    expect(compose(merged, 'child').plan?.inheritanceChain).toEqual(['base', 'child']);
+  });
+});

--- a/docs/requirements/OFTR-004-sync-and-setup.md
+++ b/docs/requirements/OFTR-004-sync-and-setup.md
@@ -166,12 +166,12 @@ bootstrap is the one gate exemption — see OFTR-004.6.10.)
     bootstrap MAY fetch its declared closure without the interactive private-catalog gate that
     `outfitter sync` applies; the gate remains a property of `sync`, not of first-party bootstrap.
 11. When `sync` validates a single fetched source in isolation, an unresolved loadout **skill or
-    agent** reference MUST NOT fail that source, because the referenced skill or agent may be
-    supplied by a catalog the source declares as a transitive dependency. Structural validity of the
-    source (schema, resource naming) MUST still be enforced. Whether every loadout skill/agent slug
-    resolves is authoritatively enforced against the merged effective set by `outfitter validate`,
-    which MUST treat an unresolved loadout skill or agent reference as an error. (This concerns only
-    skill and agent loadout slugs; an unknown MCP server reference remains a warning, unchanged.)
+    agent** reference or unresolved agent inheritance parent MUST NOT fail that source, because the
+    referenced resource may be supplied by a catalog the source declares as a transitive dependency.
+    Structural validity of the source (schema, resource naming, and inheritance cycles) MUST still be
+    enforced. Whether every loadout skill/agent slug and inheritance parent resolves is authoritatively
+    enforced against the merged effective set by `outfitter validate`, which MUST treat any such
+    unresolved reference as an error. (An unknown MCP server reference remains a warning, unchanged.)
     Consistent with OFTR-005.3.4, the run-time composer surfaces an unresolved loadout reference as a
     non-fatal warning (fatal only under `outfitter run --strict`); `outfitter validate` is the
     command that fails on it.


### PR DESCRIPTION
Fixes #393.

## Summary

- defer unresolved inherited parents while validating an individual catalog source during sync
- retain fatal validation for inheritance cycles, malformed inheritance, unrelated composition errors, and unresolved parents in the final merged catalog
- cover direct agents, subagents, workflow actors, transitive fetching, and final `base -> child` composition
- extend OFTR-004.6.11 with the transitive inheritance contract

## Verification

- focused resolver/sync tests: 7/7 pass
- ESLint: pass
- Prettier: pass
- two independent read-only review lanes: approve
- `npm run check-ci`: formatting and lint pass; 746/747 tests pass. The sole failure is the pre-existing `tests/unit/setup.test.ts` EISDIR failure also observed before this change.
