### PR TITLE
fix: preserve deterministic shadowing under strict mode

### DIFF
--- a/code/cli/src/cli/commands/DumpCommand.ts
+++ b/code/cli/src/cli/commands/DumpCommand.ts
@@ -1,10 +1,11 @@
 // Provides `outfitter dump --agent <id> --out <dir>` over the effective resource set.
 
+import { rmSync } from 'node:fs';
+import { join } from 'node:path';
 import { Command } from 'commander';
 
 import { dumpAgent } from '../../dump/Dump.js';
 import { dumpWorkflow } from '../../dump/WorkflowDump.js';
-import { strictAmbiguityFailureMessage } from '../../resolver/AmbiguityWarnings.js';
 import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
 import type { Settings } from '../../settings/Settings.js';
 import type { CommandObject } from './CommandObject.js';
@@ -58,7 +59,7 @@ const assertExclusiveSelection = (input: DumpInput): void => {
 };
 
 export const executeDumpCommand = (input: DumpInput): DumpCommandResult => {
-  const { set, settings, settingsIssues, warnings, ambiguityWarnings } = resolveEffectiveSet(input);
+  const { set, settings, settingsIssues, warnings } = resolveEffectiveSet(input);
 
   if (settingsIssues.length > 0) {
     throw new Error(`Cannot dump with invalid settings: ${settingsIssues.map((issue) => issue.message).join('; ')}`);
@@ -69,14 +70,6 @@ export const executeDumpCommand = (input: DumpInput): DumpCommandResult => {
   assertExclusiveSelection(input);
   if (input.workflow !== undefined && !settings.workflows!.includes(input.workflow))
     return disabledWorkflowResult(input.workflow, syncWarnings);
-
-  if (input.strict === true && ambiguityWarnings.length > 0) {
-    return {
-      writtenPaths: [],
-      messages: [...syncWarnings, `error: ${strictAmbiguityFailureMessage}`],
-      ok: false,
-    };
-  }
 
   const selected = input.workflow ?? resolveAgentSlug(settings, input.agent);
   const result =
@@ -90,6 +83,15 @@ export const executeDumpCommand = (input: DumpInput): DumpCommandResult => {
           settings.agentDefaults,
           settings.harnessDefaults,
         );
+  const strictFailure = input.strict === true && result.errors.length === 0 && result.warnings.length > 0;
+  if (strictFailure) {
+    rmSync(join(input.out, '.agents'), { recursive: true, force: true });
+    return {
+      writtenPaths: [],
+      messages: [...syncWarnings, ...result.warnings, 'error: Strict mode: composition warnings are fatal.'],
+      ok: false,
+    };
+  }
   const ok = result.errors.length === 0;
   const messages = ok
     ? [
@@ -112,7 +114,7 @@ export const createDumpCommand = (dependencies: DumpCommandDependencies = {}): C
         .option('--agent <id>', 'Agent slug to dump (default: settings default_agent).')
         .option('--workflow <id>', 'Workflow slug whose complete non-executable closure should be dumped.')
         .option('--out <dir>', 'Output directory.', './outfitter-dump')
-        .option('--strict', 'Treat ambiguous source resolution as fatal.')
+        .option('--strict', 'Reject incomplete or unsupported requested composition.')
         .action((options: { agent?: string; workflow?: string; out: string; strict?: boolean }) => {
           const result = executeDumpCommand({
             /* v8 ignore next 2 -- process defaults are exercised by the CLI entrypoint, not unit tests. */

--- a/code/cli/src/cli/commands/LinkCommand.ts
+++ b/code/cli/src/cli/commands/LinkCommand.ts
@@ -9,7 +9,6 @@ import type { HarnessCommandRunner, LinkAction } from '../../links/HarnessLinkAp
 import { composeLinkClosure, planHarnessLinks, resolveLinkScope } from '../../links/HarnessLinkPlan.js';
 import type { LinkClosure } from '../../links/HarnessLinkPlan.js';
 import type { HarnessDefaults } from '../../settings/Settings.js';
-import { strictAmbiguityFailureMessage } from '../../resolver/AmbiguityWarnings.js';
 import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
 import { formatSettingsIssue } from '../../settings/SettingsLoader.js';
 import type { CommandObject } from './CommandObject.js';
@@ -93,15 +92,11 @@ interface ResolvedClosure {
 }
 
 const resolveClosure = (input: LinkInput, messages: string[]): ResolvedClosure => {
-  const { set, settings, settingsIssues, warnings, ambiguityWarnings } = resolveEffectiveSet(input);
+  const { set, settings, settingsIssues, warnings } = resolveEffectiveSet(input);
   if (settingsIssues.length > 0) {
     throw new Error(`Cannot link with invalid settings: ${settingsIssues.map(formatSettingsIssue).join('; ')}`);
   }
   messages.push(...warnings.map((warning) => `warning: ${warning}`));
-  if (input.strict === true && ambiguityWarnings.length > 0) {
-    return { failure: failure([...messages, `error: ${strictAmbiguityFailureMessage}`]) };
-  }
-
   const scope = resolveLinkScope(set, settings, {
     agents: input.agents,
     workflows: input.workflows,
@@ -181,7 +176,7 @@ export const createLinkCommand = (dependencies: LinkCommandDependencies = {}): C
         .option('--all', 'Link every resolvable agent, skill, and command.')
         .option('--dry-run', 'Report what would change without touching the harness home.')
         .option('--remove', 'Remove every link this command created and forget them.')
-        .option('--strict', 'Exit non-zero on warnings, conflicts, or skipped entries.')
+        .option('--strict', 'Exit non-zero on non-advisory warnings, conflicts, or skipped entries.')
         .action((options: LinkOptions) => {
           const result = executeLinkCommand(
             {

--- a/code/cli/src/cli/commands/ListCommand.ts
+++ b/code/cli/src/cli/commands/ListCommand.ts
@@ -2,7 +2,6 @@
 
 import { Command } from 'commander';
 
-import { strictAmbiguityFailureMessage } from '../../resolver/AmbiguityWarnings.js';
 import type { EffectiveResourceSet, ResourceKind } from '../../resolver/Resource.js';
 import {
   agentLocalKinds,
@@ -129,7 +128,7 @@ const listEntry = (
 };
 
 export const executeListCommand = (input: ListInput): ListResult => {
-  const { set, settings, settingsIssues, warnings, ambiguityWarnings } = resolveEffectiveSet(input);
+  const { set, settings, settingsIssues, warnings } = resolveEffectiveSet(input);
 
   if (settingsIssues.length > 0) {
     const detail = settingsIssues.map(formatSettingsIssue).join('; ');
@@ -137,10 +136,6 @@ export const executeListCommand = (input: ListInput): ListResult => {
   }
 
   const messages: string[] = warnings.map((warning) => `warning: ${warning}`);
-
-  if (input.strict === true && ambiguityWarnings.length > 0) {
-    return { exitCode: 1, messages: [...messages, `error: ${strictAmbiguityFailureMessage}`], resources: [] };
-  }
 
   assertKnownAgent(set, input.agent);
   const entries: ListResourceEntry[] = [];
@@ -185,7 +180,7 @@ export const createListCommand = (dependencies: ListCommandDependencies = {}): C
       new Command('list')
         .description('List resolvable resources (agents, skills, knowledge, commands, workflows).')
         .argument('[kind]', 'Restrict to one kind: agents, skills, knowledge, commands, or workflows.')
-        .option('--strict', 'Treat ambiguous source resolution as fatal.')
+        .option('--strict', 'Reject incomplete or unsupported requested composition.')
         .option('--json', 'Emit stable machine-readable JSON with resource provenance.')
         .option(
           '--agent <id>',

--- a/code/cli/src/cli/commands/RunAgentCommand.ts
+++ b/code/cli/src/cli/commands/RunAgentCommand.ts
@@ -27,7 +27,6 @@ import type { PiInstallSpawner } from '../../extensions/PiExtensionCache.js';
 import { resolveOutfitterCacheDir } from '../../paths/OutfitterCache.js';
 import { projectComposition } from '../../projection/ProjectHarness.js';
 import type { AgentLaunchPlan } from '../../projection/Projection.js';
-import { strictAmbiguityFailureMessage } from '../../resolver/AmbiguityWarnings.js';
 import { findResource } from '../../resolver/Resource.js';
 import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
 import type { Harness, Isolation, Settings, SourceCachePolicy } from '../../settings/Settings.js';
@@ -384,12 +383,6 @@ export const executeRunAgentCommand = async (input: RunAgentInput): Promise<RunA
   // only to turn an unavailable selected agent into a concise synchronization action.
   const resolutionWarnings = resolutionWarningsForRun(resolved, input.strict);
 
-  if (input.strict === true && resolved.ambiguityWarnings.length > 0) {
-    const messages = [...resolutionWarnings, strictAmbiguityFailureMessage];
-    emit(messages);
-    return { exitCode: 1, messages };
-  }
-
   const { set, settings } = resolved;
   const agentSlug = resolveAgentSlug(settings.defaultAgent, input.agent);
   const harness = resolveHarness(settings.defaultHarness, input.harness);
@@ -506,7 +499,7 @@ export const createRunAgentCommand = (dependencies: RunAgentDependencies = {}): 
           .default('info')
           .env('OUTFITTER_LOG_LEVEL'),
       )
-      .option('--strict', 'Treat ambiguity, composition warnings, and unsupported loadout elements as fatal.')
+      .option('--strict', 'Treat composition warnings and unsupported loadout elements as fatal.')
       .addOption(
         new Option('--source-cache-policy <policy>', 'Remote source cache startup policy.').choices([
           ...SOURCE_CACHE_POLICIES,

--- a/code/cli/src/cli/commands/SyncCommand.ts
+++ b/code/cli/src/cli/commands/SyncCommand.ts
@@ -3,7 +3,6 @@ import { existsSync } from 'node:fs';
 
 import { Command } from 'commander';
 
-import { strictAmbiguityFailureMessage } from '../../resolver/AmbiguityWarnings.js';
 import { remoteSourceLayer } from '../../resolver/Layer.js';
 import { resolveResources } from '../../resolver/Resolver.js';
 import { resolveEffectiveSet } from '../../resolver/ResolverContext.js';
@@ -366,15 +365,9 @@ export const executeSyncCommand = (
   });
   const result = finishSync(merged.issues, remoteSettingsPhase, sourcePhase, transitiveClosure);
   const ambiguityWarnings = resolveEffectiveSet(input).ambiguityWarnings;
-  const strictFailure = input.strict === true && ambiguityWarnings.length > 0;
   return {
     ...result,
-    exitCode: strictFailure ? 1 : result.exitCode,
-    messages: [
-      ...result.messages,
-      ...ambiguityWarnings.map((warning) => `warning: ${warning}`),
-      ...(strictFailure ? [`failed: ${strictAmbiguityFailureMessage}`] : []),
-    ],
+    messages: [...result.messages, ...ambiguityWarnings.map((warning) => `warning: ${warning}`)],
   };
 };
 
@@ -385,7 +378,7 @@ export const createSyncCommand = (dependencies: SyncCommandDependencies = {}): C
     program.addCommand(
       new Command('sync')
         .description('Synchronize configured remote settings and sources into the local cache.')
-        .option('--strict', 'Treat ambiguous source resolution as fatal.')
+        .option('--strict', 'Reject incomplete or unsupported requested composition.')
         .action((options: { strict?: boolean }) => {
           const result = executeSyncCommand(
             {

--- a/code/cli/src/cli/commands/ValidateCommand.ts
+++ b/code/cli/src/cli/commands/ValidateCommand.ts
@@ -31,11 +31,24 @@ export interface ValidateCommandDependencies {
 const settingsFindings = (messages: readonly string[]): readonly ValidationFinding[] =>
   messages.map((message) => ({ severity: 'error' as const, resource: 'settings', message }));
 
+const warningFindings = (
+  messages: readonly string[],
+  ambiguityWarnings: readonly string[],
+): readonly ValidationFinding[] => {
+  const advisory = new Set(ambiguityWarnings);
+  return messages.map((message) => ({
+    severity: 'warning' as const,
+    resource: 'settings',
+    message,
+    advisory: advisory.has(message),
+  }));
+};
+
 export const executeValidateCommand = (input: ValidateInput): ValidateResult => {
-  const { set, settings, settingsIssues, warnings } = resolveEffectiveSet(input);
+  const { set, settings, settingsIssues, warnings, ambiguityWarnings } = resolveEffectiveSet(input);
   const findings = [
     ...settingsFindings(settingsIssues.map(formatSettingsIssue)),
-    ...warnings.map((message) => ({ severity: 'warning' as const, resource: 'settings', message })),
+    ...warningFindings(warnings, ambiguityWarnings),
     ...validateEffectiveSet(set, input.projectDirectory, {
       workflowRoots: settings.workflows,
       agentDefaults: settings.agentDefaults,
@@ -43,7 +56,7 @@ export const executeValidateCommand = (input: ValidateInput): ValidateResult => 
   ];
 
   const hasErrors = findings.some((finding) => finding.severity === 'error');
-  const hasWarnings = findings.some((finding) => finding.severity === 'warning');
+  const hasWarnings = findings.some((finding) => finding.severity === 'warning' && finding.advisory !== true);
   const ok = !hasErrors && !(input.strict === true && hasWarnings);
 
   const messages = input.json === true ? [JSON.stringify({ ok, findings }, null, 2)] : formatFindings(findings, ok);
@@ -70,7 +83,7 @@ export const createValidateCommand = (dependencies: ValidateCommandDependencies 
     program.addCommand(
       new Command('validate')
         .description('Validate the resolved .agents tree: schemas, loadout slugs, and shadowing.')
-        .option('--strict', 'Treat warnings, including ambiguous source resolution, as failures.')
+        .option('--strict', 'Treat incomplete or unsupported composition warnings as failures.')
         .option('--json', 'Emit findings as JSON.')
         .action((options: { strict?: boolean; json?: boolean }) => {
           /* v8 ignore next 2 -- process defaults are exercised by the CLI entrypoint, not unit tests. */

--- a/code/cli/src/resolver/AmbiguityWarnings.ts
+++ b/code/cli/src/resolver/AmbiguityWarnings.ts
@@ -17,8 +17,6 @@ interface SourceDeclaration {
   readonly declaredBy: string;
 }
 
-export const strictAmbiguityFailureMessage = 'Strict mode: ambiguous resolution is fatal.';
-
 const repositoryKey = (source: RemoteSourceReference): string =>
   redactSourceUriCredentials(normalizeGitUri(normalizeRemoteSourceUri(source)));
 

--- a/code/cli/src/resolver/ResolverValidation.ts
+++ b/code/cli/src/resolver/ResolverValidation.ts
@@ -12,6 +12,8 @@ export interface ValidationFinding {
   readonly severity: 'error' | 'warning';
   readonly resource: string;
   readonly message: string;
+  /** Deterministic precedence diagnostics stay advisory under strict mode. */
+  readonly advisory?: boolean;
 }
 
 /**
@@ -126,6 +128,7 @@ const shadowFindings = (resource: ResolvedResource): readonly ValidationFinding[
     severity: 'warning' as const,
     resource: resourceLabel(resource),
     message: `shadowed definition in ${definition.layer.label} is overridden by ${resource.winner.layer.label}.`,
+    advisory: true,
   }));
 
 // Reserved agent-local resource shapes that resolver discovers but does not yet project into a run.
@@ -531,7 +534,7 @@ const workflowCycleFindings = (definitions: ReadonlyMap<string, WorkflowDefiniti
 
 /**
  * Collects validation findings across the effective set. `error` findings always fail validation;
- * `warning` findings (such as shadowed definitions) fail only under `--strict`.
+ * non-advisory `warning` findings fail under `--strict`. Deterministic shadowing remains advisory.
  */
 export const validateEffectiveSet = (
   set: EffectiveResourceSet,

--- a/code/cli/tests/unit/ambiguity-warnings.test.ts
+++ b/code/cli/tests/unit/ambiguity-warnings.test.ts
@@ -1,11 +1,11 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
 import { Command } from 'commander';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { createDumpCommand } from '../../src/cli/commands/DumpCommand.js';
+import { createDumpCommand, executeDumpCommand } from '../../src/cli/commands/DumpCommand.js';
 import { createListCommand, executeListCommand } from '../../src/cli/commands/ListCommand.js';
 import { executeRunAgentCommand } from '../../src/cli/commands/RunAgentCommand.js';
 import { createSyncCommand, executeSyncCommand } from '../../src/cli/commands/SyncCommand.js';
@@ -189,7 +189,7 @@ describe('ambiguous source resolution warnings', () => {
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.7.1, OFTR-004.7.6).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('makes a source ref conflict fatal for run under strict mode', async () => {
+  it('reports a source ref conflict without failing run under strict mode', async () => {
     const root = createTemporaryRoot();
     runnableAgent(root);
     write(
@@ -199,16 +199,15 @@ describe('ambiguous source resolution warnings', () => {
 
     const result = await run(root, true);
 
-    expect(result.exitCode).not.toBe(0);
+    expect(result.exitCode).toBe(0);
     expect(
       result.messages.some((message) => message.includes("Ambiguous source repository 'github:acme/catalog'")),
     ).toBe(true);
-    expect(result.messages.at(-1)).toBe('Strict mode: ambiguous resolution is fatal.');
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.7.3, OFTR-004.7.6).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('makes a supplier slug collision fatal for run under strict mode', async () => {
+  it('reports a supplier slug collision without failing run under strict mode', async () => {
     const root = createTemporaryRoot();
     const first = join(root, 'first');
     const second = join(root, 'second');
@@ -219,14 +218,13 @@ describe('ambiguous source resolution warnings', () => {
 
     const result = await run(root, true);
 
-    expect(result.exitCode).not.toBe(0);
+    expect(result.exitCode).toBe(0);
     expect(result.messages.some((message) => message.includes("Ambiguous skill slug 'shared'"))).toBe(true);
-    expect(result.messages.at(-1)).toBe('Strict mode: ambiguous resolution is fatal.');
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.7.2, OFTR-004.7.6).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('makes a dropped-source replacement fatal for run under strict mode', async () => {
+  it('reports a dropped-source replacement without failing run under strict mode', async () => {
     const root = createTemporaryRoot();
     runnableAgent(root);
     write(join(root, 'home', '.agents', 'settings.yml'), 'sources:\n  - github: acme/user-catalog\n');
@@ -234,14 +232,13 @@ describe('ambiguous source resolution warnings', () => {
 
     const result = await run(root, true);
 
-    expect(result.exitCode).not.toBe(0);
+    expect(result.exitCode).toBe(0);
     expect(result.messages.some((message) => message.includes("source 'github:acme/user-catalog'"))).toBe(true);
-    expect(result.messages.at(-1)).toBe('Strict mode: ambiguous resolution is fatal.');
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.7.4, OFTR-004.7.6).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('gates ambiguity in strict sync, validate, and list while a clean strict configuration succeeds', async () => {
+  it('keeps ambiguity advisory in strict sync, validate, and list', async () => {
     const ambiguousRoot = createTemporaryRoot();
     const first = join(ambiguousRoot, 'first');
     const second = join(ambiguousRoot, 'second');
@@ -257,9 +254,9 @@ describe('ambiguous source resolution warnings', () => {
       strict: true,
     };
 
-    expect(executeSyncCommand(ambiguousInput).exitCode).not.toBe(0);
-    expect(executeValidateCommand(ambiguousInput).ok).toBe(false);
-    expect(executeListCommand({ ...ambiguousInput, kind: 'agents' }).exitCode).not.toBe(0);
+    expect(executeSyncCommand(ambiguousInput).exitCode).toBe(0);
+    expect(executeValidateCommand(ambiguousInput).ok).toBe(true);
+    expect(executeListCommand({ ...ambiguousInput, kind: 'agents' }).exitCode).toBe(0);
 
     const cleanRoot = createTemporaryRoot();
     runnableAgent(cleanRoot);
@@ -294,16 +291,16 @@ describe('ambiguous source resolution warnings', () => {
     const syncProgram = new Command();
     createSyncCommand(dependencies).register(syncProgram);
     await syncProgram.parseAsync(['node', 'outfitter', 'sync', '--strict']);
-    expect(process.exitCode).toBe(1);
-    expect(lines.at(-1)).toBe('failed: Strict mode: ambiguous resolution is fatal.');
+    expect(process.exitCode).toBeUndefined();
+    expect(lines.some((message) => message.includes('Ambiguous skill slug'))).toBe(true);
 
     process.exitCode = undefined;
     lines.length = 0;
     const listProgram = new Command();
     createListCommand(dependencies).register(listProgram);
     await listProgram.parseAsync(['node', 'outfitter', 'list', 'agents', '--strict']);
-    expect(process.exitCode).toBe(1);
-    expect(lines.at(-1)).toBe('error: Strict mode: ambiguous resolution is fatal.');
+    expect(process.exitCode).toBeUndefined();
+    expect(lines.some((message) => message.includes('Ambiguous skill slug'))).toBe(true);
 
     process.exitCode = undefined;
     lines.length = 0;
@@ -311,15 +308,15 @@ describe('ambiguous source resolution warnings', () => {
     createListCommand(dependencies).register(jsonListProgram);
     await jsonListProgram.parseAsync(['node', 'outfitter', 'list', 'agents', '--strict', '--json']);
     const json = JSON.parse(lines.join('\n')) as { ok: boolean; resources: unknown[]; diagnostics: string[] };
-    expect(process.exitCode).toBe(1);
-    expect(json.ok).toBe(false);
+    expect(process.exitCode).toBeUndefined();
+    expect(json.ok).toBe(true);
     expect(json.resources).toEqual([]);
-    expect(json.diagnostics.some((message) => message.includes('ambiguous resolution is fatal'))).toBe(true);
+    expect(json.diagnostics.some((message) => message.includes('Ambiguous skill slug'))).toBe(true);
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.7.4, OFTR-004.7.6).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('gates dump ambiguity under --strict while keeping it advisory by default', async () => {
+  it('keeps dump ambiguity advisory under --strict and by default', async () => {
     const root = createTemporaryRoot();
     const first = join(root, 'first');
     const second = join(root, 'second');
@@ -345,9 +342,9 @@ describe('ambiguous source resolution warnings', () => {
       join(root, 'strict-dump'),
       '--strict',
     ]);
-    expect(process.exitCode).toBe(1);
+    expect(process.exitCode).toBeUndefined();
     expect(lines.some((message) => message.includes("Ambiguous agent slug 'engineer'"))).toBe(true);
-    expect(lines.at(-1)).toBe('error: Strict mode: ambiguous resolution is fatal.');
+    expect(lines.some((message) => message.startsWith("Dumped 'engineer'"))).toBe(true);
 
     process.exitCode = undefined;
     lines.length = 0;
@@ -384,7 +381,7 @@ describe('ambiguous source resolution warnings', () => {
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.7.1, OFTR-004.7.2, OFTR-004.7.3, OFTR-004.7.6).
   // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
-  it('reports every ambiguity before strict mode fails', async () => {
+  it('reports every ambiguity while strict mode succeeds', async () => {
     const root = createTemporaryRoot();
     const first = join(root, 'first');
     const second = join(root, 'second');
@@ -398,14 +395,53 @@ describe('ambiguous source resolution warnings', () => {
     );
 
     const result = await run(root, true);
-    const failureIndex = result.messages.indexOf('Strict mode: ambiguous resolution is fatal.');
     const ambiguityIndexes = [
       result.messages.findIndex((message) => message.includes("source 'github:acme/dropped'")),
       result.messages.findIndex((message) => message.includes("Ambiguous source repository 'github:acme/catalog'")),
       result.messages.findIndex((message) => message.includes("Ambiguous skill slug 'shared'")),
     ];
 
-    expect(ambiguityIndexes.every((index) => index >= 0 && index < failureIndex)).toBe(true);
-    expect(failureIndex).toBe(result.messages.length - 1);
+    expect(result.exitCode).toBe(0);
+    expect(ambiguityIndexes.every((index) => index >= 0)).toBe(true);
+  });
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-004.7.2).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('ignores replaced settings scopes that declare no sources', () => {
+    const root = createTemporaryRoot();
+    write(join(root, 'home', '.agents', 'settings.yml'), 'default_agent: engineer\n');
+    write(join(root, 'project', '.agents', 'settings.yml'), 'sources: []\n');
+
+    expect(resolve(root).ambiguityWarnings).toEqual([]);
+  });
+  // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.7.1, OFTR-004.7.3, OFTR-004.7.6).
+  // YOU MUST NOT MODIFY THIS TEST UNLESS THE REQUIREMENT CHANGES.
+  it('rejects and removes a strict dump for composition warnings while preserving shadow diagnostics', () => {
+    const root = createTemporaryRoot();
+    const winner = join(root, 'winner');
+    const shadowed = join(root, 'shadowed');
+    write(
+      join(winner, 'agents', 'engineer', 'agent.md'),
+      '---\nname: engineer\nskills: [missing-skill]\nsubagents: [missing-agent]\nappend_system_prompt:\n  - repo_file: docs/missing.md\n---\n\nWinner.\n',
+    );
+    resource(shadowed, 'agents', 'engineer');
+    write(join(root, 'project', '.agents', 'settings.yml'), `sources:\n  - path: ${winner}\n  - path: ${shadowed}\n`);
+    const out = join(root, 'strict-warning-dump');
+
+    const result = executeDumpCommand({
+      homeDirectory: join(root, 'home'),
+      projectDirectory: join(root, 'project'),
+      agent: 'engineer',
+      out,
+      strict: true,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.writtenPaths).toEqual([]);
+    expect(result.messages.some((message) => message.includes("Ambiguous agent slug 'engineer'"))).toBe(true);
+    expect(result.messages.some((message) => message.includes("unknown skill 'missing-skill'"))).toBe(true);
+    expect(result.messages.some((message) => message.includes("unknown agent 'missing-agent'"))).toBe(true);
+    expect(result.messages.some((message) => message.includes("repo_file prompt source 'docs/missing.md'"))).toBe(true);
+    expect(result.messages.at(-1)).toBe('error: Strict mode: composition warnings are fatal.');
+    expect(existsSync(join(out, '.agents'))).toBe(false);
   });
 });

--- a/code/cli/tests/unit/link-command.test.ts
+++ b/code/cli/tests/unit/link-command.test.ts
@@ -190,14 +190,15 @@ describe('link command object', () => {
     await expect(run(root, ['--harness', 'claude'])).rejects.toThrow('Cannot link with invalid settings');
   });
 
-  it('treats ambiguous sources as fatal only under --strict', async () => {
+  it('keeps ambiguous sources advisory under --strict', async () => {
     const root = fixture();
     write(join(root.project, '.agents', 'skills', 'review', 'SKILL.md'), '---\nname: review\n---\n');
     const lenient = await run(root, ['--harness', 'claude']);
     expect(lenient[0]).toContain('warning: Ambiguous skill slug');
     expect(lenient.at(-1)).toBe(`claude (${join(root.home, '.claude')}): 3 created`);
     const strict = await run(root, ['--harness', 'claude', '--strict']);
-    expect(strict.at(-1)).toContain('error:');
-    expect(process.exitCode).toBe(1);
+    expect(strict[0]).toContain('warning: Ambiguous skill slug');
+    expect(strict.at(-1)).toContain('3 unchanged');
+    expect(process.exitCode).toBe(previousExitCode);
   });
 });

--- a/code/cli/tests/unit/resolver.test.ts
+++ b/code/cli/tests/unit/resolver.test.ts
@@ -444,6 +444,7 @@ describe('resource resolution', () => {
     expect(findings.some((f) => f.resource === 'agent:engineer' && /hooks/.test(f.message))).toBe(true);
     // Stubs surface as warnings (fatal only under --strict), never as errors.
     expect(findings.filter((f) => f.severity === 'error')).toHaveLength(0);
+    expect(executeValidateCommand({ homeDirectory: home, projectDirectory: project, strict: true }).ok).toBe(false);
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-006.3.17).
@@ -520,7 +521,7 @@ describe('resource resolution', () => {
     const validation = executeValidateCommand({ homeDirectory: home, projectDirectory: project });
     expect(validation.ok).toBe(true);
     expect(validation.findings.some((f) => f.severity === 'warning' && f.resource === 'agent:engineer')).toBe(true);
-    expect(executeValidateCommand({ homeDirectory: home, projectDirectory: project, strict: true }).ok).toBe(false);
+    expect(executeValidateCommand({ homeDirectory: home, projectDirectory: project, strict: true }).ok).toBe(true);
   });
 
   // THIS TEST VALIDATES A HARD REQUIREMENT (OFTR-003.2, OFTR-003.7).

--- a/docs/documentation/cli.md
+++ b/docs/documentation/cli.md
@@ -76,16 +76,16 @@ List resolvable resources across all layers, with the winning source for each sl
 | -------- | -------------------------------------------------------------------------- |
 | `[kind]` | Optional filter: `agents`, `skills`, `knowledge`, `commands`, `workflows`. |
 
-`--json` emits an object containing `ok`, `resources`, and `diagnostics`; diagnostics remain available when strict mode fails. Each workflow resource entry also contains a name-sorted `outputs` object with resolved output labels, or `{}` when the workflow declares none. Non-JSON output is unchanged. See [OFTR-013: Workflow Contract](../requirements/OFTR-013-workflow-contract.md).
+`--json` emits an object containing `ok`, `resources`, and `diagnostics`; diagnostics remain available under strict mode. Each workflow resource entry also contains a name-sorted `outputs` object with resolved output labels, or `{}` when the workflow declares none. Non-JSON output is unchanged. See [OFTR-013: Workflow Contract](../requirements/OFTR-013-workflow-contract.md).
 
 ## `outfitter validate`
 
 Validate the effective resource set: protocol layout, frontmatter, unresolved slugs in agent loadouts, broken or escaping skill references, workflow graphs and composed closures, and settings schema.
 
-| Option     | Description                              |
-| ---------- | ---------------------------------------- |
-| `--strict` | Exit non-zero when warnings are present. |
-| `--json`   | Print diagnostics as JSON.               |
+| Option     | Description                                                                                                |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| `--strict` | Exit non-zero on incomplete or unsupported composition warnings; deterministic shadowing remains advisory. |
+| `--json`   | Print diagnostics as JSON.                                                                                 |
 
 ## `outfitter dump`
 
@@ -119,7 +119,7 @@ opt-in persistent one. See [Linking into Claude Code and Codex](./linking-harnes
 | `--all`            | Link every resolvable agent, with its skills and commands.                                                                        |
 | `--dry-run`        | Report what would change (`would create`, `would update`, `would prune`) without touching the home.                               |
 | `--remove`         | Remove every entry this command created and forget it.                                                                            |
-| `--strict`         | Exit non-zero on warnings, conflicts, or skipped entries.                                                                         |
+| `--strict`         | Exit non-zero on non-advisory warnings, conflicts, or skipped entries; deterministic shadowing remains advisory.                  |
 
 ```bash
 outfitter link                                    # enabled workflows + default_agent, every installed harness

--- a/docs/documentation/linking-harnesses.md
+++ b/docs/documentation/linking-harnesses.md
@@ -57,7 +57,7 @@ This is the same boundary [state persistence](./state.md) enforces at run time: 
 | `skipped`   | The harness CLI is not on `PATH`, or its `mcp add` failed.                                                                                                                        |
 | `pruned`    | A managed symlink whose target vanished was removed and forgotten.                                                                                                                |
 
-Conflicts are reported, not resolved: move or unlink the unmanaged entry yourself, then relink. `--strict` exits 1 on any warning, conflict, or skipped entry, which is the form to use in scripts.
+Conflicts are reported, not resolved: move or unlink the unmanaged entry yourself, then relink. `--strict` exits 1 on non-advisory warnings, conflicts, or skipped entries; deterministic precedence and shadowing diagnostics remain advisory, which is the form to use in scripts.
 
 ## Relinking
 

--- a/docs/requirements/OFTR-003-profiles.md
+++ b/docs/requirements/OFTR-003-profiles.md
@@ -61,7 +61,8 @@ Outfitter resolves agents and other resources from layered `.agents` trees into 
 
 1. Outfitter MUST report an error when an agent's loadout references a `skills` or `subagents` slug that does not resolve.
 2. Outfitter MUST report a warning when a resource shadows a lower-precedence definition of the same slug.
-3. `outfitter validate --strict` MUST treat warnings as failures.
+3. `outfitter validate --strict` MUST treat incomplete or unsupported composition warnings as failures,
+   but deterministic shadowing warnings MUST remain advisory.
 4. Validation MUST parse every discovered agent-local skill and report malformed definitions, name/directory mismatches, and local resources without a resolvable owning agent.
 
 ### OFTR-003.8: Listing Resources

--- a/docs/requirements/OFTR-004-sync-and-setup.md
+++ b/docs/requirements/OFTR-004-sync-and-setup.md
@@ -193,10 +193,10 @@ disagree about the same thing, the selected declaration must be visible.
    intentionally overridden by a higher-precedence layer is still reported; visibility, not
    prohibition, is the requirement.
 4. These warnings MUST be surfaced by diagnostic commands that resolve the effective set, including
-   `sync`, `validate`, and `list agents`. `run --strict` MUST also surface them before it fails.
-   A successful non-strict `run` MUST suppress them so routine startup stays quiet.
+   `sync`, `validate`, and `list agents`. `run --strict` MUST also surface them while preserving the
+   selected winner. A successful non-strict `run` MUST suppress them so routine startup stays quiet.
 5. Detection MUST NOT change which declaration wins; precedence rules are unchanged.
-6. Under strict mode, every command that resolves the effective set MUST report every detected
-   ambiguity and then fail with a nonzero exit status. All three ambiguity classes above gate
-   uniformly. A deliberate divergence under strict mode MUST be resolved by making the
-   configuration unambiguous, not by suppressing the error.
+6. Under strict mode, every command that resolves the effective set MUST preserve deterministic
+   precedence, report every detected ambiguity, and MUST NOT fail solely because a declaration or
+   resource shadows a lower-precedence definition. Strict mode remains fatal for incomplete or
+   unsupported requested composition.

--- a/docs/requirements/OFTR-012-harness-links.md
+++ b/docs/requirements/OFTR-012-harness-links.md
@@ -46,7 +46,7 @@ and separate from the temporary projection `outfitter run` builds and removes pe
 5. A planned symlink or file MUST report `created` when the path is absent, `unchanged` when the existing entry already matches the planned target or content, and `updated` only when the manifest owns the path and its target or content differs.
 6. A manifest symlink that is not in the current plan MUST be removed and reported `pruned` only when its target no longer exists; every other manifest entry not in the plan MUST be retained in the manifest and left in place.
 7. A manifest entry that exits the plan MUST NOT be deleted from the harness home by a non-`--remove` run unless it is a dangling symlink.
-8. `--strict` MUST exit 1 when any warning, `conflict`, or `skipped` entry is reported and MUST exit 0 otherwise; without `--strict`, conflicts and skips MUST exit 0.
+8. `--strict` MUST exit 1 when any non-advisory warning, `conflict`, or `skipped` entry is reported and MUST exit 0 otherwise; deterministic precedence and shadowing diagnostics MUST remain advisory. Without `--strict`, conflicts and skips MUST exit 0.
 
 ### OFTR-012.4: Idempotent Reconciliation, Dry Run, and Removal
 


### PR DESCRIPTION
Fixes #397.

## Summary

- keep deterministic source and resource precedence diagnostics advisory under `--strict`
- preserve strict failures for missing or unsupported requested composition
- distinguish advisory shadowing from other validation warnings across run, dump, sync, list, link, and validate
- make strict dump failures remove newly generated incomplete output without weakening existing destination protection
- update the formal requirements, CLI documentation, and regression coverage

## Verification

- focused regression suite: 105/105 passed
- `OUTFITTER_SYSTEM_DIR=/tmp/outfitter-issue397-system npm run check-ci`
- full suite: 749/749 passed
- formatting and lint passed
- branch coverage: 98.03%

## Independent review

Two read-only adversarial review lanes inspected a frozen commit snapshot. The first pass found a strict-dump cleanup defect and stale link help text; both were fixed and the commit was amended. Both second-pass reviewers approved with no findings.

The opposite-harness Claude review was unavailable because the execution boundary would have transmitted repository contents to an external provider without separate authorization, so the review used independent Codex lanes instead.

Review requested from @ncrmro.
