### PR TITLE
fix(pi): isolate runtime resource discovery

### DIFF
--- a/code/cli/src/projection/ProjectHarness.ts
+++ b/code/cli/src/projection/ProjectHarness.ts
@@ -218,7 +218,12 @@ const buildPiOrClaudeLaunchPlan = (
 ): AgentLaunchPlan => {
   const isPi = input.harness === 'pi';
   const isolation = resolveProjectionIsolation(input);
-  const skillArgs = isPi ? materialized.skillDirectories.flatMap((dir) => ['--skill', dir]) : [];
+  // Pi's `--skill` value is a filesystem path, not a discovered-skill slug. Use the materialized
+  // paths explicitly and suppress implicit discovery: otherwise Pi also sees a project source copy
+  // or rediscovers the runtime copy and reports a false collision for the selected skill.
+  const skillArgs = isPi
+    ? ['--no-skills', ...materialized.skillDirectories.flatMap((directory) => ['--skill', directory])]
+    : [];
   const extensionArgs = isPi ? (input.extensionLoadDirs ?? []).flatMap((dir) => ['--extension', dir]) : [];
 
   return {

--- a/code/cli/src/resolver/Layer.ts
+++ b/code/cli/src/resolver/Layer.ts
@@ -1,5 +1,5 @@
 // Builds the ordered `.agents` layer stack (workspace over global over remote sources) from settings.
-import { existsSync } from 'node:fs';
+import { existsSync, realpathSync } from 'node:fs';
 import { join } from 'node:path';
 
 import {
@@ -114,8 +114,21 @@ export const discoverLayers = (input: LayerDiscoveryInput): LayerDiscoveryResult
     appendSourceLayer(transitive.source);
   }
 
+  // One physical `.agents` tree can be reachable through more than one precedence slot. The
+  // common case is running from $HOME, where workspace and global are identical; symlinked local
+  // sources can produce the same condition. Keep the first (highest-precedence) layer only so it
+  // cannot shadow itself and emit false ambiguity diagnostics.
+  const seenRoots = new Set<string>();
+  const layers = candidates.filter((layer) => {
+    if (!existsSync(layer.root)) return false;
+    const canonicalRoot = realpathSync(layer.root);
+    if (seenRoots.has(canonicalRoot)) return false;
+    seenRoots.add(canonicalRoot);
+    return true;
+  });
+
   return {
-    layers: candidates.filter((layer) => existsSync(layer.root)),
+    layers,
     transitiveDeclarations: expansion.declarations,
     unsynchronized,
     warnings: [...invalid, ...expansion.warnings],

--- a/code/cli/tests/unit/layer-deduplication.test.ts
+++ b/code/cli/tests/unit/layer-deduplication.test.ts
@@ -1,0 +1,36 @@
+// Tests that one physical resource tree cannot shadow itself through multiple layer paths.
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { expect, it } from 'vitest';
+
+import { discoverLayers } from '../../src/resolver/Layer.js';
+
+// THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.3).
+// YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+it('includes one layer when workspace and global resolve to the same physical root', () => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-layer-deduplication-'));
+  try {
+    const home = join(root, 'home');
+    const projectAlias = join(root, 'project-alias');
+    mkdirSync(join(home, '.agents'), { recursive: true });
+    symlinkSync(home, projectAlias, 'dir');
+
+    const discovered = discoverLayers({
+      homeDirectory: home,
+      projectDirectory: projectAlias,
+      settings: {},
+    });
+
+    expect(discovered.layers).toEqual([
+      {
+        root: join(projectAlias, '.agents'),
+        origin: 'workspace',
+        label: 'workspace',
+      },
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/code/cli/tests/unit/pi-skill-isolation.test.ts
+++ b/code/cli/tests/unit/pi-skill-isolation.test.ts
@@ -1,0 +1,44 @@
+// Tests that managed Pi skill isolation preserves caller-supplied explicit skill paths.
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { expect, it } from 'vitest';
+
+import type { CompositionPlan } from '../../src/composer/Composition.js';
+import { projectComposition } from '../../src/projection/ProjectHarness.js';
+
+const emptyPlan: CompositionPlan = {
+  agent: 'engineer',
+  identity: { agentBody: 'Body.' },
+  loadout: {
+    skills: [],
+    delegateSkills: [],
+    subagents: [],
+    mcp: [],
+    mcpServers: {},
+    extensions: [],
+    plugins: [],
+  },
+  warnings: [],
+};
+
+// THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.3.12).
+// YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+it('keeps explicit pass-through skills after disabling implicit discovery', () => {
+  const root = mkdtempSync(join(tmpdir(), 'outfitter-pi-skill-isolation-'));
+  try {
+    const explicitSkill = '/opt/skills/local-review';
+    const projection = projectComposition(emptyPlan, {
+      harness: 'pi',
+      rootDirectory: root,
+      homeDirectory: root,
+      passThroughArgs: ['--skill', explicitSkill],
+    });
+
+    expect(projection.launch.args).toContain('--no-skills');
+    expect(projection.launch.args.slice(-2)).toEqual(['--skill', explicitSkill]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/code/cli/tests/unit/run-agent.test.ts
+++ b/code/cli/tests/unit/run-agent.test.ts
@@ -117,6 +117,7 @@ describe('run agent', () => {
       expect.arrayContaining([
         '--system-prompt',
         '--append-system-prompt',
+        '--no-skills',
         '--skill',
         join(launch.runtimeDir, 'skills', 'wiki'), // pi's --skill takes a path, not a slug
         '--model',

--- a/docs/requirements/OFTR-003-profiles.md
+++ b/docs/requirements/OFTR-003-profiles.md
@@ -33,6 +33,7 @@ Outfitter resolves agents and other resources from layered `.agents` trees into 
 1. Outfitter MUST resolve resources from layered `.agents` trees ordered highest precedence first: workspace `<project>/.agents`, then global `~/.agents`, then configured `sources` in order.
 2. Only layers whose payload root exists on disk are included.
 3. A local `path` source's payload root is the directory itself; a remote source's root is its synced cache directory plus any configured subpath.
+4. If multiple precedence slots resolve to the same physical payload root, Outfitter MUST include that root once at its highest-precedence position.
 
 ### OFTR-003.4: Merge by ID
 

--- a/docs/requirements/OFTR-006-agent-adapters.md
+++ b/docs/requirements/OFTR-006-agent-adapters.md
@@ -34,6 +34,11 @@ Amended (2026-07-17, RFC #165): adapters project a harness-neutral composition, 
 
 ### OFTR-006.3: Pi Launch Controls
 
+Amendment (2026-09-04): statement 12 now requires explicit materialized paths and disables implicit
+skill discovery. Pi treats a bare slug as a path relative to the launch working directory, producing
+a false missing-path diagnostic; leaving discovery enabled can also rediscover the materialized or
+project source copy and produce a false collision diagnostic.
+
 1. The pi adapter MUST use `PI_CODING_AGENT_DIR` as the primary profile-scoped pi configuration boundary.
 2. The pi adapter MUST support profile-controlled environment variables.
 3. The pi adapter MUST support profile-controlled pi CLI arguments.
@@ -45,7 +50,7 @@ Amended (2026-07-17, RFC #165): adapters project a harness-neutral composition, 
 9. The pi adapter SHOULD support pi model, provider, and thinking controls where native pi flags exist.
 10. The pi adapter MUST merge `.mcp.json` files from contributing `cli_specific/pi/` profile folders into the composite profile, adding unique array entries by identity while keeping the last entry for duplicate identities.
 11. The pi adapter MUST make native Pi `models.json` available inside the composite profile so custom providers and model definitions are visible before Pi resolves `--provider` and `--model` flags.
-12. The pi adapter MUST expose valid Agent Skills from contributing profile `skills/` folders as `--skill` arguments, and MAY also expose Pi-specific skills from `cli_specific/pi/skills/`.
+12. The pi adapter MUST disable implicit Pi skill discovery and expose valid Agent Skills from contributing profile `skills/` folders as `--skill` arguments whose values are the absolute materialized skill directories under `PI_CODING_AGENT_DIR`, and MAY also expose Pi-specific skills from `cli_specific/pi/skills/`. Explicit pass-through `--skill` arguments MUST remain usable.
 13. The pi adapter MUST expose DeepWork jobs from contributing profile `deepwork/jobs/` folders through `DEEPWORK_ADDITIONAL_JOBS_FOLDERS`, and MAY also expose Pi-specific jobs from `cli_specific/pi/deepwork/jobs/`.
 14. The pi adapter MUST resolve `controls.deepwork.jobs` entries as DeepWork job names from shared Outfitter job roots such as `.outfitter/deepwork/jobs/<job-name>/job.yml` and expose the matching jobs root through `DEEPWORK_ADDITIONAL_JOBS_FOLDERS`.
 15. The pi adapter MUST NOT treat flat profile source roots as profile-bundled job folders unless a named DeepWork job resolves to a shared jobs root.


### PR DESCRIPTION
## What changed

- load Pi skills only from Outfitter's materialized projection
- pass projected skill directories explicitly and disable Pi's ambient skill discovery
- canonicalize physical resource roots so a symlinked workspace/global `.agents` directory is included once
- add focused regressions for both isolation boundaries

## Why

`outfitter run` could let Pi rediscover the user's ambient `~/.agents/skills`, producing duplicate skill collisions even though Outfitter had already composed the intended loadout. When invoked from the home directory, the workspace and user layers could also resolve to the same physical `.agents` tree and report self-shadowing collisions.

This rebases the Pi skill-isolation work from #365 onto current `main` and pairs it with the resolver fix required for the reported live startup path. It intentionally excludes the agent-name and hosted-GitHub authentication work already under review in #391.

## Validation

- `OUTFITTER_SYSTEM_DIR=/tmp/outfitter-empty-system-hooks npm run check-ci`
- 69 test files passed; 749 tests passed
- statements 99.25%, branches 98.04%, functions 99.17%, lines 99.5%
- live `outfitter run luce` startup no longer reports skill collisions and connects the configured MCP server
